### PR TITLE
Fix AR dragging, UI knobs, and update AR workflow

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/ArView.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/ArView.kt
@@ -179,9 +179,9 @@ fun ArView(
                         val pointerCount = event.changes.size
 
                         // Rule Check:
-                        // If 1 pointer -> Must have started on object
+                        // If 1 pointer -> Allowed (Global drag to support robust moving even if bounds are flaky)
                         // If 2+ pointers -> Allowed
-                        val isGestureAllowed = (pointerCount == 1 && isStartOnObject) || (pointerCount >= 2)
+                        val isGestureAllowed = pointerCount >= 1
 
                         if (isGestureAllowed) {
                             val zoomChange = event.calculateZoom()

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
@@ -147,6 +147,13 @@ fun MainScreen(viewModel: MainViewModel) {
         contract = ActivityResultContracts.CreateDocument("application/zip")
     ) { uri -> uri?.let { viewModel.exportProjectToUri(it) } }
 
+    // Image Picker Request Handler
+    LaunchedEffect(viewModel) {
+        viewModel.requestImagePicker.collect {
+            overlayImagePicker.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
+        }
+    }
+
     // Helper for automation
     fun onModeSelected(mode: EditorMode) {
         viewModel.onEditorModeChanged(mode)
@@ -157,9 +164,7 @@ fun MainScreen(viewModel: MainViewModel) {
 
         if (!hasSelectedModeOnce) {
             hasSelectedModeOnce = true
-            // Auto-launch image picker
-            overlayImagePicker.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
-            // If AR, auto-launch target capture
+            // If AR, auto-launch target capture (which now starts with INSTRUCTION step)
             if (mode == EditorMode.AR) {
                 viewModel.onCreateTargetClicked()
             }
@@ -437,7 +442,7 @@ fun MainScreen(viewModel: MainViewModel) {
                             azDivider()
 
                             azRailSubItem(id = "adjust", hostId = "design_host", text = "Adjust") {
-                                showSliderDialog = "Adjust"
+                                showSliderDialog = if (showSliderDialog == "Adjust") null else "Adjust"
                                 showColorBalanceDialog = false
                             }
                             azRailSubItem(id = "color_balance", hostId = "design_host", text = "Balance") {
@@ -480,7 +485,10 @@ fun MainScreen(viewModel: MainViewModel) {
                         azDivider()
 
                         if (uiState.editorMode == EditorMode.AR || uiState.editorMode == EditorMode.OVERLAY) {
-                            azRailItem(id = "light", text = "Light", onClick = viewModel::onToggleFlashlight)
+                            azRailItem(id = "light", text = "Light", onClick = {
+                                viewModel.onToggleFlashlight()
+                                showSliderDialog = null; showColorBalanceDialog = false
+                            })
                         }
                     }
                 }

--- a/app/src/main/java/com/hereliesaz/graffitixr/UiState.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/UiState.kt
@@ -35,6 +35,7 @@ enum class TargetCreationState : Parcelable {
  */
 @Parcelize
 enum class CaptureStep : Parcelable {
+    INSTRUCTION,
     FRONT,
     LEFT,
     RIGHT,

--- a/app/src/main/java/com/hereliesaz/graffitixr/composables/TargetCreationOverlay.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/composables/TargetCreationOverlay.kt
@@ -148,12 +148,21 @@ fun TargetCreationOverlay(
                     .background(glowColor.value, CircleShape)
                     .border(2.dp, Color.White, CircleShape)
             ) {
-                Icon(
-                    imageVector = Icons.Default.CameraAlt,
-                    contentDescription = "Capture",
-                    tint = Color.White,
-                    modifier = Modifier.size(40.dp)
-                )
+                if (step == CaptureStep.INSTRUCTION) {
+                    Text(
+                        text = "START",
+                        color = Color.White,
+                        fontWeight = FontWeight.Bold,
+                        style = MaterialTheme.typography.labelLarge
+                    )
+                } else {
+                    Icon(
+                        imageVector = Icons.Default.CameraAlt,
+                        contentDescription = "Capture",
+                        tint = Color.White,
+                        modifier = Modifier.size(40.dp)
+                    )
+                }
             }
         }
     }
@@ -186,6 +195,7 @@ fun FlashingArrow(
 
 private fun getArrowForStep(step: CaptureStep): ImageVector? {
     return when (step) {
+        CaptureStep.INSTRUCTION -> null
         CaptureStep.FRONT -> null
         CaptureStep.LEFT -> Icons.Default.ArrowBack // Pointing Left
         CaptureStep.RIGHT -> Icons.Default.ArrowForward // Pointing Right
@@ -197,6 +207,7 @@ private fun getArrowForStep(step: CaptureStep): ImageVector? {
 
 private fun getArrowDescriptionForStep(step: CaptureStep): String {
     return when (step) {
+        CaptureStep.INSTRUCTION -> ""
         CaptureStep.FRONT -> ""
         CaptureStep.LEFT -> "Move Left"
         CaptureStep.RIGHT -> "Move Right"
@@ -208,6 +219,7 @@ private fun getArrowDescriptionForStep(step: CaptureStep): String {
 
 private fun getInstructionText(step: CaptureStep): String {
     return when (step) {
+        CaptureStep.INSTRUCTION -> "Move device slowly to scan surfaces.\nPress START when ready."
         CaptureStep.FRONT -> "Stand directly in front of the target surface."
         CaptureStep.LEFT -> "Take a step to the LEFT."
         CaptureStep.RIGHT -> "Take a step to the RIGHT."

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -18,6 +18,13 @@
 -   **Requirement:** A physical Android device supporting ARCore.
 -   **Emulator:** The standard Android Emulator supports a "Virtual Scene" for ARCore, which is sufficient for basic logic checks but not for performance or camera quality tuning.
 
+### **Regression Checks**
+-   **AR Gestures (Drag, Pinch-Zoom, Twist-Rotate):**
+    -   Verify that the AR image can be dragged with one finger.
+    -   Verify that the AR image can be scaled (pinch) and rotated (twist) with two fingers.
+    -   Verify that two-finger drag also moves the image.
+    -   **Important:** This must be verified on every build affecting AR input logic to prevent regression.
+
 ### **Build Verification**
 -   **Command:** `./gradlew assembleDebug`
 -   **Mandatory:** Must pass before every commit.


### PR DESCRIPTION
- **AR Dragging:** Restored robust 1-finger drag in `ArView.kt` by removing strict bounding box check.
- **UI:** Fixed "Adjust" button to toggle visibility and ensured "Light" button clears active panels.
- **Workflow:**
    - Removed automatic image picker launch on mode entry.
    - Added `CaptureStep.INSTRUCTION` with "Start" button to guide scanning.
    - Delayed image picker launch until surface tap/anchor placement.
- **Reset:** Reset `activeRotationAxis` to Z whenever a mode is loaded.
- **Docs:** Added regression checks to `docs/testing.md`.

## Summary by Sourcery

Improve AR capture workflow, restore robust AR dragging, and refine editor UI behavior.

New Features:
- Introduce an INSTRUCTION capture step with on-screen guidance and a START action before target scanning begins.
- Trigger the image picker only after AR image placement via a dedicated request event from the view model.

Bug Fixes:
- Allow one-finger AR drag gestures regardless of initial hit-test to prevent regressions in object movement.
- Make the Adjust rail item behave as a toggle and ensure the Light action closes any open adjustment panels.

Enhancements:
- Reset the active rotation axis to Z whenever the editor mode changes, including when entering Help mode.

Documentation:
- Add AR gesture regression checks to the testing guide to ensure drag, pinch-zoom, and rotate are validated on builds affecting AR input logic.