### PR TITLE
Force noMenu on library screen to prevent rail from swallowing taps

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -303,6 +303,11 @@ class MainActivity : ComponentActivity() {
                         !showSettings &&
                         !isExporting
 
+                // AzNavRail caches `isExpanded` in rememberSaveable; forcing
+                // noMenu on the library screen re-initialises it to false so
+                // its outer fillMaxSize Box never attaches tapOutsideToCollapse.
+                val railMenuDisabled = !isRailVisible || showLibrary
+
                 var permissionRequestedAtLeastOnce by remember { mutableStateOf(hasCameraPermission) }
 
                 LaunchedEffect(Unit) {
@@ -422,7 +427,7 @@ class MainActivity : ComponentActivity() {
                     azConfig(
                         packButtons = true,
                         dockingSide = if (editorUiState.isRightHanded) AzDockingSide.LEFT else AzDockingSide.RIGHT,
-                        noMenu = !isRailVisible
+                        noMenu = railMenuDisabled
                     )
                     azAdvanced(
                         helpEnabled = true,
@@ -1791,16 +1796,16 @@ class MainActivity : ComponentActivity() {
                 }
             }
             azRailItem(id = "tool.lockTrace", text = lockText, color = navItemColor, onClick = lockAction)
+
+            azDivider()
+
+            azHelpRailItem(
+                id = "tool.helpMain",
+                text = navStrings.help,
+                color = navItemColor,
+                shape = AzButtonShape.RECTANGLE
+            )
         }
-
-        azDivider()
-
-        azHelpRailItem(
-            id = "tool.helpMain",
-            text = navStrings.help,
-            color = navItemColor,
-            shape = AzButtonShape.RECTANGLE
-        )
     }
 }
 


### PR DESCRIPTION
## Summary

Even after bumping to AzNavRail 9.2, the launch-screen buttons remain dead because the root cause was different from the 9.0 outer-Box pointerInput regression we originally suspected:

- AzNavRail's `isExpanded` flag is backed by a `rememberSaveable`. If a prior session left the rail expanded, on the next launch — even with `initiallyExpanded = false` — the cached state is restored.
- When `isExpanded == true`, AzNavRail attaches `tapOutsideToCollapse` (a `pointerInput { detectTapGestures { isExpanded = false } }`) to its outer `Modifier.fillMaxSize()` Box.
- That Box sits above the `onscreen` slot in `AzHostActivityLayout`'s z-order, so the detector consumes taps over the centered library buttons before they can reach `ProjectLibraryScreen`'s clickables. (The user reported the rail's own help button still gave press feedback — consistent with the rail receiving taps while the content area underneath does not.)

Fix:

1. Force `noMenu = true` whenever we're on the library route. AzNavRail evaluates `isExpanded = if (scope.noMenu) false else isExpandedInternal` on its first composition, so `noMenu = true` re-initialises `isExpanded` to `false` unconditionally, the tap-outside handler never attaches, and library taps land.
2. Move the trailing `azDivider()` + `azHelpRailItem("tool.helpMain")` inside the existing `!showLibrary` block, so the rail has zero entries on the library screen — consistent with the other editor-scoped items and removing the only extraneous interaction surface there.

## Test plan

- [ ] Cold launch: library buttons (`New Project`, `Import Project`) respond to taps on first launch, even after a prior session that left the rail expanded.
- [ ] Tap a project card in the list: opens the editor (`Trace` mode) as expected.
- [ ] After navigating into the editor, the full rail (modes, design, project, light/lock, help) is visible and functional.
- [ ] Returning to the library via `project.load` rail item: library buttons remain tappable.

https://claude.ai/code/session_01SoZEc2VxiatADjGGjuaGXe

---
_Generated by [Claude Code](https://claude.ai/code/session_01SoZEc2VxiatADjGGjuaGXe)_