### PR TITLE
AR tap-to-distance (sub-project C): spec, plan + tested depth/format core

### DIFF
--- a/docs/superpowers/plans/2026-06-01-ar-tap-distance.md
+++ b/docs/superpowers/plans/2026-06-01-ar-tap-distance.md
@@ -1,0 +1,144 @@
+# AR Tap-to-Distance — Implementation Plan (Sub-project C)
+
+> Use superpowers:subagent-driven-development or executing-plans. Steps use `- [ ]`.
+
+**Goal:** Show camera→wall distance — a live center reticle + a pinned label at each tapped mark (m/ft) — and feed each confident tap into the Sub-project B fusion as a support anchor.
+
+**Architecture:** Pure, unit-tested `DistanceFormat` + `DepthLookup` do the math. The renderer maps a tap to an image-normalized depth pixel via ARCore `transformCoordinates2d` (GL thread) and returns the range through `onTargetCaptured`. `ArUiState` carries `TapMark(nx,ny,distanceMeters)`. The overlay renders the reticle + per-tap chips. Taps also call `addSupportAnchor` to strengthen B's consensus.
+
+**Tech Stack:** Kotlin, ARCore, Compose, JUnit.
+
+**Spec:** `docs/superpowers/specs/2026-06-01-ar-tap-distance-design.md`
+
+**Verified sites:** `ArUiState.currentCenterDepth`, `tapHighlightKeypoints` (decl + add in `onTargetCaptured` + clear in `clearTapHighlights`), `isImperialUnits`; `ArRenderer` center-depth sample (~410) + `onTargetCaptured` callback; `BackgroundRenderer.kt:91` (`transformCoordinates2d`); `AnchorOrchestrator.addSupportAnchor`; `ArViewModel.arCoreHitTestToWorld`. Depth format: `raw and 0x1FFF` mm, valid `0 < mm < 7900`.
+
+---
+
+## Task 1: DistanceFormat (pure, TDD)
+
+**Files:** Create `feature/ar/.../eval/DistanceFormat.kt`; Test `.../eval/DistanceFormatTest.kt`.
+(Place in the existing `eval` package — shared formatting utility.)
+
+- [ ] **Step 1: failing test**
+```kotlin
+package com.hereliesaz.graffitixr.feature.ar.eval
+import org.junit.Assert.assertEquals
+import org.junit.Test
+class DistanceFormatTest {
+    @Test fun `metric`() { assertEquals("2.3 m", DistanceFormat.format(2.34f, imperial = false)) }
+    @Test fun `imperial converts meters to feet`() { assertEquals("7.5 ft", DistanceFormat.format(2.286f, imperial = true)) } // 2.286 m = 7.50 ft
+    @Test fun `invalid is dash`() {
+        assertEquals("—", DistanceFormat.format(0f, false)); assertEquals("—", DistanceFormat.format(-1f, true))
+    }
+}
+```
+- [ ] **Step 2: run → FAIL** `sh gradlew --offline :feature:ar:testDebugUnitTest --tests "*DistanceFormatTest"`
+- [ ] **Step 3: implement**
+```kotlin
+package com.hereliesaz.graffitixr.feature.ar.eval
+object DistanceFormat {
+    private const val FEET_PER_METER = 3.28084f
+    fun format(meters: Float, imperial: Boolean): String {
+        if (meters <= 0f) return "—"
+        return if (imperial) "%.1f ft".format(meters * FEET_PER_METER) else "%.1f m".format(meters)
+    }
+}
+```
+- [ ] **Step 4: run → PASS** ; **Step 5: commit** `feat(ar-tap): distance formatter with tests`
+
+---
+
+## Task 2: DepthLookup (pure, TDD)
+
+**Files:** Create `feature/ar/.../eval/DepthLookup.kt`; Test `.../eval/DepthLookupTest.kt`.
+
+- [ ] **Step 1: failing test** — synthetic 2x2 16-bit depth buffer, stride = width*2.
+```kotlin
+package com.hereliesaz.graffitixr.feature.ar.eval
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+class DepthLookupTest {
+    private fun buf(vararg mm: Short): ByteBuffer {
+        val b = ByteBuffer.allocateDirect(mm.size * 2).order(ByteOrder.nativeOrder())
+        mm.forEach { b.putShort(it) }; b.position(0); return b
+    }
+    @Test fun `reads mm to meters at a pixel`() {
+        // 2x2, stride=4 bytes/row. pixels: (0,0)=1000mm (1,0)=2000 (0,1)=3000 (1,1)=4000
+        val b = buf(1000, 2000, 3000, 4000)
+        assertEquals(1.0f, DepthLookup.depthMetersAt(b, stride = 4, depthW = 2, depthH = 2, u = 0.0f, v = 0.0f), 1e-3f)
+        assertEquals(4.0f, DepthLookup.depthMetersAt(b, 4, 2, 2, u = 0.99f, v = 0.99f), 1e-3f)
+    }
+    @Test fun `out of range yields -1`() {
+        val b = buf(0, 8000, 0, 0) // 0 invalid, 8000 > 7900 invalid
+        assertEquals(-1f, DepthLookup.depthMetersAt(b, 4, 2, 2, 0f, 0f), 1e-3f)
+        assertEquals(-1f, DepthLookup.depthMetersAt(b, 4, 2, 2, 0.99f, 0f), 1e-3f)
+    }
+}
+```
+- [ ] **Step 2: run → FAIL**
+- [ ] **Step 3: implement**
+```kotlin
+package com.hereliesaz.graffitixr.feature.ar.eval
+import java.nio.ByteBuffer
+object DepthLookup {
+    /** @param u,v image-normalized [0,1]. Returns meters, or -1f if invalid/out-of-range. */
+    fun depthMetersAt(buffer: ByteBuffer, stride: Int, depthW: Int, depthH: Int, u: Float, v: Float): Float {
+        if (depthW <= 0 || depthH <= 0) return -1f
+        val x = (u.coerceIn(0f, 1f) * depthW).toInt().coerceIn(0, depthW - 1)
+        val y = (v.coerceIn(0f, 1f) * depthH).toInt().coerceIn(0, depthH - 1)
+        val off = y * stride + x * 2
+        if (off < 0 || off + 2 > buffer.limit()) return -1f
+        val raw = buffer.getShort(off).toInt() and 0xFFFF
+        val mm = raw and 0x1FFF
+        return if (mm in 1..7899) mm / 1000f else -1f
+    }
+}
+```
+- [ ] **Step 4: run → PASS** ; **Step 5: commit** `feat(ar-tap): tapped-pixel depth lookup with tests`
+
+---
+
+## Task 3: TapMark in state
+
+**Files:** `core/common/.../model/UiState.kt`.
+
+- [ ] Add `data class TapMark(val nx: Float, val ny: Float, val distanceMeters: Float)`. Replace
+  `tapHighlightKeypoints: List<Pair<Float, Float>>` with `tapMarks: List<TapMark> = emptyList()`.
+- [ ] Build `:core:common:assembleDebug`. (Compile will flag the 3 `ArViewModel` references — fixed in Task 4.)
+- [ ] Commit `feat(ar-tap): TapMark state model`.
+
+## Task 4: Renderer + ViewModel wiring
+
+**Files:** `ArRenderer.kt`, `ArViewModel.kt`.
+
+- [ ] Renderer: in the capture path where `onTargetCaptured` is invoked (GL thread, live `frame`),
+  before invoking the callback, if a pending tap exists, compute
+  `val out = FloatArray(2); frame.transformCoordinates2d(Coordinates2d.VIEW_NORMALIZED, floatArrayOf(nx, ny), Coordinates2d.IMAGE_NORMALIZED, out)`
+  then `val dist = DepthLookup.depthMetersAt(depthBuffer, depthStride, depthW, depthH, out[0], out[1])`.
+  Add `tapDistanceMeters: Float` to the `onTargetCaptured` callback signature and pass `dist`.
+- [ ] Renderer: add `fun addTapSupportAnchor(nx: Float, ny: Float)` — on the GL thread, hit-test the tap
+  (reuse the existing `latestFrame`/hit-test used by `arCoreHitTestToWorld`) and
+  `anchorOrchestrator.addSupportAnchor(session, hitPose)` when a hit exists and an anchor is established.
+- [ ] ViewModel: in `onTargetCaptured`, replace the `tapHighlightKeypoints + tapPos` add with
+  `tapMarks + TapMark(tapPos.first, tapPos.second, tapDistanceMeters)`; update `clearTapHighlights` to
+  clear `tapMarks`. After storing, if `tapDistanceMeters > 0`, call `renderer?.addTapSupportAnchor(nx, ny)`.
+- [ ] Build `:feature:ar:assembleDebug`. Commit `feat(ar-tap): depth-at-tap + support-anchor wiring`.
+
+## Task 5: Overlay reticle + chips
+
+**Files:** `app/.../MainActivity.kt`.
+
+- [ ] Reticle: where AR overlays render (gated `editorMode == EditorMode.AR && !showLibrary && !showSettings && arUiState.isDepthApiSupported`), draw a centered `Text(DistanceFormat.format(arUiState.currentCenterDepth, arUiState.isImperialUnits))`.
+- [ ] Chips: `arUiState.tapMarks.forEach { m -> }` place a small `Text(DistanceFormat.format(m.distanceMeters, arUiState.isImperialUnits))` offset to `(m.nx*width, m.ny*height)` (use the same `fullSize`/Box used by `OffscreenIndicators`).
+- [ ] Build `:app:assembleDebug`. Commit `feat(ar-tap): reticle + per-tap distance chips`.
+
+## Final verification
+- [ ] `sh gradlew --offline :feature:ar:testDebugUnitTest --tests "*DistanceFormatTest" --tests "*DepthLookupTest"` → PASS.
+- [ ] `:core:common`, `:feature:ar`, `:app` assemble; full `:feature:ar` test suite shows only the 3 known pre-existing failures.
+- [ ] On-device (deferred): tap a tape-measured wall; verify reticle + chip; confirm taps add support anchors.
+
+## Notes
+- Reuses Sub-project A's `eval` package for the pure utilities. Depends on B's `addSupportAnchor` (merged).
+- If `transformCoordinates2d` enum names differ in the pinned ARCore version, match `BackgroundRenderer.kt:91`'s usage.

