### PR TITLE
Fix unresolved references in MainActivity.kt

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -101,6 +101,8 @@ import com.hereliesaz.graffitixr.feature.dashboard.SettingsScreen
 import com.hereliesaz.graffitixr.feature.dashboard.SettingsViewModel
 import com.hereliesaz.graffitixr.feature.editor.EditorUi
 import com.hereliesaz.graffitixr.feature.editor.EditorViewModel
+import com.hereliesaz.graffitixr.feature.editor.MockupScreen
+import com.hereliesaz.graffitixr.feature.editor.OverlayScreen
 import com.hereliesaz.graffitixr.feature.editor.TraceScreen
 import com.hereliesaz.graffitixr.data.OnboardingManager
 import com.hereliesaz.graffitixr.feature.editor.util.ImageProcessor as EditorImageProcessor


### PR DESCRIPTION
Added missing imports for `OverlayScreen` and `MockupScreen` in `MainActivity.kt` to resolve compilation errors reported in the build log. verified the fix by successfully running `:app:compileDebugKotlin` and relevant unit tests.

Fixes #1468

---
*PR created automatically by Jules for task [2806346772274787382](https://jules.google.com/task/2806346772274787382) started by @HereLiesAz*

## Summary by Sourcery

Bug Fixes:
- Add missing imports for MockupScreen and OverlayScreen in MainActivity to fix Kotlin compilation errors.