### PR TITLE
Tutorial: advance on any tap (non-blocking) + per-step timer

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -525,8 +525,10 @@ class MainActivity : ComponentActivity() {
                                 val lines = railTutorialLines(tutId)
                                 if (lines.isNotEmpty()) {
                                     ModeOnboardingOverlay(
-                                        stepKey = tutId,
+                                        positionKey = tutId,
+                                        step = mainUiState.currentTutorialStep,
                                         lines = lines,
+                                        onAdvance = { mainViewModel.advanceTutorial() },
                                         onDismiss = { mainViewModel.dismissCurrentTutorial() }
                                     )
                                 } else {

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainViewModel.kt
@@ -40,7 +40,10 @@ data class MainUiState(
     // When true, interacting with a rail item surfaces that item's existing tutorial text.
     val tutorialModeActive: Boolean = false,
     // The rail-item id whose tutorial text is currently being shown (null = none).
-    val currentTutorialId: String? = null
+    val currentTutorialId: String? = null,
+    // The line index within the current tutorial. Advanced by any tap (rail or screen)
+    // or by the per-step timer; the overlay dismisses once it runs past the last line.
+    val currentTutorialStep: Int = 0
 )
 
 @HiltViewModel
@@ -64,24 +67,36 @@ class MainViewModel @Inject constructor(
 
     /** Toggle the tutorial walkthrough mode. Tapping rail items only shows text while this is on. */
     fun toggleTutorialMode() {
-        _uiState.update { it.copy(tutorialModeActive = !it.tutorialModeActive, currentTutorialId = null) }
+        _uiState.update {
+            it.copy(tutorialModeActive = !it.tutorialModeActive, currentTutorialId = null, currentTutorialStep = 0)
+        }
     }
 
     /**
-     * Called on every rail interaction. Surfaces that item's existing tutorial text, gated by
-     * [shouldShowTutorial]. We don't author new text here — [id] is looked up against the existing
-     * onboarding/help strings at the call site.
+     * Called on every rail interaction. While tutorial mode is on, any rail tap *advances* the
+     * card that's already showing (so tapping the rail never blocks the walkthrough); if nothing
+     * is showing yet it starts that item's tutorial, gated by [shouldShowTutorial]. The rail item's
+     * own action still runs at the call site, so interaction is never blocked. We don't author new
+     * text here — [id] is looked up against the existing onboarding/help strings at the call site.
      */
     fun onRailTap(id: String) {
-        if (shouldShowTutorial(id)) {
-            _uiState.update { it.copy(currentTutorialId = id) }
+        if (!_uiState.value.tutorialModeActive) return
+        if (_uiState.value.currentTutorialId != null) {
+            advanceTutorial()
+        } else if (shouldShowTutorial(id)) {
+            _uiState.update { it.copy(currentTutorialId = id, currentTutorialStep = 0) }
         }
+    }
+
+    /** Move to the next line of the current tutorial. The overlay dismisses once step runs past the end. */
+    fun advanceTutorial() {
+        _uiState.update { it.copy(currentTutorialStep = it.currentTutorialStep + 1) }
     }
 
     /** Dismiss the currently shown tutorial text and remember it as seen so it won't nag again. */
     fun dismissCurrentTutorial() {
         _uiState.value.currentTutorialId?.let { markTutorialCompletePersistent(it) }
-        _uiState.update { it.copy(currentTutorialId = null) }
+        _uiState.update { it.copy(currentTutorialId = null, currentTutorialStep = 0) }
     }
 
     /**

--- a/app/src/main/java/com/hereliesaz/graffitixr/onboarding/ModeOnboardingOverlay.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/onboarding/ModeOnboardingOverlay.kt
@@ -1,6 +1,5 @@
 package com.hereliesaz.graffitixr.onboarding
 
-import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.fillMaxSize
@@ -9,58 +8,95 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.changedToDownIgnoreConsumed
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.util.fastAny
 import kotlin.random.Random
+import kotlinx.coroutines.delay
 
 @Composable
 fun ModeOnboardingOverlay(
     onboarding: ModeOnboarding,
     onDismiss: () -> Unit,
-) = ModeOnboardingOverlay(stepKey = onboarding.mode, lines = onboarding.lines, onDismiss = onDismiss)
+) {
+    // First-run per-mode onboarding manages its own step locally (no rail-tap driving).
+    var step by rememberSaveable(onboarding.mode) { mutableStateOf(0) }
+    ModeOnboardingOverlay(
+        positionKey = onboarding.mode,
+        step = step,
+        lines = onboarding.lines,
+        onAdvance = { step++ },
+        onDismiss = onDismiss,
+    )
+}
 
 /**
- * Generic tap-to-advance onboarding overlay over arbitrary [lines]. [stepKey] resets the
- * step counter when it changes (so a new rail-item context starts from line 0) and seeds
- * the popup zone. Used both for per-mode onboarding and for rail-tap tutorial text.
+ * Generic onboarding overlay over arbitrary [lines]. The current [step] is controlled by the
+ * caller so any tap source — the non-consuming screen observer below, the per-step timer, or an
+ * external rail tap — can drive advancement through the same [onAdvance]. [positionKey] seeds the
+ * popup zone and resets the tap observer when the context changes.
+ *
+ * The overlay never consumes pointer events, so taps fall through to the canvas/editor underneath
+ * and the walkthrough never blocks interaction.
  */
 @Composable
 fun ModeOnboardingOverlay(
-    stepKey: Any,
+    positionKey: Any,
+    step: Int,
     lines: List<String>,
+    onAdvance: () -> Unit,
     onDismiss: () -> Unit,
 ) {
-    var step by rememberSaveable(stepKey) { mutableStateOf(0) }
     val line = lines.getOrNull(step)
     if (line == null) {
         onDismiss()
         return
     }
 
+    // Keep advance current without restarting the pointer loop on every step.
+    val advance by rememberUpdatedState(onAdvance)
+
+    // Per-step timer: longer lines linger longer. Restarts whenever the step (from any
+    // source) or context changes; firing past the last line trips the dismiss guard above.
+    LaunchedEffect(positionKey, step) {
+        delay(stepDurationMs(line))
+        advance()
+    }
+
     BoxWithConstraints(
         modifier = Modifier
             .fillMaxSize()
-            .pointerInput(stepKey) {
-                detectTapGestures {
-                    val next = step + 1
-                    if (next >= lines.size) onDismiss() else step = next
+            .pointerInput(positionKey) {
+                awaitPointerEventScope {
+                    while (true) {
+                        // Observe in the Initial pass and never consume, so the tap still
+                        // reaches whatever is underneath while also advancing the step.
+                        val event = awaitPointerEvent(PointerEventPass.Initial)
+                        if (event.changes.fastAny { it.changedToDownIgnoreConsumed() }) {
+                            advance()
+                        }
+                    }
                 }
             }
     ) {
         // Pick one of nine in-bounds zones based on a (key, step) seed so the
         // text moves between popups but never the same zone twice in a row.
-        val seed = stepKey.hashCode()
-        val zone = remember(stepKey, step) {
+        val seed = positionKey.hashCode()
+        val zone = remember(positionKey, step) {
             zoneForSeed(seed * 1000 + step, prevStep = step - 1, prevMode = seed)
         }
 
@@ -89,6 +125,9 @@ fun ModeOnboardingOverlay(
         }
     }
 }
+
+private fun stepDurationMs(line: String): Long =
+    (3000L + 50L * line.length).coerceIn(3000L, 10000L)
 
 private val zones: List<Alignment> = listOf(
     Alignment.TopStart, Alignment.TopCenter, Alignment.TopEnd,

--- a/app/src/main/java/com/hereliesaz/graffitixr/onboarding/ModeOnboardingOverlay.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/onboarding/ModeOnboardingOverlay.kt
@@ -62,8 +62,13 @@ fun ModeOnboardingOverlay(
     onDismiss: () -> Unit,
 ) {
     val line = lines.getOrNull(step)
+    LaunchedEffect(line) {
+        if (line == null) {
+            onDismiss()
+        }
+    }
+
     if (line == null) {
-        onDismiss()
         return
     }
 

--- a/app/src/test/java/com/hereliesaz/graffitixr/MainViewModelTest.kt
+++ b/app/src/test/java/com/hereliesaz/graffitixr/MainViewModelTest.kt
@@ -74,4 +74,72 @@ class MainViewModelTest {
         viewModel.setCaptureStep(CaptureStep.REVIEW)
         assertEquals(CaptureStep.REVIEW, viewModel.uiState.value.captureStep)
     }
+
+    @Test
+    fun `onRailTap does nothing while tutorial mode is off`() = runTest {
+        viewModel.onRailTap("mode.host")
+        assertEquals(null, viewModel.uiState.value.currentTutorialId)
+    }
+
+    @Test
+    fun `onRailTap starts tutorial when none is showing`() = runTest {
+        viewModel.toggleTutorialMode()
+
+        viewModel.onRailTap("mode.host")
+
+        val state = viewModel.uiState.value
+        assertEquals("mode.host", state.currentTutorialId)
+        assertEquals(0, state.currentTutorialStep)
+    }
+
+    @Test
+    fun `onRailTap advances current tutorial when one is showing`() = runTest {
+        viewModel.toggleTutorialMode()
+        viewModel.onRailTap("mode.host")
+
+        // A second rail tap advances the showing card rather than replacing it.
+        viewModel.onRailTap("design.host")
+
+        val state = viewModel.uiState.value
+        assertEquals("mode.host", state.currentTutorialId)
+        assertEquals(1, state.currentTutorialStep)
+    }
+
+    @Test
+    fun `advanceTutorial increments the step`() = runTest {
+        viewModel.toggleTutorialMode()
+        viewModel.onRailTap("mode.host")
+
+        viewModel.advanceTutorial()
+        viewModel.advanceTutorial()
+
+        assertEquals(2, viewModel.uiState.value.currentTutorialStep)
+    }
+
+    @Test
+    fun `dismissCurrentTutorial clears id and resets step`() = runTest {
+        viewModel.toggleTutorialMode()
+        viewModel.onRailTap("mode.host")
+        viewModel.advanceTutorial()
+
+        viewModel.dismissCurrentTutorial()
+
+        val state = viewModel.uiState.value
+        assertEquals(null, state.currentTutorialId)
+        assertEquals(0, state.currentTutorialStep)
+    }
+
+    @Test
+    fun `toggleTutorialMode off resets tutorial state`() = runTest {
+        viewModel.toggleTutorialMode()
+        viewModel.onRailTap("mode.host")
+        viewModel.advanceTutorial()
+
+        viewModel.toggleTutorialMode()
+
+        val state = viewModel.uiState.value
+        assertEquals(false, state.tutorialModeActive)
+        assertEquals(null, state.currentTutorialId)
+        assertEquals(0, state.currentTutorialStep)
+    }
 }


### PR DESCRIPTION
## Summary

The app-side tap-to-tutorial system (added in #1509) didn't behave as intended: rail taps never advanced the card, the overlay's `detectTapGestures` **consumed** every tap (blocking the canvas/editor underneath), and there was no auto-advance. This makes the walkthrough work the way it was meant to:

- **Any tap advances** — screen/canvas taps and rail taps both advance the current step. The tutorial step is now hoisted into `MainViewModel` (`currentTutorialStep`) so every advance path funnels through one method (`advanceTutorial()`). `onRailTap` advances the showing card instead of being ignored.
- **Never blocks interaction** — `ModeOnboardingOverlay` observes taps in the `Initial` pointer pass and never consumes them, so taps fall through to the canvas/editor (and the nav rail, which sits on top, keeps working). The item's own action still runs on a rail tap.
- **Per-step timer** — each step auto-advances after a length-scaled delay (~3s + 50ms/char, clamped to 3–10s). Advancing past the last line dismisses the card and marks it seen.

## Changes

- `MainViewModel.kt`: `currentTutorialStep` state; `advanceTutorial()`; `onRailTap` starts a tutorial when none is showing and advances when one is; `dismissCurrentTutorial`/`toggleTutorialMode` reset the step.
- `onboarding/ModeOnboardingOverlay.kt`: externally-controlled `step` + `onAdvance`; non-consuming `Initial`-pass tap observer; per-step length-based timer. First-run onboarding keeps local step state via a thin overload.
- `MainActivity.kt`: tutorial overlay wired to VM step/advance/dismiss.
- `MainViewModelTest.kt`: unit coverage for start-vs-advance, advance, dismiss, and toggle-reset.

## Test plan

- [ ] `./gradlew :app:assembleDebug :app:testDebugUnitTest` — **could not run in the cloud session**: the environment's network policy blocks Google's Maven (AGP `9.2.1` → HTTP 403), so no Android module can configure. Needs a local/CI run.
- [ ] Manual (device/emulator), tutorial mode on:
  - [ ] tapping the canvas advances the card **and** still pans/manipulates underneath (non-blocking)
  - [ ] tapping rail items advances the card while still performing their action
  - [ ] an untouched step auto-advances after a few seconds (longer lines linger longer)
  - [ ] advancing past the last line dismisses the card and it doesn't reappear (marked seen)

https://claude.ai/code/session_014pndfs3dqvFTHf1WdEtCc4

---
_Generated by [Claude Code](https://claude.ai/code/session_014pndfs3dqvFTHf1WdEtCc4)_

## Summary by Sourcery

Make tutorial walkthrough steps centrally controlled and advance on any tap without blocking interaction, with per-step auto-advance timing.

Enhancements:
- Hoist current tutorial step into MainUiState and add view model logic to start, advance, and dismiss tutorials via rail taps and screen taps.
- Refactor ModeOnboardingOverlay to be externally step-driven, observe non-consuming taps, and add a length-based per-step auto-advance timer.
- Wire MainActivity to drive the onboarding overlay from MainViewModel tutorial state and callbacks.

Tests:
- Extend MainViewModel tests to cover rail tap behaviour, tutorial step advancement, dismissal, and tutorial mode reset.