### PR TITLE
fix(ar): Clear captured image state after rectify target creation

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainViewModel.kt
@@ -364,7 +364,8 @@ class MainViewModel(
                             targetCreationState = TargetCreationState.SUCCESS,
                             isArTargetCreated = true,
                             arState = ArState.SEARCHING,
-                            fingerprintJson = fingerprintJson
+                            fingerprintJson = fingerprintJson,
+                            capturedTargetImages = emptyList() // Clear the image cache
                         )
                     )
                 }


### PR DESCRIPTION
Resolves an issue where an overlay image would not appear after creating an AR target using the "rectify" method.

The `capturedTargetImages` state in the `MainViewModel` was not being cleared after the target was successfully created. This caused the app to retain a reference to the rectified bitmap, which interfered with the subsequent selection and display of a new overlay image.

This commit clears the `capturedTargetImages` state in the `onConfirmTargetCreation` function, ensuring that the app is ready to accept a new overlay image without any state conflicts.

## Summary by Sourcery

Bug Fixes:
- Clear capturedTargetImages when confirming AR target creation so subsequent overlay image selections display correctly.