### PR TITLE
Force patched versions of vulnerable dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,27 @@
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        // No direct dependencies here usually if using plugins block, but we need to configure resolutionStrategy
+    }
+    configurations.all {
+        resolutionStrategy {
+            force("commons-beanutils:commons-beanutils:1.11.0")
+            // Protobuf 3.25.5 is the patched version compatible with AGP 9.0.1 (which uses 3.x)
+            force("com.google.protobuf:protobuf-java:3.25.5")
+            force("com.google.protobuf:protobuf-javalite:3.25.5")
+            force("com.google.protobuf:protobuf-kotlin:3.25.5")
+            force("com.google.protobuf:protobuf-kotlin-lite:3.25.5")
+            force("org.jdom:jdom2:2.0.6.1")
+            force("io.netty:netty-codec-http2:4.1.124.Final")
+            force("io.netty:netty-handler:4.1.124.Final")
+            force("org.bitbucket.b_c:jose4j:0.9.6")
+        }
+    }
+}
+
 import org.gradle.api.plugins.quality.CheckstyleExtension
 
 plugins {
@@ -16,5 +40,20 @@ allprojects {
     configure<CheckstyleExtension> {
         toolVersion = "10.12.0"
         configFile = rootProject.file("config/checkstyle/checkstyle.xml")
+    }
+
+    configurations.all {
+        resolutionStrategy {
+            force("commons-beanutils:commons-beanutils:1.11.0")
+            // For app dependencies, we can use the latest patched version 4.28.2
+            force("com.google.protobuf:protobuf-java:4.28.2")
+            force("com.google.protobuf:protobuf-javalite:4.28.2")
+            force("com.google.protobuf:protobuf-kotlin:4.28.2")
+            force("com.google.protobuf:protobuf-kotlin-lite:4.28.2")
+            force("org.jdom:jdom2:2.0.6.1")
+            force("io.netty:netty-codec-http2:4.1.124.Final")
+            force("io.netty:netty-handler:4.1.124.Final")
+            force("org.bitbucket.b_c:jose4j:0.9.6")
+        }
     }
 }


### PR DESCRIPTION
Applied a resolution strategy in the root build.gradle.kts to force patched versions of several transitive dependencies to address reported vulnerabilities.
Specifically:
- `commons-beanutils` forced to `1.11.0` to fix improper access control (CVE-2019-10086).
- `protobuf-java` (and variants) forced to `3.25.5` in `buildscript` to maintain compatibility with Android Gradle Plugin, and `4.28.2` in `allprojects` for application security.
- `org.jdom:jdom2` forced to `2.0.6.1` to fix XXE vulnerability.
- `io.netty:netty-codec-http2` and `netty-handler` forced to `4.1.124.Final` to fix native crash/DoS issues.
- `org.bitbucket.b_c:jose4j` forced to `0.9.6` to fix DoS vulnerability.

---
*PR created automatically by Jules for task [5702372926820504448](https://jules.google.com/task/5702372926820504448) started by @HereLiesAz*