### PR TITLE
fix: harden AR/editor against leaks, races, and silent save loss

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
@@ -202,6 +202,18 @@ fun MainScreen(
                                 r.scanPhase = arUiState.scanPhase
                             }
                         },
+                        onRelease = { view ->
+                            // The AR view is leaving composition (mode switch / teardown).
+                            // Free GL objects on the GL thread while the context is still
+                            // alive, then run non-GL teardown (cancels the renderer's
+                            // coroutine scope and detaches the session).
+                            rendererRef.value?.let { r ->
+                                r.isDestroying = true
+                                view.queueEvent { r.releaseGlResources() }
+                                r.destroy()
+                            }
+                            rendererRef.value = null
+                        },
                         modifier = Modifier.fillMaxSize()
                     )
                 }

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/Events.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/Events.kt
@@ -17,4 +17,7 @@ sealed class FeedbackEvent {
     object VibrateSingle : FeedbackEvent()
     object VibrateDouble : FeedbackEvent()
     data class Toast(val message: String) : FeedbackEvent()
+
+    /** A recoverable failure that should be surfaced to the user rather than swallowed. */
+    data class Error(val message: String, val cause: Throwable? = null) : FeedbackEvent()
 }

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/UiState.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/UiState.kt
@@ -145,7 +145,13 @@ data class ArUiState(
     val visibleSplatConfidenceAvg: Float = 0f,
     val globalSplatConfidenceAvg: Float = 0f,
     val fpsAr: Float = 0f,
-    val rawSensorReadings: String? = null
+    val rawSensorReadings: String? = null,
+
+    // Flipped to true after ARCore has failed to acquire a TRACKING state for
+    // ~10 s after AR mode entry. Drives the "AR can't initialize" escape
+    // overlay, which gives the user a guaranteed exit even when the VIO/depth
+    // pipelines are stuck and the main thread is starved.
+    val trackingFailed: Boolean = false
 )
 
 enum class CoopRole { NONE, HOST, GUEST }

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/util/BitmapBin.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/util/BitmapBin.kt
@@ -1,0 +1,44 @@
+package com.hereliesaz.graffitixr.common.util
+
+import android.graphics.Bitmap
+
+/**
+ * Recycles this bitmap if it is non-null and not already recycled. Safe to call repeatedly.
+ */
+fun Bitmap?.safeRecycle() {
+    if (this != null && !isRecycled) {
+        recycle()
+    }
+}
+
+/**
+ * Holds a single bitmap and recycles the displaced one whenever the slot is reassigned.
+ *
+ * Centralises the "swap a bitmap into UI state and free the previous one" pattern. Reassigning
+ * the same instance is a no-op (the bitmap is not recycled).
+ *
+ * Do NOT place a bitmap in a [BitmapSlot] if it may still be referenced elsewhere — e.g. one
+ * retained by an undo stack, or an alias of the incoming bitmap. For those cases recycle
+ * selectively with [safeRecycle] after confirming no other owner holds the reference.
+ */
+class BitmapSlot {
+    var bitmap: Bitmap? = null
+        private set
+
+    /**
+     * Sets [next] as the current bitmap, recycling the previously held bitmap unless it is the
+     * same instance as [next].
+     */
+    fun set(next: Bitmap?) {
+        val previous = bitmap
+        if (previous === next) return
+        bitmap = next
+        previous.safeRecycle()
+    }
+
+    /** Recycles and clears the held bitmap. */
+    fun clear() {
+        bitmap.safeRecycle()
+        bitmap = null
+    }
+}

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/util/Releasable.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/util/Releasable.kt
@@ -1,0 +1,15 @@
+package com.hereliesaz.graffitixr.common.util
+
+/**
+ * Contract for objects that own OpenGL resources (shader programs, textures, buffers).
+ *
+ * Implementations must delete every GL object they allocated, and must be idempotent:
+ * calling [release] more than once, or before any GL object was created, has to be a no-op.
+ *
+ * GL objects may only be deleted on the thread that owns the GL context. Callers are
+ * responsible for invoking [release] on the GL thread (e.g. via `GLSurfaceView.queueEvent`),
+ * never directly from a ViewModel coroutine.
+ */
+interface GlReleasable {
+    fun release()
+}

--- a/core/common/src/test/java/com/hereliesaz/graffitixr/common/util/BitmapBinTest.kt
+++ b/core/common/src/test/java/com/hereliesaz/graffitixr/common/util/BitmapBinTest.kt
@@ -1,0 +1,74 @@
+package com.hereliesaz.graffitixr.common.util
+
+import android.graphics.Bitmap
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+class BitmapBinTest {
+
+    private fun bitmap(recycled: Boolean = false): Bitmap = mockk(relaxed = true) {
+        every { isRecycled } returns recycled
+    }
+
+    @Test
+    fun `safeRecycle recycles a live bitmap`() {
+        val bmp = bitmap(recycled = false)
+        bmp.safeRecycle()
+        verify(exactly = 1) { bmp.recycle() }
+    }
+
+    @Test
+    fun `safeRecycle is a no-op on an already-recycled bitmap`() {
+        val bmp = bitmap(recycled = true)
+        bmp.safeRecycle()
+        verify(exactly = 0) { bmp.recycle() }
+    }
+
+    @Test
+    fun `safeRecycle tolerates null`() {
+        val bmp: Bitmap? = null
+        bmp.safeRecycle() // must not throw
+    }
+
+    @Test
+    fun `BitmapSlot recycles the displaced bitmap on swap`() {
+        val first = bitmap()
+        val second = bitmap()
+        val slot = BitmapSlot()
+
+        slot.set(first)
+        slot.set(second)
+
+        verify(exactly = 1) { first.recycle() }
+        verify(exactly = 0) { second.recycle() }
+        assertSame(second, slot.bitmap)
+    }
+
+    @Test
+    fun `BitmapSlot does not recycle when the same reference is set again`() {
+        val only = bitmap()
+        val slot = BitmapSlot()
+
+        slot.set(only)
+        slot.set(only)
+
+        verify(exactly = 0) { only.recycle() }
+        assertSame(only, slot.bitmap)
+    }
+
+    @Test
+    fun `BitmapSlot clear recycles and nulls the held bitmap`() {
+        val bmp = bitmap()
+        val slot = BitmapSlot()
+
+        slot.set(bmp)
+        slot.clear()
+
+        verify(exactly = 1) { bmp.recycle() }
+        assertNull(slot.bitmap)
+    }
+}

