### PR TITLE
fix: lower gaussian splat confidence threshold for rendering

### DIFF
--- a/core/nativebridge/src/main/cpp/MobileGS.cpp
+++ b/core/nativebridge/src/main/cpp/MobileGS.cpp
@@ -81,7 +81,7 @@ static const char* kFragmentShader =
         "in float vConfidence;\n"
         "out vec4 oColor;\n"
         "void main() {\n"
-        "  if (vConfidence < 0.6) discard;\n"
+        "  if (vConfidence < 0.2) discard;\n"
         "  vec2 d = gl_PointCoord - 0.5;\n"
         "  float r2 = dot(d, d) * 4.0;\n"
         "  if (r2 > 1.0) discard;\n"


### PR DESCRIPTION
The user reported that Gaussian splats were not rendering properly and suspected the confidence threshold was too high. I investigated the C++ rendering engine (`MobileGS.cpp`) and found that the fragment shader (`kFragmentShader`) hardcoded a discard threshold of `0.6` (`if (vConfidence < 0.6) discard;`).

During initialization and processing, the baseline confidence and gain are quite low (e.g., initial boost is `0.1`, gain is `0.05` to `0.12`). A threshold of `0.6` was preventing the vast majority of valid splats from rendering until they were tracked for an extensive amount of time.

I lowered this discard threshold in the shader from `0.6` to `0.2` to allow splats to render much sooner while still rejecting completely unconfident points. Tests were run, and a perfect code review was obtained prior to submission.

---
*PR created automatically by Jules for task [7301439460142755928](https://jules.google.com/task/7301439460142755928) started by @HereLiesAz*

## Summary by Sourcery

Bug Fixes:
- Adjust Gaussian splat fragment shader confidence cutoff from 0.6 to 0.2 so valid splats are no longer prematurely discarded during rendering.