### PR TITLE
fix: two on-device AR crashes (recording ILLEGAL_STATE, composite OOM)

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
@@ -455,11 +455,21 @@ internal fun compositeLayersForAr(layers: List<Layer>): AndroidBitmap {
         if (bottom > maxY) maxY = bottom
     }
 
-    val width = (maxX - minX).coerceAtLeast(1f).toInt()
-    val height = (maxY - minY).coerceAtLeast(1f).toInt()
+    val rawWidth = (maxX - minX).coerceAtLeast(1f)
+    val rawHeight = (maxY - minY).coerceAtLeast(1f)
+
+    // Cap the composite size: a zoomed-in (large layer.scale) or far-panned layer can otherwise
+    // request a multi-hundred-MB ARGB_8888 bitmap and OOM. Downscale proportionally past the cap so
+    // the result still fits as an overlay texture; downscale == 1 leaves the common case untouched.
+    val maxDim = 4096f
+    val downscale = minOf(1f, maxDim / rawWidth, maxDim / rawHeight)
+    val width = (rawWidth * downscale).toInt().coerceAtLeast(1)
+    val height = (rawHeight * downscale).toInt().coerceAtLeast(1)
 
     val result = createBitmap(width, height, AndroidBitmap.Config.ARGB_8888)
     val canvas = Canvas(result)
+    // Layer matrices are built in raw composite coordinates; this maps them into the capped bitmap.
+    canvas.scale(downscale, downscale)
     val paint = Paint(Paint.ANTI_ALIAS_FLAG)
 
     for (layer in layers) {

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/ArRecordingController.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/ArRecordingController.kt
@@ -18,22 +18,45 @@ class ArRecordingController(private val context: Context) {
 
     fun recordingsDir(): File = File(context.filesDir, "eval/recordings").apply { mkdirs() }
 
-    /** Start recording the live session to an MP4 dataset. Returns the target file. */
-    fun startRecording(session: Session, name: String): File {
-        val file = File(recordingsDir(), "$name.mp4")
-        val config = RecordingConfig(session).setMp4DatasetUri(Uri.fromFile(file))
-        session.startRecording(config)
-        Timber.i("eval: recording -> ${file.absolutePath}")
-        return file
+    /**
+     * Start recording the live session to an MP4 dataset. Returns the target file, or null if
+     * recording could not be started. ARCore throws AR_ERROR_ILLEGAL_STATE if recording is started
+     * after the session has resumed (it must be configured at resume time) or if a recording is
+     * already active — this is a dev-only bench control, so a failure must never crash the app.
+     */
+    fun startRecording(session: Session, name: String): File? {
+        if (session.recordingStatus == RecordingStatus.OK) {
+            Timber.w("eval: recording already in progress; ignoring start")
+            return null
+        }
+        return try {
+            val file = File(recordingsDir(), "$name.mp4")
+            val config = RecordingConfig(session).setMp4DatasetUri(Uri.fromFile(file))
+            session.startRecording(config)
+            Timber.i("eval: recording -> ${file.absolutePath}")
+            file
+        } catch (e: Exception) {
+            // Most commonly AR_ERROR_ILLEGAL_STATE: recording must be configured before session.resume().
+            Timber.w(e, "eval: startRecording failed (recording must be set up at session resume)")
+            null
+        }
     }
 
     fun stopRecording(session: Session) {
-        if (session.recordingStatus == RecordingStatus.OK) session.stopRecording()
+        try {
+            if (session.recordingStatus == RecordingStatus.OK) session.stopRecording()
+        } catch (e: Exception) {
+            Timber.w(e, "eval: stopRecording failed")
+        }
     }
 
     /** Set a recorded dataset for playback. Session must be paused; caller resumes after. */
-    fun startPlayback(session: Session, file: File) {
+    fun startPlayback(session: Session, file: File): Boolean = try {
         session.setPlaybackDatasetUri(Uri.fromFile(file))
+        true
+    } catch (e: Exception) {
+        Timber.w(e, "eval: startPlayback failed (set the dataset while the session is paused)")
+        false
     }
 
     fun isPlaying(session: Session): Boolean = session.playbackStatus == PlaybackStatus.OK


### PR DESCRIPTION
Found via on-device validation logcat.

1. **Recording button crashed the app** — ARCore `Session.startRecording` returns `AR_ERROR_ILLEGAL_STATE` (recording must be configured before `session.resume()`; the eval-overlay "Rec▶" button starts it mid-session), and `ArRecordingController.startRecording` rethrew → FATAL. Now crash-safe: catch/log, return `null`, no-op if already recording; `stopRecording`/`startPlayback` guarded too. A dev-only bench control must never take down the app.
2. **OOM in `compositeLayersForAr`** — the composite bitmap was sized from unbounded layer bounds, so a zoomed-in/far-panned layer requested a multi-hundred-MB ARGB_8888 bitmap. Now capped at 4096px with proportional downscale (`downscale==1` leaves the common case untouched).

Builds: `:feature:ar`, `:app` SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Handle AR session recording/playback errors more defensively and cap AR composite bitmap size to prevent crashes and OOMs.

Bug Fixes:
- Prevent AR recording controls from crashing the app when recording is started or stopped in an invalid ARCore session state.
- Avoid out-of-memory errors during AR layer compositing by capping the composite bitmap dimensions and proportionally downscaling large overlays.