### PR TITLE
Fix: Resolve NavController crash in AzNavRail

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ The user interacts with the application through a simple user interface. The mai
 -   **State Management:** All UI state is held in the immutable `UiState.kt` data class and managed via a `StateFlow` in `MainViewModel.kt`.
 
 ### **Key Files**
--   `MainActivity.kt`: The single activity entry point. It handles permissions, initializes the ARCore session, and hosts the `MainScreen` composable.
+-   `MainActivity.kt`: The single activity entry point. It handles permissions, initializes the ARCore session, and sets up the Jetpack Navigation `NavController` and `NavHost`, which hosts the `MainScreen` composable.
 -   **`MainViewModel.kt`**: The central logic hub. It manages all state changes and user events.
 -   `ARScreen.kt`: The composable for the AR experience.
 -   `ARCoreRenderer.kt`: The renderer for the AR experience.

--- a/docs/file_descriptions.md
+++ b/docs/file_descriptions.md
@@ -45,7 +45,7 @@ ProGuard/R8 configuration rules. Essential for preserving code that is accessed 
 
 #### `MainActivity.kt`
 The single `Activity` entry point.
--   **Responsibilities:** Initializes OpenCV, handles runtime permissions (Camera), manages the global `MainViewModel`, and hosts the Compose UI content.
+-   **Responsibilities:** Initializes OpenCV, handles runtime permissions (Camera), manages the global `MainViewModel`, and hosts the Compose UI content. It also sets up the Jetpack Navigation `NavController` and `NavHost`.
 -   **Key Features:** Implements a hidden "Unlock" mechanism via volume keys.
 
 #### `MainViewModel.kt`


### PR DESCRIPTION
Add a `NavController` to `MainActivity` and pass it to `MainScreen` and `AzNavRail` to resolve a runtime `IllegalArgumentException`. The crash was caused by the `AzNavRail` library's internal dependency on a `NavController` that was not properly configured with a `NavHost`.

- Created a `NavController` in `MainActivity` and wrapped the main content in a `NavHost`.
- Passed the `NavController` down to `MainScreen` and `AzNavRail`.
- Updated documentation to reflect the use of Jetpack Navigation.