### PR TITLE
Fix collaboration module linker error

### DIFF
--- a/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
+++ b/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
@@ -576,4 +576,28 @@ Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeUnrollMesh(JNIEnv*
     return result;
 }
 
+JNIEXPORT jbyteArray JNICALL
+Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeExportFingerprint(
+        JNIEnv* env, jobject thiz) {
+    if (!gSlamEngine) return nullptr;
+    std::vector<uint8_t> fingerprint = gSlamEngine->exportFingerprint();
+    if (fingerprint.empty()) return nullptr;
+
+    jbyteArray result = env->NewByteArray(fingerprint.size());
+    env->SetByteArrayRegion(result, 0, fingerprint.size(), (jbyte*)fingerprint.data());
+    return result;
+}
+
+JNIEXPORT void JNICALL
+Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeAlignToFingerprint(
+        JNIEnv* env, jobject thiz, jbyteArray data) {
+    if (!gSlamEngine) return;
+    jsize size = env->GetArrayLength(data);
+    jbyte* buffer = env->GetByteArrayElements(data, nullptr);
+
+    gSlamEngine->alignToFingerprint((uint8_t*)buffer, size);
+
+    env->ReleaseByteArrayElements(data, buffer, JNI_ABORT);
+}
+
 } // extern "C"

--- a/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
+++ b/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
@@ -161,6 +161,9 @@ class SlamManager @Inject constructor() {
     fun getPersistentMesh(vertices: FloatArray, weights: FloatArray) = nativeGetPersistentMesh(vertices, weights)
     fun unrollMesh(vertices: FloatArray): FloatArray = nativeUnrollMesh(vertices)
 
+    fun exportFingerprint(): ByteArray? = nativeExportFingerprint()
+    fun alignToFingerprint(data: ByteArray) = nativeAlignToFingerprint(data)
+
     fun destroy() {
         if (isInitialized) {
             nativeDestroy()
@@ -210,6 +213,8 @@ class SlamManager @Inject constructor() {
     private external fun nativeSetMuralMethod(method: Int)
     private external fun nativeGetPersistentMesh(vertices: FloatArray, weights: FloatArray)
     private external fun nativeUnrollMesh(vertices: FloatArray): FloatArray
+    private external fun nativeExportFingerprint(): ByteArray?
+    private external fun nativeAlignToFingerprint(data: ByteArray)
     private external fun nativeSetWallFingerprint(
         bitmap: Bitmap, mask: Bitmap?,
         depthBuffer: ByteBuffer,


### PR DESCRIPTION
This change resolves a C++ linker error in the collaboration module where native symbols were undefined. It refactors the architecture by moving the collaboration JNI hooks into the core nativebridge module, centralizing native interactions and ensuring correct linking with the SLAM engine.
- Added exportFingerprint and alignToFingerprint to SlamManager and GraffitiJNI.cpp.
- Refactored CollaborationManager to depend on SlamManager.
- Removed redundant CollaborationBridge.cpp and CMakeLists.txt in collab.
- Updated ArViewModel to provide the injected SlamManager to CollaborationManager.
- Standardized compileSdk to 36 across modified modules.

Fixes #1470

---
*PR created automatically by Jules for task [416953672030438684](https://jules.google.com/task/416953672030438684) started by @HereLiesAz*

## Summary by Sourcery

Move SLAM fingerprint JNI bindings into the core nativebridge module and expose them via SlamManager to resolve collaboration-related native linking issues.

New Features:
- Expose SLAM fingerprint export and alignment capabilities through SlamManager APIs backed by native implementations.

Bug Fixes:
- Fix undefined native symbol linker errors in the collaboration module by centralizing JNI hooks in the core nativebridge module.