### PR TITLE
Fix build failure in MobileGS.cpp due to undeclared camToWorld function

### DIFF
--- a/core/nativebridge/src/main/cpp/MobileGS.cpp
+++ b/core/nativebridge/src/main/cpp/MobileGS.cpp
@@ -347,6 +347,12 @@ void MobileGS::setVoxelSize(float size) {
     LOGI("Voxel size adjusted to %.4f. Grid re-hashed.", size);
 }
 
+static inline void camToWorld(const float* V, float xc, float yc, float zc, float& xw, float& yw, float& zw) {
+    xw = V[0] * xc + V[4] * yc + V[8] * zc + V[12];
+    yw = V[1] * xc + V[5] * yc + V[9] * zc + V[13];
+    zw = V[2] * xc + V[6] * yc + V[10] * zc + V[14];
+}
+
 cv::Point3f MobileGS::getCameraWorldPosition() const {
     float r00 = mViewMatrix[0], r10 = mViewMatrix[1], r20 = mViewMatrix[2];
     float r01 = mViewMatrix[4], r11 = mViewMatrix[5], r21 = mViewMatrix[6];


### PR DESCRIPTION
Defined the missing `camToWorld` helper function in `core/nativebridge/src/main/cpp/MobileGS.cpp`. This function is used to transform coordinates from camera space to world space using a 4x4 column-major matrix, resolving the "use of undeclared identifier 'camToWorld'" errors during the native build. Verified the fix with a successful build of the native module and passing unit tests.

Fixes #1441

---
*PR created automatically by Jules for task [8177475826068098135](https://jules.google.com/task/8177475826068098135) started by @HereLiesAz*

## Summary by Sourcery

Bug Fixes:
- Add a cam-to-world coordinate transformation helper to resolve undeclared identifier build errors in MobileGS.cpp.