### PR TITLE
Fix AR dragging, spin issue, and update workflow

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/ArRenderer.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/ArRenderer.kt
@@ -20,6 +20,7 @@ import com.google.ar.core.AugmentedImageDatabase
 import com.google.ar.core.Config
 import com.google.ar.core.Frame
 import com.google.ar.core.Plane
+import com.google.ar.core.Pose
 import com.google.ar.core.Session
 import com.google.ar.core.TrackingState
 import com.google.ar.core.exceptions.NotYetAvailableException
@@ -422,11 +423,21 @@ class ArRenderer(
         for (hit in hitResult) {
             val trackable = hit.trackable
             if (trackable is Plane && trackable.isPoseInPolygon(hit.hitPose)) {
+                // Stabilize rotation: Preserve the current anchor's rotation to prevent unintended spinning while dragging.
+                // We only want to use the Translation from the new hit.
+                val currentPose = activeAnchor?.pose ?: hit.hitPose
+                val hitPose = hit.hitPose
+
+                val newPose = Pose(
+                    floatArrayOf(hitPose.tx(), hitPose.ty(), hitPose.tz()),
+                    floatArrayOf(currentPose.qx(), currentPose.qy(), currentPose.qz(), currentPose.qw())
+                )
+
                 activeAnchor?.detach()
-                activeAnchor = hit.createAnchor()
+                activeAnchor = trackable.createAnchor(newPose)
 
                 // Bolt Optimization: Reuse matrix
-                hit.hitPose.toMatrix(calculationPoseMatrix, 0)
+                newPose.toMatrix(calculationPoseMatrix, 0)
                 arImagePose = calculationPoseMatrix
                 break
             }


### PR DESCRIPTION
- **AR Dragging:** Fixed "wild spin" issue during drag in `ArRenderer.kt` by preserving anchor rotation while updating translation.
- **Gesture:** Restored robust 1-finger drag in `ArView.kt`.
- **UI:** Fixed "Adjust" button toggle and ensured "Light" button clears active panels.
- **Workflow:**
    - Removed automatic image picker launch.
    - Added `CaptureStep.INSTRUCTION` with "Start" button.
    - Delayed image picker launch until surface tap.
- **Reset:** Reset `activeRotationAxis` to Z on mode load.
- **Docs:** Added regression checks to `docs/testing.md`.

## Summary by Sourcery

Stabilize AR object dragging and refine the capture workflow and UI interactions.

Bug Fixes:
- Prevent AR anchors from spinning during drag by preserving the existing rotation while updating position.
- Restore reliable single-finger drag gestures in the AR view.
- Fix the Adjust button toggle behavior and ensure the Light button correctly clears other active panels.
- Reset the active rotation axis to Z when loading the relevant mode to avoid inconsistent rotation state.

Enhancements:
- Update the capture workflow to add an instruction step with an explicit Start action and delay the image picker launch until the user taps the surface.
- Remove automatic image picker launch on mode entry to give users more explicit control over capture.

Documentation:
- Document new regression checks and behaviors in docs/testing.md.