### PR TITLE
AR tap-to-distance wiring (sub-project C): depth-at-tap, support anchors, overlay

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -831,6 +831,29 @@ class MainActivity : ComponentActivity() {
                                 screenSize = fullSize
                             )
 
+                            // Tap-to-distance (Sub-project C): live center reticle + a distance chip
+                            // pinned at each tapped wall mark. Only when depth is available in AR mode.
+                            if (editorUiState.editorMode == EditorMode.AR && !showLibrary && !showSettings && arUiState.isDepthApiSupported) {
+                                androidx.compose.material3.Text(
+                                    text = com.hereliesaz.graffitixr.feature.ar.eval.DistanceFormat.format(
+                                        arUiState.currentCenterDepth, arUiState.isImperialUnits
+                                    ),
+                                    color = androidx.compose.ui.graphics.Color.Cyan,
+                                    modifier = Modifier.align(Alignment.Center)
+                                )
+                                arUiState.tapMarks.forEach { mark ->
+                                    androidx.compose.material3.Text(
+                                        text = com.hereliesaz.graffitixr.feature.ar.eval.DistanceFormat.format(
+                                            mark.distanceMeters, arUiState.isImperialUnits
+                                        ),
+                                        color = androidx.compose.ui.graphics.Color.Yellow,
+                                        modifier = Modifier.align(
+                                            androidx.compose.ui.BiasAlignment(mark.nx * 2f - 1f, mark.ny * 2f - 1f)
+                                        )
+                                    )
+                                }
+                            }
+
                             // Auto-fired by AR state, so it must yield to any user-driven modal
                             // rather than stack on top of it. Stays true in state and re-renders
                             // once the higher-priority modal dismisses.

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
@@ -171,12 +171,12 @@ fun MainScreen(
                             val renderer = ArRenderer(
                                 context = ctx,
                                 slamManager = slamManager,
-                                onTargetCaptured = { bmp, cw, ch, depth, dw, dh, stride, intr, viewMat, rot ->
+                                onTargetCaptured = { bmp, cw, ch, depth, dw, dh, stride, intr, viewMat, rot, tapDist ->
                                     arViewModel.onTargetCaptured(
                                         bmp, depth,
                                         cw, ch,
                                         dw, dh, stride,
-                                        intr, viewMat, rot
+                                        intr, viewMat, rot, tapDist
                                     )
                                 },
                                 onTrackingUpdated = { isTracking, splatCount, immutableSplatCount, isDepthSupported, yaw, distanceMeters, relDir, isDualLens, isHardwareStereo, centerDepth, visConf, globConf ->

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/UiState.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/UiState.kt
@@ -18,6 +18,10 @@ data class EvalLiveMetrics(
     val batteryMa: Float = 0f,
 )
 
+/** A tapped wall mark: normalized screen coords (0..1) plus the camera→point range in meters
+ *  (-1 when depth was unavailable/out of range at that pixel). */
+data class TapMark(val nx: Float, val ny: Float, val distanceMeters: Float)
+
 data class ArUiState(
     val isScanning: Boolean = false,
     val splatCount: Int = 0,
@@ -88,9 +92,9 @@ data class ArUiState(
     // Phase 3 — True once the renderer has confirmed ARCore Depth API is available on this device.
     val isDepthApiSupported: Boolean = false,
 
-    // Phase 4 — Tap-to-target: list of normalized screen coords (0..1) where the user has tapped
-    // their painted reference marks. Displayed as cyan circles on the live camera view.
-    val tapHighlightKeypoints: List<Pair<Float, Float>> = emptyList(),
+    // Phase 4 — Tap-to-target: marks the user tapped on their painted reference, each with the
+    // camera→point distance measured at that pixel. Rendered as a chip on the live camera view.
+    val tapMarks: List<TapMark> = emptyList(),
 
     // Phase 5 — When true, OverlayRenderer draws an orange line-loop around the anchor quad boundary.
     val showAnchorBoundary: Boolean = false,

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -896,7 +896,8 @@ class ArViewModel @Inject constructor(
         depthBufStride: Int,
         intrinsics: FloatArray?,
         viewMatrix: FloatArray,
-        displayRotation: Int
+        displayRotation: Int,
+        tapDistanceMeters: Float
     ) {
         val tapPos = pendingTapPosition
         val extent = computePhysicalExtent(depthBuffer, depthBufW, depthBufH, colorW, colorH, intrinsics, depthBufStride)
@@ -920,7 +921,7 @@ class ArViewModel @Inject constructor(
 
             _uiState.update {
                 it.copy(
-                    tapHighlightKeypoints = it.tapHighlightKeypoints + tapPos,
+                    tapMarks = it.tapMarks + com.hereliesaz.graffitixr.common.model.TapMark(tapPos.first, tapPos.second, tapDistanceMeters),
                     targetRawBitmap = bitmap,
                     targetDisplayRotation = displayRotation,
                     targetDepthBuffer = depthBuffer,
@@ -982,11 +983,14 @@ class ArViewModel @Inject constructor(
 
     fun onScreenTap(nx: Float, ny: Float) {
         pendingTapPosition = nx to ny
+        // Hand the tap to the renderer so it can measure the camera→point distance at that pixel
+        // (and add a fusion support anchor) on the GL thread during capture.
+        renderer?.pendingCaptureTap = floatArrayOf(nx, ny)
         requestCapture()
     }
 
     fun clearTapHighlights() {
-        _uiState.update { it.copy(tapHighlightKeypoints = emptyList()) }
+        _uiState.update { it.copy(tapMarks = emptyList()) }
         pendingTapPosition = null
     }
 

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -34,7 +34,8 @@ import kotlin.concurrent.withLock
 class ArRenderer(
     private val context: Context,
     private val slamManager: SlamManager,
-    private val onTargetCaptured: (Bitmap, Int, Int, ByteBuffer?, Int, Int, Int, FloatArray?, FloatArray, Int) -> Unit,
+    // Last arg is the camera→point distance (meters) at the tapped pixel, or -1f when unavailable.
+    private val onTargetCaptured: (Bitmap, Int, Int, ByteBuffer?, Int, Int, Int, FloatArray?, FloatArray, Int, Float) -> Unit,
     private val onTrackingUpdated: (Boolean, Int, Int, Boolean, Float, Float, Triple<Float, Float, Float>?, Boolean, Boolean, Float, Float, Float) -> Unit,
     private val onLightUpdated: (Float) -> Unit,
     private val onDiag: (String) -> Unit = {},
@@ -145,6 +146,10 @@ class ArRenderer(
     private var lastPoseZ = 0f
 
     @Volatile var captureRequested: Boolean = false
+    // Normalized (0..1) screen tap to measure distance for on the next capture; consumed on the GL thread.
+    @Volatile var pendingCaptureTap: FloatArray? = null
+    @Volatile private var surfaceWidth: Int = 0
+    @Volatile private var surfaceHeight: Int = 0
     @Volatile var isCapturingTarget: Boolean = false
     @Volatile var isInPlaneRealignment: Boolean = false
     @Volatile var pendingAnchorEstablishment: Boolean = false
@@ -240,6 +245,8 @@ class ArRenderer(
 
     override fun onSurfaceChanged(gl: GL10?, width: Int, height: Int) {
         GLES30.glViewport(0, 0, width, height)
+        surfaceWidth = width
+        surfaceHeight = height
         displayRotationHelper.onSurfaceChanged(width, height)
         slamManager.setViewportSize(width, height)
     }
@@ -529,12 +536,40 @@ class ArRenderer(
                             intrinsics.principalPoint[0], intrinsics.principalPoint[1]
                         )
 
+                        // Camera→point distance at the tapped pixel (Sub-project C). Map the tap from
+                        // view pixels to the depth image via ARCore's rotation/crop-aware transform,
+                        // then read the depth buffer. A confident tap also becomes a fusion support
+                        // anchor (done here on the GL thread, where frame + activeSession are valid).
+                        var tapDistanceMeters = -1f
+                        val tap = pendingCaptureTap
+                        pendingCaptureTap = null
+                        val capturedDepth = depthBuffer
+                        if (tap != null && capturedDepth != null && depthWidth > 0 && surfaceWidth > 0) {
+                            try {
+                                val viewPx = floatArrayOf(tap[0] * surfaceWidth, tap[1] * surfaceHeight)
+                                val imgNorm = FloatArray(2)
+                                frame.transformCoordinates2d(
+                                    com.google.ar.core.Coordinates2d.VIEW, viewPx,
+                                    com.google.ar.core.Coordinates2d.IMAGE_NORMALIZED, imgNorm
+                                )
+                                tapDistanceMeters = com.hereliesaz.graffitixr.feature.ar.eval.DepthLookup
+                                    .depthMetersAt(capturedDepth, depthStride, depthWidth, depthHeight, imgNorm[0], imgNorm[1])
+                                if (tapDistanceMeters > 0f && anchorEstablished) {
+                                    frame.hitTest(viewPx[0], viewPx[1]).firstOrNull()?.let {
+                                        anchorOrchestrator.addSupportAnchor(activeSession, it.hitPose)
+                                    }
+                                }
+                            } catch (e: Exception) {
+                                Timber.w(e, "Tap depth/support-anchor lookup failed")
+                            }
+                        }
+
                         onTargetCaptured(
                             bitmap, image.width, image.height,
                             depthBuffer,
                             depthWidth, depthHeight, depthStride,
                             intrArr, mappingViewMatrix.copyOf(),
-                            rotationNeeded
+                            rotationNeeded, tapDistanceMeters
                         )
                     }
                 } catch (e: Exception) {

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/ArViewModelTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/ArViewModelTest.kt
@@ -252,18 +252,19 @@ class ArViewModelTest {
             depthBufW = 100, depthBufH = 100, depthBufStride = 200,
             intrinsics = null,
             viewMatrix = FloatArray(16),
-            displayRotation = 0
+            displayRotation = 0,
+            tapDistanceMeters = -1f
         )
 
         assertFalse(viewModel.uiState.value.isCaptureRequested)
-        assertEquals(1, viewModel.uiState.value.tapHighlightKeypoints.size)
+        assertEquals(1, viewModel.uiState.value.tapMarks.size)
     }
 
     @Test
     fun `clearTapHighlights clears keypoints and bitmaps`() = runTest {
         viewModel.clearTapHighlights()
         val state = viewModel.uiState.value
-        assertTrue(state.tapHighlightKeypoints.isEmpty())
+        assertTrue(state.tapMarks.isEmpty())
         assertNull(state.annotatedCaptureBitmap)
         assertNull(state.tempCaptureBitmap)
     }
@@ -323,7 +324,7 @@ class ArViewModelTest {
             bitmap = rawBmp, depthBuffer = null,
             colorW = 100, colorH = 100,
             depthBufW = 0, depthBufH = 0, depthBufStride = 0,
-            intrinsics = null, viewMatrix = FloatArray(16), displayRotation = 0
+            intrinsics = null, viewMatrix = FloatArray(16), displayRotation = 0, tapDistanceMeters = -1f
         )
         // withContext(Dispatchers.Default) runs on a real thread pool; give it time to finish,
         // then advance testDispatcher to process the resulting state-update continuation.
@@ -407,7 +408,7 @@ class ArViewModelTest {
             bitmap = rawBmp, depthBuffer = null,
             colorW = 100, colorH = 100,
             depthBufW = 0, depthBufH = 0, depthBufStride = 0,
-            intrinsics = null, viewMatrix = FloatArray(16), displayRotation = 0
+            intrinsics = null, viewMatrix = FloatArray(16), displayRotation = 0, tapDistanceMeters = -1f
         )
 
         val state = viewModel.uiState.value


### PR DESCRIPTION
Completes Sub-project C (the foundation merged in #1516): the renderer/state/UI wiring that turns a tap into a measured camera→wall distance, shows it, and feeds it into the pose fusion.

## What this adds (plan Tasks 3–5)
- **`TapMark` state**: migrated `tapHighlightKeypoints` → `tapMarks: List<TapMark(nx, ny, distanceMeters)>`.
- **Depth-at-tap (GL thread)**: on capture, the renderer maps the tapped pixel via ARCore `frame.transformCoordinates2d(VIEW → IMAGE_NORMALIZED)` (rotation/crop-aware) then reads it with `DepthLookup.depthMetersAt`; the range is returned through `onTargetCaptured`.
- **Fusion constraint**: a confident tap also hit-tests on the GL thread and calls `AnchorOrchestrator.addSupportAnchor`, strengthening Sub-project B's consensus.
- **Overlay**: a live center **reticle** (`currentCenterDepth`) + a distance **chip** pinned at each tapped mark, unit-formatted via `isImperialUnits`, gated to AR mode with depth support.

## Verification
- All eval/fusion/tap unit tests pass (PoseMath, PoseFusion, DistanceFormat, DepthLookup, Eval*).
- `:core:common`, `:feature:ar`, `:app` all `assembleDebug` SUCCESSFUL.
- Full `:feature:ar` suite: 70 tests, only the 3 known pre-existing `ArViewModelTest` failures (no new regressions). Updated the test for the new `onTargetCaptured` arg + `tapMarks`.

## Ready for your device validation
- Tap a wall mark at a tape-measured distance → compare the chip + reticle (mono + dual-lens).
- Confirm taps add support anchors (with B's `fusionEnabled` on, overlay stability/lock should improve).

This closes out A→B→C. (`OVERLAY`/2D modes are out of scope — no depth source.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)