### PR TITLE
Fix IllegalArgumentException when opening sub-menus

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -1685,9 +1685,8 @@ class MainActivity : ComponentActivity() {
                                 }
                             }
 
-                            azHelpSubItem(
+                            azHelpRailItem(
                                 id = "help_layer_${layer.id}",
-                                hostId = "layer_${layer.id}",
                                 text = navStrings.help,
                                 color = navItemColor,
                                 shape = AzButtonShape.RECTANGLE


### PR DESCRIPTION
Fixes IllegalArgumentException in MainActivity.kt

---
*PR created automatically by Jules for task [7236658723062605562](https://jules.google.com/task/7236658723062605562) started by @HereLiesAz*

## Summary by Sourcery

Bug Fixes:
- Resolve IllegalArgumentException in MainActivity when interacting with the layer help menu by using the appropriate rail item type instead of a sub-item.