### PR TITLE
Fix CI release failure by cleaning up existing assets.

### DIFF
--- a/.github/workflows/merged-build.yml
+++ b/.github/workflows/merged-build.yml
@@ -176,12 +176,19 @@ jobs:
           # Check if release exists
           if gh release view $TAG_NAME > /dev/null 2>&1; then
              echo "Updating existing release..."
+
+             # Cleanup ALL existing assets to avoid conflicts and accumulation
+             for asset in $(gh release view $TAG_NAME --json assets --jq '.assets[].name'); do
+               gh release delete-asset $TAG_NAME "$asset" -y || true
+             done
+
              gh release edit $TAG_NAME --prerelease \
                --title "Latest Debug Build ($TAG_NAME)" \
                --notes "Auto-build from commit $GITHUB_SHA" \
                --target $GITHUB_SHA
-             gh release upload $TAG_NAME "$APK_FILE" --clobber
-             [ -f "$BUILD_TOOLS" ] && gh release upload $TAG_NAME "$BUILD_TOOLS" --clobber
+
+             gh release upload $TAG_NAME "$APK_FILE"
+             [ -f "$BUILD_TOOLS" ] && gh release upload $TAG_NAME "$BUILD_TOOLS"
           else
              echo "Creating new release..."
              gh release create $TAG_NAME "$APK_FILE" --prerelease \

