### PR TITLE
Restore 5-step AR target creation and fix native crashes

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,7 +25,7 @@
         android:name=".GraffitiApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
-        android.fullBackupContent="@xml/backup_rules"
+        android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"

--- a/app/src/main/java/com/hereliesaz/graffitixr/ArView.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/ArView.kt
@@ -122,13 +122,13 @@ fun ArView(
             when (event) {
                 Lifecycle.Event.ON_RESUME -> {
                     if (activity != null) {
-                        glSurfaceView.queueEvent { renderer.onResume(activity) }
+                        renderer.onResume(activity)
                         glSurfaceView.onResume()
                     }
                 }
                 Lifecycle.Event.ON_PAUSE -> {
+                    renderer.onPause()
                     glSurfaceView.onPause()
-                    glSurfaceView.queueEvent { renderer.onPause() }
                 }
                 else -> {}
             }


### PR DESCRIPTION
Restored the robust 5-step target creation workflow (Front, Left, Right, Up, Down) in MainViewModel, ensuring a diverse image set is passed to ARCore for tracking. Fixed native crashes (JNIEnv, Unknown old image) by optimizing AR session lifecycle management in ArView and decoupling frame analysis from the GL thread in ArRenderer. Integrated ML Kit Subject Segmentation with the multi-angle capture process, applying the mask to the primary (Front) image while utilizing all angles for tracking stability. Corrected AndroidManifest.xml syntax error.