### PR TITLE
Fix C++ Build and Kotlin Compilation Errors

### DIFF
--- a/app/src/main/cpp/GraffitiJNI.cpp
+++ b/app/src/main/cpp/GraffitiJNI.cpp
@@ -4,7 +4,7 @@
 #include <cstdint>
 #include <opencv2/core.hpp>
 #include <android/log.h>
-#include "include/MobileGS.h"
+#include "MobileGS.h"
 
 #define TAG "GraffitiJNI"
 #define LOGE(...) __android_log_print(ANDROID_LOG_ERROR, TAG, __VA_ARGS__)

--- a/app/src/main/cpp/MobileGS.cpp
+++ b/app/src/main/cpp/MobileGS.cpp
@@ -1,4 +1,4 @@
-#include "include/MobileGS.h"
+#include "MobileGS.h"
 #include <algorithm>
 #include <android/log.h>
 #include <opencv2/imgproc.hpp>

--- a/app/src/main/cpp/include/MobileGS.h
+++ b/app/src/main/cpp/include/MobileGS.h
@@ -1,161 +1,90 @@
-#include "include/MobileGS.h"
-#include <algorithm>
-#include <android/log.h>
-#include <fstream>
+#pragma once
 
-#define TAG "MobileGS"
-#define LOGI(...) __android_log_print(ANDROID_LOG_INFO, TAG, __VA_ARGS__)
+#include <vector>
+#include <string>
+#include <mutex>
+#include <thread>
+#include <atomic>
+#include <condition_variable>
+#include <map>
+#include <GLES3/gl3.h>
+#include <glm/glm.hpp>
+#include <opencv2/core.hpp>
 
-const float CONFIDENCE_THRESHOLD = 0.6f;
-const float CONFIDENCE_INCREMENT = 0.05f;
+// Constants inferred from usage
+const int MAX_POINTS = 500000;
+const float VOXEL_SIZE = 0.05f;
 
-// ... (Shaders remain the same) ...
+struct SplatGaussian {
+    glm::vec3 position;
+    glm::vec3 scale;
+    glm::vec3 color;
+    float opacity;
+};
 
