### PR TITLE
fix: stabilize jumpy tap-to-distance readout (patch median + EMA)

### DIFF
--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/DepthLookup.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/DepthLookup.kt
@@ -8,14 +8,36 @@ object DepthLookup {
      * @param u,v image-normalized [0,1] (e.g. from frame.transformCoordinates2d → IMAGE_NORMALIZED).
      * @return distance in meters, or -1f when the sample is missing/out of the valid 0..7900mm range.
      */
-    fun depthMetersAt(buffer: ByteBuffer, stride: Int, depthW: Int, depthH: Int, u: Float, v: Float): Float {
+    fun depthMetersAt(buffer: ByteBuffer, stride: Int, depthW: Int, depthH: Int, u: Float, v: Float): Float =
+        depthMetersAtPatch(buffer, stride, depthW, depthH, u, v, radius = 0)
+
+    /**
+     * Median of the valid depth samples in the (2*radius+1)² window centered on (u,v). ARCore depth
+     * is noisy and pocked with holes per pixel/frame, so a single sample flickers wildly; the median
+     * over a small patch is robust to outliers and dropouts. Returns meters, or -1f if no valid
+     * sample (0 < mm < 7900) is found in the window. radius = 0 reproduces a single-pixel read.
+     */
+    fun depthMetersAtPatch(
+        buffer: ByteBuffer, stride: Int, depthW: Int, depthH: Int, u: Float, v: Float, radius: Int
+    ): Float {
         if (depthW <= 0 || depthH <= 0) return -1f
-        val x = (u.coerceIn(0f, 1f) * depthW).toInt().coerceIn(0, depthW - 1)
-        val y = (v.coerceIn(0f, 1f) * depthH).toInt().coerceIn(0, depthH - 1)
-        val off = y * stride + x * 2
-        if (off < 0 || off + 2 > buffer.limit()) return -1f
-        val raw = buffer.getShort(off).toInt() and 0xFFFF
-        val mm = raw and 0x1FFF
-        return if (mm in 1..7899) mm / 1000f else -1f
+        val cx = (u.coerceIn(0f, 1f) * depthW).toInt().coerceIn(0, depthW - 1)
+        val cy = (v.coerceIn(0f, 1f) * depthH).toInt().coerceIn(0, depthH - 1)
+        val samples = ArrayList<Int>()
+        for (dy in -radius..radius) {
+            val y = cy + dy
+            if (y < 0 || y >= depthH) continue
+            for (dx in -radius..radius) {
+                val x = cx + dx
+                if (x < 0 || x >= depthW) continue
+                val off = y * stride + x * 2
+                if (off < 0 || off + 2 > buffer.limit()) continue
+                val mm = buffer.getShort(off).toInt() and 0x1FFF
+                if (mm in 1..7899) samples.add(mm)
+            }
+        }
+        if (samples.isEmpty()) return -1f
+        samples.sort()
+        return samples[samples.size / 2] / 1000f
     }
 }

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -150,6 +150,8 @@ class ArRenderer(
     @Volatile var pendingCaptureTap: FloatArray? = null
     @Volatile private var surfaceWidth: Int = 0
     @Volatile private var surfaceHeight: Int = 0
+    // EMA-smoothed center depth (meters) for the live reticle; raw per-pixel ARCore depth is too noisy.
+    @Volatile private var smoothedCenterDepth: Float = -1f
     @Volatile var isCapturingTarget: Boolean = false
     @Volatile var isInPlaneRealignment: Boolean = false
     @Volatile var pendingAnchorEstablishment: Boolean = false
@@ -454,21 +456,20 @@ class ArRenderer(
                     val visConf = slamManager.getVisibleConfidenceAvg()
                     val globConf = slamManager.getGlobalConfidenceAvg()
 
-                    var centerDepth = -1f
+                    // Keep last smoothed value across invalid/dropped frames so the readout is stable.
+                    var centerDepth = smoothedCenterDepth
                     try {
                         frame.acquireDepthImage16Bits().use { depthImage ->
                             val plane = depthImage.planes[0]
-                            val cx = depthImage.width / 2
-                            val cy = depthImage.height / 2
-                            val stride = plane.rowStride
-                            val offset = cy * stride + cx * 2
-                            if (offset + 2 <= plane.buffer.limit()) {
-                                val raw = plane.buffer.getShort(offset).toInt() and 0xFFFF
-                                val depthMm = raw and 0x1FFF
-                                // Filter out invalid range jumps (like the ghost 7.94m reading)
-                                if (depthMm > 0 && depthMm < 7900) {
-                                    centerDepth = depthMm / 1000f
-                                }
+                            // Median of a 7x7 patch (radius 3) rejects per-pixel noise/holes; the
+                            // single-pixel read made the live distance flicker wildly.
+                            val raw = com.hereliesaz.graffitixr.feature.ar.eval.DepthLookup.depthMetersAtPatch(
+                                plane.buffer, plane.rowStride, depthImage.width, depthImage.height, 0.5f, 0.5f, radius = 3
+                            )
+                            if (raw > 0f) {
+                                smoothedCenterDepth = if (smoothedCenterDepth <= 0f) raw
+                                    else 0.2f * raw + 0.8f * smoothedCenterDepth
+                                centerDepth = smoothedCenterDepth
                             }
                         }
                     } catch (e: Exception) { /* ignore */ }
@@ -553,7 +554,7 @@ class ArRenderer(
                                     com.google.ar.core.Coordinates2d.IMAGE_NORMALIZED, imgNorm
                                 )
                                 tapDistanceMeters = com.hereliesaz.graffitixr.feature.ar.eval.DepthLookup
-                                    .depthMetersAt(capturedDepth, depthStride, depthWidth, depthHeight, imgNorm[0], imgNorm[1])
+                                    .depthMetersAtPatch(capturedDepth, depthStride, depthWidth, depthHeight, imgNorm[0], imgNorm[1], radius = 3)
                                 if (tapDistanceMeters > 0f && anchorEstablished) {
                                     frame.hitTest(viewPx[0], viewPx[1]).firstOrNull()?.let {
                                         anchorOrchestrator.addSupportAnchor(activeSession, it.hitPose)

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/eval/DepthLookupTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/eval/DepthLookupTest.kt
@@ -23,4 +23,21 @@ class DepthLookupTest {
         assertEquals(-1f, DepthLookup.depthMetersAt(b, 4, 2, 2, 0f, 0f), 1e-3f)
         assertEquals(-1f, DepthLookup.depthMetersAt(b, 4, 2, 2, 0.99f, 0f), 1e-3f)
     }
+
+    @Test fun `patch median rejects an outlier center pixel`() {
+        // 3x3, stride = 6 bytes/row. Center (1,1) is a 7000mm spike; its 8 neighbors are all 1000mm.
+        // Single-pixel read at center returns 7.0; patch median (radius 1) returns 1.0.
+        val b = buf(
+            1000, 1000, 1000,
+            1000, 7000, 1000,
+            1000, 1000, 1000,
+        )
+        assertEquals(7.0f, DepthLookup.depthMetersAt(b, 6, 3, 3, 0.5f, 0.5f), 1e-3f)
+        assertEquals(1.0f, DepthLookup.depthMetersAtPatch(b, 6, 3, 3, 0.5f, 0.5f, radius = 1), 1e-3f)
+    }
+
+    @Test fun `patch ignores holes and returns -1 when all invalid`() {
+        val b = buf(0, 0, 0, 0) // all holes
+        assertEquals(-1f, DepthLookup.depthMetersAtPatch(b, 4, 2, 2, 0.5f, 0.5f, radius = 1), 1e-3f)
+    }
 }


### PR DESCRIPTION
Reported during validation: the distance readout "jumps around pretty wildly."

**Cause:** both the live reticle (`ArRenderer` center-depth) and the tapped chip sampled a *single* ARCore depth pixel. ARCore depth — especially mono — is noisy and hole-pocked per pixel/frame, so a single sample flickers.

**Fix:**
- `DepthLookup.depthMetersAtPatch` — median over a (2r+1)² window, rejecting outlier pixels and holes (returns -1 only if the whole patch is invalid). `depthMetersAt` now delegates with radius 0.
- Reticle + tap use radius 3 (7×7 patch).
- Reticle additionally EMA-smooths across frames and holds the last good value over invalid/dropped frames, so the number is stable instead of strobing.

Tests: new patch-median cases (outlier rejection, all-holes → -1) pass; `:feature:ar`/`:app` build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Stabilize AR depth-based distance readouts by aggregating and smoothing noisy ARCore depth samples.

Bug Fixes:
- Use a median depth value over a configurable pixel patch instead of a single-pixel sample to avoid flickering and outlier spikes in distance measurements.
- Apply EMA smoothing and frame-to-frame persistence to the reticle center depth so the on-screen readout remains stable even when individual depth frames are noisy or missing.

Enhancements:
- Expose a patch-based depth lookup helper that generalizes single-pixel depth queries to median-filtered windows.
- Add unit tests covering patch-median behavior, including outlier rejection and all-hole handling.