### PR TITLE
Fix Build Failures on Main

### DIFF
--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -12,6 +12,7 @@ import com.google.ar.core.TrackingState
 import com.google.ar.core.exceptions.NotYetAvailableException
 import com.google.ar.core.exceptions.SessionPausedException
 import com.hereliesaz.graffitixr.common.model.ArScanMode
+import com.hereliesaz.graffitixr.common.model.MuralMethod
 import com.hereliesaz.graffitixr.common.util.ImageProcessingUtils
 import com.hereliesaz.graffitixr.feature.ar.DisplayRotationHelper
 import com.hereliesaz.graffitixr.nativebridge.SlamManager

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/OverlayRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/OverlayRenderer.kt
@@ -148,6 +148,7 @@ class OverlayRenderer(private val context: Context) {
         GLES30.glBindBuffer(GLES30.GL_ARRAY_BUFFER, 0)
     }
 
+    /**
      * @param meshVertices Optional warped vertices (x,y,z) from SlamManager.
      * @param meshWeights Optional vertex confidence weights (0..1).
      * If null, renders a flat quad.

--- a/feature/dashboard/src/main/java/com/hereliesaz/graffitixr/feature/dashboard/SettingsScreen.kt
+++ b/feature/dashboard/src/main/java/com/hereliesaz/graffitixr/feature/dashboard/SettingsScreen.kt
@@ -57,6 +57,7 @@ import com.hereliesaz.aznavrail.AzButton
 import com.hereliesaz.aznavrail.AzLoad
 import com.hereliesaz.graffitixr.common.model.AppLanguage
 import com.hereliesaz.graffitixr.common.model.ArScanMode
+import com.hereliesaz.graffitixr.common.model.MuralMethod
 import com.hereliesaz.graffitixr.design.theme.AppStrings
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -217,7 +218,7 @@ fun SettingsScreen(
                             val nextMode = modes[(arScanMode.ordinal + 1) % modes.size]
                             val scanModeValue = when (arScanMode) {
                                 ArScanMode.CLOUD_POINTS -> strings.settings.pointCloud
-                                ArScanMode.MURAL -> strings.settings.mural
+                                ArScanMode.MURAL -> strings.nav.mural
                             }
                             SettingsItem(
                                 label = strings.settings.scanMode,

--- a/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/SurfaceUnroller.kt
+++ b/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/SurfaceUnroller.kt
@@ -127,7 +127,7 @@ class SurfaceUnroller(
      * KLmax Loss: L = sum( P_ij * log( max(P_ij, Q_ij) ) )
      * This loss function is specifically designed to improve global structure preservation.
      */
-    private fun computeKLmaxGradients(P: Array<FloatArray>, Y: Array<floatArray>): Array<floatArray> {
+    private fun computeKLmaxGradients(P: Array<FloatArray>, Y: Array<FloatArray>): Array<FloatArray> {
         val Q = FloatArray(count * count)
         var sumQ = 0f
         
@@ -179,20 +179,20 @@ class SurfaceUnroller(
         return dx * dx + dy * dy + dz * dz
     }
 
-    private fun dist2dSquared(y1: floatArray, y2: floatArray): Float {
+    private fun dist2dSquared(y1: FloatArray, y2: FloatArray): Float {
         val dx = y1[0] - y2[0]
         val dy = y1[1] - y2[1]
         return dx * dx + dy * dy
     }
 
-    private fun center(Y: Array<floatArray>) {
+    private fun center(Y: Array<FloatArray>) {
         var meanX = 0f; var meanY = 0f
         for (y in Y) { meanX += y[0]; meanY += y[1] }
         meanX /= count; meanY /= count
         for (y in Y) { y[0] -= meanX; y[1] -= meanY }
     }
 
-    private fun normalize(Y: Array<floatArray>): List<Offset> {
+    private fun normalize(Y: Array<FloatArray>): List<Offset> {
         var minX = Float.MAX_VALUE; var minY = Float.MAX_VALUE
         var maxX = Float.MIN_VALUE; var maxY = Float.MIN_VALUE
         for (y in Y) {


### PR DESCRIPTION
I have fixed the build failures reported on the main branch. The errors were spread across three feature modules: editor, dashboard, and ar.

1. In `:feature:editor`, I corrected several occurrences of the incorrect primitive type `floatArray` to the proper Kotlin `FloatArray` in `SurfaceUnroller.kt`. This was causing type inference failures and unresolved references for standard collection functions like `.map`.

2. In `:feature:dashboard`, I fixed `SettingsScreen.kt` by adding the missing import for `MuralMethod` and updating a reference to a string resource that had moved from `settings` to `nav` (`mural`).

3. In `:feature:ar`, I added the missing `MuralMethod` import to `ArRenderer.kt` and fixed a syntax error in `OverlayRenderer.kt` caused by a missing opening `/**` for a KDoc comment.

I verified these fixes with a clean compilation of all affected modules (`./gradlew :feature:dashboard:compileDebugKotlin :feature:ar:compileDebugKotlin :feature:editor:compileDebugKotlin -x lint`) which now succeeds. Relevant unit tests were also run.

Fixes #1455

---
*PR created automatically by Jules for task [10380869135816727445](https://jules.google.com/task/10380869135816727445) started by @HereLiesAz*

## Summary by Sourcery

Resolve build failures across editor, dashboard, and AR feature modules.

Bug Fixes:
- Correct FloatArray type usage in SurfaceUnroller to fix editor compilation errors.
- Add missing MuralMethod import and update mural string resource reference in SettingsScreen to restore dashboard build.
- Add missing MuralMethod import in ArRenderer and fix KDoc syntax in OverlayRenderer to resolve AR module compilation issues.