### PR TITLE
feat: dev-overlay Fusion ON/OFF A/B toggle (sub-project B Task 7)

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -813,6 +813,7 @@ class MainActivity : ComponentActivity() {
                                     onStartLog = { arViewModel.evalStartLog() },
                                     onStopLog = { arViewModel.evalStopLog() },
                                     onInduceLoss = { arViewModel.evalInduceLoss() },
+                                    onToggleFusion = { arViewModel.evalSetFusionEnabled(it) },
                                 )
                             }
 
@@ -2434,7 +2435,10 @@ private fun EvalOverlay(
     onStartLog: () -> Unit,
     onStopLog: () -> Unit,
     onInduceLoss: () -> Unit,
+    onToggleFusion: (Boolean) -> Unit,
 ) {
+    // Local UI state for the A/B switch; defaults to true to match ArRenderer.fusionEnabled.
+    val fusionOn = androidx.compose.runtime.remember { androidx.compose.runtime.mutableStateOf(true) }
     androidx.compose.foundation.layout.Column(
         androidx.compose.ui.Modifier
             .background(androidx.compose.ui.graphics.Color(0xAA000000))
@@ -2452,6 +2456,12 @@ private fun EvalOverlay(
             androidx.compose.material3.TextButton(onClick = onInduceLoss) { androidx.compose.material3.Text("Loss") }
             androidx.compose.material3.TextButton(onClick = onStartRecord) { androidx.compose.material3.Text("Rec▶") }
             androidx.compose.material3.TextButton(onClick = onStopRecord) { androidx.compose.material3.Text("Rec■") }
+            androidx.compose.material3.TextButton(onClick = {
+                fusionOn.value = !fusionOn.value
+                onToggleFusion(fusionOn.value)
+            }) {
+                androidx.compose.material3.Text(if (fusionOn.value) "Fusion ON" else "Fusion OFF")
+            }
         }
     }
 }

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -233,6 +233,9 @@ class ArViewModel @Inject constructor(
         session?.let { evalRecorder.stopRecording(it) }
     }
 
+    /** A/B switch for the pose fusion (Sub-project B): on = corrected snap-back fusion, off = old toggle. */
+    fun evalSetFusionEnabled(on: Boolean) { renderer?.fusionEnabled = on }
+
     // ── Glasses session lifecycle ─────────────────────────────────────────────
 
     fun startGlassesSession() {


### PR DESCRIPTION
Wires the one deferred piece of Sub-project B: a runtime A/B switch for the pose fusion, in the dev eval overlay.

- `ArViewModel.evalSetFusionEnabled(on)` → sets `ArRenderer.fusionEnabled`.
- `EvalOverlay` gains a **Fusion ON/OFF** button (defaults ON, matching the renderer).

Lets you flip the corrected snap-back fusion against the old pre/post-anchor toggle on-device while watching the drift/jitter readouts — the intended acceptance comparison.

Builds: `:feature:ar`, `:app` SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a runtime A/B toggle in the dev eval overlay to enable or disable AR pose fusion via the view model.

New Features:
- Introduce a Fusion ON/OFF control in the eval overlay to switch pose fusion at runtime.
- Expose an evalSetFusionEnabled hook on ArViewModel to control the renderer's fusionEnabled flag from the UI.