### PR TITLE
fix: anchor overlay to wall plane at true distance (stop placing it short)

### DIFF
--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -559,6 +559,9 @@ class ArViewModel @Inject constructor(
             val config = Config(s)
             config.focusMode = Config.FocusMode.AUTO
             config.updateMode = Config.UpdateMode.LATEST_CAMERA_IMAGE
+            // Detect walls so the overlay can anchor to the real surface at its true distance. Without
+            // this, hit-tests only return sparse feature points and the overlay lands short of the wall.
+            config.planeFindingMode = Config.PlaneFindingMode.HORIZONTAL_AND_VERTICAL
             
             // ROOT-CAUSE TEST (VIO never tracked): ARCore's Depth API (DepthMode.AUTOMATIC) runs an ML
             // depth/perception graph that was erroring continuously on this device

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -297,28 +297,45 @@ class ArRenderer(
                     fallbackMatrix[13] += -fallbackMatrix[9] * 2.0f
                     fallbackMatrix[14] += -fallbackMatrix[10] * 2.0f
 
-                    if (hits.isEmpty()) {
-                        anchorModelMatrix = fallbackMatrix
-                    } else {
-                        val pose = hits[0].hitPose
-                        pose.toMatrix(anchorModelMatrix, 0)
+                    // Prefer a real surface (a wall/plane) over the nearest hit. hits[0] is the closest
+                    // result, which is usually a stray feature point in front of the wall — anchoring to
+                    // it puts the overlay between the camera and the marks. Pick the first Plane hit
+                    // inside its polygon; else a depth/feature point; else the nearest hit.
+                    var chosen: com.google.ar.core.HitResult? = null
+                    for (h in hits) {
+                        val t = h.trackable
+                        if (t is com.google.ar.core.Plane && t.isPoseInPolygon(h.hitPose)) { chosen = h; break }
+                        if (chosen == null && (t is com.google.ar.core.DepthPoint || t is com.google.ar.core.Point)) chosen = h
+                    }
+                    if (chosen == null) chosen = hits.firstOrNull()
+
+                    var anchor: com.google.ar.core.Anchor? = null
+                    if (chosen != null) {
+                        val pose = chosen.hitPose
                         val camPose = camera.pose
                         val dx = pose.tx() - camPose.tx()
                         val dy = pose.ty() - camPose.ty()
                         val dz = pose.tz() - camPose.tz()
-                        val dist = Math.sqrt((dx*dx + dy*dy + dz*dz).toDouble())
-                        if (dist < 0.1 || dist > 10.0) {
-                            anchorModelMatrix = fallbackMatrix
+                        val dist = Math.sqrt((dx * dx + dy * dy + dz * dz).toDouble())
+                        if (dist in 0.1..10.0) {
+                            pose.toMatrix(anchorModelMatrix, 0) // full surface pose (position + normal)
+                            // Anchor to the hit's trackable so ARCore keeps it pinned to the wall as the
+                            // artist moves, instead of a free world point at a guessed depth.
+                            anchor = chosen.createAnchor()
                         }
                     }
-
-                    val anchor = activeSession.createAnchor(com.google.ar.core.Pose(
-                        floatArrayOf(anchorModelMatrix[12], anchorModelMatrix[13], anchorModelMatrix[14]),
-                        floatArrayOf(0f, 0f, 0f, 1f)
-                    ))
+                    if (anchor == null) {
+                        anchorModelMatrix = fallbackMatrix
+                        anchor = activeSession.createAnchor(
+                            com.google.ar.core.Pose(
+                                floatArrayOf(anchorModelMatrix[12], anchorModelMatrix[13], anchorModelMatrix[14]),
+                                floatArrayOf(0f, 0f, 0f, 1f)
+                            )
+                        )
+                    }
 
                     slamManager.updateAnchorTransform(anchorModelMatrix)
-                    setPrimaryAnchor(anchor)
+                    setPrimaryAnchor(anchor!!) // non-null: the fallback branch always creates one
                     anchorEstablished = true
                     hideVisualization = true
                     onAnchorEstablished()


### PR DESCRIPTION
Fixes the core complaint: the overlay sits *between the camera and the marks* and doesn't correct as you move.

**Cause:** plane detection was never enabled (`config.planeFindingMode` unset), and anchor placement used `hits[0]` — the *nearest* hit-test result, typically a stray feature point in front of the wall — creating a world anchor at that wrong depth with identity rotation (fallback: a hardcoded 2 m guess).

**Fix:** enable `HORIZONTAL_AND_VERTICAL` plane finding; prefer the first **Plane** hit inside its polygon (true wall distance + surface orientation), depth/feature point only as fallback; **anchor to the hit's trackable** so ARCore keeps it pinned to the wall during movement.

Build: `:feature:ar` OK. Needs on-device confirmation that the overlay now lands ON the wall and holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Anchor AR overlays to detected wall planes at a reliable distance instead of guessing or using the nearest feature point.

Bug Fixes:
- Prevent AR overlays from appearing short of the wall by preferring in-polygon plane hits and validating hit distance before anchoring.

Enhancements:
- Anchor overlays directly to the ARCore trackable associated with the hit result, falling back to a world anchor only when no valid surface is found.