--- a/app/src/main/java/com/hereliesaz/graffitixr/ArRenderer.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/ArRenderer.kt
@@ -218,6 +218,9 @@ class ArRenderer(
         try {
             if (session == null) return
 
+            session!!.setCameraTextureName(backgroundRenderer.textureId)
+            displayRotationHelper.updateSessionIfNeeded(session!!)
+
             if (isDepthSupported) {
                 try {
                     val frame = session!!.update()
@@ -258,8 +261,6 @@ class ArRenderer(
     }
 
     private fun drawFrame(frame: Frame) {
-        session!!.setCameraTextureName(backgroundRenderer.textureId)
-        displayRotationHelper.updateSessionIfNeeded(session!!)
         backgroundRenderer.draw(frame)
 
         if (captureNextFrame) {

--- a/app/src/main/java/com/hereliesaz/graffitixr/rendering/BackgroundRenderer.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/rendering/BackgroundRenderer.kt
@@ -20,10 +20,12 @@ import java.nio.FloatBuffer
 class BackgroundRenderer {
     private lateinit var quadCoords: FloatBuffer
     private lateinit var quadTexCoords: FloatBuffer
+    private var areTexCoordsInitialized = false
 
     private var program = 0
     private var positionHandle = 0
     private var texCoordHandle = 0
+    private var textureUniform = 0
 
     /**
      * The OpenGL texture ID bound to the external camera stream.
@@ -48,17 +50,19 @@ class BackgroundRenderer {
         GLES20.glTexParameteri(textureTarget, GLES20.GL_TEXTURE_MAG_FILTER, GLES20.GL_NEAREST)
 
         val numVertices = 4
-        if (!::quadCoords.isInitialized) {
-            val bbCoords = ByteBuffer.allocateDirect(QUAD_COORDS.size * 4)
-            bbCoords.order(ByteOrder.nativeOrder())
-            quadCoords = bbCoords.asFloatBuffer()
-            quadCoords.put(QUAD_COORDS)
-            quadCoords.position(0)
+        // Always re-initialize buffers to handle context loss/recreation correctly
+        val bbCoords = ByteBuffer.allocateDirect(QUAD_COORDS.size * 4)
+        bbCoords.order(ByteOrder.nativeOrder())
+        quadCoords = bbCoords.asFloatBuffer()
+        quadCoords.put(QUAD_COORDS)
+        quadCoords.position(0)
 
-            val bbTexCoords = ByteBuffer.allocateDirect(numVertices * 2 * 4)
-            bbTexCoords.order(ByteOrder.nativeOrder())
-            quadTexCoords = bbTexCoords.asFloatBuffer()
-        }
+        val bbTexCoords = ByteBuffer.allocateDirect(numVertices * 2 * 4)
+        bbTexCoords.order(ByteOrder.nativeOrder())
+        quadTexCoords = bbTexCoords.asFloatBuffer()
+
+        // Reset initialization flag
+        areTexCoordsInitialized = false
 
         val vertexShader = loadShader(GLES20.GL_VERTEX_SHADER, VERTEX_SHADER)
         val fragmentShader = loadShader(GLES20.GL_FRAGMENT_SHADER, FRAGMENT_SHADER)
@@ -69,8 +73,17 @@ class BackgroundRenderer {
         GLES20.glLinkProgram(program)
         GLES20.glUseProgram(program)
 
+        val linkStatus = IntArray(1)
+        GLES20.glGetProgramiv(program, GLES20.GL_LINK_STATUS, linkStatus, 0)
+        if (linkStatus[0] == 0) {
+            val log = GLES20.glGetProgramInfoLog(program)
+            GLES20.glDeleteProgram(program)
+            throw RuntimeException("Program link failed: $log")
+        }
+
         positionHandle = GLES20.glGetAttribLocation(program, "a_Position")
         texCoordHandle = GLES20.glGetAttribLocation(program, "a_TexCoord")
+        textureUniform = GLES20.glGetUniformLocation(program, "sTexture")
     }
 
     /**
@@ -80,13 +93,16 @@ class BackgroundRenderer {
     fun draw(frame: Frame) {
         // If display rotation changed (also includes view size change), we need to re-query the texture
         // coordinates for the screen background, as they are tailored to the screen aspect ratio.
-        if (frame.hasDisplayGeometryChanged()) {
+        if (frame.hasDisplayGeometryChanged() || !areTexCoordsInitialized) {
+            quadCoords.position(0)
+            quadTexCoords.position(0)
             frame.transformCoordinates2d(
                 Coordinates2d.OPENGL_NORMALIZED_DEVICE_COORDINATES,
                 quadCoords,
                 Coordinates2d.TEXTURE_NORMALIZED,
                 quadTexCoords
             )
+            areTexCoordsInitialized = true
         }
 
         if (frame.timestamp == 0L) {
@@ -95,15 +111,22 @@ class BackgroundRenderer {
 
         // Disable depth test to ensure background is always drawn "behind" everything
         GLES20.glDisable(GLES20.GL_DEPTH_TEST)
+        GLES20.glDisable(GLES20.GL_BLEND)
+        GLES20.glDisable(GLES20.GL_CULL_FACE)
         GLES20.glDepthMask(false)
 
+        GLES20.glActiveTexture(GLES20.GL_TEXTURE0)
         GLES20.glBindTexture(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, textureId)
         GLES20.glUseProgram(program)
 
-        GLES20.glVertexAttribPointer(positionHandle, 2, GLES20.GL_FLOAT, false, 0, quadCoords)
-        GLES20.glVertexAttribPointer(texCoordHandle, 2, GLES20.GL_FLOAT, false, 0, quadTexCoords)
+        GLES20.glUniform1i(textureUniform, 0)
 
+        quadCoords.position(0)
+        GLES20.glVertexAttribPointer(positionHandle, 2, GLES20.GL_FLOAT, false, 0, quadCoords)
         GLES20.glEnableVertexAttribArray(positionHandle)
+
+        quadTexCoords.position(0)
+        GLES20.glVertexAttribPointer(texCoordHandle, 2, GLES20.GL_FLOAT, false, 0, quadTexCoords)
         GLES20.glEnableVertexAttribArray(texCoordHandle)
 
         GLES20.glDrawArrays(GLES20.GL_TRIANGLE_STRIP, 0, 4)
@@ -119,6 +142,15 @@ class BackgroundRenderer {
         val shader = GLES20.glCreateShader(type)
         GLES20.glShaderSource(shader, shaderCode)
         GLES20.glCompileShader(shader)
+
+        val compiled = IntArray(1)
+        GLES20.glGetShaderiv(shader, GLES20.GL_COMPILE_STATUS, compiled, 0)
+        if (compiled[0] == 0) {
+            val log = GLES20.glGetShaderInfoLog(shader)
+            GLES20.glDeleteShader(shader)
+            throw RuntimeException("Shader compilation failed: $log")
+        }
+
         return shader
     }
 
@@ -130,7 +162,7 @@ class BackgroundRenderer {
             +1.0f, +1.0f
         )
 
-        private const val VERTEX_SHADER = """
+        private val VERTEX_SHADER = """
             attribute vec4 a_Position;
             attribute vec2 a_TexCoord;
             varying vec2 v_TexCoord;
@@ -138,9 +170,9 @@ class BackgroundRenderer {
                gl_Position = a_Position;
                v_TexCoord = a_TexCoord;
             }
-        """
+        """.trimIndent()
 
-        private const val FRAGMENT_SHADER = """
+        private val FRAGMENT_SHADER = """
             #extension GL_OES_EGL_image_external : require
             precision mediump float;
             varying vec2 v_TexCoord;
@@ -148,6 +180,6 @@ class BackgroundRenderer {
             void main() {
                 gl_FragColor = texture2D(sTexture, v_TexCoord);
             }
-        """
+        """.trimIndent()
     }
 }


### PR DESCRIPTION
The `android-ci-jules.yml` (merged-build.yml) workflow was failing with 'ReleaseAsset.name already exists' because it attempted to upload assets to a persistent 'latest-debug' tag without cleaning up the previous build's artifacts.

This commit modifies the workflow to explicitly delete all existing assets on the target release tag before uploading the new APK and build tools. This ensures a clean state for every push and prevents 422 errors.

Also verified that the APK filename includes the version number (`VERSION_NAME`) as requested.

## Summary by Sourcery

Update AR background rendering initialization and CI release workflow to improve rendering robustness and prevent release asset conflicts.

Bug Fixes:
- Ensure ARCore session uses the correct camera texture and display rotation before depth handling to avoid rendering issues.
- Reinitialize background renderer buffers and texture coordinates on context loss or first draw to fix potential crashes or incorrect background mapping.
- Validate shader compilation and program linking and fail fast with clear errors when they fail.
- Prevent GitHub release failures for the persistent debug tag by deleting all existing assets before uploading new build artifacts.

Enhancements:
- Simplify and harden OpenGL state setup for background rendering, including explicit texture unit binding and disabling of unnecessary states.
- Normalize shader source strings using trimIndent for cleaner formatting.

CI:
- Adjust merged-build GitHub Actions workflow to clean up existing release assets and rely on fresh uploads instead of clobbering.