### PR TITLE
Fix Kotlin compilation errors in MainActivity and MainScreen

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -476,9 +476,7 @@ class MainActivity : ComponentActivity() {
                         helpEnabled = true,
                         helpList = activeHelpList,
                         onDismissHelp = { },
-                        tutorials = tutorials,
-                        tutorialModal = false,
-                        tutorialDim = 0.0f
+                        tutorials = tutorials
                     )
 
                     if (isRailVisible) {

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
@@ -127,7 +127,7 @@ fun MainScreen(
                     }
 
                     val visibleLayers = uiState.layers.filter { it.isVisible && it.bitmap != null }
-                    val showPlaneConfirm = mainUiState.planeConfirmationPending
+                    val showPlaneConfirm = mainUiState.isInPlaneRealignment
 
                     LaunchedEffect(visibleLayers, arUiState.isAnchorEstablished, showPlaneConfirm) {
                         if (!arUiState.isAnchorEstablished || showPlaneConfirm || visibleLayers.isEmpty()) {


### PR DESCRIPTION
The build on the main branch was failing due to three Kotlin compilation errors. These errors stemmed from mismatched API parameters in the `az-nav-rail` library and an unresolved reference to a UI state property.

Changes:
- In `MainActivity.kt`, I removed the `tutorialModal` and `tutorialDim` arguments from the `azAdvanced` function call. These parameters were deprecated and removed in recent library updates.
- In `MainScreen.kt`, I updated the logic to use `mainUiState.isInPlaneRealignment` instead of the non-existent `mainUiState.planeConfirmationPending`. This correctly restores the intended behavior of hiding the AR overlay during plane realignment.

Verification:
- Ran `./gradlew :app:compileDebugKotlin -x lint` and confirmed it finishes successfully.
- Ran unit tests for the affected modules. `:app` and `:feature:editor` tests passed. Pre-existing compilation issues in `:feature:ar` tests were observed but left untouched according to the policy of not fixing unrelated pre-existing failures.
- Obtained two positive code reviews.

Fixes #1476

---
*PR created automatically by Jules for task [17577073141130818490](https://jules.google.com/task/17577073141130818490) started by @HereLiesAz*

## Summary by Sourcery

Resolve Kotlin compilation errors by aligning app code with updated AR navigation APIs and UI state properties.

Bug Fixes:
- Remove deprecated tutorial arguments from the azAdvanced navigation rail configuration in MainActivity to match the updated library API.
- Use the existing isInPlaneRealignment flag instead of the removed planeConfirmationPending property to control AR overlay visibility in MainScreen.