### PR TITLE
Implement MobileGS native AR engine

### DIFF
--- a/core/native/src/main/cpp/MobileGS.cpp
+++ b/core/native/src/main/cpp/MobileGS.cpp
@@ -2,28 +2,96 @@
 #include <jni.h>
 #include <GLES2/gl2.h>
 #include <android/log.h>
+#include <fstream>
+#include <cmath>
+#include <vector>
 
 #define LOG_TAG "MobileGS_Native"
 #define LOGI(...) __android_log_print(ANDROID_LOG_INFO, LOG_TAG, __VA_ARGS__)
 
-#define MAX_SPLATS 5000
-#define DRAW_STRIDE 20
+// Shader sources
+const char* VS_SRC =
+    "attribute vec4 vPosition;\n"
+    "attribute vec4 vColor;\n"
+    "varying vec4 fColor;\n"
+    "uniform mat4 uMVP;\n"
+    "void main() {\n"
+    "  gl_Position = uMVP * vPosition;\n"
+    "  gl_PointSize = 15.0;\n"
+    "  fColor = vColor;\n"
+    "}\n";
+
+const char* FS_SRC =
+    "precision mediump float;\n"
+    "varying vec4 fColor;\n"
+    "void main() {\n"
+    "  gl_FragColor = fColor;\n"
+    "}\n";
+
+// Global shader handles
+GLuint gProgram = 0;
+GLint gLocMVP = -1;
 
 MobileGS::MobileGS() {
     m_Splats.reserve(MAX_SPLATS);
+    m_DrawBuffer.reserve(MAX_SPLATS * 7);
     LOGI("MobileGS Created");
 }
 
 MobileGS::~MobileGS() {
     std::lock_guard<std::mutex> lock(m_SplatsMutex);
     m_Splats.clear();
+    mVoxelGrid.clear();
+    m_DrawBuffer.clear();
     LOGI("MobileGS Destroyed");
 }
 
 void MobileGS::initialize() {
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-    LOGI("MobileGS Initialized");
+
+    // Compile Shaders
+    GLuint vs = glCreateShader(GL_VERTEX_SHADER);
+    glShaderSource(vs, 1, &VS_SRC, NULL);
+    glCompileShader(vs);
+
+    GLint compiled;
+    glGetShaderiv(vs, GL_COMPILE_STATUS, &compiled);
+    if (!compiled) {
+        LOGI("Vertex shader compilation failed");
+        return;
+    }
+
+    GLuint fs = glCreateShader(GL_FRAGMENT_SHADER);
+    glShaderSource(fs, 1, &FS_SRC, NULL);
+    glCompileShader(fs);
+
+    glGetShaderiv(fs, GL_COMPILE_STATUS, &compiled);
+    if (!compiled) {
+        LOGI("Fragment shader compilation failed");
+        return;
+    }
+
+    gProgram = glCreateProgram();
+    glAttachShader(gProgram, vs);
+    glAttachShader(gProgram, fs);
+
+    // Bind attributes BEFORE linking
+    glBindAttribLocation(gProgram, 0, "vPosition");
+    glBindAttribLocation(gProgram, 1, "vColor");
+
+    glLinkProgram(gProgram);
+
+    GLint linked;
+    glGetProgramiv(gProgram, GL_LINK_STATUS, &linked);
+    if (!linked) {
+        LOGI("Shader linking failed");
+        return;
+    }
+
+    gLocMVP = glGetUniformLocation(gProgram, "uMVP");
+
+    LOGI("MobileGS Initialized with Shader. Program: %d", gProgram);
 }
 
 void MobileGS::updateCamera(const float* view, const float* proj) {
@@ -36,46 +104,157 @@ void MobileGS::updateCamera(const float* view, const float* proj) {
 void MobileGS::processDepthFrame(const cv::Mat& depth, int width, int height) {
     std::lock_guard<std::mutex> lock(m_SplatsMutex);
 
-    if (m_Splats.size() >= MAX_SPLATS) {
-        size_t removeCount = m_Splats.size() / 10;
-        if (removeCount < 1) removeCount = 1;
-        m_Splats.erase(m_Splats.begin(), m_Splats.begin() + removeCount);
+    // 1. Invert Matrices
+    // Transpose raw column-major data to row-major OpenCV matrices
+    cv::Mat viewMat(4, 4, CV_32F, m_ViewMatrix);
+    viewMat = viewMat.t();
+
+    cv::Mat projMat(4, 4, CV_32F, m_ProjMatrix);
+    projMat = projMat.t();
+
+    cv::Mat invView, invProj;
+
+    if (cv::determinant(viewMat) == 0 || cv::determinant(projMat) == 0) return;
+
+    cv::invert(viewMat, invView);
+    cv::invert(projMat, invProj);
+
+    const int STRIDE = 8; // Process 1 out of every 8x8 pixels
+
+    for (int y = 0; y < height; y += STRIDE) {
+        const uint16_t* rowPtr = depth.ptr<uint16_t>(y);
+        for (int x = 0; x < width; x += STRIDE) {
+            uint16_t d_mm = rowPtr[x];
+
+            if (d_mm == 0 || d_mm > 8000) continue;
+
+            float d_meters = d_mm * 0.001f;
+            if (d_meters > CULL_DISTANCE) continue;
+
+            // 2. Unproject to View Space
+            float ndc_x = (2.0f * x / width) - 1.0f;
+            float ndc_y = 1.0f - (2.0f * y / height); // Flip Y
+
+            // Clip space vector
+            cv::Mat clipVec = (cv::Mat_<float>(4, 1) << ndc_x, ndc_y, 0.0f, 1.0f);
+            cv::Mat viewVec = invProj * clipVec;
+
+            float w = viewVec.at<float>(3, 0);
+            if (std::abs(w) < 1e-5) continue;
+
+            float vx = viewVec.at<float>(0, 0) / w;
+            float vy = viewVec.at<float>(1, 0) / w;
+            float vz = viewVec.at<float>(2, 0) / w;
+
+            if (std::abs(vz) < 1e-5) continue;
+            float scale = -d_meters / vz;
+
+            float px_view = vx * scale;
+            float py_view = vy * scale;
+            float pz_view = vz * scale;
+
+            // 3. Transform to World Space
+            cv::Mat pView = (cv::Mat_<float>(4, 1) << px_view, py_view, pz_view, 1.0f);
+            cv::Mat pWorld = invView * pView;
+
+            float wx = pWorld.at<float>(0, 0);
+            float wy = pWorld.at<float>(1, 0);
+            float wz = pWorld.at<float>(2, 0);
+
+            // 4. Voxel Hashing
+            VoxelKey key;
+            key.x = (int)std::floor(wx / VOXEL_SIZE);
+            key.y = (int)std::floor(wy / VOXEL_SIZE);
+            key.z = (int)std::floor(wz / VOXEL_SIZE);
+
+            auto it = mVoxelGrid.find(key);
+            if (it != mVoxelGrid.end()) {
+                // Update existing splat
+                int idx = it->second;
+                Splat& s = m_Splats[idx];
+
+                float alpha = 0.1f;
+                s.x = s.x * (1.0f - alpha) + wx * alpha;
+                s.y = s.y * (1.0f - alpha) + wy * alpha;
+                s.z = s.z * (1.0f - alpha) + wz * alpha;
+
+                if (s.confidence < CONFIDENCE_THRESHOLD + 5.0f) {
+                    s.confidence += CONFIDENCE_INCREMENT;
+                }
+            } else {
+                // Create new splat
+                if (m_Splats.size() < MAX_SPLATS) {
+                    Splat s;
+                    s.x = wx;
+                    s.y = wy;
+                    s.z = wz;
+
+                    // Simple coloring: Gradient based on Y (height)
+                    s.r = 0.5f + (wy * 0.2f);
+                    s.g = 0.8f;
+                    s.b = 0.9f;
+                    s.a = 0.0f;
+                    s.confidence = 1.0f;
+
+                    m_Splats.push_back(s);
+                    mVoxelGrid[key] = m_Splats.size() - 1;
+                }
+            }
+        }
     }
-    // Projection logic would go here
 }
 
 void MobileGS::draw() {
     std::lock_guard<std::mutex> lock(m_SplatsMutex);
-    if (m_Splats.empty()) return;
+    if (m_Splats.empty() || gProgram == 0) return;
+
+    glUseProgram(gProgram);
+
+    // Compute MVP using Corrected Matrices
+    cv::Mat viewMat(4, 4, CV_32F, m_ViewMatrix);
+    viewMat = viewMat.t();
+
+    cv::Mat projMat(4, 4, CV_32F, m_ProjMatrix);
+    projMat = projMat.t();
+
+    cv::Mat mvp = projMat * viewMat;
+
+    // Transpose back for OpenGL Column-Major order
+    cv::Mat mvpGL = mvp.t();
+
+    glUniformMatrix4fv(gLocMVP, 1, GL_FALSE, (float*)mvpGL.data);
 
     glEnable(GL_BLEND);
 
-    std::vector<float> drawBuffer;
-    drawBuffer.reserve((m_Splats.size() / DRAW_STRIDE) * 7);
+    // Optimization: reuse m_DrawBuffer
+    m_DrawBuffer.clear();
+    // Assuming m_DrawBuffer capacity is sufficient from constructor or previous runs
 
-    for (size_t i = 0; i < m_Splats.size(); i += DRAW_STRIDE) {
-        const auto& s = m_Splats[i];
+    for (const auto& s : m_Splats) {
+        float alpha = (s.confidence >= CONFIDENCE_THRESHOLD) ? 1.0f : (s.confidence / CONFIDENCE_THRESHOLD);
+        if (alpha < 0.1f) continue;
 
-        drawBuffer.push_back(s.x);
-        drawBuffer.push_back(s.y);
-        drawBuffer.push_back(s.z);
+        m_DrawBuffer.push_back(s.x);
+        m_DrawBuffer.push_back(s.y);
+        m_DrawBuffer.push_back(s.z);
 
-        drawBuffer.push_back(s.r);
-        drawBuffer.push_back(s.g);
-        drawBuffer.push_back(s.b);
-        drawBuffer.push_back(0.3f);
+        // Debug Color (Green/Blue)
+        m_DrawBuffer.push_back(0.2f);
+        m_DrawBuffer.push_back(0.8f);
+        m_DrawBuffer.push_back(1.0f);
+        m_DrawBuffer.push_back(alpha);
     }
 
-    if (drawBuffer.empty()) return;
+    if (m_DrawBuffer.empty()) return;
 
-    glEnableVertexAttribArray(0);
-    glEnableVertexAttribArray(1);
+    glEnableVertexAttribArray(0); // vPosition
+    glEnableVertexAttribArray(1); // vColor
 
     int stride = 7 * sizeof(float);
-    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, stride, drawBuffer.data());
-    glVertexAttribPointer(1, 4, GL_FLOAT, GL_FALSE, stride, drawBuffer.data() + 3);
+    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, stride, m_DrawBuffer.data());
+    glVertexAttribPointer(1, 4, GL_FLOAT, GL_FALSE, stride, m_DrawBuffer.data() + 3);
 
-    glDrawArrays(GL_POINTS, 0, drawBuffer.size() / 7);
+    glDrawArrays(GL_POINTS, 0, m_DrawBuffer.size() / 7);
 
     glDisableVertexAttribArray(0);
     glDisableVertexAttribArray(1);
@@ -87,14 +266,41 @@ int MobileGS::getPointCount() {
 }
 
 bool MobileGS::saveModel(const std::string& path) {
-    LOGI("saveModel: %s", path.c_str());
-    // Placeholder: Return true to indicate success
+    std::lock_guard<std::mutex> lock(m_SplatsMutex);
+    std::ofstream out(path, std::ios::binary);
+    if (!out) return false;
+
+    uint64_t count = m_Splats.size();
+    out.write(reinterpret_cast<const char*>(&count), sizeof(count));
+    out.write(reinterpret_cast<const char*>(m_Splats.data()), count * sizeof(Splat));
+    out.close();
+    LOGI("Saved model to %s with %llu splats", path.c_str(), (unsigned long long)count);
     return true;
 }
 
 bool MobileGS::loadModel(const std::string& path) {
-    LOGI("loadModel: %s", path.c_str());
-    // Placeholder: Return true to indicate success
+    std::lock_guard<std::mutex> lock(m_SplatsMutex);
+    std::ifstream in(path, std::ios::binary);
+    if (!in) return false;
+
+    uint64_t count = 0;
+    in.read(reinterpret_cast<char*>(&count), sizeof(count));
+
+    m_Splats.resize(count);
+    in.read(reinterpret_cast<char*>(m_Splats.data()), count * sizeof(Splat));
+    in.close();
+
+    mVoxelGrid.clear();
+    for (size_t i = 0; i < m_Splats.size(); ++i) {
+        const auto& s = m_Splats[i];
+        VoxelKey key;
+        key.x = (int)std::floor(s.x / VOXEL_SIZE);
+        key.y = (int)std::floor(s.y / VOXEL_SIZE);
+        key.z = (int)std::floor(s.z / VOXEL_SIZE);
+        mVoxelGrid[key] = i;
+    }
+
+    LOGI("Loaded model from %s with %llu splats", path.c_str(), (unsigned long long)count);
     return true;
 }
 
@@ -105,4 +311,6 @@ void MobileGS::applyTransform(const float* transform) {
 void MobileGS::clear() {
     std::lock_guard<std::mutex> lock(m_SplatsMutex);
     m_Splats.clear();
+    mVoxelGrid.clear();
+    m_DrawBuffer.clear();
 }

--- a/core/native/src/main/cpp/include/MobileGS.h
+++ b/core/native/src/main/cpp/include/MobileGS.h
@@ -4,13 +4,36 @@
 #include <string>
 #include <vector>
 #include <mutex>
+#include <unordered_map>
 #include <opencv2/core.hpp>
+
+// Constants
+constexpr float VOXEL_SIZE = 0.02f; // 2cm voxels
+constexpr float CONFIDENCE_THRESHOLD = 3.0f;
+constexpr float CONFIDENCE_INCREMENT = 1.0f;
+constexpr int MAX_SPLATS = 500000;
+constexpr float CULL_DISTANCE = 5.0f; // Meters
 
 // Internal structure for a gaussian splat point
 struct Splat {
     float x, y, z;
     float r, g, b, a;
     float confidence;
+};
+
+// Voxel Key for Sparse Hashing
+struct VoxelKey {
+    int x, y, z;
+    bool operator==(const VoxelKey& other) const {
+        return x == other.x && y == other.y && z == other.z;
+    }
+};
+
+// Hash function for VoxelKey
+struct VoxelKeyHash {
+    std::size_t operator()(const VoxelKey& k) const {
+        return std::hash<int>()(k.x) ^ (std::hash<int>()(k.y) << 1) ^ (std::hash<int>()(k.z) << 2);
+    }
 };
 
 class MobileGS {
@@ -25,7 +48,6 @@ public:
 
     int getPointCount();
 
-    // CHANGED: Return bool to satisfy JNI check
     bool saveModel(const std::string& path);
     bool loadModel(const std::string& path);
 
@@ -34,6 +56,8 @@ public:
 
 private:
     std::vector<Splat> m_Splats;
+    std::vector<float> m_DrawBuffer; // Reuse buffer to reduce allocations
+    std::unordered_map<VoxelKey, int, VoxelKeyHash> mVoxelGrid;
     std::mutex m_SplatsMutex;
     float m_ViewMatrix[16];
     float m_ProjMatrix[16];

--- a/docs/NATIVE_ENGINE.md
+++ b/docs/NATIVE_ENGINE.md
@@ -7,34 +7,37 @@ The `MobileGS` (Mobile Gaussian Splatting) engine is a custom C++ library design
 
 ### 1. Voxel Grid (`mVoxelGrid`)
 *   **Type**: `std::unordered_map<VoxelKey, int, VoxelKeyHash>`
-*   **Purpose**: Maps 3D integer coordinates (voxels) to an index in the `mGaussians` vector.
+*   **Purpose**: Maps 3D integer coordinates (voxels) to an index in the `mSplats` vector.
 *   **Logic**:
     *   The world is divided into cubes of size `VOXEL_SIZE` (defined in `MobileGS.h`).
     *   When a new depth point is detected, we calculate its voxel key.
     *   If the voxel is empty, a new splat is created.
     *   If the voxel is occupied, the existing splat is updated (position averaging and confidence boost).
 
-### 2. Splat Metadata (`SplatMetadata`)
+### 2. Splat Structure
 Contains:
-*   `renderData`: Struct passed to the GPU (Position, Scale, Color, Opacity).
-*   `creationTime`: Timestamp for pruning logic.
+*   `x, y, z`: Position in world space (meters).
+*   `r, g, b, a`: Color and Opacity.
+*   `confidence`: A score indicating how many times this voxel has been observed. Used for opacity blending.
 
 ### 3. Rendering Pipeline
-The engine uses **Instanced Rendering** to draw thousands of splats efficiently.
-*   **Geometry**: A single quad (4 vertices) is stored in `mQuadVBO`.
-*   **Instance Data**: Position, Color, and Scale for every splat are stored in `mVBO`.
-*   **Shader**: `VS_SRC` and `FS_SRC` (embedded in `MobileGS.cpp`) handle the billboard calculation (making splats face the camera).
+The engine uses **GL_POINTS** for efficient rendering of the voxel map.
+*   **Geometry**: Points are drawn from a vertex buffer (`m_DrawBuffer`) populated from `m_Splats`.
+*   **Shader**: A custom shader (`VS_SRC`, `FS_SRC`) handles projection (MVP) and coloring.
+*   **Attributes**: `vPosition` (Location 0) and `vColor` (Location 1).
 
-### 4. Sorting Thread
-Gaussian Splatting requires back-to-front sorting for correct alpha blending.
-*   **Thread**: `sortThreadLoop` runs continuously in the background.
-*   **Algorithm**: Calculates the distance of every splat to the camera plane, sorts them, and updates the index buffer.
-*   **Synchronization**: Uses double-buffering logic to avoid stalling the render thread.
+### 4. Depth Processing (`processDepthFrame`)
+*   **Input**: 16-bit depth buffer from ARCore (in millimeters) + Camera View & Projection matrices.
+*   **Unprojection**:
+    *   Depth pixels are unprojected to View Space using camera intrinsics derived from the Projection Matrix.
+    *   View Space points are transformed to World Space using the Inverse View Matrix.
+*   **Voxel Hashing**:
+    *   World points are quantized into voxels.
+    *   `mVoxelGrid` is queried to update existing points or add new ones.
 
 ## Memory Management
-*   **Pruning**: The `pruneMap()` function removes points that:
-    *   Have low confidence (opacity) after a certain time (`MIN_AGE_MS`).
-    *   Are the "least confident" when the `MAX_POINTS` limit is reached.
+*   **Limits**: `MAX_SPLATS` is set to 500,000 to prevent OOM.
+*   **Culling**: Points further than `CULL_DISTANCE` (5m) are ignored.
 
 ## JNI Interface
 The engine is exposed to Kotlin via `GraffitiJNI.cpp`, which maps native pointers to Java `long` handles.
@@ -42,3 +45,5 @@ The engine is exposed to Kotlin via `GraffitiJNI.cpp`, which maps native pointer
 **Key Methods:**
 *   `updateCamera(viewMtx, projMtx)`: Updates the camera pose using raw OpenGL matrices.
 *   `feedDepthData(buffer, width, height)`: Ingests the 16-bit depth buffer for voxel unprojection.
+*   `draw()`: Renders the current state of the voxel map.
+*   `saveModel(path)` / `loadModel(path)`: Serializes/Deserializes the map to binary format.

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArView.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArView.kt
@@ -4,6 +4,7 @@ import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/PointCloudRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/PointCloudRenderer.kt
@@ -24,6 +24,7 @@ class PointCloudRenderer {
     private val maxPoints = 1000 // Or appropriate default
     private val localBuffer = FloatArray(maxPoints * 4)
     private var accumulatedPointCount = 0
+    private var lastTimestamp: Long = 0
 
     fun createOnGlThread(context: Context) {
         val buffers = IntArray(1)


### PR DESCRIPTION
Implemented the MobileGS (Mobile Gaussian Splatting) native engine for AR mode.
- core:native: Implemented MobileGS.cpp and MobileGS.h with Sparse Voxel Hashing, 16-bit depth unprojection using OpenCV, and GL_POINTS rendering.
- feature:ar: Updated ArRenderer.kt to drive SlamManager, feeding camera matrices and depth images to the native engine.
- feature:ar: Cleaned up duplicate ArRenderer.kt files and fixed ArView.kt imports.
- docs: Updated NATIVE_ENGINE.md to reflect the implementation.
Verified with successful compilation and unit tests.

---
*PR created automatically by Jules for task [9257527013326492644](https://jules.google.com/task/9257527013326492644) started by @HereLiesAz*

## Summary by Sourcery

Integrate the MobileGS native AR engine end-to-end, including depth-based voxel mapping, point rendering, and AR pipeline wiring.

New Features:
- Add a voxel-hashed MobileGS engine that unprojects 16-bit depth frames into world-space splats and renders them as GL_POINTS with a custom shader.
- Expose model persistence in the MobileGS engine via binary save and load operations.
- Wire the AR renderer to SlamManager to stream camera matrices and depth images into the native engine and draw its output.

Bug Fixes:
- Fix AR module package structure and imports for ArRenderer and ArView to remove duplicate files and ensure correct rendering setup.

Enhancements:
- Optimize MobileGS memory usage and rendering by reusing a draw buffer and capping splats with distance-based culling.
- Extend the MobileGS data model with voxel hashing and confidence tracking for incremental map updates.
- Clarify native engine documentation to match the new voxel-based rendering pipeline, depth processing, and persistence APIs.

Documentation:
- Update NATIVE_ENGINE.md to describe voxel hashing, splat structure, GL_POINTS rendering, depth unprojection, memory limits, and model serialization APIs.