### PR TITLE
Fix MobileGS::loadSuperPoint redefinition build error

### DIFF
--- a/core/nativebridge/src/main/cpp/MobileGS.cpp
+++ b/core/nativebridge/src/main/cpp/MobileGS.cpp
@@ -214,4 +214,3 @@ bool MobileGS::loadSuperPoint(const std::vector<uchar>& onnxBytes) {
 }
 void MobileGS::setArtworkFingerprint(const cv::Mat& c, const uint8_t* d, int w, int h, int s, const float* i, const float* v) {}
 MobileGS::FingerprintData MobileGS::generateFingerprint(const cv::Mat& i, const cv::Mat& m, const uint8_t* d, int w, int h, int s, const float* intr, const float* v) { return {}; }
-bool MobileGS::loadSuperPoint(const std::vector<uchar>& onnxBytes) { return mSuperPoint.load(onnxBytes); }


### PR DESCRIPTION
This change fixes a build failure in the native bridge module where the `MobileGS::loadSuperPoint` method was defined twice in `MobileGS.cpp`. I removed the redundant one-line definition at the end of the file and verified that the remaining implementation correctly delegates to `mSuperPoint.load(onnxBytes)`.

Verification:
- Successfully built the native bridge module using `./gradlew :core:nativebridge:assembleDebug -x lint`.
- Ran native bridge unit tests using `./gradlew :core:nativebridge:test -x lint` and confirmed they pass.

Fixes #1460

---
*PR created automatically by Jules for task [9607335027501021850](https://jules.google.com/task/9607335027501021850) started by @HereLiesAz*

## Summary by Sourcery

Bug Fixes:
- Fix native bridge build error caused by MobileGS::loadSuperPoint being defined twice in MobileGS.cpp.