### PR TITLE
Fix Typography.kt compilation errors

### DIFF
--- a/core/design/src/main/java/com/hereliesaz/graffitixr/design/theme/Typography.kt
+++ b/core/design/src/main/java/com/hereliesaz/graffitixr/design/theme/Typography.kt
@@ -18,14 +18,14 @@ val BlackoutFontFamily = FontFamily(
 val Typography = Typography(
     bodyLarge = TextStyle(
         fontFamily = BlackoutFontFamily,
-        fontWeight = FontWeight.Large,
+        fontWeight = FontWeight.Bold,
         fontSize = 18.sp,
         lineHeight = 24.sp,
         letterSpacing = 0.5.sp
     ),
     titleLarge = TextStyle(
         fontFamily = BlackoutFontFamily,
-        fontWeight = FontWeight.Large,
+        fontWeight = FontWeight.Bold,
         fontSize = 18.sp,
         lineHeight = 24.sp,
         letterSpacing = 0.sp
@@ -45,11 +45,11 @@ val Typography = Typography(
         letterSpacing = 0.25.sp
     ),
     labelLarge = TextStyle(
-        fontFamily = BlackoutFontFamily
-        fontWeight = FontWeight.Large,
+        fontFamily = BlackoutFontFamily,
+        fontWeight = FontWeight.Bold,
         fontSize = 20.sp,
         lineHeight = 18.sp,
-        letterSpacing = 0.1
+        letterSpacing = 0.1.sp
     ),
     displayLarge = TextStyle(
         fontFamily = BlackoutFontFamily,
@@ -74,7 +74,7 @@ val Typography = Typography(
     ),
     headlineLarge = TextStyle(
         fontFamily = BlackoutFontFamily,
-        fontWeight = FontWeight.Large,
+        fontWeight = FontWeight.Bold,
         fontSize = 28.sp,
         lineHeight = 28.sp,
         letterSpacing = 0.sp


### PR DESCRIPTION
This PR fixes several compilation errors in the `core:design` module, specifically within `Typography.kt`. The errors included unresolved references for `FontWeight.Large` (which does not exist in Compose), a missing comma that caused subsequent parameters to be misidentified, and a missing `TextUnit` (sp) on a `letterSpacing` value.

Fixes #1439

---
*PR created automatically by Jules for task [12865041509996287455](https://jules.google.com/task/12865041509996287455) started by @HereLiesAz*

## Summary by Sourcery

Fix typography configuration in the design theme to resolve Compose compilation errors.

Bug Fixes:
- Replace invalid font weight constants in typography styles with supported values.
- Correct typography style definitions by fixing a missing comma and adding the proper TextUnit to letter spacing.