### PR TITLE
diag: probe ARCore hardware-stereo camera config availability

### DIFF
--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -585,6 +585,23 @@ class ArViewModel @Inject constructor(
             }
             _uiState.update { it.copy(isDualLensActive = false, isHardwareStereoActive = false) }
 
+            // Dual-lens mandate probe: ask ARCore whether this device exposes ANY hardware-stereo
+            // camera config. This is read-only (does NOT change the selected config) — it answers the
+            // "why only one lens?" question with device ground truth. If count > 0 we can enable
+            // stereo (via PREFER_AND_USE) on this device; if 0, ARCore cannot pair the lenses here and
+            // hardware stereo is impossible without abandoning ARCore tracking. Grep logcat for "dual-lens probe".
+            try {
+                val stereoFilter = CameraConfigFilter(s).apply {
+                    facingDirection = CameraConfig.FacingDirection.BACK
+                    stereoCameraUsage = java.util.EnumSet.of(CameraConfig.StereoCameraUsage.REQUIRE_AND_USE)
+                }
+                val stereoConfigs = s.getSupportedCameraConfigs(stereoFilter)
+                Timber.i("dual-lens probe: ${stereoConfigs.size} hardware-stereo camera config(s) on this device")
+                stereoConfigs.forEach { Timber.i("dual-lens probe: stereo cameraId=${it.cameraId} imageSize=${it.imageSize}") }
+            } catch (e: Exception) {
+                Timber.w(e, "dual-lens probe failed")
+            }
+
             session = s
             _isCameraInUseByAr.value = true
             


### PR DESCRIPTION
Read-only diagnostic to answer 'why only one lens?'. Logs how many ARCore hardware-stereo (REQUIRE_AND_USE) camera configs the device exposes. Does not change the selected (mono) config. Grep logcat for `dual-lens probe`. Drives the decision: enable stereo via PREFER_AND_USE if count>0, otherwise hardware stereo is impossible on this device without abandoning ARCore tracking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Log the number and details of ARCore hardware-stereo camera configs to help determine whether dual-lens stereo is supported on a device.