### PR TITLE
Fix native build failure due to undefined symbols

### DIFF
--- a/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
+++ b/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
@@ -11,7 +11,7 @@
 #define LOGD(...) __android_log_print(ANDROID_LOG_DEBUG, "GraffitiJNI", __VA_ARGS__)
 
 static std::string gLastDepthTrace;
-extern std::string gLastSplatTrace;
+static std::string gLastSplatTrace;
 #define DEPTH_TRACE(fmt, ...) do {     char _buf[256];     snprintf(_buf, sizeof(_buf), fmt, ##__VA_ARGS__);     LOGD("DEPTH_PIPE: %s", _buf);     gLastDepthTrace += std::string(_buf) + "\n"; } while(0)
 #define LOGE(...) __android_log_print(ANDROID_LOG_ERROR, "GraffitiJNI", __VA_ARGS__)
 

--- a/core/nativebridge/src/main/cpp/MobileGS.cpp
+++ b/core/nativebridge/src/main/cpp/MobileGS.cpp
@@ -166,6 +166,7 @@ void MobileGS::updateMappingCamera(float* viewMat, float* projMat) {
 }
 
 void MobileGS::updateLightLevel(float level) {
+    std::lock_guard<std::mutex> lock(mMutex);
     mLightLevel = level;
 }
 

--- a/core/nativebridge/src/main/cpp/MobileGS.cpp
+++ b/core/nativebridge/src/main/cpp/MobileGS.cpp
@@ -63,6 +63,10 @@ void MobileGS::initGl() {
     mSurfaceMesh.initGl();
 }
 
+void MobileGS::resetGlContext() {
+    initGl();
+}
+
 void MobileGS::draw() {
     std::lock_guard<std::mutex> lock(mMutex);
     interpolateAnchorStep();
@@ -155,6 +159,16 @@ void MobileGS::updateCamera(float* viewMat, float* projMat) {
     mCameraReady = true;
 }
 
+void MobileGS::updateMappingCamera(float* viewMat, float* projMat) {
+    std::lock_guard<std::mutex> lock(mMutex);
+    memcpy(mMappingViewMatrix, viewMat, 16 * sizeof(float));
+    memcpy(mMappingProjMatrix, projMat, 16 * sizeof(float));
+}
+
+void MobileGS::updateLightLevel(float level) {
+    mLightLevel = level;
+}
+
 void MobileGS::updateAnchorTransform(float* transformMat) {
     std::lock_guard<std::mutex> lock(mMutex);
     memcpy(mAnchorMatrix, transformMat, 16 * sizeof(float));
@@ -190,3 +204,4 @@ void MobileGS::restoreWallFingerprint(const cv::Mat& d, const std::vector<cv::Po
 void MobileGS::scheduleRelocCheck(const cv::Mat& f) { mRelocColorFrame = f.clone(); mRelocRequested = true; mRelocCv.notify_one(); }
 void MobileGS::setArtworkFingerprint(const cv::Mat& c, const uint8_t* d, int w, int h, int s, const float* i, const float* v) {}
 MobileGS::FingerprintData MobileGS::generateFingerprint(const cv::Mat& i, const cv::Mat& m, const uint8_t* d, int w, int h, int s, const float* intr, const float* v) { return {}; }
+bool MobileGS::loadSuperPoint(const std::vector<uchar>& onnxBytes) { return mSuperPoint.load(onnxBytes); }

--- a/core/nativebridge/src/main/cpp/include/MobileGS.h
+++ b/core/nativebridge/src/main/cpp/include/MobileGS.h
@@ -174,6 +174,7 @@ private:
     bool mPersistentMeshInitialized = false;
 
     uint64_t mFrameCounter = 0;
+    float mLightLevel = 1.0f;
 
     float mViewMatrix[16];
     float mProjMatrix[16];


### PR DESCRIPTION
Fixed several 'undefined symbol' linker errors in the native bridge by implementing the missing functions in `MobileGS.cpp` and providing a definition for `gLastSplatTrace` in `GraffitiJNI.cpp`. Verified the fix by successfully running the build and all unit tests for the `:core:nativebridge` module.

Fixes #1458

---
*PR created automatically by Jules for task [753440153332349183](https://jules.google.com/task/753440153332349183) started by @HereLiesAz*

## Summary by Sourcery

Resolve native bridge linker issues and wire up missing rendering state handling.

Bug Fixes:
- Define previously missing MobileGS::loadSuperPoint and gLastSplatTrace to eliminate undefined symbol linker errors in the native bridge.
- Ensure MobileGS::resetGlContext correctly reinitializes GL state by delegating to initGl().

Enhancements:
- Track and store light level updates in MobileGS with thread-safe access to support future rendering adjustments.