### PR TITLE
chore(ar): depth-API off-config + gate dead depth-acquire + README fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ And then, there's a decent suite of pertinent design tools, with support for mul
 *   **Persistent Voxel Memory:** C++17 native engine using a zero-allocation fixed-size spatial hash table for O(1) discovery speed.
 *   **Opaque Surfel Pipeline:** High-performance rendering with hardware Z-buffering, replacing expensive alpha blending.
 *   **Stochastic Integration:** Optimized depth integration (2048 random pixels per frame) to reduce CPU overhead by 90%.
-*   **Mandatory Dual-Lens:** Automatically leverages hardware stereo depth for rock-solid tracking stability.
+*   **Dual-Lens Aware:** Auto-selects hardware stereo depth on devices that expose it; falls back to single-camera tracking with motion-based (VIO-baseline) depth elsewhere.
 *   **AI Glasses Support:** Integrated support for **Meta Ray-Bans** and **Xreal Air/Ultra** via a provider-based abstraction layer.
 *   **Co-op Mode:** Robust peer-to-peer AR synchronization for collaborative painting.
 *   **AzNavRail UI:** Thumb-driven, one-handed navigation designed for artists holding a spray can.

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -563,21 +563,21 @@ class ArViewModel @Inject constructor(
             // this, hit-tests only return sparse feature points and the overlay lands short of the wall.
             config.planeFindingMode = Config.PlaneFindingMode.HORIZONTAL_AND_VERTICAL
             
-            // ROOT-CAUSE TEST (VIO never tracked): ARCore's Depth API (DepthMode.AUTOMATIC) runs an ML
-            // depth/perception graph that was erroring continuously on this device
-            // (feature_track_ml_depth_provider, mediapipe normal_detector RET_CHECK) while VIO sat in
-            // kNotTracking for the ENTIRE session. Disable the Depth API to isolate whether that
-            // pipeline is starving/wedging tracking. While disabled, depth-only features (surface mesh,
-            // tap distance) go dark — that's the trade for the test. Flip back to re-enable.
-            val disableDepthForVioTest = true
-            if (!disableDepthForVioTest && s.isDepthModeSupported(Config.DepthMode.AUTOMATIC)) {
+            // ARCore's ML Depth API (DepthMode.AUTOMATIC) ran a perception graph that errored
+            // continuously and starved VIO into permanent kNotTracking on this hardware (confirmed via
+            // logcat: feature_track_ml_depth_provider + mediapipe normal_detector RET_CHECK). It stays
+            // OFF. Metric depth comes from VIO-baseline triangulation (and hardware stereo where the
+            // device offers it); the wall anchor uses plane detection. Re-enabling requires first
+            // solving the VIO starvation.
+            val useArCoreDepthApi = false
+            if (useArCoreDepthApi && s.isDepthModeSupported(Config.DepthMode.AUTOMATIC)) {
                 config.depthMode = Config.DepthMode.AUTOMATIC
                 _uiState.update { it.copy(isDepthApiSupported = true) }
             } else {
                 config.depthMode = Config.DepthMode.DISABLED
                 _uiState.update { it.copy(isDepthApiSupported = false) }
-                Timber.i("VIO test: ARCore Depth API DISABLED to isolate the kNotTracking failure")
             }
+            renderer?.depthApiEnabled = useArCoreDepthApi
 
             s.configure(config)
 

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -86,6 +86,9 @@ class ArRenderer(
     private val poseFusion = com.hereliesaz.graffitixr.feature.ar.anchor.PoseFusion()
     // A/B switch for the Sub-project A harness: when false, reproduce the old pre/post-anchor toggle.
     @Volatile var fusionEnabled: Boolean = true
+    // Whether the ARCore Depth API is actually enabled this session. Off by default — it starves VIO
+    // on this hardware; metric depth comes from triangulation/stereo instead. Set from ArViewModel.
+    @Volatile var depthApiEnabled: Boolean = false
 
     @Volatile var scanMode: ArScanMode = ArScanMode.MURAL
     @Volatile var muralMethod: MuralMethod = MuralMethod.VOXEL_HASH
@@ -388,7 +391,7 @@ class ArRenderer(
             }
 
             val isTracking = camera.trackingState == TrackingState.TRACKING
-            val depthSupported = activeSession.isDepthModeSupported(Config.DepthMode.AUTOMATIC)
+            val depthSupported = depthApiEnabled && activeSession.isDepthModeSupported(Config.DepthMode.AUTOMATIC)
 
             val yawRad = kotlin.math.atan2(-viewMatrix[2].toDouble(), -viewMatrix[10].toDouble())
             val yawDeg = Math.toDegrees(yawRad).toFloat()
@@ -468,7 +471,7 @@ class ArRenderer(
 
                     // Keep last smoothed value across invalid/dropped frames so the readout is stable.
                     var centerDepth = smoothedCenterDepth
-                    try {
+                    if (depthApiEnabled) try {
                         frame.acquireDepthImage16Bits().use { depthImage ->
                             val plane = depthImage.planes[0]
                             // Median of a 7x7 patch (radius 3) rejects per-pixel noise/holes; the
@@ -525,7 +528,7 @@ class ArRenderer(
                         var depthHeight = 0
                         var depthStride = 0
 
-                        if (activeSession.isDepthModeSupported(Config.DepthMode.AUTOMATIC)) {
+                        if (depthApiEnabled) {
                             try {
                                 frame.acquireDepthImage16Bits().use { depthImage ->
                                     val plane = depthImage.planes[0]


### PR DESCRIPTION
Resolves the depth strategy (#2) and cleanups (#4): ARCore ML Depth API stays off via a real config (it starves VIO; metric depth comes from triangulation/stereo, anchor uses plane detection); gate all depth-acquire sites so disabling depth no longer spams NotYetAvailable; fix the README's 'Mandatory Dual-Lens' claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Keep ARCore ML Depth API disabled by configuration and gate depth usage throughout the AR renderer while updating documentation to reflect conditional dual-lens support.

Bug Fixes:
- Guard all depth image acquisition paths behind a runtime flag so disabling the Depth API no longer triggers repeated NotYetAvailable errors.

Enhancements:
- Introduce a configuration flag to keep ARCore ML Depth API off by default and propagate its state into the renderer to control depth-dependent behavior.
- Adjust depth support checks in the renderer to depend on the configured Depth API state rather than only on session capabilities.

Documentation:
- Clarify README hardware depth behavior to describe dual-lens as conditionally used when available, with fallback to single-camera motion-derived depth.