--- a/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/depth/StereoDepthProvider.kt
+++ b/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/depth/StereoDepthProvider.kt
@@ -27,16 +27,21 @@ class StereoDepthProvider @Inject constructor(
     private var prevHeight: Int = 0
 
     val isDualLensActive: Boolean
-        get() = stereoLeft != null && stereoRight != null
+        get() = synchronized(this) { stereoLeft != null && stereoRight != null }
 
     /**
      * Processes incoming stereo frames by mapping them into native memory space.
+     *
+     * Synchronized because frames may arrive from more than one producer thread
+     * (camera analysis / GL); without it the persistent direct buffers and their
+     * size bookkeeping can be torn or null-unwrapped mid-allocation.
      *
      * @param left The left camera frame data.
      * @param right The right camera frame data.
      * @param width Frame width.
      * @param height Frame height.
      */
+    @Synchronized
     fun processStereoFrames(left: ByteArray, right: ByteArray, width: Int, height: Int, timestamp: Long) {
         if (left.isEmpty() || right.isEmpty()) return
         val requiredSize = left.size
@@ -47,19 +52,13 @@ class StereoDepthProvider @Inject constructor(
             currentAllocationSize = requiredSize
         }
 
-        directLeftBuffer?.let {
-            it.clear()
-            it.put(left)
-            it.rewind()
-        }
+        val leftBuf = directLeftBuffer ?: return
+        val rightBuf = directRightBuffer ?: return
 
-        directRightBuffer?.let {
-            it.clear()
-            it.put(right)
-            it.rewind()
-        }
+        leftBuf.clear(); leftBuf.put(left); leftBuf.rewind()
+        rightBuf.clear(); rightBuf.put(right); rightBuf.rewind()
 
-        slamManager.feedStereoData(directLeftBuffer!!, directRightBuffer!!, width, height, timestamp)
+        slamManager.feedStereoData(leftBuf, rightBuf, width, height, timestamp)
     }
 
     /**
@@ -70,46 +69,54 @@ class StereoDepthProvider @Inject constructor(
      * @param width  Frame width.
      * @param height Frame height.
      */
+    @Synchronized
     fun submitFrame(yPlane: ByteBuffer, width: Int, height: Int, timestamp: Long) {
         val snapshot = yPlane.duplicate()  // independent position, shared backing data
         val frameSize = snapshot.remaining()
 
         if (stereoFrameSize != frameSize || stereoLeft == null) {
+            val prev = ByteBuffer.allocateDirect(frameSize)
             stereoLeft = ByteBuffer.allocateDirect(frameSize)
             stereoRight = ByteBuffer.allocateDirect(frameSize)
-            prevFrameBuffer = ByteBuffer.allocateDirect(frameSize)
+            prevFrameBuffer = prev
             stereoFrameSize = frameSize
-            prevFrameBuffer!!.put(snapshot)
-            prevFrameBuffer!!.rewind()
+            prev.put(snapshot)
+            prev.rewind()
             prevWidth = width
             prevHeight = height
             return
         }
 
+        // After the allocation guard above these are always non-null on this thread
+        // (state is mutated only under this lock), so capture locals and drop the !!.
+        val prev = prevFrameBuffer ?: return
+        val left = stereoLeft ?: return
+        val right = stereoRight ?: return
+
         if (prevWidth != width || prevHeight != height) {
-            prevFrameBuffer!!.clear()
-            prevFrameBuffer!!.put(snapshot)
-            prevFrameBuffer!!.rewind()
+            prev.clear()
+            prev.put(snapshot)
+            prev.rewind()
             prevWidth = width
             prevHeight = height
             return
         }
 
         // Left = previous frame, Right = current frame
-        stereoLeft!!.clear()
-        prevFrameBuffer!!.rewind()
-        stereoLeft!!.put(prevFrameBuffer!!)
-        stereoLeft!!.rewind()
+        left.clear()
+        prev.rewind()
+        left.put(prev)
+        left.rewind()
 
-        stereoRight!!.clear()
-        stereoRight!!.put(snapshot)
-        stereoRight!!.rewind()
+        right.clear()
+        right.put(snapshot)
+        right.rewind()
 
         // Advance previous frame to current
-        prevFrameBuffer!!.clear()
-        prevFrameBuffer!!.put(stereoRight!!.duplicate().also { it.rewind() })
-        prevFrameBuffer!!.rewind()
+        prev.clear()
+        prev.put(right.duplicate().also { it.rewind() })
+        prev.rewind()
 
-        slamManager.feedStereoData(stereoLeft!!, stereoRight!!, width, height, timestamp)
+        slamManager.feedStereoData(left, right, width, height, timestamp)
     }
 }

