### PR TITLE
fix: codebase bug audit — leaks, NPE race, modal gating, teardown

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -495,7 +495,9 @@ class MainActivity : ComponentActivity() {
                         // is that auto overlays (onboarding, AR-unavailable explainer) must
                         // early-return on EVERY modal, not just one — collapsing the repeated
                         // boolean chains here prevents a future overlay from forgetting one.
-                        val anyModalActive = showLibrary || showSettings || isExporting || mainUiState.isCapturingTarget
+                        val anyModalActive = showLibrary || showSettings || isExporting ||
+                            mainUiState.isCapturingTarget || showSaveDialog ||
+                            dashboardUiState.showNewProjectDialog
 
                         // The ordered do-it-to-advance walkthrough for the current mode/layers.
                         // Derived from the rail enumeration + help/text maps so it always matches
@@ -817,7 +819,10 @@ class MainActivity : ComponentActivity() {
                                 screenSize = fullSize
                             )
 
-                            if (arUiState.showCoopNotFoundDialog) {
+                            // Auto-fired by AR state, so it must yield to any user-driven modal
+                            // rather than stack on top of it. Stays true in state and re-renders
+                            // once the higher-priority modal dismisses.
+                            if (arUiState.showCoopNotFoundDialog && !anyModalActive) {
                                 CoopNotFoundDialog(
                                     onDismiss = { arViewModel.dismissCoopNotFoundDialog() },
                                     onHost = { arViewModel.startHosting() },

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,9 +28,18 @@ buildscript {
         "com.google.protobuf:protobuf-kotlin-lite"
     )
 
+    // Protobuf is intentionally pinned to TWO different versions: the buildscript classpath needs
+    // 3.25.5 for AGP 9.0.1, while the application runtime needs the 4.x line for security fixes.
+    // These are named (not inline literals) so the split is explicit in one place and a future edit
+    // can't silently collide them. See the resolutionStrategy blocks below and in allprojects.
+    val protobufBuildscriptVersion = "3.25.5"
+    val protobufRuntimeVersion = "4.28.2"
+
     // Store in extra properties so allprojects can access it
     extra["commonForcedDependencies"] = commonForcedDependencies
     extra["protobufModules"] = protobufModules
+    extra["protobufBuildscriptVersion"] = protobufBuildscriptVersion
+    extra["protobufRuntimeVersion"] = protobufRuntimeVersion
 
     repositories {
         google()
@@ -44,7 +53,7 @@ buildscript {
             // Force common dependencies
             commonForcedDependencies.forEach { force(it) }
             // AGP 9.0.1 requires Protobuf 3.25.5 in the buildscript classpath
-            protobufModules.forEach { force("$it:3.25.5") }
+            protobufModules.forEach { force("$it:$protobufBuildscriptVersion") }
         }
     }
 }
@@ -74,13 +83,20 @@ allprojects {
     val commonForcedDependencies = rootProject.extra["commonForcedDependencies"] as List<String>
     @Suppress("UNCHECKED_CAST")
     val protobufModules = rootProject.extra["protobufModules"] as List<String>
+    val protobufRuntimeVersion = rootProject.extra["protobufRuntimeVersion"] as String
+
+    // Security invariant: the app runtime must stay on the 4.x protobuf line (the buildscript's
+    // 3.25.x is for AGP only). Fail fast if a future edit drops it back to 3.x.
+    check(protobufRuntimeVersion.startsWith("4.")) {
+        "Application runtime protobuf must remain on the 4.x line (was $protobufRuntimeVersion)"
+    }
 
     configurations.all {
         resolutionStrategy {
             // Force common dependencies
             commonForcedDependencies.forEach { force(it) }
-            // Force Protobuf 4.28.2 for application runtime security
-            protobufModules.forEach { force("$it:4.28.2") }
+            // Force Protobuf 4.x for application runtime security
+            protobufModules.forEach { force("$it:$protobufRuntimeVersion") }
         }
     }
 }

--- a/collab/src/main/java/com/hereliesaz/graffitixr/core/collaboration/CollaborationManager.kt
+++ b/collab/src/main/java/com/hereliesaz/graffitixr/core/collaboration/CollaborationManager.kt
@@ -106,6 +106,16 @@ class CollaborationManager @Inject constructor() {
         _state.value = CoopSessionState.Idle
     }
 
+    /**
+     * Fire-and-forget [leaveSession] for lifecycle owners (e.g. ViewModel.onCleared) whose own
+     * coroutine scope is already cancelled at teardown time and therefore cannot run the suspend
+     * variant. Runs on this singleton's [scope], which outlives the caller, so the host server
+     * socket / guest connection is actually released instead of leaking until process death.
+     */
+    fun leaveSessionAsync() {
+        scope.launch { leaveSession() }
+    }
+
     /** Called by OpEmitterImpl on every editor mutation. */
     internal fun enqueueHostOp(op: Op) {
         hostSession?.enqueueOp(op)

--- a/collab/src/main/java/com/hereliesaz/graffitixr/core/collaboration/session/GuestSession.kt
+++ b/collab/src/main/java/com/hereliesaz/graffitixr/core/collaboration/session/GuestSession.kt
@@ -60,8 +60,11 @@ internal class GuestSession(
     private suspend fun connectLoop(isReconnect: Boolean): Boolean {
         return try {
             val s = Socket()
-            s.connect(java.net.InetSocketAddress(host, port), 5000)
+            // Publish the socket to the field before connecting so a connect() failure (timeout /
+            // refused / unreachable) still has its descriptor closed by the catch below — otherwise
+            // the local would leak one FD per failed attempt across the reconnect loop.
             socket = s
+            s.connect(java.net.InetSocketAddress(host, port), 5000)
             val input = s.getInputStream()
             val output = s.getOutputStream()
 
@@ -110,6 +113,10 @@ internal class GuestSession(
             }
         } catch (e: Exception) {
             // Transient: let the caller decide whether to retry (reconnect) or end the session.
+            // Close the half-open socket now so a failed attempt doesn't leak an FD — the reconnect
+            // loop reassigns the field on the next try and would otherwise orphan this one.
+            try { socket?.close() } catch (_: Exception) {}
+            socket = null
             false
         }
     }

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/crash/CrashReporter.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/crash/CrashReporter.kt
@@ -49,12 +49,15 @@ class CrashReporter(private val context: Context) : Thread.UncaughtExceptionHand
     }
 
     private fun collectLogcat(): String {
+        var process: Process? = null
         return try {
-            val process = Runtime.getRuntime().exec(arrayOf("logcat", "-d", "-t", "1000", "--pid=${android.os.Process.myPid()}"))
-            val reader = InputStreamReader(process.inputStream)
-            reader.readText()
+            process = Runtime.getRuntime().exec(arrayOf("logcat", "-d", "-t", "1000", "--pid=${android.os.Process.myPid()}"))
+            InputStreamReader(process.inputStream).use { it.readText() }
         } catch (e: Exception) {
             "Failed to collect Logcat: ${e.message}"
+        } finally {
+            // Release the subprocess's pipes/FDs; readText() above already drained stdout.
+            process?.destroy()
         }
     }
 

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/crash/CrashUploadWorker.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/crash/CrashUploadWorker.kt
@@ -54,7 +54,8 @@ class CrashUploadWorker(private val context: Context) {
             if (response.isSuccessful) {
                 true
             } else {
-                Log.e("CrashUploadWorker", "GitHub API Error: ${response.code()} ${response.errorBody()?.string()}")
+                val errorText = response.errorBody()?.use { it.string() }
+                Log.e("CrashUploadWorker", "GitHub API Error: ${response.code()} $errorText")
                 false
             }
         } catch (e: Exception) {

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -1110,7 +1110,13 @@ class ArViewModel @Inject constructor(
 
     override fun onCleared() {
         super.onCleared()
-        leaveSession()
+        // viewModelScope is already cancelled by the time onCleared runs, so leaveSession()'s
+        // viewModelScope.launch would never execute and the collaboration session would leak.
+        // Cancel the local collector synchronously and tear the session down on the manager's
+        // own (surviving) scope instead.
+        coopStateJob?.cancel()
+        coopStateJob = null
+        collaborationManager.leaveSessionAsync()
         destroyArSession()
     }
 }

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/PointCloudRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/PointCloudRenderer.kt
@@ -34,6 +34,12 @@ class PointCloudRenderer : GlReleasable {
     private val localBuffer = FloatArray(maxPoints * 4)
     private val pointIdMap = HashMap<Int, Int>()
 
+    // Reusable GL upload buffers (GL thread only). [update] runs every frame while scanning, so
+    // allocating a fresh direct buffer each call churned the GC and caused scan-time jank; allocate
+    // the max-size buffer once and re-fill the used prefix instead.
+    private val uploadByteBuffer = ByteBuffer.allocateDirect(maxPoints * 4 * 4).order(ByteOrder.nativeOrder())
+    private val uploadFloatBuffer = uploadByteBuffer.asFloatBuffer()
+
     fun createOnGlThread(context: Context) {
         val vertexShaderCode = """
             uniform mat4 u_MvpMatrix;
@@ -115,12 +121,12 @@ class PointCloudRenderer : GlReleasable {
         if (hasUpdates) {
             GLES20.glBindBuffer(GLES20.GL_ARRAY_BUFFER, vboId)
 
-            val byteBuffer = ByteBuffer.allocateDirect(accumulatedPointCount * 4 * 4).order(ByteOrder.nativeOrder())
-            val floatBuffer = byteBuffer.asFloatBuffer()
-            floatBuffer.put(localBuffer, 0, accumulatedPointCount * 4)
-            floatBuffer.position(0)
+            val byteCount = accumulatedPointCount * 4 * 4
+            uploadFloatBuffer.clear()
+            uploadFloatBuffer.put(localBuffer, 0, accumulatedPointCount * 4)
+            uploadByteBuffer.position(0)
 
-            GLES20.glBufferSubData(GLES20.GL_ARRAY_BUFFER, 0, accumulatedPointCount * 4 * 4, byteBuffer)
+            GLES20.glBufferSubData(GLES20.GL_ARRAY_BUFFER, 0, byteCount, uploadByteBuffer)
             GLES20.glBindBuffer(GLES20.GL_ARRAY_BUFFER, 0)
         }
     }

--- a/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/EditorViewModel.kt
+++ b/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/EditorViewModel.kt
@@ -208,7 +208,17 @@ class EditorViewModel @Inject constructor(
         }
     }
 
-    fun setEditorMode(mode: EditorMode) = dispatch(EditorIntent.SetEditorMode(mode))
+    fun setEditorMode(mode: EditorMode) {
+        // A mode switch is a view change, not a container change — but any interaction in flight
+        // (a stroke not yet lifted, a segmentation not yet confirmed) must not survive it, or its
+        // callbacks would commit to the previous view's layer. Mirror the reducer's no-op guard.
+        if (_uiState.value.editorMode != mode) {
+            clearTransientStrokeState()
+            pendingStencilSourceLayerId = null
+            pendingStencilProjectId = null
+        }
+        dispatch(EditorIntent.SetEditorMode(mode))
+    }
 
     private fun pushHistory() {
         history.pushProperty(_uiState.value.layers.map { it.copy(bitmap = null) })
@@ -1172,6 +1182,10 @@ class EditorViewModel @Inject constructor(
         // original bitmap so each drag frame shows the full accumulated warp.
         if (_uiState.value.activeTool == Tool.LIQUIFY) {
             val layerId = strokeLayerId ?: return
+            // Capture the original bitmap once: onStrokeEnd may null the field while the warp job
+            // below is still queued on the default dispatcher, and a fast tool switch can enter this
+            // branch before onStrokeStart populated it. Bailing here is preferable to an NPE.
+            val original = liquifyOriginalBitmap ?: return
             val points = strokeCollectedPoints.toList()
             val canvasW = strokeCanvasW
             val canvasH = strokeCanvasH
@@ -1184,20 +1198,20 @@ class EditorViewModel @Inject constructor(
             if (points.size >= 2) {
                 val p1 = points[points.size - 2]
                 val p2 = points.last()
-                
+
                 // We need to map these screen points to the bitmap space
                 val mapped = ImageProcessor.mapScreenToBitmap(
-                    listOf(p1, p2), canvasW, canvasH, liquifyOriginalBitmap!!.width, liquifyOriginalBitmap!!.height,
+                    listOf(p1, p2), canvasW, canvasH, original.width, original.height,
                     capturedScale, capturedOffset, capturedRotZ
                 )
-                
+
                 val strokeArr = floatArrayOf(mapped[0].x, mapped[0].y, mapped[1].x, mapped[1].y)
                 slamManager.applyLiquify(strokeArr, brushSize, 0.5f)
             }
 
             liquifyJob?.cancel()
             liquifyJob = viewModelScope.launch(dispatchers.default) {
-                val warpBitmap = liquifyOriginalBitmap!!.copy(Bitmap.Config.ARGB_8888, true)
+                val warpBitmap = original.copy(Bitmap.Config.ARGB_8888, true)
                 slamManager.bakeLiquify(warpBitmap)
 
                 if (isActive) {
@@ -1250,7 +1264,9 @@ class EditorViewModel @Inject constructor(
             val bitmap = layer.bitmap ?: return
             
             val finalBitmap = if (state.activeTool == Tool.LIQUIFY) {
-                val baked = liquifyOriginalBitmap!!.copy(Bitmap.Config.ARGB_8888, true)
+                // Fall back to the committed layer bitmap if the original was already cleared
+                // (e.g. a second onStrokeEnd, or a start that never populated it) rather than NPE.
+                val baked = (liquifyOriginalBitmap ?: bitmap).copy(Bitmap.Config.ARGB_8888, true)
                 slamManager.bakeLiquify(baked)
                 baked
             } else {
@@ -1329,7 +1345,16 @@ class EditorViewModel @Inject constructor(
             opEmitter.emit(Op.StrokeComplete(layerId, brushStroke))
         }
 
-        // Clear stroke working state.
+        clearTransientStrokeState()
+    }
+
+    /**
+     * Resets the imperative, in-flight stroke/liquify scratch state. These live as ViewModel fields
+     * (not in [EditorUiState]), so the pure reducer can't clear them — any caller that abandons an
+     * in-progress stroke (stroke end, mode switch, project load) must invoke this so a later
+     * onStrokePoint/onStrokeEnd can't commit to a stale layer or bitmap.
+     */
+    private fun clearTransientStrokeState() {
         strokeWorkingBitmap = null
         strokeWorkingCanvas = null
         strokePaint = null
@@ -1337,7 +1362,6 @@ class EditorViewModel @Inject constructor(
         strokeCollectedPoints = mutableListOf()
         strokeLayerId = null
 
-        // Clean up Liquify live-preview state.
         liquifyJob?.cancel()
         liquifyJob = null
         liquifyOriginalBitmap = null


### PR DESCRIPTION
Vetted fixes from a full-codebase bug audit. Every finding was hand-verified before fixing; disproven agent findings were intentionally left unchanged.

## Real bugs fixed
- **EditorViewModel** — liquify NPE race: `onStrokeEnd` nulled `liquifyOriginalBitmap` while the warp coroutine dereferenced it on a background dispatcher. Captured into a null-guarded local.
- **GuestSession** — socket FD leak: a failed `connect()` orphaned the socket; reconnect loop multiplied it. Closed in the catch.
- **CrashReporter** — logcat `Process`/reader never released. Now `use{}` + `destroy()`.
- **MainActivity** — auto-fired `CoopNotFoundDialog` could stack over user modals. Gated behind the shared `anyModalActive` set (extended to include the save/new-project dialogs).
- **EditorViewModel** — stale imperative stroke/stencil state survived a mode switch and could commit to the wrong layer. Added `clearTransientStrokeState()` on mode switch.
- **ArViewModel / CollaborationManager** — `onCleared` ran `leaveSession()` on an already-cancelled `viewModelScope`, so `collaborationManager.leaveSession()` never executed → host server socket / guest connection leaked on teardown. Tear down via the manager's surviving scope (`leaveSessionAsync`) and cancel the collector synchronously.

## Hardening
- **CrashUploadWorker** — close `errorBody()` via `use{}`.
- **PointCloudRenderer** — reuse a pre-sized GL upload buffer instead of allocating a direct buffer every frame (scan-time GC jank).
- **build.gradle.kts** — centralize the intentional protobuf buildscript (3.25.5) vs runtime (4.28.2) split into named props + a guard keeping runtime on the 4.x line.

## Disproven findings (left as-is)
- `Uri.fromFile` in `ProjectManager` — URIs are read in-process; share path already uses `FileProvider`. Converting would be harmful.
- Sketch/Canny linked-group insertion — walk-up already reaches the true group top; agent had list order reversed.
- pointCloud.points / updateFlashlight / plane.polygon "crashes" — guarded by try/catch or ARCore `@NonNull`.

## Verification
- `compileDebugKotlin` across all 6 touched modules: **BUILD SUCCESSFUL**.
- Unit tests: collab, core:common, core:data, feature:editor all green. Only the 3 pre-existing `ArViewModelTest` failures remain (unrelated to these edits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix multiple resource leaks, race conditions, and teardown issues found in a codebase-wide bug audit, while tightening protobuf dependency management and reducing AR rendering jank.

Bug Fixes:
- Prevent liquify tool from dereferencing a cleared bitmap and ensure transient stroke state is cleared on editor mode switches to avoid stale commits and NPEs.
- Ensure collaboration sessions are properly torn down on ViewModel clearance by delegating to a long-lived manager scope and cancelling local collectors.
- Fix a guest collaboration socket file descriptor leak by publishing the socket before connect and always closing it on connection failures.
- Avoid leaking the logcat collection subprocess by properly closing its streams and destroying the process after reading output.
- Gate the auto-triggered CoopNotFound dialog behind a shared modal-active flag so it cannot stack on top of other user dialogs.

Enhancements:
- Reuse a preallocated GL upload buffer in the point cloud renderer to eliminate per-frame buffer allocations and associated GC jank.
- Introduce a dedicated helper to clear in-flight stroke/liquify scratch state used by the editor, and invoke it from relevant flows like stroke completion and mode switches.
- Add an async leaveSession entry point on the collaboration manager for lifecycle owners whose own coroutine scopes are already cancelled at teardown.
- Refine protobuf version management by centralizing buildscript/runtime versions into shared properties and enforcing the runtime stays on the 4.x line via a check.

Build:
- Update Gradle configuration to centralize protobuf buildscript and runtime versions in extra properties and use them consistently in resolution strategies.