### PR TITLE
Fix AR camera view not displaying by removing native glClear

### DIFF
--- a/core/nativebridge/src/main/cpp/MobileGS.cpp
+++ b/core/nativebridge/src/main/cpp/MobileGS.cpp
@@ -123,9 +123,6 @@ void MobileGS::onSurfaceChanged(int width, int height) {
 }
 
 void MobileGS::draw() {
-    glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
-    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-
     if (!isInitialized) return;
 
     if (visMode == 0 && vulkanRenderer) {


### PR DESCRIPTION
Diagnosed and fixed the issue where the AR camera view was not displaying. The root cause was identified as an erroneous `glClear` call in the native `MobileGS::draw` method, which was wiping the framebuffer after the camera feed had been drawn by the Java-side `BackgroundRenderer`. Removed the `glClear` and `glClearColor` calls from `core/nativebridge/src/main/cpp/MobileGS.cpp` to ensure the camera feed remains visible behind the 3D content. Verified that the native module compiles successfully.

---
*PR created automatically by Jules for task [11154614767355902375](https://jules.google.com/task/11154614767355902375) started by @HereLiesAz*

## Summary by Sourcery

Bug Fixes:
- Fix AR camera feed being cleared from the framebuffer by removing unnecessary glClear calls in the native draw path.