### PR TITLE
Fix duplicate loadSuperPoint definition in MobileGS.cpp

### DIFF
--- a/core/nativebridge/src/main/cpp/MobileGS.cpp
+++ b/core/nativebridge/src/main/cpp/MobileGS.cpp
@@ -209,9 +209,6 @@ void MobileGS::setViewportSize(int w, int h) { mScreenWidth = w; mScreenHeight =
 void MobileGS::setRelocEnabled(bool e) { mRelocEnabled = e; }
 void MobileGS::restoreWallFingerprint(const cv::Mat& d, const std::vector<cv::Point3f>& p) { mWallDescriptors = d.clone(); mWallKeypoints3D = p; }
 void MobileGS::scheduleRelocCheck(const cv::Mat& f) { mRelocColorFrame = f.clone(); mRelocRequested = true; mRelocCv.notify_one(); }
-bool MobileGS::loadSuperPoint(const std::vector<uchar>& onnxBytes) {
-    return mSuperPoint.load(onnxBytes);
-}
+bool MobileGS::loadSuperPoint(const std::vector<uchar>& onnxBytes) { return mSuperPoint.load(onnxBytes); }
 void MobileGS::setArtworkFingerprint(const cv::Mat& c, const uint8_t* d, int w, int h, int s, const float* i, const float* v) {}
 MobileGS::FingerprintData MobileGS::generateFingerprint(const cv::Mat& i, const cv::Mat& m, const uint8_t* d, int w, int h, int s, const float* intr, const float* v) { return {}; }
-bool MobileGS::loadSuperPoint(const std::vector<uchar>& onnxBytes) { return mSuperPoint.load(onnxBytes); }


### PR DESCRIPTION
The build was failing due to a redefinition of the `loadSuperPoint` function in `MobileGS.cpp`. This PR removes the duplicate implementation and keeps the functional one, allowing the native bridge to compile successfully. All tests pass and the fix has been verified with multiple code reviews.

Fixes #1461

---
*PR created automatically by Jules for task [17161144339964483571](https://jules.google.com/task/17161144339964483571) started by @HereLiesAz*

## Summary by Sourcery

Bug Fixes:
- Remove the duplicate loadSuperPoint definition in MobileGS to prevent function redefinition build errors.