### PR TITLE
Fix MobileGS::loadSuperPoint redefinition error

### DIFF
--- a/core/nativebridge/src/main/cpp/MobileGS.cpp
+++ b/core/nativebridge/src/main/cpp/MobileGS.cpp
@@ -209,9 +209,6 @@ void MobileGS::setViewportSize(int w, int h) { mScreenWidth = w; mScreenHeight =
 void MobileGS::setRelocEnabled(bool e) { mRelocEnabled = e; }
 void MobileGS::restoreWallFingerprint(const cv::Mat& d, const std::vector<cv::Point3f>& p) { mWallDescriptors = d.clone(); mWallKeypoints3D = p; }
 void MobileGS::scheduleRelocCheck(const cv::Mat& f) { mRelocColorFrame = f.clone(); mRelocRequested = true; mRelocCv.notify_one(); }
-bool MobileGS::loadSuperPoint(const std::vector<uchar>& onnxBytes) {
-    return mSuperPoint.load(onnxBytes);
-}
 void MobileGS::setArtworkFingerprint(const cv::Mat& c, const uint8_t* d, int w, int h, int s, const float* i, const float* v) {}
 MobileGS::FingerprintData MobileGS::generateFingerprint(const cv::Mat& i, const cv::Mat& m, const uint8_t* d, int w, int h, int s, const float* intr, const float* v) { return {}; }
 bool MobileGS::loadSuperPoint(const std::vector<uchar>& onnxBytes) { return mSuperPoint.load(onnxBytes); }


### PR DESCRIPTION
Fixed a C++ build error in `MobileGS.cpp` caused by a duplicate definition of the `loadSuperPoint` method. The redundant multi-line stub was removed, leaving the correct one-line implementation. Verified with successful compilation and unit tests for the native bridge module.

Fixes #1462

---
*PR created automatically by Jules for task [1566748899569402966](https://jules.google.com/task/1566748899569402966) started by @HereLiesAz*

## Summary by Sourcery

Bug Fixes:
- Remove the redundant loadSuperPoint method definition in MobileGS.cpp that caused a redefinition compilation error.