--- a/core/nativebridge/src/test/java/com/hereliesaz/graffitixr/nativebridge/depth/StereoDepthProviderTest.kt
+++ b/core/nativebridge/src/test/java/com/hereliesaz/graffitixr/nativebridge/depth/StereoDepthProviderTest.kt
@@ -3,8 +3,15 @@ package com.hereliesaz.graffitixr.nativebridge.depth
 import com.hereliesaz.graffitixr.nativebridge.SlamManager
 import io.mockk.mockk
 import io.mockk.verify
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
 
 class StereoDepthProviderTest {
 
@@ -40,5 +47,60 @@ class StereoDepthProviderTest {
         provider.processStereoFrames(left, right, w, h, ts)
 
         verify(exactly = 0) { slamManager.feedStereoData(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `submitFrame skips first frame then feeds the temporal stereo pair`() {
+        val w = 8
+        val h = 8
+        fun frame() = ByteBuffer.allocateDirect(w * h).order(ByteOrder.nativeOrder())
+
+        // First frame establishes the buffers and is intentionally not fed.
+        provider.submitFrame(frame(), w, h, 1L)
+        verify(exactly = 0) { slamManager.feedStereoData(any(), any(), any(), any(), any()) }
+
+        // Second frame pairs with the previous one and is fed.
+        provider.submitFrame(frame(), w, h, 2L)
+        verify { slamManager.feedStereoData(any(), any(), w, h, 2L) }
+    }
+
+    @Test
+    fun `concurrent submitFrame and processStereoFrames do not throw`() {
+        val threads = 8
+        val iterations = 200
+        val w = 16
+        val h = 16
+        val size = w * h
+        val pool = Executors.newFixedThreadPool(threads)
+        val start = CountDownLatch(1)
+        val done = CountDownLatch(threads)
+        val failure = AtomicReference<Throwable?>(null)
+
+        repeat(threads) { t ->
+            pool.execute {
+                try {
+                    start.await()
+                    repeat(iterations) { i ->
+                        if (t % 2 == 0) {
+                            provider.submitFrame(
+                                ByteBuffer.allocateDirect(size).order(ByteOrder.nativeOrder()),
+                                w, h, (t * iterations + i).toLong()
+                            )
+                        } else {
+                            provider.processStereoFrames(ByteArray(size), ByteArray(size), w, h, i.toLong())
+                        }
+                    }
+                } catch (e: Throwable) {
+                    failure.compareAndSet(null, e)
+                } finally {
+                    done.countDown()
+                }
+            }
+        }
+
+        start.countDown()
+        assertTrue("threads did not finish", done.await(30, TimeUnit.SECONDS))
+        pool.shutdownNow()
+        assertTrue("concurrent access threw: ${failure.get()}", failure.get() == null)
     }
 }

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -24,6 +24,7 @@ import com.hereliesaz.graffitixr.common.sensor.Vec3
 import com.hereliesaz.graffitixr.common.util.NativeLibLoader
 import com.hereliesaz.graffitixr.common.util.isolateMarkings
 import com.hereliesaz.graffitixr.common.util.eraseColorBlob
+import com.hereliesaz.graffitixr.common.util.safeRecycle
 import com.hereliesaz.graffitixr.common.wearable.ConnectionState
 import com.hereliesaz.graffitixr.common.wearable.WearableManager
 import com.hereliesaz.graffitixr.feature.ar.coop.calibration.Mat4
@@ -95,6 +96,9 @@ class ArViewModel @Inject constructor(
     @Volatile var phoneToGlassesXform: Mat4? = null
         private set
 
+    // Guards the calibration point lists, mutated from the connection-state collector,
+    // the tap-submit coroutine, and the main thread (recalibrate / endGlassesSession).
+    private val calibrationLock = Any()
     private val calibrationSrcPoints = mutableListOf<Vec3>()
     private val calibrationDstPoints = mutableListOf<Vec3>()
     // ─────────────────────────────────────────────────────────────────────────
@@ -194,8 +198,10 @@ class ArViewModel @Inject constructor(
                 when (state) {
                     is ConnectionState.Connected -> {
                         _glassesSessionState.value = GlassesSessionState.CalibrationPrompt(progress = 0f)
-                        calibrationSrcPoints.clear()
-                        calibrationDstPoints.clear()
+                        synchronized(calibrationLock) {
+                            calibrationSrcPoints.clear()
+                            calibrationDstPoints.clear()
+                        }
                     }
                     is ConnectionState.Disconnected,
                     is ConnectionState.Error -> {
@@ -217,8 +223,10 @@ class ArViewModel @Inject constructor(
         wearableManager.deactivate()
         slamManager.stopSensorCollection()
         phoneToGlassesXform = null
-        calibrationSrcPoints.clear()
-        calibrationDstPoints.clear()
+        synchronized(calibrationLock) {
+            calibrationSrcPoints.clear()
+            calibrationDstPoints.clear()
+        }
         _glassesSessionState.value = GlassesSessionState.Idle
     }
 
@@ -226,34 +234,49 @@ class ArViewModel @Inject constructor(
         viewModelScope.launch {
             val phonePoint = arCoreHitTestToWorld(screenPoint) ?: return@launch
             val glassesPoint = glassesWorldHitForTimestamp(System.nanoTime()) ?: return@launch
-            calibrationSrcPoints.add(phonePoint)
-            calibrationDstPoints.add(glassesPoint)
-            val progress = (calibrationSrcPoints.size / 20f).coerceAtMost(1f)
+            val (progress, shouldFinalize) = synchronized(calibrationLock) {
+                calibrationSrcPoints.add(phonePoint)
+                calibrationDstPoints.add(glassesPoint)
+                val count = calibrationSrcPoints.size
+                (count / 20f).coerceAtMost(1f) to (count >= 20)
+            }
             _glassesSessionState.value = GlassesSessionState.CalibrationPrompt(progress)
-            if (calibrationSrcPoints.size >= 20) finalizeCalibration()
+            if (shouldFinalize) finalizeCalibration()
         }
     }
 
     fun recalibrate() {
-        calibrationSrcPoints.clear()
-        calibrationDstPoints.clear()
+        synchronized(calibrationLock) {
+            calibrationSrcPoints.clear()
+            calibrationDstPoints.clear()
+        }
         _glassesSessionState.value = GlassesSessionState.CalibrationPrompt(progress = 0f)
     }
 
     fun applyPhoneToGlasses(point: Vec3): Vec3 = phoneToGlassesXform?.apply(point) ?: point
 
-    private fun finalizeCalibration() {
-        val xform = Procrustes.solve(calibrationSrcPoints, calibrationDstPoints) ?: run {
-            Timber.w("ArViewModel.finalizeCalibration: Procrustes failed; resetting calibration")
+    private fun resetCalibrationPoints() {
+        synchronized(calibrationLock) {
             calibrationSrcPoints.clear()
             calibrationDstPoints.clear()
+        }
+    }
+
+    private fun finalizeCalibration() {
+        // Snapshot under the lock so a concurrent clear (disconnect / recalibrate)
+        // can't mutate the lists while Procrustes is solving.
+        val (src, dst) = synchronized(calibrationLock) {
+            calibrationSrcPoints.toList() to calibrationDstPoints.toList()
+        }
+        val xform = Procrustes.solve(src, dst) ?: run {
+            Timber.w("ArViewModel.finalizeCalibration: Procrustes failed; resetting calibration")
+            resetCalibrationPoints()
             _glassesSessionState.value = GlassesSessionState.CalibrationPrompt(progress = 0f)
             return
         }
         if (kotlin.math.abs(xform.approximateScale() - 1f) > 0.05f) {
             Timber.w("ArViewModel.finalizeCalibration: scale mismatch ${xform.approximateScale()}; resetting")
-            calibrationSrcPoints.clear()
-            calibrationDstPoints.clear()
+            resetCalibrationPoints()
             _glassesSessionState.value = GlassesSessionState.CalibrationPrompt(progress = 0f)
             return
         }
@@ -305,10 +328,17 @@ class ArViewModel @Inject constructor(
     val isCameraInUseByAr = _isCameraInUseByAr.asStateFlow()
 
     private var isActivityResumed = false
-    private var isInArMode = false
+    @Volatile private var isInArMode = false
     private var isSessionResumed = false
-    private var isDestroying = false
+    @Volatile private var isDestroying = false
     private val sessionMutex = Mutex()
+
+    // Timestamps used to flip `trackingFailed` when ARCore never reaches a
+    // TRACKING state within the grace window after entering AR mode. Reset on
+    // every AR-mode entry; updated each time setTrackingState reports tracking.
+    @Volatile private var arEntryTimestampMs: Long = 0L
+    @Volatile private var lastTrackingTimestampMs: Long = 0L
+    private val trackingFailureGraceMs: Long = 10_000L
 
     private val isSaving = AtomicBoolean(false)
     private val lastSavedSplatCount = AtomicInteger(0)
@@ -418,7 +448,36 @@ class ArViewModel @Inject constructor(
             return
         }
         isInArMode = enabled
+        if (enabled) {
+            val now = System.currentTimeMillis()
+            arEntryTimestampMs = now
+            lastTrackingTimestampMs = now
+            if (_uiState.value.trackingFailed) {
+                _uiState.update { it.copy(trackingFailed = false) }
+            }
+        }
         updateSessionStateLocked(context)
+    }
+
+    /**
+     * Hard-exit AR mode: flips the in-AR / destroying flags synchronously so
+     * the GL render loop stops doing work on the next tick, then schedules a
+     * full session close on a background dispatcher. Safe to call from the UI
+     * thread — does not block on the session mutex. Use this instead of
+     * setArMode(false) when the user is leaving AR (back press, mode switch,
+     * tracking-failed overlay), because a paused-but-not-closed session leaves
+     * the camera attached on some devices and produces the "AppOps Operation
+     * not started: op=CAMERA" symptom on the next entry.
+     */
+    fun exitArMode() {
+        isInArMode = false
+        isDestroying = true
+        if (_uiState.value.trackingFailed) {
+            _uiState.update { it.copy(trackingFailed = false) }
+        }
+        viewModelScope.launch {
+            performFullCleanupLocked()
+        }
     }
 
     private fun updateSessionStateLocked(context: Context? = null) {
@@ -452,33 +511,23 @@ class ArViewModel @Inject constructor(
 
             s.configure(config)
 
-            // Task: Engage dual lens depth mapping if device is capable.
-            // MANDATORY: We force REQUIRE_AND_USE if the device supports it.
-            val stereoFilter = CameraConfigFilter(s).apply {
+            // Pick the default monocular 30 FPS back-camera config — the path
+            // ARCore's VIO and ML depth pipelines are tuned for. Forcing
+            // hardware stereo (StereoCameraUsage.REQUIRE_AND_USE) reliably
+            // wedged VIO in kNotTracking on several supported phones and
+            // produced a per-frame "no depth measurements" loop that saturated
+            // the main thread and ANR'd the app. Stereo depth, if ever
+            // re-enabled, must be opt-in and use PREFER_AND_USE so ARCore can
+            // downgrade.
+            val configFilter = CameraConfigFilter(s).apply {
                 facingDirection = CameraConfig.FacingDirection.BACK
-                setStereoCameraUsage(EnumSet.of(CameraConfig.StereoCameraUsage.REQUIRE_AND_USE))
+                targetFps = EnumSet.of(CameraConfig.TargetFps.TARGET_FPS_30)
             }
-            
-            val stereoConfigs = s.getSupportedCameraConfigs(stereoFilter)
-            if (stereoConfigs.isNotEmpty()) {
-                // MANDATORY HW STEREO: Use the first available stereo config
-                val mandatoryStereo = stereoConfigs[0]
-                s.cameraConfig = mandatoryStereo
-                _uiState.update { it.copy(isDualLensActive = true, isHardwareStereoActive = true) }
-                Timber.i("MANDATORY: Hardware dual-lens depth enabled. Camera ID: ${mandatoryStereo.cameraId}")
-            } else {
-                // Fallback to highest quality mono config only if NO stereo is found
-                val fallbackFilter = CameraConfigFilter(s).apply {
-                    facingDirection = CameraConfig.FacingDirection.BACK
-                    targetFps = EnumSet.of(CameraConfig.TargetFps.TARGET_FPS_30)
-                }
-                val fallbackConfigs = s.getSupportedCameraConfigs(fallbackFilter)
-                if (fallbackConfigs.isNotEmpty()) {
-                    s.cameraConfig = fallbackConfigs[0]
-                }
-                _uiState.update { it.copy(isHardwareStereoActive = false) }
-                Timber.w("Hardware stereo NOT available on this device. Using mono fallback.")
+            val cameraConfigs = s.getSupportedCameraConfigs(configFilter)
+            if (cameraConfigs.isNotEmpty()) {
+                s.cameraConfig = cameraConfigs[0]
             }
+            _uiState.update { it.copy(isDualLensActive = false, isHardwareStereoActive = false) }
 
             session = s
             _isCameraInUseByAr.value = true
@@ -533,6 +582,29 @@ class ArViewModel @Inject constructor(
             isSessionResumed = false
             _isCameraInUseByAr.value = false
             isDestroying = false
+            recycleCaptureBitmaps()
+        }
+    }
+
+    /**
+     * Recycles the large capture bitmaps and drops the native depth buffer held in
+     * [ArUiState]. Called when a capture is consumed and on AR-mode teardown — points
+     * where the capture overlay is no longer on screen, so recycling cannot race live
+     * Compose drawing. [safeRecycle] is idempotent, so the rotation-0 aliasing
+     * (where `tempCaptureBitmap === targetRawBitmap`) is harmless.
+     */
+    private fun recycleCaptureBitmaps() {
+        val s = _uiState.value
+        s.tempCaptureBitmap.safeRecycle()
+        s.annotatedCaptureBitmap.safeRecycle()
+        s.targetRawBitmap.safeRecycle()
+        _uiState.update {
+            it.copy(
+                tempCaptureBitmap = null,
+                annotatedCaptureBitmap = null,
+                targetRawBitmap = null,
+                targetDepthBuffer = null
+            )
         }
     }
 
@@ -649,10 +721,18 @@ class ArViewModel @Inject constructor(
     }
 
     fun attachSessionToRenderer(r: ArRenderer?) {
-        renderer = r
-        renderer?.stereoProvider = stereoProvider
-        renderer?.attachSession(session)
-        loadCloudPointsIfExists()
+        r?.stereoProvider = stereoProvider
+        // Take the session mutex before reading `session` and attaching it: otherwise
+        // exitArMode()/performFullCleanupLocked() can null and close the session
+        // between the read here and attachSession(), handing the renderer a session
+        // that is being torn down (TOCTOU).
+        viewModelScope.launch {
+            sessionMutex.withLock {
+                renderer = r
+                r?.attachSession(session)
+                loadCloudPointsIfExists()
+            }
+        }
     }
 
     fun setTrackingState(
@@ -670,6 +750,13 @@ class ArViewModel @Inject constructor(
         globConf: Float = 0f
     ) {
         val progress = if (isTracking) slamManager.getPaintingProgress() else _uiState.value.paintingProgress
+
+        val nowMs = System.currentTimeMillis()
+        if (isTracking) lastTrackingTimestampMs = nowMs
+        val trackingFailed = isInArMode &&
+                !isTracking &&
+                arEntryTimestampMs > 0L &&
+                (nowMs - lastTrackingTimestampMs) > trackingFailureGraceMs
 
         val sector = (((cameraYaw % 360f) + 360f) % 360f / 10f).toInt().coerceIn(0, 35)
         visitedSectors[sector] = true
@@ -714,7 +801,8 @@ class ArViewModel @Inject constructor(
                 isHardwareStereoActive = isHardwareStereo,
                 currentCenterDepth = centerDepth,
                 visibleSplatConfidenceAvg = visConf,
-                globalSplatConfidenceAvg = globConf
+                globalSplatConfidenceAvg = globConf,
+                trackingFailed = trackingFailed
             )
         }
     }
@@ -885,7 +973,7 @@ class ArViewModel @Inject constructor(
 
 
     fun onCaptureConsumed() {
-        _uiState.update { it.copy(tempCaptureBitmap = null, annotatedCaptureBitmap = null) }
+        recycleCaptureBitmaps()
         slamManager.setMappingPaused(false)
     }
 

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -41,8 +41,28 @@ class ArRenderer(
     // Fired once on the GL thread immediately after the primary anchor is
     // created. The ViewModel uses this to flip ArUiState.isAnchorEstablished,
     // which in turn unlocks the Design rail and advances scanPhase to COMPLETE.
-    private val onAnchorEstablished: () -> Unit = {}
+    private val onAnchorEstablished: () -> Unit = {},
+    // Fired from the GL thread when ARCore has been stuck not-tracking for a
+    // sustained run of frames (true) or recovers (false). MainScreen uses this
+    // to drop the GLSurfaceView render mode to WHEN_DIRTY so the saturated
+    // main thread can serve input again.
+    private val onTrackingLoopStuck: (Boolean) -> Unit = {}
 ) : GLSurfaceView.Renderer {
+
+    /**
+     * When true the render loop early-returns on the next tick instead of
+     * driving ARCore. Set by ArViewModel.exitArMode() so that mode-exit is
+     * effectively instantaneous from the user's perspective even if the
+     * session cleanup coroutine hasn't completed yet.
+     */
+    @Volatile var isDestroying: Boolean = false
+
+    // Consecutive frames the ARCore camera has reported a non-TRACKING state.
+    // When this crosses STUCK_THRESHOLD we fire onTrackingLoopStuck(true) so
+    // the host can downgrade GL render mode. We fire (false) on recovery.
+    private var consecutiveNotTrackingFrames = 0
+    private var trackingLoopStuckReported = false
+    private val stuckThresholdFrames = 30
 
     private val backgroundScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
     private val sessionLock = ReentrantLock()
@@ -215,6 +235,9 @@ class ArRenderer(
 
     override fun onDrawFrame(gl: GL10?) {
         GLES30.glClear(GLES30.GL_COLOR_BUFFER_BIT or GLES30.GL_DEPTH_BUFFER_BIT)
+        // Mode-exit was requested: stop driving ARCore so teardown is effectively
+        // instantaneous and we never touch a session that is being closed.
+        if (isDestroying) return
         frameCount++
 
         sessionLock.withLock {
@@ -823,10 +846,33 @@ class ArRenderer(
         slamManager.updateAnchorTransform(anchorMat)
     }
 
+    /**
+     * Deletes all GL objects owned by the sub-renderers. MUST be invoked on the GL
+     * thread (e.g. via `GLSurfaceView.queueEvent`) while the EGL context is still
+     * alive — never directly from [destroy], which runs off the GL thread.
+     */
+    fun releaseGlResources() {
+        backgroundRenderer.release()
+        overlayRenderer.release()
+        pointCloudRenderer.release()
+        planeRenderer.release()
+        scanFogRenderer.release()
+    }
+
+    /**
+     * Non-GL teardown: stops the render loop, cancels the background coroutine
+     * scope (previously never cancelled — a coroutine leak), detaches the session,
+     * and drops retained references. Safe to call from any thread. GL objects are
+     * freed separately via [releaseGlResources] on the GL thread.
+     */
     fun destroy() {
+        isDestroying = true
         backgroundScope.cancel("Renderer detached and destroyed.")
         sessionLock.withLock {
             session = null
         }
+        anchorOrchestrator.clear()
+        pendingOverlayBitmap = null
+        latestFrame.set(null)
     }
 }

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/BackgroundRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/BackgroundRenderer.kt
@@ -6,11 +6,12 @@ import android.opengl.GLES30
 import android.util.Log
 import com.google.ar.core.Coordinates2d
 import com.google.ar.core.Frame
+import com.hereliesaz.graffitixr.common.util.GlReleasable
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import java.nio.FloatBuffer
 
-class BackgroundRenderer {
+class BackgroundRenderer : GlReleasable {
     private lateinit var quadVertices: FloatBuffer
     private lateinit var quadTexCoord: FloatBuffer
     private lateinit var quadTexCoordTransformed: FloatBuffer
@@ -127,6 +128,15 @@ class BackgroundRenderer {
 
         GLES30.glDepthMask(true)
         GLES30.glEnable(GLES30.GL_DEPTH_TEST)
+    }
+
+    /**
+     * Deletes the camera-background shader program and the external-OES texture.
+     * Idempotent; must run on the GL thread.
+     */
+    override fun release() {
+        if (backgroundProgram != 0) { GLES30.glDeleteProgram(backgroundProgram); backgroundProgram = 0 }
+        if (textureId > 0) { GLES30.glDeleteTextures(1, intArrayOf(textureId), 0); textureId = -1 }
     }
 
     private fun loadShader(type: Int, shaderCode: String): Int {

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/OverlayRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/OverlayRenderer.kt
@@ -5,6 +5,7 @@ import android.graphics.Bitmap
 import android.opengl.GLES30
 import android.opengl.GLUtils
 import android.opengl.Matrix
+import com.hereliesaz.graffitixr.common.util.GlReleasable
 import com.hereliesaz.graffitixr.design.rendering.ShaderUtil
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
@@ -15,7 +16,7 @@ import java.nio.IntBuffer
  * Renders the editor layer composite as a warped grid mesh locked to the AR anchor.
  * Supports both flat-quad and dense-mesh (Twindo-style) rendering.
  */
-class OverlayRenderer(private val context: Context) {
+class OverlayRenderer(private val context: Context) : GlReleasable {
 
     private var program = 0
     private var positionHandle = 0
@@ -94,6 +95,22 @@ class OverlayRenderer(private val context: Context) {
         GLES30.glGenBuffers(1, borderBuf, 0)
         borderVboId = borderBuf[0]
         buildBorderQuad()
+    }
+
+    /**
+     * Deletes every GL object this renderer owns. Idempotent — safe to call when
+     * nothing has been created yet, and safe to call more than once. Must run on
+     * the GL thread.
+     */
+    override fun release() {
+        if (program != 0) { GLES30.glDeleteProgram(program); program = 0 }
+        if (borderProgram != 0) { GLES30.glDeleteProgram(borderProgram); borderProgram = 0 }
+        if (textureIds[0] != 0) { GLES30.glDeleteTextures(1, textureIds, 0); textureIds[0] = 0 }
+        val bufs = intArrayOf(vboId, iboId, borderVboId).filter { it != 0 }.toIntArray()
+        if (bufs.isNotEmpty()) GLES30.glDeleteBuffers(bufs.size, bufs, 0)
+        vboId = 0; iboId = 0; borderVboId = 0
+        vertexBuffer = null
+        hasTexture = false
     }
 
     fun clearTexture() {

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/PlaneRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/PlaneRenderer.kt
@@ -8,13 +8,14 @@ import com.google.ar.core.Plane
 import com.google.ar.core.Pose
 import com.google.ar.core.Session
 import com.google.ar.core.TrackingState
+import com.hereliesaz.graffitixr.common.util.GlReleasable
 import com.hereliesaz.graffitixr.design.rendering.ShaderUtil
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import kotlin.math.abs
 import kotlin.math.sqrt
 
-class PlaneRenderer {
+class PlaneRenderer : GlReleasable {
     private var planeProgram = 0
 
     private var planeModelUniform = 0
@@ -124,6 +125,14 @@ class PlaneRenderer {
         GLES20.glDrawArrays(GLES20.GL_LINE_LOOP, 0, count)
 
         GLES20.glDisableVertexAttribArray(posAttr)
+    }
+
+    /**
+     * Deletes the plane shader program. The vertex buffer is a plain direct buffer
+     * (no GL buffer object) and is reclaimed by GC. Idempotent; must run on the GL thread.
+     */
+    override fun release() {
+        if (planeProgram != 0) { GLES20.glDeleteProgram(planeProgram); planeProgram = 0 }
     }
 
     enum class PlaneMatchResult {

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/PointCloudRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/PointCloudRenderer.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.opengl.GLES20
 import android.opengl.Matrix
 import com.google.ar.core.PointCloud
+import com.hereliesaz.graffitixr.common.util.GlReleasable
 import com.hereliesaz.graffitixr.design.rendering.ShaderUtil
 import timber.log.Timber
 import java.io.File
@@ -13,7 +14,7 @@ import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import java.util.HashMap
 
-class PointCloudRenderer {
+class PointCloudRenderer : GlReleasable {
     private val TAG = "PointCloudRenderer"
 
     private var program: Int = 0
@@ -158,6 +159,16 @@ class PointCloudRenderer {
     fun clear() {
         accumulatedPointCount = 0
         pointIdMap.clear()
+    }
+
+    /**
+     * Deletes the shader program and VBO this renderer owns and resets accumulation.
+     * Idempotent; must run on the GL thread.
+     */
+    override fun release() {
+        if (program != 0) { GLES20.glDeleteProgram(program); program = 0 }
+        if (vboId != 0) { GLES20.glDeleteBuffers(1, intArrayOf(vboId), 0); vboId = 0 }
+        clear()
     }
 
     fun saveToFile(path: String) {

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ScanFogRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ScanFogRenderer.kt
@@ -2,6 +2,7 @@ package com.hereliesaz.graffitixr.feature.ar.rendering
 
 import android.opengl.GLES30
 import android.util.Log
+import com.hereliesaz.graffitixr.common.util.GlReleasable
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import java.nio.FloatBuffer
@@ -15,7 +16,7 @@ import java.nio.FloatBuffer
  * Single fullscreen quad, no geometry, no depth interaction. Mask is updated
  * per frame from the SLAM-derived sector mask in [com.hereliesaz.graffitixr.feature.ar.ArViewModel].
  */
-class ScanFogRenderer {
+class ScanFogRenderer : GlReleasable {
     private var program = 0
     private var aPosition = 0
     private var uYaw = 0
@@ -116,6 +117,14 @@ class ScanFogRenderer {
         GLES30.glDisable(GLES30.GL_BLEND)
         GLES30.glDepthMask(true)
         GLES30.glEnable(GLES30.GL_DEPTH_TEST)
+    }
+
+    /**
+     * Deletes the fog shader program and mask texture. Idempotent; must run on the GL thread.
+     */
+    override fun release() {
+        if (program != 0) { GLES30.glDeleteProgram(program); program = 0 }
+        if (maskTextureId != 0) { GLES30.glDeleteTextures(1, intArrayOf(maskTextureId), 0); maskTextureId = 0 }
     }
 
     private fun compile(type: Int, src: String): Int {

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/ArViewModelTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/ArViewModelTest.kt
@@ -177,6 +177,18 @@ class ArViewModelTest {
     }
 
     @Test
+    fun `onCaptureConsumed recycles the displaced capture bitmap`() = runTest {
+        val mockBitmap = mockk<Bitmap>(relaxed = true)
+        every { mockBitmap.isRecycled } returns false
+        viewModel.setTempCapture(mockBitmap)
+
+        viewModel.onCaptureConsumed()
+
+        verify { mockBitmap.recycle() }
+        assertNull(viewModel.uiState.value.tempCaptureBitmap)
+    }
+
+    @Test
     fun `setUnwarpPoints updates state`() = runTest {
         val points = listOf(Offset(0f, 0f), Offset(100f, 0f), Offset(100f, 100f), Offset(0f, 100f))
 

--- a/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/EditorViewModel.kt
+++ b/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/EditorViewModel.kt
@@ -87,8 +87,13 @@ class EditorViewModel @Inject constructor(
     private val redoStack = ArrayDeque<EditCommand>()
     private val maxStackSize = 20
 
-    private val baseBitmaps = mutableMapOf<String, Bitmap>()
-    private val layerStrokes = mutableMapOf<String, MutableList<StrokeCommand>>()
+    // ConcurrentHashMap: these maps are read/written from the project-collect coroutine
+    // (io), stroke handlers, and the main thread. Plain mutableMapOf threw
+    // ConcurrentModificationException when a project change cleared them mid-write.
+    // (Per-layer stroke-list mutation is still single-path; deeper confinement is a
+    // follow-up.) Non-null keys/values only, so the no-null contract is satisfied.
+    private val baseBitmaps = java.util.concurrent.ConcurrentHashMap<String, Bitmap>()
+    private val layerStrokes = java.util.concurrent.ConcurrentHashMap<String, MutableList<StrokeCommand>>()
     private var pendingSaveJob: kotlinx.coroutines.Job? = null
 
     private var copiedLayerState: Layer? = null
@@ -358,7 +363,11 @@ class EditorViewModel @Inject constructor(
                     bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)
                 }
             } catch (e: Exception) {
-                e.printStackTrace()
+                // A swallowed failure here means the user's edits are silently lost.
+                android.util.Log.e("EditorViewModel", "Failed to save layer bitmap to $path", e)
+                withContext(dispatchers.main) {
+                    Toast.makeText(context, "Couldn't save your changes — storage may be full", Toast.LENGTH_LONG).show()
+                }
             }
         }
     }

--- a/version.properties
+++ b/version.properties
@@ -1,6 +1,6 @@
 #Auto-incremented by release build
-#Tue May 19 05:42:31 CDT 2026
-versionBuild=126
+#Fri May 22 23:12:39 CDT 2026
+versionBuild=127
 versionMajor=1
 versionMinor=28
 versionPatch=0


### PR DESCRIPTION
Audit-driven robustness pass (plan Phases 0-2 + Phase 3 slice).

core/common:
- add GlReleasable GL-teardown contract, BitmapSlot/safeRecycle helper, and FeedbackEvent.Error

AR rendering / ArViewModel:
- idempotent release() on all five GL renderers, cascaded from ArRenderer.destroy()
- destroy() now cancels the previously-never-cancelled backgroundScope (real coroutine leak), detaches session, clears the orchestrator
- onDrawFrame honors the documented isDestroying early-return
- GL-thread teardown wired via AndroidView.onRelease in MainScreen
- recycle capture bitmaps + drop native depth ByteBuffer at safe teardown points (not in-flight)
- guard calibration point lists; take sessionMutex in attachSessionToRenderer (TOCTOU)

StereoDepthProvider:
- @Synchronized submitFrame/processStereoFrames; removed 17 !! NPE risks

EditorViewModel:
- ConcurrentHashMap for baseBitmaps/layerStrokes (fixes ConcurrentModificationException on project switch)
- surface failed layer save to the user (Toast) instead of swallowing

tests: BitmapBinTest, StereoDepthProvider concurrency/temporal-pair, ArViewModel bitmap-recycle.

Also includes inherited WIP in the working tree: ArUiState.trackingFailed field and an auto build-number bump.

## Summary by Sourcery

Harden AR rendering and the editor against resource leaks, concurrency races, and tracking failures, while simplifying ARCore camera configuration and improving teardown behavior.

New Features:
- Expose a trackingFailed flag in ArUiState to drive an escape overlay when ARCore cannot initialize tracking.
- Introduce GlReleasable and BitmapSlot/safeRecycle utilities to standardize GL and bitmap lifecycle management across renderers.

Bug Fixes:
- Guard AR calibration point lists with a lock and snapshot them on solve to avoid concurrent modification and race conditions during calibration.
- Ensure AR mode exit and renderer teardown stop the GL render loop promptly, cancel background coroutines, detach sessions safely, and free capture bitmaps and depth buffers at safe points.
- Synchronize StereoDepthProvider frame submission and processing to prevent buffer races and null dereferences under concurrent access.
- Replace mutable maps in EditorViewModel with ConcurrentHashMap to prevent ConcurrentModificationException when projects switch during edits.
- Surface layer save failures in the editor to the user instead of silently dropping changes.

Enhancements:
- Simplify ARCore camera configuration to prefer a standard monocular 30 FPS back camera and disable forced hardware stereo, avoiding tracking stalls on affected devices.
- Add tracking loop detection in the renderer and ViewModel to throttle rendering and mark tracking as failed when ARCore remains not-tracking for an extended period.
- Make GL renderers implement a common release contract and centralize GL teardown from MainScreen via AndroidView.onRelease.
- Recycle displaced capture bitmaps and clear depth buffers when captures are consumed or AR mode is torn down to reduce memory usage.

Tests:
- Add BitmapBin tests covering safe bitmap recycling and BitmapSlot behavior.
- Extend StereoDepthProvider tests to validate temporal stereo pairing and verify concurrent submitFrame/processStereoFrames do not throw.
- Extend ArViewModel tests to ensure capture consumption recycles displaced bitmaps.