-MobileGS::MobileGS() :
-        mProgram(0), mVAO(0), mVBO(0), mQuadVBO(0),
-        mViewMatrix(1.0f), mProjMatrix(1.0f), mSortViewMatrix(1.0f),
-        mSortRunning(false), mStopThread(false), mSortResultReady(false),
-        mMapChanged(false), mIsInitialized(false)
-{
-    mLastUpdateTime = std::chrono::steady_clock::now();
-    mSortThread = std::thread(&MobileGS::sortThreadLoop, this);
-}
-
-// ... (Destructor and initialize remain the same) ...
-
-int MobileGS::getPointCount() {
-    std::lock_guard<std::mutex> lock(mDataMutex);
-    return (int)mRenderGaussians.size();
-}
-
-void MobileGS::processDepthFrame(const cv::Mat& depthMap, int width, int height) {
-    // ... (Throttling logic same as before) ...
-    auto now = std::chrono::steady_clock::now();
-    if (std::chrono::duration_cast<std::chrono::milliseconds>(now - mLastUpdateTime).count() < 33) return;
-    mLastUpdateTime = now;
-
-    std::lock_guard<std::mutex> lock(mDataMutex);
-    if (mProjMatrix[0][0] == 0) return;
-
-    if (mRenderGaussians.size() > MAX_POINTS * 0.9) {
-        pruneMap();
+struct VoxelKey {
+    int x, y, z;
+    bool operator<(const VoxelKey& other) const {
+        if (x != other.x) return x < other.x;
+        if (y != other.y) return y < other.y;
+        return z < other.z;
     }
+};
 
-    // ... (Matrix calculation same as before) ...
-    glm::mat4 invView = glm::inverse(mViewMatrix);
-    float p00 = mProjMatrix[0][0];
-    float p11 = mProjMatrix[1][1];
-    float p20 = mProjMatrix[2][0];
-    float p21 = mProjMatrix[2][1];
+struct Sortable {
+    int index;
+    float depth;
+};
 
-    int step = 2; 
-    for (int y = 0; y < height; y += step) {
-        const uint16_t* rowPtr = depthMap.ptr<uint16_t>(y);
-        for (int x = 0; x < width; x += step) {
-            uint16_t d_raw = rowPtr[x];
-            if (d_raw < 200 || d_raw > 4000) continue;
+class MobileGS {
+public:
+    MobileGS();
+    ~MobileGS();
 
-            float z = d_raw * 0.001f;
-            // ... (Projection math same as before) ...
-            float ndc_x = ((float)x / width) * 2.0f - 1.0f;
-            float ndc_y = 1.0f - ((float)y / height) * 2.0f;
-            glm::vec4 viewPos;
-            viewPos.x = (ndc_x + p20) * z / p00;
-            viewPos.y = (ndc_y + p21) * z / p11;
-            viewPos.z = -z;
-            viewPos.w = 1.0f;
-            glm::vec4 worldPos = invView * viewPos;
+    void initialize();
+    void updateCamera(const float* viewMtx, const float* projMtx);
+    void processDepthFrame(const cv::Mat& depthMap, int width, int height);
+    void processImage(const cv::Mat& image, int width, int height, int64_t timestamp);
+    void draw();
+    void clear();
+    bool saveModel(const std::string& path);
+    bool loadModel(const std::string& path);
+    int getPointCount();
 
-            VoxelKey key;
-            key.x = static_cast<int>(std::floor(worldPos.x / VOXEL_SIZE));
-            key.y = static_cast<int>(std::floor(worldPos.y / VOXEL_SIZE));
-            key.z = static_cast<int>(std::floor(worldPos.z / VOXEL_SIZE));
+private:
+    void sortThreadLoop();
+    void compileShaders();
+    void pruneMap();
+    void setBackgroundFrame(const cv::Mat& frame);
 
-            auto it = mVoxelGrid.find(key);
-            if (it != mVoxelGrid.end()) {
-                SplatGaussian& g = mRenderGaussians[it->second];
-                g.opacity = std::min(1.0f, g.opacity + CONFIDENCE_INCREMENT);
-                // Simple running average for position refinement
-                g.position = glm::mix(g.position, glm::vec3(worldPos), 0.1f);
-            } else if (mRenderGaussians.size() < MAX_POINTS) {
-                SplatGaussian g;
-                g.position = glm::vec3(worldPos);
-                g.scale = glm::vec3(VOXEL_SIZE * 1.8f); // Slightly overlapping
-                g.opacity = CONFIDENCE_INCREMENT;
-                g.color = glm::vec3(0.0f, 0.8f, 1.0f);
-                mRenderGaussians.push_back(g);
-                mVoxelGrid[key] = (int)(mRenderGaussians.size() - 1);
-            }
-        }
-    }
-}
+    std::mutex mDataMutex;
+    std::mutex mBgMutex;
+    std::mutex mSortMutex;
+    std::condition_variable mSortCV;
+    std::thread mSortThread;
+    std::atomic<bool> mStopThread;
+    std::atomic<bool> mSortRunning;
+    std::atomic<bool> mSortResultReady;
+    bool mMapChanged;
+    bool mIsInitialized;
 
-void MobileGS::pruneMap() {
-    // FIX: Invalidate sort when changing the vector layout
-    mMapChanged = true;
-    
-    std::vector<SplatGaussian> survived;
-    survived.reserve(mRenderGaussians.size());
-    mVoxelGrid.clear();
+    std::vector<SplatGaussian> mRenderGaussians;
+    std::map<VoxelKey, int> mVoxelGrid;
 
-    for (const auto& g : mRenderGaussians) {
-        if (g.opacity >= CONFIDENCE_THRESHOLD) {
-            survived.push_back(g);
-            VoxelKey key = { 
-                (int)std::floor(g.position.x/VOXEL_SIZE), 
-                (int)std::floor(g.position.y/VOXEL_SIZE), 
-                (int)std::floor(g.position.z/VOXEL_SIZE) 
-            };
-            mVoxelGrid[key] = (int)(survived.size() - 1);
-        }
-    }
-    mRenderGaussians = std::move(survived);
-    LOGI("Garbage Collection: Pruned to %zu points", mRenderGaussians.size());
-}
+    glm::mat4 mViewMatrix;
+    glm::mat4 mProjMatrix;
+    glm::mat4 mSortViewMatrix;
 
-// ... (processImage, setBackgroundFrame, compileShaders remain same) ...
+    GLuint mProgram;
+    GLuint mVAO, mVBO, mQuadVBO;
+    GLuint mBgProgram, mBgVAO, mBgVBO, mBgTexture;
 
-void MobileGS::sortThreadLoop() {
-    while (!mStopThread) {
-        {
-            std::unique_lock<std::mutex> lock(mSortMutex);
-            mSortCV.wait(lock, [this] { return mStopThread || mSortRunning.load(); });
-            if (mStopThread) return;
-        }
+    std::chrono::steady_clock::time_point mLastUpdateTime;
 
-        // ... (Sort logic same as before) ...
-        std::vector<glm::vec3> positions;
-        glm::mat4 view;
-        {
-            std::lock_guard<std::mutex> dataLock(mDataMutex);
-            view = mSortViewMatrix;
-            positions.reserve(mRenderGaussians.size());
-            for(const auto& g : mRenderGaussians) positions.push_back(g.position);
-        }
+    bool mNewBgAvailable;
+    bool mHasBgData;
+    cv::Mat mPendingBgFrame;
 
-        if (!positions.empty()) {
-            std::vector<Sortable> sorted;
-            sorted.reserve(positions.size());
-            for(size_t i=0; i<positions.size(); ++i) {
-                const auto& p = positions[i];
-                float depth = view[0][2] * p.x + view[1][2] * p.y + view[2][2] * p.z + view[3][2];
-                sorted.push_back({(int)i, depth});
-            }
-            std::sort(sorted.begin(), sorted.end(), [](const Sortable& a, const Sortable& b){
-                return a.depth > b.depth;
-            });
-
-            std::lock_guard<std::mutex> dataLock(mDataMutex);
-            // If map changed while we were sorting, discard this result
-            if (!mMapChanged) {
-                mSortListBack = std::move(sorted);
-                mSortResultReady = true;
-            } else {
-                mMapChanged = false; // Reset flag, try again next frame
-            }
-        }
-        mSortRunning = false;
-    }
-}
-
-// ... (draw, saveModel, loadModel, clear remain the same) ...
+    std::vector<Sortable> mSortListBack;
+    std::vector<Sortable> mSortListFront;
+};

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainViewModel.kt
@@ -95,7 +95,7 @@ class MainViewModel(
             _uiState.value.layers.find { it.id == activeId }?.let { layer ->
                 ImageUtils.loadBitmapFromUri(context, layer.uri)?.let { original ->
                     snapshotState()
-                    val processed = BackgroundRemover.removeBackground(original)
+                    val processed = BackgroundRemover.removeBackground(context, original)
                     if (processed != null) {
                         val newUri = ImageUtils.saveBitmapToCache(context, processed)
                         updateActiveLayer { it.copy(uri = newUri) }
@@ -350,4 +350,8 @@ class MainViewModel(
     fun onMagicClicked() {}
     fun checkForUpdates() {}
     fun installLatestUpdate() {}
+
+    fun setHandedness(isRight: Boolean) = _uiState.update { it.copy(isRightHanded = isRight) }
+    fun onResume() {}
+    fun onPause() {}
 }

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainViewModelFactory.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainViewModelFactory.kt
@@ -12,7 +12,7 @@ class MainViewModelFactory(
         if (modelClass.isAssignableFrom(MainViewModel::class.java)) {
             val projectManager = ProjectManager() // Initialize dependency
             @Suppress("UNCHECKED_CAST")
-            return MainViewModel(application, projectManager) as T
+            return MainViewModel(projectManager) as T
         }
         throw IllegalArgumentException("Unknown ViewModel class")
     }

--- a/app/src/test/java/com/hereliesaz/graffitixr/MainViewModelTest.kt
+++ b/app/src/test/java/com/hereliesaz/graffitixr/MainViewModelTest.kt
@@ -46,7 +46,7 @@ class MainViewModelTest {
         every { editor.apply() } just Runs
         every { prefs.getBoolean("is_right_handed", true) } returns true
 
-        viewModel = MainViewModel(application, projectManager)
+        viewModel = MainViewModel(projectManager)
     }
 
     @After


### PR DESCRIPTION
- **C++ Fixes**:
  - Corrected include paths in `GraffitiJNI.cpp` and `MobileGS.cpp` to use `#include "MobileGS.h"`.
  - Reconstructed `app/src/main/cpp/include/MobileGS.h` which was corrupted (contained implementation code). The new header properly defines the `MobileGS` class and constants `MAX_POINTS` and `VOXEL_SIZE`.

- **Kotlin Fixes**:
  - In `MainViewModel.kt`:
    - Updated `onRemoveBackgroundClicked` to pass `context` to `BackgroundRemover.removeBackground`.
    - Added missing `setHandedness`, `onResume`, and `onPause` methods required by consumers.
  - In `MainViewModelFactory.kt` and `MainViewModelTest.kt`:
    - Removed incorrect `Application` argument from `MainViewModel` constructor calls.

- **Verification**:
  - Verified successful C++ build (`:app:buildCMakeDebug[arm64-v8a]`).
  - Verified successful Kotlin build (`:app:compileDebugKotlin`).
  - Verified `MainViewModelTest` passes.

---
*PR created automatically by Jules for task [12109252647254784812](https://jules.google.com/task/12109252647254784812) started by @HereLiesAz*

## Summary by Sourcery

Restore correct C++ header structure and Android/Kotlin integration to fix native and Kotlin compilation errors.

Bug Fixes:
- Reintroduce a proper MobileGS C++ header with class declarations, constants, and types instead of inlined implementation code.
- Fix native includes to reference MobileGS.h from GraffitiJNI and MobileGS sources so the C++ build resolves headers correctly.
- Update background removal in MainViewModel to pass Context into BackgroundRemover.removeBackground to match its API.
- Expose setHandedness, onResume, and onPause on MainViewModel to satisfy existing consumers and lifecycle expectations.
- Align MainViewModelFactory and MainViewModelTest to the current MainViewModel constructor signature by removing the obsolete Application parameter.

Tests:
- Adjust MainViewModelTest construction to use the updated MainViewModel signature so unit tests compile and run against the fixed API.