### PR TITLE
Fix native build failure in MobileGS.cpp

### DIFF
--- a/core/nativebridge/src/main/cpp/VoxelHash.cpp
+++ b/core/nativebridge/src/main/cpp/VoxelHash.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <cmath>
 #include <fstream>
+#include <cstdlib>
 #define GLM_ENABLE_EXPERIMENTAL
 #include <glm/gtc/matrix_inverse.hpp>
 #include <glm/gtc/quaternion.hpp>

--- a/core/nativebridge/src/main/cpp/include/VoxelHash.h
+++ b/core/nativebridge/src/main/cpp/include/VoxelHash.h
@@ -2,6 +2,7 @@
 #include <opencv2/opencv.hpp>
 #include <vector>
 #include <unordered_map>
+#include <unordered_set>
 #include <mutex>
 #include <GLES3/gl3.h>
 #include <glm/glm.hpp>
@@ -9,11 +10,17 @@
 
 // Dense Opaque Surfel Structure
 struct Splat {
-    float x, y, z;          // Position (Mean)
-    float r, g, b, a;       // Color and Opacity (Opaque)
-    float nx, ny, nz;       // Surface Normal
-    float radius;           // Calculated physical scale
-    float confidence;       // Observation count
+    float x, y, z;          // Position (Mean): Offset 0
+    float r, g, b, a;       // Color and Opacity (Opaque): Offset 12
+    float sh[9];            // Spherical Harmonics (Level 1): Offsets 28, 40, 52
+    float scale[3];         // Anisotropic scale: Offset 64
+    float rot[4];           // Rotation quaternion: Offset 76
+    float confidence;       // Observation count: Offset 92
+    float velocity[3];      // Motion vector: Offset 96
+
+    // Gradient tracking for adaptive densification (Not sent to GPU)
+    float gradAccum;
+    int gradCount;
 };
 
 struct Keyframe {
@@ -21,6 +28,8 @@ struct Keyframe {
     cv::Mat color;
     float viewMatrix[16];
     float projMatrix[16];
+    float angularVelocity[3];
+    float linearVelocity[3];
 };
 
 struct VoxelKey {
@@ -43,9 +52,11 @@ public:
 
     void initGl();
     void update(const cv::Mat& depth, const cv::Mat& color, const float* viewMat, const float* projMat, float voxelSize, float initialConfidence);
-    void addSparsePoints(const std::vector<float>& points);
+    void addSparsePoints(const std::vector<float>& points, const float* viewMat, const float* projMat);
     void addKeyframe(const Keyframe& kf);
     void draw(const glm::mat4& mvp, const glm::mat4& view, float focalY, int screenHeight);
+    void sort(const glm::vec3& camPos);
+    void densify(float threshold, float scaleLimit);
     void clear();
     void prune(float threshold);
     void save(const std::string& path);
@@ -64,9 +75,14 @@ private:
     std::vector<Keyframe> mKeyframes;
     std::unordered_map<VoxelKey, int, VoxelKeyHash> mVoxelGrid;
 
+    std::vector<glm::vec3> mProtoSplats;
+    std::unordered_set<VoxelKey, VoxelKeyHash> mProtoGrid;
+
     float mLastVoxelSize = 0.02f;
     GLuint mProgram = 0;
     GLuint mPointVbo = 0;
+    GLuint mQuadVbo = 0;
+    GLuint mVao = 0;
     bool mDataDirty = false;
     int mNextRefineIndex = 0;
 


### PR DESCRIPTION
Fixed build failures in the native bridge module by synchronizing `VoxelHash.h` with its implementation and usage in `MobileGS.cpp`. Specifically, added missing fields to `Splat` and `Keyframe` structs, updated method signatures, and added missing class members and includes.

Fixes #1481

---
*PR created automatically by Jules for task [2035002179455727382](https://jules.google.com/task/2035002179455727382) started by @HereLiesAz*

## Summary by Sourcery

Align VoxelHash native interface and data structures with their actual usage to resolve mobile native build failures.

Bug Fixes:
- Extend Splat and Keyframe structs with missing fields used by the renderer and motion model to prevent struct layout mismatches.
- Update VoxelHash method signatures and internal state to match current call sites and rendering requirements, restoring successful compilation.

Enhancements:
- Introduce additional GPU-related buffers, proto-splat storage, and associated containers to support densification and sorting operations in VoxelHash.
- Add necessary standard library and OpenGL-related includes to support the expanded VoxelHash functionality.