--- a/docs/superpowers/specs/2026-06-01-ar-tap-distance-design.md
+++ b/docs/superpowers/specs/2026-06-01-ar-tap-distance-design.md
@@ -1,0 +1,92 @@
+# AR Tap-to-Distance (Sub-project C)
+
+*Design spec — 2026-06-01*
+
+## Context
+
+Artists tap the wall marks they paint as anchors. This adds the camera→wall **distance** at those taps:
+a live center-reticle readout plus a pinned distance label at each tapped mark, and — because a tapped
+mark with a known range is a high-confidence metric point — each tap is also fed into the Sub-project B
+pose fusion as a **support anchor**, tightening the consensus.
+
+Reality (verified earlier this session):
+- ARCore's Depth API yields a **full per-pixel depth map** (mono ML-derived; dual-lens hardware-stereo).
+  `ArRenderer` already samples the **center** pixel into `ArUiState.currentCenterDepth` every frame
+  (`ArRenderer.kt:~410`); the live reticle just needs to display it.
+- On tap, the renderer already captures the whole depth buffer + intrinsics + view matrix into
+  `ArUiState` (`targetDepthBuffer`, `targetDepthBufferWidth/Height`, `targetDepthStride`,
+  `targetIntrinsics`, `targetCaptureViewMatrix`) — but nothing reads depth **at the tapped pixel**.
+- `tapHighlightKeypoints: List<Pair<Float,Float>>` (normalized) is currently **stored but never
+  rendered** — our chips give it a purpose.
+- Robust screen→image-pixel mapping is `frame.transformCoordinates2d` (already used in
+  `BackgroundRenderer.kt:91`), handling display rotation + crop. The current camera `frame` is only
+  available on the GL thread.
+- `isImperialUnits` already exists in `ArUiState` (m vs ft). `AnchorOrchestrator.addSupportAnchor(session,
+  worldPose)` and `ArViewModel.arCoreHitTestToWorld(screenPoint)` already exist.
+
+## Goals
+
+- **Live reticle**: a small center readout of `currentCenterDepth`, unit-formatted, in `EditorMode.AR`.
+- **Pinned per-tap distance**: on each tap, camera→point range at the tapped pixel, shown as a chip at
+  that screen position; persists until cleared.
+- **Units**: reuse `isImperialUnits` (m / ft).
+- **Fusion constraint**: each confident tap also becomes a `addSupportAnchor` in B's fusion.
+- Pure depth-lookup + formatting are **unit-tested**.
+
+## Non-goals
+
+- No new depth source; `OVERLAY` (CameraX) and 2D modes are out of scope (no depth).
+- No change to the tap→capture target-creation flow beyond reading depth at the tap and pinning a label.
+
+## Components
+
+### Pure, unit-tested (`:feature:ar`)
+1. `DistanceFormat.format(meters, imperial)` → `"2.3 m"` / `"7.5 ft"`; invalid (≤0) → `"—"`.
+2. `DepthLookup.depthMetersAt(buffer, stride, depthW, depthH, u, v)` — `u,v` are image-normalized
+   `[0,1]`; clamps to bounds, reads the 16-bit sample (`raw and 0x1FFF` mm → m), returns `-1f` for
+   invalid/out-of-range (matching the existing `0 < mm < 7900` filter).
+
+### State (`:core:common`)
+3. `data class TapMark(val nx: Float, val ny: Float, val distanceMeters: Float)`. Migrate
+   `ArUiState.tapHighlightKeypoints: List<Pair<Float,Float>>` → `tapMarks: List<TapMark>` (3 references:
+   the decl, the add in `onTargetCaptured`, the clear in `clearTapHighlights`).
+
+### Renderer (`:feature:ar`)
+4. On the capture tick (GL thread, live `frame`), map the pending tap (`nx,ny` view-normalized) →
+   image-normalized via `frame.transformCoordinates2d(VIEW_NORMALIZED → IMAGE_NORMALIZED)`, then
+   `DepthLookup.depthMetersAt(...)`. Return the distance via the `onTargetCaptured` callback (new
+   `tapDistanceMeters` param).
+
+### ViewModel (`:feature:ar`)
+5. Store the distance into the new `TapMark` alongside the existing keypoint add. Expose the reticle value
+   (already in `currentCenterDepth`).
+6. **Fusion constraint**: when a tap yields a valid distance and an anchor exists, call
+   `arCoreHitTestToWorld(tapPixel)` and, if non-null, `anchorOrchestrator.addSupportAnchor(session,
+   Pose(worldPoint))`. (The renderer owns `anchorOrchestrator`; expose a small
+   `renderer.addTapSupportAnchor(nx, ny)` that does the hit-test + add on the GL thread, called from the
+   capture path.)
+
+### UI (`:app`)
+7. Reticle: a centered label showing `format(currentCenterDepth, isImperialUnits)` when in
+   `EditorMode.AR`, depth supported, not guest, not in a modal. Reuse the existing distance HUD style.
+8. Chips: for each `TapMark`, a small label at `(nx*width, ny*height)` showing its formatted distance.
+
+## Error / edge cases
+
+- Invalid/out-of-range tapped depth → chip shows `"—"` (still pins the point); no support anchor added.
+- Depth API unsupported (`isDepthApiSupported == false`) → no reticle; taps still work for capture.
+- `transformCoordinates2d` / hit-test failure → null distance / no constraint; never crash the frame.
+- Guest / modal open → reticle hidden (matches existing overlay gating).
+
+## Testing
+
+- **Unit**: `DistanceFormat` (m, ft, invalid); `DepthLookup.depthMetersAt` over a synthetic buffer
+  (known stride/values; center vs corner; out-of-range → -1).
+- **Build**: `:core:common`, `:feature:ar`, `:app` assemble.
+- **On-device (deferred)**: tap a wall at a tape-measured distance; compare reticle + chip; confirm taps
+  add support anchors (B fusion stability improves). Mono + dual-lens.
+
+## Sequencing
+
+This is **C** of A→B→C — the final slice. It depends on B's `AnchorOrchestrator` support-anchor path
+(merged) and reuses the Sub-project A depth/units groundwork.

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/DepthLookup.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/DepthLookup.kt
@@ -1,0 +1,21 @@
+package com.hereliesaz.graffitixr.feature.ar.eval
+
+import java.nio.ByteBuffer
+
+/** Reads a metric range from an ARCore 16-bit depth buffer at a normalized image coordinate. */
+object DepthLookup {
+    /**
+     * @param u,v image-normalized [0,1] (e.g. from frame.transformCoordinates2d → IMAGE_NORMALIZED).
+     * @return distance in meters, or -1f when the sample is missing/out of the valid 0..7900mm range.
+     */
+    fun depthMetersAt(buffer: ByteBuffer, stride: Int, depthW: Int, depthH: Int, u: Float, v: Float): Float {
+        if (depthW <= 0 || depthH <= 0) return -1f
+        val x = (u.coerceIn(0f, 1f) * depthW).toInt().coerceIn(0, depthW - 1)
+        val y = (v.coerceIn(0f, 1f) * depthH).toInt().coerceIn(0, depthH - 1)
+        val off = y * stride + x * 2
+        if (off < 0 || off + 2 > buffer.limit()) return -1f
+        val raw = buffer.getShort(off).toInt() and 0xFFFF
+        val mm = raw and 0x1FFF
+        return if (mm in 1..7899) mm / 1000f else -1f
+    }
+}

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/DistanceFormat.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/DistanceFormat.kt
@@ -1,0 +1,12 @@
+package com.hereliesaz.graffitixr.feature.ar.eval
+
+/** Formats a camera→point distance for the AR HUD, honoring the imperial/metric preference. */
+object DistanceFormat {
+    private const val FEET_PER_METER = 3.28084f
+
+    /** @return e.g. "2.3 m" / "7.5 ft"; "—" for invalid (<= 0) distances. */
+    fun format(meters: Float, imperial: Boolean): String {
+        if (meters <= 0f) return "—"
+        return if (imperial) "%.1f ft".format(meters * FEET_PER_METER) else "%.1f m".format(meters)
+    }
+}

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/eval/DepthLookupTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/eval/DepthLookupTest.kt
@@ -1,0 +1,26 @@
+package com.hereliesaz.graffitixr.feature.ar.eval
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+class DepthLookupTest {
+    private fun buf(vararg mm: Short): ByteBuffer {
+        val b = ByteBuffer.allocateDirect(mm.size * 2).order(ByteOrder.nativeOrder())
+        mm.forEach { b.putShort(it) }; b.position(0); return b
+    }
+
+    @Test fun `reads mm to meters at a pixel`() {
+        // 2x2, stride = 4 bytes/row. (0,0)=1000mm (1,0)=2000 (0,1)=3000 (1,1)=4000
+        val b = buf(1000, 2000, 3000, 4000)
+        assertEquals(1.0f, DepthLookup.depthMetersAt(b, stride = 4, depthW = 2, depthH = 2, u = 0.0f, v = 0.0f), 1e-3f)
+        assertEquals(4.0f, DepthLookup.depthMetersAt(b, 4, 2, 2, u = 0.99f, v = 0.99f), 1e-3f)
+    }
+
+    @Test fun `out of range yields -1`() {
+        val b = buf(0, 8000, 0, 0) // 0 invalid; 8000 > 7900 invalid
+        assertEquals(-1f, DepthLookup.depthMetersAt(b, 4, 2, 2, 0f, 0f), 1e-3f)
+        assertEquals(-1f, DepthLookup.depthMetersAt(b, 4, 2, 2, 0.99f, 0f), 1e-3f)
+    }
+}

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/eval/DistanceFormatTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/eval/DistanceFormatTest.kt
@@ -1,0 +1,20 @@
+package com.hereliesaz.graffitixr.feature.ar.eval
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DistanceFormatTest {
+    @Test fun `metric`() {
+        assertEquals("2.3 m", DistanceFormat.format(2.34f, imperial = false))
+    }
+
+    @Test fun `imperial converts meters to feet`() {
+        // 2.286 m = 7.50 ft
+        assertEquals("7.5 ft", DistanceFormat.format(2.286f, imperial = true))
+    }
+
+    @Test fun `invalid is dash`() {
+        assertEquals("—", DistanceFormat.format(0f, false))
+        assertEquals("—", DistanceFormat.format(-1f, true))
+    }
+}


