### PR TITLE
Implement 3D Gaussian Splatting Rendering in MobileGS

### DIFF
--- a/core/nativebridge/src/main/cpp/include/MobileGS.h
+++ b/core/nativebridge/src/main/cpp/include/MobileGS.h
@@ -7,6 +7,8 @@
 #include <unordered_map>
 #include <GLES3/gl3.h>
 #include <opencv2/core.hpp>
+#include <glm/glm.hpp>
+#include <glm/gtc/quaternion.hpp>
 
 // Voxel Key for Spatial Hashing
 struct VoxelKey {
@@ -23,8 +25,10 @@ struct VoxelKeyHash {
 };
 
 struct Splat {
-    float x, y, z;
-    float r, g, b;
+    glm::vec3 pos;
+    glm::vec3 scale;
+    glm::quat rot;
+    glm::vec3 color;
     float opacity; // Used for confidence
 };
 
@@ -57,9 +61,14 @@ public:
 private:
     // GL State
     GLuint mProgram = 0;
-    GLint mLocMVP = -1;
-    GLint mLocPointSize = -1;
-    GLuint mVBO = 0;
+    GLint mLocView = -1;
+    GLint mLocProj = -1;
+    GLint mLocCamPos = -1;
+
+    // Instancing buffers
+    GLuint mVBO_Quad = 0;      // Static unit quad
+    GLuint mVBO_Instance = 0;  // Dynamic splat data
+
     bool mGlDirty = true; // Signals need to re-upload VBO
 
     // Data State
@@ -68,9 +77,9 @@ private:
     std::mutex mChunkMutex;
 
     // Matrices
-    float mViewMatrix[16];
-    float mProjMatrix[16];
-    float mMVPMatrix[16];
+    glm::mat4 mViewMat;
+    glm::mat4 mProjMat;
+    glm::vec3 mCamPos;
 
     // Target (Teleological)
     cv::Mat mTargetDescriptors;
@@ -80,8 +89,9 @@ private:
     int mViewportWidth = 0;
     int mViewportHeight = 0;
 
-    void updateMVP();
+    void updateMatrices();
     void uploadSplatData(); // Helper to send mSplats to GPU
+    void sortSplats();
 };
 
 #endif // MOBILE_GS_H


### PR DESCRIPTION
This change replaces the basic point cloud rendering in the native engine (`MobileGS`) with a 3D Gaussian Splatting implementation. This provides a denser, higher-quality reconstruction by rendering scaled and rotated splats instead of fixed-size points. Key changes include updating the `Splat` struct, rewriting the shaders to handle Gaussian splatting logic, implementing instanced rendering for performance, and adding sorting for correct transparency. Map serialization was also updated to version 2 to support the new data structure while maintaining backward compatibility for loading version 1 maps.

---
*PR created automatically by Jules for task [11447115055786287585](https://jules.google.com/task/11447115055786287585) started by @HereLiesAz*

## Summary by Sourcery

Replace point-based rendering in the MobileGS native engine with instanced 3D Gaussian splatting using quads, including updated shaders, data structures, and camera handling.

New Features:
- Introduce a richer Splat representation supporting position, per-axis scale, rotation (quaternion), color, and opacity for 3D Gaussian splats.
- Implement instanced quad-based rendering with Gaussian falloff in shaders to produce dense, high-quality splat visuals.
- Add depth-based sorting of splats to ensure correct alpha blending during rendering.

Enhancements:
- Refactor matrix and vector math to use GLM for view/projection, pose handling, and camera position extraction.
- Improve voxel integration logic to refine existing splats via moving averages for position and color, and adjusted opacity ramping.

Chores:
- Extend on-disk map format to version 2 for the new Splat layout while maintaining backward-compatible loading of version 1 models.