### PR TITLE
fix: gate editor behind library overlay so launch buttons are clickable

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -276,7 +276,7 @@ class MainActivity : ComponentActivity() {
                     }
                 }
 
-                BackHandler(enabled = showLibrary) { showLibrary = false }
+                BackHandler(enabled = showLibrary && editorUiState.projectId != null) { showLibrary = false }
                 BackHandler(enabled = showSettings) { showSettings = false }
                 BackHandler(enabled = mainUiState.isInPlaneRealignment) {
                     mainViewModel.endPlaneRealignment()
@@ -530,21 +530,23 @@ class MainActivity : ComponentActivity() {
                         var fullSize by remember { mutableStateOf(IntSize.Zero) }
 
                         Box(Modifier.fillMaxSize().onSizeChanged { fullSize = it }) {
-                            AzNavHost(startDestination = EditorMode.TRACE.name) {
-                                composable(EditorMode.AR.name) {
-                                    EditorOverlay(editorViewModel, mainUiState, strings)
-                                }
-                                composable(EditorMode.OVERLAY.name) {
-                                    OverlayScreen(editorViewModel, showLibrary, arUiState)
-                                    EditorOverlay(editorViewModel, mainUiState, strings)
-                                }
-                                composable(EditorMode.MOCKUP.name) {
-                                    MockupScreen(editorViewModel, showLibrary, arUiState)
-                                    EditorOverlay(editorViewModel, mainUiState, strings)
-                                }
-                                composable(EditorMode.TRACE.name) {
-                                    TraceScreen(editorViewModel, showLibrary, arUiState)
-                                    EditorOverlay(editorViewModel, mainUiState, strings)
+                            if (!showLibrary) {
+                                AzNavHost(startDestination = EditorMode.TRACE.name) {
+                                    composable(EditorMode.AR.name) {
+                                        EditorOverlay(editorViewModel, mainUiState, strings)
+                                    }
+                                    composable(EditorMode.OVERLAY.name) {
+                                        OverlayScreen(editorViewModel, showLibrary, arUiState)
+                                        EditorOverlay(editorViewModel, mainUiState, strings)
+                                    }
+                                    composable(EditorMode.MOCKUP.name) {
+                                        MockupScreen(editorViewModel, showLibrary, arUiState)
+                                        EditorOverlay(editorViewModel, mainUiState, strings)
+                                    }
+                                    composable(EditorMode.TRACE.name) {
+                                        TraceScreen(editorViewModel, showLibrary, arUiState)
+                                        EditorOverlay(editorViewModel, mainUiState, strings)
+                                    }
                                 }
                             }
 

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
@@ -292,7 +292,7 @@ fun MainScreen(
 
         val isGuest = arUiState.coopRole == com.hereliesaz.graffitixr.common.model.CoopRole.GUEST
 
-        if (uiState.editorMode != EditorMode.STENCIL) {
+        if (uiState.editorMode != EditorMode.STENCIL && isCameraActive) {
             Box(
                 modifier = Modifier
                     .fillMaxSize()


### PR DESCRIPTION
## Summary

On first launch the library (with **New** / **Import**) sits on top of an active `AzNavHost` (TraceScreen + EditorOverlay) and `MainScreen`'s full-screen `pointerInput` gesture box. That layering left the launch buttons unresponsive, and pressing back dismissed the library straight into trace mode without a loaded project — exactly the two symptoms you described.

## Changes

- `MainActivity.kt`: only compose `AzNavHost` when `!showLibrary`, so the editor doesn't render behind the launch screen.
- `MainActivity.kt`: only consume the back press to close the library when `editorUiState.projectId != null`; otherwise let the system back press exit the app instead of dropping the user into a projectless trace mode.
- `MainScreen.kt`: gate the full-screen `pointerInput` Box on `isCameraActive` (already `!showLibrary`) so the background layer doesn't install gesture handlers while the library is up.

## Test plan
- [ ] Cold launch: tap **New** — opens the new-project dialog; tap **Import** — opens the file picker.
- [ ] Cold launch: tap **Back** with no projects — app exits instead of falling through to trace mode.
- [ ] With a project loaded, open the library from the rail and press back — returns to the project view.
- [ ] Create a new project from the library — editor opens with the new project loaded.
- [ ] Import a project from the library — list refreshes and the project can be opened.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SoZEc2VxiatADjGGjuaGXe)_