### PR DESCRIPTION
Final slice of the AR-method merge (A→B→C). This lands the **design + the unit-tested pure core**; the renderer/state/UI wiring (plan Tasks 3–5) is fully specified for a follow-up.

## In this PR
- **Spec + plan**: `docs/superpowers/specs/2026-06-01-ar-tap-distance-design.md`, `docs/superpowers/plans/2026-06-01-ar-tap-distance.md`.
- **`DistanceFormat`** (tested): meters/feet formatting honoring `isImperialUnits`; "—" for invalid.
- **`DepthLookup.depthMetersAt`** (tested): reads a metric range from an ARCore 16-bit depth buffer at an image-normalized coordinate; bounds-clamped; valid `0<mm<7900` → meters, else -1.

5 unit tests pass; `:feature:ar` builds.

## Remaining wiring (plan Tasks 3–5, well-specified)
- **TapMark state**: migrate `tapHighlightKeypoints` → `tapMarks: List<TapMark(nx,ny,distanceMeters)>` (3 sites).
- **Renderer/VM**: on capture (GL thread, live frame) map the tap via `frame.transformCoordinates2d(VIEW_NORMALIZED→IMAGE_NORMALIZED)` → `DepthLookup`, return the range through `onTargetCaptured`; feed each confident tap into B's fusion via `AnchorOrchestrator.addSupportAnchor` (a new `renderer.addTapSupportAnchor`).
- **Overlay**: live center reticle (`currentCenterDepth`) + a distance chip at each `TapMark`.

These are mechanical, single-session changes; split out only to keep every merge clean under a session-limit constraint.

## Deferred (needs a device)
- On-device: tap a tape-measured wall, verify reticle + chip; confirm taps strengthen B's consensus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add core distance-formatting and depth-lookup utilities for AR tap-to-distance and document the design and implementation plan for wiring them through renderer, state, and UI.

New Features:
- Introduce a DistanceFormat utility to format camera-to-point distances in metric or imperial units with a fallback for invalid values.
- Introduce a DepthLookup utility to read metric distances from ARCore 16-bit depth buffers at image-normalized coordinates.

Enhancements:
- Document the AR tap-to-distance feature with a detailed design spec and step-by-step implementation plan, including renderer, state, and UI integration.

Documentation:
- Add a design spec describing the AR tap-to-distance feature, its goals, constraints, and integration points.
- Add an implementation plan outlining tasks and sequencing for wiring tap-to-distance through AR renderer, view model, and UI.

Tests:
- Add unit tests for DistanceFormat covering metric, imperial, and invalid distance formatting.
- Add unit tests for DepthLookup covering valid depth reads and out-of-range handling from a synthetic depth buffer.