### PR TITLE
Fix undefined symbol gLastSplatTrace in native library

### DIFF
--- a/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
+++ b/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
@@ -10,8 +10,9 @@
 #define LOGD(...) __android_log_print(ANDROID_LOG_DEBUG, "GraffitiJNI", __VA_ARGS__)
 
 static std::string gLastDepthTrace;
-extern std::string gLastSplatTrace;
+static std::string gLastSplatTrace;
 #define DEPTH_TRACE(fmt, ...) do {     char _buf[256];     snprintf(_buf, sizeof(_buf), fmt, ##__VA_ARGS__);     LOGD("DEPTH_PIPE: %s", _buf);     gLastDepthTrace += std::string(_buf) + "\n"; } while(0)
+#define SPLAT_TRACE(fmt, ...) do {     char _buf[256];     snprintf(_buf, sizeof(_buf), fmt, ##__VA_ARGS__);     LOGD("SPLAT_PIPE: %s", _buf);     gLastSplatTrace += std::string(_buf) + "\n"; } while(0)
 #define LOGE(...) __android_log_print(ANDROID_LOG_ERROR, "GraffitiJNI", __VA_ARGS__)
 
 MobileGS* gSlamEngine = nullptr;


### PR DESCRIPTION
This PR fixes a build failure in the `core:nativebridge` module where the C++ linker reported an undefined symbol `gLastSplatTrace`. The symbol was being used by JNI methods but lacked a definition in the translation unit. I've defined it as a `static std::string` in `GraffitiJNI.cpp`, consistent with `gLastDepthTrace`, and added a `SPLAT_TRACE` macro to enable structured logging for the Gaussian splat pipeline. Verified with a clean build and full test suite.

Fixes #1443

---
*PR created automatically by Jules for task [6549811953396240331](https://jules.google.com/task/6549811953396240331) started by @HereLiesAz*

## Summary by Sourcery

Define the Gaussian splat trace buffer in the native JNI code to resolve linker errors and enable structured logging for the splat pipeline.

Bug Fixes:
- Fix undefined symbol linker error for gLastSplatTrace in the core:nativebridge native library.

Enhancements:
- Add a SPLAT_TRACE logging macro to capture and log Gaussian splat pipeline traces similarly to depth traces.