### PR TITLE
Fix Gemini API key reference in gemini-check-issues workflow

### DIFF
--- a/.github/workflows/gemini-check-issues.yml
+++ b/.github/workflows/gemini-check-issues.yml
@@ -23,6 +23,6 @@ jobs:
         uses: 'google-github-actions/run-gemini-cli@v0'
         with:
           prompt: "Check the source code against the ${{ github.repository }} repository issues. If any open issue is completed or resolved by the current code, close the issue."
-          gemini_api_key: ${{ secrets.GOOGLE_API_KEY }}
+          gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Updated `.github/workflows/gemini-check-issues.yml` to correctly use `secrets.GEMINI_API_KEY` instead of `secrets.GOOGLE_API_KEY` for the `gemini_api_key` parameter. This resolves the 400 "API key not valid" error when running the GitHub action.

---
*PR created automatically by Jules for task [300676166133177809](https://jules.google.com/task/300676166133177809) started by @HereLiesAz*

## Summary by Sourcery

CI:
- Fix the gemini-check-issues GitHub Actions workflow to use secrets.GEMINI_API_KEY instead of secrets.GOOGLE_API_KEY, preventing invalid API key errors.