### PR TITLE
diag: disable ARCore Depth API to isolate VIO kNotTracking

### DIFF
--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -560,9 +560,20 @@ class ArViewModel @Inject constructor(
             config.focusMode = Config.FocusMode.AUTO
             config.updateMode = Config.UpdateMode.LATEST_CAMERA_IMAGE
             
-            if (s.isDepthModeSupported(Config.DepthMode.AUTOMATIC)) {
+            // ROOT-CAUSE TEST (VIO never tracked): ARCore's Depth API (DepthMode.AUTOMATIC) runs an ML
+            // depth/perception graph that was erroring continuously on this device
+            // (feature_track_ml_depth_provider, mediapipe normal_detector RET_CHECK) while VIO sat in
+            // kNotTracking for the ENTIRE session. Disable the Depth API to isolate whether that
+            // pipeline is starving/wedging tracking. While disabled, depth-only features (surface mesh,
+            // tap distance) go dark — that's the trade for the test. Flip back to re-enable.
+            val disableDepthForVioTest = true
+            if (!disableDepthForVioTest && s.isDepthModeSupported(Config.DepthMode.AUTOMATIC)) {
                 config.depthMode = Config.DepthMode.AUTOMATIC
                 _uiState.update { it.copy(isDepthApiSupported = true) }
+            } else {
+                config.depthMode = Config.DepthMode.DISABLED
+                _uiState.update { it.copy(isDepthApiSupported = false) }
+                Timber.i("VIO test: ARCore Depth API DISABLED to isolate the kNotTracking failure")
             }
 
             s.configure(config)


### PR DESCRIPTION
Diagnostic: VIO never tracked an entire session (625x kNotTracking, 0 successful) while ARCore's ML depth/perception graph errored continuously. This disables DepthMode.AUTOMATIC to test whether the depth pipeline is what's killing tracking. Depth-only features go dark while disabled; revert the `disableDepthForVioTest` flag to restore. Reversible by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Add a temporary feature flag to control ARCore DepthMode usage and log when depth is explicitly disabled for VIO diagnostics.