### PR TITLE
Fix MainScreen compilation errors and missing test dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -109,6 +109,7 @@ dependencies {
     implementation(libs.coil.compose)
 
     testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
 

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
@@ -199,7 +199,6 @@ fun MainScreen(
     }
 
     val isRailVisible = !editorUiState.hideUiForCapture && !uiState.isTouchLocked
-    val targetCreationState = com.hereliesaz.graffitixr.feature.ar.rememberTargetCreationState()
 
     AzHostActivityLayout(navController = localNavController) {
         // --- 1. THE RAIL ---
@@ -232,11 +231,12 @@ fun MainScreen(
                     com.hereliesaz.graffitixr.feature.ar.TargetCreationBackground(
                         uiState = arUiState,
                         captureStep = uiState.captureStep,
-                        state = targetCreationState,
                         onPhotoCaptured = { bitmap ->
                             arViewModel.setTempCapture(bitmap)
                             localNavController.navigate("target_evolution")
-                        }
+                        },
+                        onCaptureConsumed = arViewModel::onCaptureConsumed,
+                        onInitUnwarpPoints = arViewModel::updateUnwarpPoints
                     )
                 }
             } else if (currentNavRoute == "surveyor") {
@@ -352,7 +352,6 @@ fun MainScreen(
                         uiState = arUiState,
                         isRightHanded = editorUiState.isRightHanded,
                         captureStep = uiState.captureStep,
-                        state = targetCreationState,
                         onConfirm = {
                             val bitmapToSave = arUiState.tempCaptureBitmap
                             if (bitmapToSave != null) {
@@ -388,7 +387,12 @@ fun MainScreen(
                             val extracted = ImageProcessor.detectEdges(maskedBitmap) ?: maskedBitmap
                             arViewModel.setTempCapture(extracted)
                             viewModel.setCaptureStep(CaptureStep.REVIEW)
-                        }
+                        },
+                        onRequestCapture = arViewModel::requestCapture,
+                        onUpdateUnwarpPoints = arViewModel::updateUnwarpPoints,
+                        onSetActiveUnwarpPoint = arViewModel::setActiveUnwarpPointIndex,
+                        onSetMagnifierPosition = arViewModel::setMagnifierPosition,
+                        onUpdateMaskPath = arViewModel::setMaskPath
                     )
                 }
 


### PR DESCRIPTION
Resolved compilation errors in MainScreen.kt by updating TargetCreationBackground and TargetCreationUi calls to match the new API in feature:ar. Removed usage of rememberTargetCreationState and mapped UI callbacks to ArViewModel methods. Also added missing kotlinx-coroutines-test dependency to app module to fix unit test compilation.

---
*PR created automatically by Jules for task [6774951373895650668](https://jules.google.com/task/6774951373895650668) started by @HereLiesAz*

## Summary by Sourcery

Update AR target creation integration in MainScreen and add missing test dependency.

Bug Fixes:
- Align MainScreen AR target creation composables with the updated feature:ar API to resolve compilation errors.
- Add the missing kotlinx-coroutines-test dependency in the app module to fix unit test compilation failures.