### PR TITLE
metric depth + relocalization-first specs + triangulation core

### DIFF
--- a/docs/superpowers/specs/2026-06-02-metric-depth-strategy-design.md
+++ b/docs/superpowers/specs/2026-06-02-metric-depth-strategy-design.md
@@ -1,0 +1,100 @@
+# Metric Depth Strategy: dual-lens priority + motion triangulation
+
+*Design spec — 2026-06-02*
+
+## Context
+
+The app's central failure is metric distance — "how far is the wall/mark I'm looking at." Today every
+distance comes from ARCore's depth map, and on devices without hardware stereo (e.g. Pixel 5) that's an
+ML-estimated depth that is jittery, hole-pocked, and (per logcat) errors continuously while also
+appearing to starve VIO. The fingerprint's 3D marks (`MobileGS.generateFingerprint`) are back-projected
+straight from that depth (`Z = depthMm/1000`), and keypoints with missing depth are dropped — so bad
+depth ⇒ a sparse/wrong 3D fingerprint ⇒ relocalization can't recover pose ⇒ the overlay drifts. The
+existing "stereo" path (`StereoDepthProvider` temporal stereo → `StereoProcessor`) pairs *consecutive*
+frames (near-zero baseline while painting) and converts raw disparity with `*1/16` and **no baseline /
+no focal length**, so it cannot produce metric depth.
+
+The maintainer's hard requirements: (1) get metric distance *right*, and (2) **use and prioritize dual
+lens when the device has it.**
+
+## Goal
+
+A single **metric-depth source selector** with a priority ladder:
+
+1. **Hardware stereo (dual lens) — preferred.** When `isHardwareStereoActive` (ARCore selected a
+   hardware-stereo `CameraConfig`, PR #1522), ARCore's depth is hardware-derived and reliable; use it
+   for the marks' 3D positions and distance.
+2. **Motion (VIO-baseline) triangulation — when stereo is unavailable.** Triangulate the marks from two
+   camera views with a sufficient *metric* baseline taken from ARCore VIO poses (the artist's natural
+   step-in/step-back). Single lens, metric, improves with movement.
+3. **ARCore ML depth — last resort.** Only if neither above yields a value; never the primary on mono
+   devices. (It also stays disabled-by-default while we confirm the VIO-starvation fix.)
+
+Reliable metric marks feed the fingerprint (`mWallKeypoints3D`), which is what makes relocalization —
+the app's real main loop — actually work.
+
+## Non-goals
+
+- Not replacing ARCore VIO/tracking (that's the separate in-flight fix). Triangulation *depends* on VIO
+  poses being valid.
+- Not Depth Anything / a per-frame depth model: it yields relative (non-metric) depth and is compute-
+  heavy; triangulation gives metric depth from motion the app already has.
+- Not dense full-frame depth. We need metric depth **at the marks** (sparse) for the fingerprint; dense
+  surface depth (mesh) remains a separate, lower-priority concern.
+
+## The triangulation core (layer 2)
+
+Classic two-view linear triangulation (DLT), metric because the camera poses come from VIO:
+
+- For each of two observations of the same mark: a 3×4 projection `P = K · [R | t]`, where `K` is the
+  camera intrinsics and `[R|t]` is the **world→camera** transform from the ARCore view matrix at that
+  frame, and the mark's 2D pixel `(u,v)`.
+- Solve `A x = 0` (the 4×4 DLT system from the two `(u,v)` ↔ `P` pairs) via SVD for the homogeneous 3D
+  point `X`; de-homogenize. Result is in ARCore **world** (metric) coordinates.
+- Quality gates: triangulation **baseline** (‖t₂ − t₁‖) ≥ ~8 cm; **parallax angle** ≥ ~1–2°; positive
+  depth (cheirality) in both views; low reprojection residual. Reject marks that fail.
+
+This is a pure function: `triangulate(p0: 3x4, p1: 3x4, uv0, uv1) → Point3 + residual`. Unit-testable
+with synthetic cameras (place a known 3D point, project into two poses, triangulate, assert recovery).
+
+## Observation capture + pairing (layer 2 wiring)
+
+- As the artist moves, periodically (throttled) record an **observation**: detect the marks/features in
+  the current frame (reuse the existing ORB/SuperPoint detector + the artwork mask) and store their 2D
+  positions **with the current ARCore view matrix + intrinsics**. Keep a small ring of recent
+  observations.
+- Match marks across observations by descriptor (the matcher already exists for relocalization).
+- When a matched pair has adequate baseline/parallax, triangulate each shared mark → metric 3D.
+- Aggregate over several pairs (median / running estimate) for stability; this is the "gets better the
+  more you move" behavior.
+
+## Source selection + fingerprint integration
+
+- A selector decides per capture: `isHardwareStereoActive` → ARCore depth back-projection (layer 1);
+  else → triangulated 3D (layer 2); else → ML depth (layer 3, only if enabled).
+- `generateFingerprint` consumes the selected metric 3D for `mWallKeypoints3D` instead of unconditionally
+  reading the depth map. Same downstream PnP relocalization; just fed correct metric geometry.
+
+## Where the math lives
+
+- **Pure triangulation + gates: Kotlin** (`feature/ar` or `core/nativebridge` Kotlin), unit-tested — the
+  poses (VIO view matrices) and intrinsics are already in Kotlin, and OpenCV isn't needed for 2-view DLT.
+- Observation capture: `ArRenderer` (GL thread has the live frame + view matrix) → a small collector.
+- Integration into `mWallKeypoints3D`: pass triangulated points into the native fingerprint instead of
+  (or alongside) the depth-derived ones.
+
+## Testing
+
+- Unit: `triangulate` recovers a known synthetic point within tolerance; rejects degenerate (zero-
+  baseline, behind-camera) configs; baseline/parallax gates behave. Aggregation median is correct.
+- On-device (after VIO confirmed): step in/out ~0.5 m in front of marks; confirm triangulated mark
+  distances match a tape measure and that relocalization re-locks across distances. Dual-lens device:
+  confirm layer 1 (hardware stereo) is selected and used.
+
+## Dependencies / sequencing
+
+- **Depends on VIO tracking** (the in-flight depth-disable experiment). Triangulation is worthless
+  without valid metric poses. Build the pure core now (no VIO needed); wire capture/integration once VIO
+  is confirmed.
+- Layer 1 (dual-lens priority) is already wired (PR #1522) — this spec adds the selector that *prefers*
+  it and the layer-2 triangulation for everyone else.

--- a/docs/superpowers/specs/2026-06-02-relocalization-first-design.md
+++ b/docs/superpowers/specs/2026-06-02-relocalization-first-design.md
@@ -1,0 +1,106 @@
+# Relocalization-First Architecture (with Teleological SLAM)
+
+*Design spec — 2026-06-02*
+
+## Context & priority
+
+The real product is: **the instant the camera sees the wall again — out of a pocket, screen back on,
+from any distance, seeing only part of the marks — the overlay snaps to exactly the right place.** The
+maintainer ranks **instantaneous, perfect cold relocalization above everything**, because the phone goes
+in/out of a pocket constantly and the screen is off in between.
+
+Today this fails, and the survey shows why:
+- **Cold relock can't lean on VIO.** Screen-off pauses ARCore; on resume VIO is cold and needs
+  motion/time. So the snap must come from **single-frame PnP against a saved fingerprint**, independent
+  of VIO.
+- **The marks' 3D positions come only from ARCore ML depth** (`generateFingerprint`, `Z=depthMm/1000`),
+  which is unreliable on mono devices; depth-less keypoints are dropped → sparse/wrong fingerprint →
+  PnP can't solve, especially on partial views.
+- **Teleological SLAM is entirely stubbed** (`setArtworkFingerprint`/`runPnPMatch`/`tryUpdateFingerprint`
+  are `{}`; `mPaintingProgress` never written). So relocalization only matches the original marks — which
+  get **painted over** — and must degrade as the work progresses.
+- Reloc uses plain `solvePnPRansac` with fixed thresholds (≥15 matches, ≥12 inliers, `MobileGS.cpp`),
+  which rejects legitimate close-up **partial** views and can flip on coplanar (flat-wall) points.
+
+## Goal
+
+Make relocalization the **primary driver of the overlay pose**, robust to cold start, partial views,
+distance changes, and the marks being painted over. VIO becomes a secondary smoother that coasts the
+overlay only when relocalization has no view to match.
+
+## Architecture
+
+### 1. Pose source: relocalization-first
+- Every frame the wall is visible, solve **PnP** against the fused fingerprint → absolute pose in the
+  saved world frame; apply it. This is independent of VIO convergence.
+- VIO (ARCore) smooths/coasts **between** successful PnP solves (marks out of view, motion blur).
+- **Cold relock = hard snap.** On the first confident PnP after a resume/tracking-loss, set the pose
+  immediately (no smoothing); only smooth *subsequent* in-session corrections (extends `PoseFusion`:
+  add a `coldSnap` path that bypasses the SLERP on the first lock).
+
+### 2. Two relocalization references, fused (Teleological SLAM)
+PnP matches the live frame against the union of:
+- **(a) Mark fingerprint** — `mWallKeypoints3D` from the artist's marks. **Metric** via the
+  dual-lens→triangulation→ML depth ladder (see the metric-depth spec). Dominant early; **fades** as
+  paint covers the marks.
+- **(b) Artwork fingerprint** — `mArtworkKeypoints3D`: features of the **target image**, with 3D taken
+  from the **anchor-plane geometry** (each artwork-image feature lies on the known wall plane at the
+  anchor pose → metric, *no depth needed*). **Grows** as the painting comes to resemble the target.
+
+Both contribute correspondences to a single PnP; the artwork set is **weighted up as painting progress
+rises**. Implement the stubs: `setArtworkFingerprint` (build (b) from the registered target), and the
+per-frame teleological match (`runPnPMatch`).
+
+### 3. Painting progress (powers the weighting + "tighter as you go")
+- `progress` = fraction of artwork features currently detectable/matchable on the wall (compare live
+  frame, registered via the current pose, to the artwork fingerprint). Write `mPaintingProgress` (it's
+  currently always 0). Drives: artwork-vs-marks weighting, relocalization confidence, and the UI.
+
+### 4. Partial-view & flat-wall robustness
+- **Partials are first-class:** PnP needs only the visible subset. Keep the fingerprint **densely
+  covered** (fixing metric depth keeps marks valid instead of dropped) so any patch has enough points.
+- **Adaptive thresholds:** use distance + camera FOV + the fingerprint's physical extent to estimate how
+  much *should* be visible, and lower the inlier/match bar for a legitimate close-up partial instead of
+  rejecting it. (This is the concrete payoff of "depth informs partial awareness.")
+- **Planar PnP:** wall points are coplanar → use `SOLVEPNP_IPPE` and **resolve the two-fold flip** with
+  the prior/VIO-hinted pose, so a small partial patch can't lock backwards.
+
+### 5. Multi-scale / continuous fingerprint (so frame-1 matches)
+- The close-up partial out of the pocket looks different from the original capture. Implement
+  `tryUpdateFingerprint`: as the artist works at various distances, **augment** the fingerprint with
+  current-scale descriptors (both mark and artwork sets), so future relocations have matching-scale
+  references. Cap/decay so it doesn't grow unbounded.
+
+### 6. Persistence / cold resume
+- Fingerprint (marks + artwork + progress) persists and **reloads on resume** (mostly present:
+  `restoreWallFingerprint`, atomic save). Verify the artwork set + progress are saved/restored, and that
+  PnP runs immediately on resume (don't gate on VIO).
+
+### 7. Metric depth ladder (dependency)
+Per `2026-06-02-metric-depth-strategy-design.md`: **dual-lens hardware stereo first**, else **VIO-baseline
+triangulation** (core built), else ML depth. Feeds reference (a)'s metric 3D. Reference (b) is metric
+from anchor geometry regardless.
+
+## What's stubbed today (must implement)
+- `MobileGS::setArtworkFingerprint` `{}`, `runPnPMatch` `{}`, `tryUpdateFingerprint` `{}`.
+- `mArtworkDescriptors` / `mArtworkKeypoints3D` never populated; `mPaintingProgress` never written.
+- Reloc: fixed thresholds + non-planar `solvePnPRansac`; no partial/IPPE handling; no cold-snap; no
+  continuous PnP driving the pose (PnP currently only snaps `mAnchorMatrix` on the reloc thread).
+
+## Testing
+- **Unit (pure):** PnP correspondence fusion & weighting by progress; adaptive-threshold computation from
+  distance/FOV/extent; IPPE flip-resolution selecting the pose consistent with a prior; cold-snap vs
+  smooth selection. (Triangulation core already tested.)
+- **On-device (after VIO confirmed):** pocket → out → confirm sub-second snap from a partial, close-up,
+  off-axis view; paint over ~half the marks → confirm relock still holds via the artwork reference;
+  verify across distances; dual-lens device confirms hardware-stereo path.
+
+## Sequencing
+1. **Continuous PnP + cold-snap** (drive pose by reloc; hard snap on first lock).
+2. **Partial/planar robustness** (IPPE + flip resolution + adaptive thresholds).
+3. **Teleological artwork reference** (implement `setArtworkFingerprint` + fused match + `mPaintingProgress`).
+4. **Continuous/multi-scale fingerprint** (`tryUpdateFingerprint`).
+5. **Metric marks** wired from the depth ladder (triangulation core done; stereo priority done).
+
+All of it rides on VIO at least initializing a session (the in-flight depth-disable experiment); the
+**snap itself is PnP**, so it survives weak mono tracking.

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/Triangulation.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/Triangulation.kt
@@ -1,0 +1,102 @@
+package com.hereliesaz.graffitixr.feature.ar.anchor
+
+import kotlin.math.abs
+import kotlin.math.sqrt
+
+/**
+ * Two-view linear (DLT) triangulation of a point seen from two camera poses. Metric because the poses
+ * come from ARCore VIO (world→camera view matrices). Pure math — no Android/OpenCV — so it's unit-
+ * testable. This is layer 2 of the metric-depth strategy: recover a mark's real-world distance from the
+ * artist's natural step-in/step-back baseline, with no second lens and no ML depth.
+ *
+ * Conventions: view matrices are column-major 4x4 (OpenGL/ARCore). Projection matrices produced here are
+ * 3x4 row-major (length 12, P[r*4+c]). Pixel coords are (u,v) in the same image space the intrinsics
+ * (fx,fy,cx,cy) describe.
+ */
+object Triangulation {
+
+    /** Build a 3x4 projection P = K·[R|t] (row-major, length 12) from a column-major world→camera view. */
+    fun projectionFromView(view: FloatArray, fx: Float, fy: Float, cx: Float, cy: Float): FloatArray {
+        // [R|t] (3x4): rt[r][c] = view[c*4+r] for the rotation/translation rows.
+        // K (3x3): [[fx,0,cx],[0,fy,cy],[0,0,1]]
+        val p = FloatArray(12)
+        for (c in 0 until 4) {
+            val r0 = view[c * 4 + 0] // [R|t] row 0, col c
+            val r1 = view[c * 4 + 1] // row 1
+            val r2 = view[c * 4 + 2] // row 2
+            p[0 * 4 + c] = fx * r0 + cx * r2
+            p[1 * 4 + c] = fy * r1 + cy * r2
+            p[2 * 4 + c] = r2
+        }
+        return p
+    }
+
+    /** Project a world point through a 3x4 projection into pixel (u,v); null if behind the camera. */
+    fun project(p: FloatArray, x: Float, y: Float, z: Float): FloatArray? {
+        val pw = p[8] * x + p[9] * y + p[10] * z + p[11]
+        if (pw <= 0f) return null // behind camera (cheirality)
+        val pu = p[0] * x + p[1] * y + p[2] * z + p[3]
+        val pv = p[4] * x + p[5] * y + p[6] * z + p[7]
+        return floatArrayOf(pu / pw, pv / pw)
+    }
+
+    /**
+     * Triangulate the 3D world point seen at (u0,v0) in camera 0 and (u1,v1) in camera 1.
+     * @return [x,y,z] in world coords, or null if the system is degenerate (e.g. zero baseline).
+     */
+    fun triangulate(p0: FloatArray, p1: FloatArray, u0: Float, v0: Float, u1: Float, v1: Float): FloatArray? {
+        // Rows of A x = 0 (x = [X,Y,Z,W]):
+        //   u*P[2] - P[0],  v*P[2] - P[1]   for each view.
+        val a = arrayOf(
+            FloatArray(4) { u0 * p0[8 + it] - p0[0 + it] },
+            FloatArray(4) { v0 * p0[8 + it] - p0[4 + it] },
+            FloatArray(4) { u1 * p1[8 + it] - p1[0 + it] },
+            FloatArray(4) { v1 * p1[8 + it] - p1[4 + it] },
+        )
+        // Inhomogeneous DLT: fix W=1 → solve the 4x3 system M·[X,Y,Z] = b (b = -A[:,3]) by normal
+        // equations (3x3). Robust for finite points (marks on a wall are never at infinity).
+        val m = Array(4) { row -> floatArrayOf(a[row][0], a[row][1], a[row][2]) }
+        val b = FloatArray(4) { -a[it][3] }
+        // N = MᵀM (3x3), rhs = Mᵀb (3)
+        val n = Array(3) { i -> FloatArray(3) { j -> (0 until 4).sumOf { (m[it][i] * m[it][j]).toDouble() }.toFloat() } }
+        val rhs = FloatArray(3) { i -> (0 until 4).sumOf { (m[it][i] * b[it]).toDouble() }.toFloat() }
+        return solve3x3(n, rhs)
+    }
+
+    /** Metric baseline between two column-major view matrices' camera centers. */
+    fun baselineMeters(view0: FloatArray, view1: FloatArray): Float {
+        val c0 = cameraCenter(view0); val c1 = cameraCenter(view1)
+        val dx = c0[0] - c1[0]; val dy = c0[1] - c1[1]; val dz = c0[2] - c1[2]
+        return sqrt(dx * dx + dy * dy + dz * dz)
+    }
+
+    /** Camera center in world = -Rᵀ t, for a column-major world→camera view matrix. */
+    private fun cameraCenter(view: FloatArray): FloatArray {
+        // R (3x3): r[row][col] = view[col*4+row]; t = (view[12],view[13],view[14])
+        val tx = view[12]; val ty = view[13]; val tz = view[14]
+        // -Rᵀ t : Rᵀ[i][k] = R[k][i] = view[i*4+k]
+        return floatArrayOf(
+            -(view[0] * tx + view[1] * ty + view[2] * tz),
+            -(view[4] * tx + view[5] * ty + view[6] * tz),
+            -(view[8] * tx + view[9] * ty + view[10] * tz),
+        )
+    }
+
+    /** Solve a 3x3 linear system n·x = rhs via the adjugate/determinant; null if near-singular. */
+    private fun solve3x3(n: Array<FloatArray>, rhs: FloatArray): FloatArray? {
+        val a = n[0][0]; val b = n[0][1]; val c = n[0][2]
+        val d = n[1][0]; val e = n[1][1]; val f = n[1][2]
+        val g = n[2][0]; val h = n[2][1]; val i = n[2][2]
+        val det = a * (e * i - f * h) - b * (d * i - f * g) + c * (d * h - e * g)
+        // Relative singularity test: N's entries can be ~1e5, so an absolute epsilon misses a
+        // rank-deficient (e.g. zero-baseline) system whose det is float-noise, not zero. Scale by
+        // the matrix magnitude (det grows as scale^3 for a 3x3).
+        val scale = maxOf(abs(a), abs(b), abs(c), abs(d), abs(e), abs(f), abs(g), abs(h), abs(i))
+        if (scale < 1e-12f || abs(det) < 1e-4f * scale * scale * scale) return null
+        val inv = 1f / det
+        val x = inv * (rhs[0] * (e * i - f * h) - b * (rhs[1] * i - f * rhs[2]) + c * (rhs[1] * h - e * rhs[2]))
+        val y = inv * (a * (rhs[1] * i - f * rhs[2]) - rhs[0] * (d * i - f * g) + c * (d * rhs[2] - rhs[1] * g))
+        val z = inv * (a * (e * rhs[2] - rhs[1] * h) - b * (d * rhs[2] - rhs[1] * g) + rhs[0] * (d * h - e * g))
+        return floatArrayOf(x, y, z)
+    }
+}

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/TriangulationTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/TriangulationTest.kt
@@ -1,0 +1,35 @@
+package com.hereliesaz.graffitixr.feature.ar.anchor
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class TriangulationTest {
+    private fun identity() = floatArrayOf(1f,0f,0f,0f, 0f,1f,0f,0f, 0f,0f,1f,0f, 0f,0f,0f,1f)
+    // World→camera view with identity rotation and camera centered at (cx,cy,cz): t = -C.
+    private fun viewWithCenter(cx: Float, cy: Float, cz: Float) =
+        identity().also { it[12] = -cx; it[13] = -cy; it[14] = -cz }
+
+    @Test fun `recovers a known point from two views`() {
+        val fx = 500f; val fy = 500f; val ppx = 320f; val ppy = 320f
+        val p0 = Triangulation.projectionFromView(viewWithCenter(0f, 0f, 0f), fx, fy, ppx, ppy)
+        val p1 = Triangulation.projectionFromView(viewWithCenter(0.2f, 0f, 0f), fx, fy, ppx, ppy)
+        val x = 0.05f; val y = 0.1f; val z = 2f // off-axis, 2 m in front
+        val uv0 = Triangulation.project(p0, x, y, z)!!
+        val uv1 = Triangulation.project(p1, x, y, z)!!
+        val r = Triangulation.triangulate(p0, p1, uv0[0], uv0[1], uv1[0], uv1[1])!!
+        assertEquals(x, r[0], 1e-2f)
+        assertEquals(y, r[1], 1e-2f)
+        assertEquals(z, r[2], 1e-2f)
+    }
+
+    @Test fun `baseline is the camera-center distance`() {
+        assertEquals(0.2f, Triangulation.baselineMeters(viewWithCenter(0f, 0f, 0f), viewWithCenter(0.2f, 0f, 0f)), 1e-4f)
+    }
+
+    @Test fun `zero baseline is rejected as degenerate`() {
+        val p = Triangulation.projectionFromView(viewWithCenter(0f, 0f, 0f), 500f, 500f, 320f, 320f)
+        val uv = Triangulation.project(p, 0.05f, 0.1f, 2f)!!
+        assertNull(Triangulation.triangulate(p, p, uv[0], uv[1], uv[0], uv[1]))
+    }
+}


### PR DESCRIPTION
Foundation for the distance/relocalization rework.

- **Specs:** metric-depth strategy (dual-lens priority → VIO-baseline triangulation → ML last) and relocalization-first architecture (cold-start PnP as primary pose driver, marks+artwork fused references weighted by painting progress, partial/planar IPPE robustness, distance/FOV-adaptive thresholds, continuous fingerprint). Documents that Teleological SLAM is currently fully stubbed.
- **Code:** pure, unit-tested two-view metric `Triangulation` core (DLT from two VIO poses → metric world 3D; projection-from-view, baseline, cheirality, relative-epsilon degeneracy rejection). Layer-2 foundation for single-lens metric depth.

No behavior change yet (core not wired); this is the tested substrate + the agreed design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add design specs for relocalization-first pose architecture and metric depth strategy, and introduce a pure two-view triangulation core with unit tests to support metric mark depth from VIO motion.

Enhancements:
- Introduce a pure Kotlin two-view metric triangulation core for computing 3D world points and camera baselines from ARCore VIO poses.

Documentation:
- Add design specifications for a relocalization-first architecture with Teleological SLAM and for a metric depth strategy prioritizing dual-lens stereo then VIO-based triangulation.

Tests:
- Add unit tests validating triangulation accuracy, baseline computation, and degeneracy handling for the triangulation core.

Chores:
- Document that current Teleological SLAM integration is stubbed and outline sequencing for wiring continuous PnP, partial-view robustness, and metric marks into the existing AR pipeline.