### PR TITLE
Implement dynamic Patch versioning logic in build scripts

### DIFF
--- a/.github/workflows/merged-build.yml
+++ b/.github/workflows/merged-build.yml
@@ -115,7 +115,15 @@ jobs:
           # Extract version info from properties file
           MAJOR=$(grep 'versionMajor=' version.properties | cut -d'=' -f2)
           MINOR=$(grep 'versionMinor=' version.properties | cut -d'=' -f2)
-          PATCH=$(grep 'versionPatch=' version.properties | cut -d'=' -f2)
+
+          # Calculate Patch version programmatically based on commits since Minor update
+          MINOR_COMMIT=$(git blame -L '/versionMinor=/',+1 version.properties | awk '{print $1}' | tr -d '^')
+          if [ -n "$MINOR_COMMIT" ]; then
+            PATCH=$(git rev-list --count $MINOR_COMMIT..HEAD)
+          else
+            PATCH=$(grep 'versionPatch=' version.properties | cut -d'=' -f2)
+          fi
+
           VERSION_NAME="$MAJOR.$MINOR.$PATCH.$BUILD_NUMBER"
           
           TAG_NAME="latest-debug-v${MAJOR}.${MINOR}"


### PR DESCRIPTION
- Modified `app/build.gradle.kts` to calculate the Patch version dynamically:
    - Implemented `PatchVersionValueSource` and `BuildVersionValueSource` using Gradle's `ValueSource` API for Configuration Cache compatibility.
    - Logic uses `git blame` to find the last change to `versionMinor` in `version.properties` and counts commits since then for the Patch number.
    - Logic uses `git rev-list --count HEAD` for the Build number.
    - Added fallbacks to `version.properties` values if git commands fail.
- Updated `.github/workflows/merged-build.yml` to mirror this logic in the release pipeline:
    - Added a bash script step to calculate `PATCH` based on the same `git blame` strategy.
    - Ensures release artifacts and tags reflect the dynamic versioning.
- Fixed `Unresolved reference 'io'` errors in build script by explicitly importing `java.io.File` and `java.io.ByteArrayOutputStream`.