### PR TITLE
Relocalization-first: live reloc, persistent fusion, IPPE, depth-off triangulation fingerprint

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainViewModel.kt
@@ -308,6 +308,11 @@ class MainViewModel @Inject constructor(
     )
     private var pendingMetricKf0: MetricKf0? = null
 
+    override fun onCleared() {
+        super.onCleared()
+        pendingMetricKf0 = null
+    }
+
     /**
      * Depth-off target creation: capture two keyframes a side-step apart and triangulate. The first
      * tap stores keyframe 0 and re-enters capture; the second tap supplies keyframe 1 and builds.

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainViewModel.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.hereliesaz.graffitixr.common.model.CaptureStep
 import com.hereliesaz.graffitixr.data.ProjectManager
+import com.hereliesaz.graffitixr.feature.ar.anchor.MetricFingerprintBuilder
 import com.hereliesaz.graffitixr.domain.repository.ProjectRepository
 import com.hereliesaz.graffitixr.domain.repository.SettingsRepository
 import com.hereliesaz.graffitixr.nativebridge.SlamManager
@@ -231,18 +232,17 @@ class MainViewModel @Inject constructor(
         intrinsics: FloatArray? = null,
         viewMatrix: FloatArray? = null
     ) {
-        _uiState.update {
-            it.copy(
-                isCapturingTarget = false,
-                captureStep = CaptureStep.NONE,
-                isWaitingForTap = false,
-                captureOriginatedFromTap = false
-            )
+        if (bitmap == null || intrinsics == null || viewMatrix == null) { resetCaptureUi(); return }
+        val safeIntr = intrinsics
+        val safeView = viewMatrix
+
+        if (depthBuffer == null) {
+            // No depth source: build the wall fingerprint from two keyframes via triangulation.
+            handleMetricCapture(bitmap, safeIntr, safeView)
+            return
         }
-        bitmap ?: return
-        val safeDepth = depthBuffer ?: return
-        val safeIntr = intrinsics ?: return
-        val safeView = viewMatrix ?: return
+        resetCaptureUi()
+        val safeDepth = depthBuffer
 
         viewModelScope.launch(Dispatchers.IO) {
             val currentProject = projectRepository.currentProject.value ?: return@launch
@@ -292,7 +292,69 @@ class MainViewModel @Inject constructor(
         }
     }
 
+    private fun resetCaptureUi() {
+        _uiState.update {
+            it.copy(
+                isCapturingTarget = false,
+                captureStep = CaptureStep.NONE,
+                isWaitingForTap = false,
+                captureOriginatedFromTap = false
+            )
+        }
+    }
+
+    private class MetricKf0(
+        val bitmap: Bitmap, val view: FloatArray, val intr: FloatArray, val anchor: FloatArray
+    )
+    private var pendingMetricKf0: MetricKf0? = null
+
+    /**
+     * Depth-off target creation: capture two keyframes a side-step apart and triangulate. The first
+     * tap stores keyframe 0 and re-enters capture; the second tap supplies keyframe 1 and builds.
+     */
+    private fun handleMetricCapture(bitmap: Bitmap, intr: FloatArray, view: FloatArray) {
+        val kf0 = pendingMetricKf0
+        if (kf0 == null) {
+            pendingMetricKf0 = MetricKf0(bitmap, view.copyOf(), intr.copyOf(), slamManager.getAnchorTransform())
+            // Re-enter tap-capture so the next tap supplies the second view.
+            _uiState.update {
+                it.copy(isCapturingTarget = true, captureStep = CaptureStep.NONE,
+                    isWaitingForTap = true, captureOriginatedFromTap = true)
+            }
+            Toast.makeText(context,
+                "First view captured. Step ~20 cm to the side and tap your marks again.",
+                Toast.LENGTH_LONG).show()
+            return
+        }
+        pendingMetricKf0 = null
+        resetCaptureUi()
+        viewModelScope.launch(Dispatchers.IO) {
+            val currentProject = projectRepository.currentProject.value ?: return@launch
+            val fp = MetricFingerprintBuilder.build(
+                slamManager, kf0.bitmap, kf0.view, kf0.intr, bitmap, view, intr, kf0.anchor
+            )
+            if (fp == null) {
+                withContext(Dispatchers.Main) {
+                    Toast.makeText(context,
+                        "Not enough overlap between the two views. Try again with a smaller side-step.",
+                        Toast.LENGTH_LONG).show()
+                }
+                return@launch
+            }
+            projectManager.saveProject(
+                context = context,
+                projectData = currentProject.copy(fingerprint = fp),
+                targetImages = listOf(bitmap)
+            )
+            projectRepository.loadProject(currentProject.id)
+            withContext(Dispatchers.Main) {
+                Toast.makeText(context, "Target Saved & Locked", Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
     fun onCancelCaptureClicked() {
+        pendingMetricKf0 = null
         _uiState.update {
             it.copy(
                 isCapturingTarget = false,

--- a/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
+++ b/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
@@ -481,6 +481,29 @@ Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeRestoreWallFingerp
     }
 }
 
+JNIEXPORT void JNICALL
+Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeRestoreWallFingerprintMetric(
+        JNIEnv* env, jobject thiz, jbyteArray descArray, jint rows, jint cols, jint type,
+        jfloatArray ptsArray, jfloatArray anchorArray, jfloatArray intrArray) {
+    if (!gSlamEngine) return;
+    jbyte* descData = env->GetByteArrayElements(descArray, nullptr);
+    cv::Mat descriptors(rows, cols, type, descData);
+    jsize ptsLen = env->GetArrayLength(ptsArray);
+    jfloat* ptsData = env->GetFloatArrayElements(ptsArray, nullptr);
+    std::vector<cv::Point3f> points3d;
+    points3d.reserve(ptsLen / 3);
+    for (int i = 0; i + 2 < ptsLen; i += 3) {
+        points3d.push_back(cv::Point3f(ptsData[i], ptsData[i+1], ptsData[i+2]));
+    }
+    jfloat* anchor = env->GetFloatArrayElements(anchorArray, nullptr);
+    jfloat* intr = env->GetFloatArrayElements(intrArray, nullptr);
+    gSlamEngine->restoreWallFingerprintMetric(descriptors, points3d, anchor, intr);
+    env->ReleaseByteArrayElements(descArray, descData, JNI_ABORT);
+    env->ReleaseFloatArrayElements(ptsArray, ptsData, JNI_ABORT);
+    env->ReleaseFloatArrayElements(anchorArray, anchor, JNI_ABORT);
+    env->ReleaseFloatArrayElements(intrArray, intr, JNI_ABORT);
+}
+
 jobject buildFingerprintObject(JNIEnv* env, const MobileGS::FingerprintData& fd) {
     if (fd.descriptors.empty()) return nullptr;
 

--- a/core/nativebridge/src/main/cpp/MobileGS.cpp
+++ b/core/nativebridge/src/main/cpp/MobileGS.cpp
@@ -318,8 +318,15 @@ void MobileGS::relocThreadFunc() {
         if (imgPts.size() >= 15) {
             cv::Mat rvec, tvec;
             std::vector<int> inliers;
-            // Physical intrinsics from Mapping camera
-            cv::Mat intr = (cv::Mat_<double>(3,3) << 1000.0, 0, 960.0, 0, 1000.0, 540.0);
+            // Camera matrix: reuse the intrinsics the fingerprint's 3D points were built with (keeps
+            // the 2D<->3D correspondence consistent) when available, else a coarse default. The old
+            // hardcoded init supplied only 6 of the 9 entries, leaving the bottom row uninitialised.
+            double fx = 1000.0, fy = 1000.0, cx = 960.0, cy = 540.0;
+            if (mFingerprintIntrinsics[0] > 0.0f && mFingerprintIntrinsics[1] > 0.0f) {
+                fx = mFingerprintIntrinsics[0]; fy = mFingerprintIntrinsics[1];
+                cx = mFingerprintIntrinsics[2]; cy = mFingerprintIntrinsics[3];
+            }
+            cv::Mat intr = (cv::Mat_<double>(3,3) << fx, 0, cx, 0, fy, cy, 0, 0, 1);
             StageTimer _pnpTimer(&mStageAccumMs[4], &mStageSamples[4]);
             if (cv::solvePnPRansac(objPts, imgPts, intr, cv::Mat(), rvec, tvec, false, 100, 8.0, 0.99, inliers)) {
                 if (inliers.size() >= 12) {
@@ -461,7 +468,21 @@ void MobileGS::alignToFingerprint(const uint8_t* data, size_t size) {
     }
     LOGI("Co-op: Received fingerprint with %u points. Relocalization triggered.", numPoints);
 }
-void MobileGS::scheduleRelocCheck(const cv::Mat& f) {}
+void MobileGS::scheduleRelocCheck(const cv::Mat& f) {
+    // Feed the latest camera frame to the background relocalization thread. Previously a no-op, which
+    // meant mRelocColorFrame was never populated and the reloc thread always saw an empty frame —
+    // live-camera PnP relocalization never ran. Throttles to the reloc thread's consume rate: while a
+    // request is still pending we skip, so we only copy a frame when the worker is ready for the next.
+    if (f.empty() || !mRelocEnabled) return;
+    if (mWallDescriptors.empty()) return; // nothing to match against yet
+    {
+        std::lock_guard<std::mutex> lock(mRelocMutex);
+        if (mRelocRequested) return;
+        f.copyTo(mRelocColorFrame);
+        mRelocRequested = true;
+    }
+    mRelocCv.notify_one();
+}
 
 extern MobileGS* gSlamEngine;
 namespace mobilegs {
@@ -606,6 +627,7 @@ MobileGS::FingerprintData MobileGS::generateFingerprint(
         mWallDescriptors  = fd.descriptors.clone();
         mWallKeypoints3D  = std::move(pts3d);
         memcpy(mFingerprintAnchorMatrix, mAnchorMatrix, 16 * sizeof(float));
+        memcpy(mFingerprintIntrinsics, intr, 4 * sizeof(float));
     }
 
     return fd;

--- a/core/nativebridge/src/main/cpp/MobileGS.cpp
+++ b/core/nativebridge/src/main/cpp/MobileGS.cpp
@@ -330,6 +330,31 @@ void MobileGS::relocThreadFunc() {
             StageTimer _pnpTimer(&mStageAccumMs[4], &mStageSamples[4]);
             if (cv::solvePnPRansac(objPts, imgPts, intr, cv::Mat(), rvec, tvec, false, 100, 8.0, 0.99, inliers)) {
                 if (inliers.size() >= 12) {
+                    // Refine on the RANSAC inliers. The marks lie on the wall plane, so resolve the
+                    // planar two-fold (flip) ambiguity with IPPE and keep whichever pose reprojects
+                    // best — but only adopt it if it strictly beats the RANSAC pose, so a non-coplanar
+                    // inlier set can never make relocalization worse.
+                    {
+                        std::vector<cv::Point3f> inObj; std::vector<cv::Point2f> inImg;
+                        inObj.reserve(inliers.size()); inImg.reserve(inliers.size());
+                        for (int idx : inliers) { inObj.push_back(objPts[idx]); inImg.push_back(imgPts[idx]); }
+                        auto reproj = [&](const cv::Mat& rv, const cv::Mat& tv) {
+                            std::vector<cv::Point2f> pr;
+                            cv::projectPoints(inObj, rv, tv, intr, cv::Mat(), pr);
+                            double e = 0; for (size_t k = 0; k < pr.size(); ++k) e += cv::norm(pr[k] - inImg[k]);
+                            return e;
+                        };
+                        double bestErr = reproj(rvec, tvec);
+                        try {
+                            std::vector<cv::Mat> rvecs, tvecs;
+                            int n = cv::solvePnPGeneric(inObj, inImg, intr, cv::Mat(), rvecs, tvecs,
+                                                        false, cv::SOLVEPNP_IPPE);
+                            for (int s = 0; s < n; ++s) {
+                                double e = reproj(rvecs[s], tvecs[s]);
+                                if (e < bestErr) { bestErr = e; rvecs[s].copyTo(rvec); tvecs[s].copyTo(tvec); }
+                            }
+                        } catch (const cv::Exception&) { /* keep RANSAC pose */ }
+                    }
                     cv::Mat R;
                     cv:: Rodrigues(rvec, R);
 

--- a/core/nativebridge/src/main/cpp/MobileGS.cpp
+++ b/core/nativebridge/src/main/cpp/MobileGS.cpp
@@ -435,6 +435,14 @@ bool MobileGS::importModel3D(const std::string& p) { return false; }
 void MobileGS::setViewportSize(int w, int h) { mScreenWidth = w; mScreenHeight = h; }
 void MobileGS::setRelocEnabled(bool e) { mRelocEnabled = e; }
 void MobileGS::restoreWallFingerprint(const cv::Mat& d, const std::vector<cv::Point3f>& p) { mWallDescriptors = d.clone(); mWallKeypoints3D = p; }
+void MobileGS::restoreWallFingerprintMetric(const cv::Mat& d, const std::vector<cv::Point3f>& p,
+                                            const float* anchorMatrix16, const float* intrinsics4) {
+    std::lock_guard<std::mutex> lock(mMutex);
+    mWallDescriptors = d.clone();
+    mWallKeypoints3D = p;
+    if (anchorMatrix16) memcpy(mFingerprintAnchorMatrix, anchorMatrix16, 16 * sizeof(float));
+    if (intrinsics4)    memcpy(mFingerprintIntrinsics, intrinsics4, 4 * sizeof(float));
+}
 
 std::vector<uint8_t> MobileGS::exportFingerprint() {
     std::lock_guard<std::mutex> lock(mMutex);

--- a/core/nativebridge/src/main/cpp/include/MobileGS.h
+++ b/core/nativebridge/src/main/cpp/include/MobileGS.h
@@ -145,6 +145,8 @@ private:
     std::atomic<int> mPnpMatchCount{0};
     std::atomic<long> mPnpResultSeq{0};
     float mFingerprintAnchorMatrix[16] = {1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1};
+    // fx,fy,cx,cy the wall fingerprint's 3D points were built with; {0,..} => unset (use a default).
+    float mFingerprintIntrinsics[4] = {0,0,0,0};
     uint64_t mFrameCounter = 0;
     float mLightLevel = 1.0f;
     float mLastAngularVelocity[3] = {0,0,0};

--- a/core/nativebridge/src/main/cpp/include/MobileGS.h
+++ b/core/nativebridge/src/main/cpp/include/MobileGS.h
@@ -36,6 +36,10 @@ public:
 
     void setArCoreTrackingState(bool isTracking);
     void restoreWallFingerprint(const cv::Mat& descriptors, const std::vector<cv::Point3f>& points3d);
+    // Ingest a fingerprint built from triangulated metric marks (no depth source): also fixes the
+    // fingerprint anchor pose and the intrinsics the reloc PnP should use.
+    void restoreWallFingerprintMetric(const cv::Mat& descriptors, const std::vector<cv::Point3f>& points3d,
+                                      const float* anchorMatrix16, const float* intrinsics4);
     void scheduleRelocCheck(const cv::Mat& colorFrame);
     void getAnchorTransform(float* outMat16) const;
     void getRelocResult(float* out19) const;       // [0..15]=pnpMat,16=inliers,17=matches,18=seq

--- a/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
+++ b/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
@@ -86,6 +86,18 @@ class SlamManager @Inject constructor(
         nativeRestoreWallFingerprint(descriptorsData, rows, cols, type, points3d)
     }
 
+    /**
+     * Ingest a fingerprint built from triangulated metric marks (no depth source). Also fixes the
+     * fingerprint anchor pose (column-major 4x4) and the camera intrinsics (fx,fy,cx,cy) the reloc
+     * PnP should use. points3d are in keyframe-0's CV camera frame (see [MetricMarks]).
+     */
+    fun restoreWallFingerprintMetric(
+        descriptorsData: ByteArray, rows: Int, cols: Int, type: Int,
+        points3d: FloatArray, anchorMatrix: FloatArray, intrinsics: FloatArray,
+    ) {
+        nativeRestoreWallFingerprintMetric(descriptorsData, rows, cols, type, points3d, anchorMatrix, intrinsics)
+    }
+
     fun setArtworkFingerprint(
         bitmap: Bitmap,
         depthBuffer: ByteBuffer,
@@ -388,6 +400,10 @@ class SlamManager @Inject constructor(
     ): Fingerprint?
     private external fun nativeRestoreWallFingerprint(
         descriptorsData: ByteArray, rows: Int, cols: Int, type: Int, points3d: FloatArray
+    )
+    private external fun nativeRestoreWallFingerprintMetric(
+        descriptorsData: ByteArray, rows: Int, cols: Int, type: Int,
+        points3d: FloatArray, anchorMatrix: FloatArray, intrinsics: FloatArray
     )
     private external fun nativeSetArtworkFingerprint(
         bitmap: Bitmap, depthBuffer: ByteBuffer,

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/MetricFingerprintBuilder.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/MetricFingerprintBuilder.kt
@@ -1,0 +1,109 @@
+package com.hereliesaz.graffitixr.feature.ar.anchor
+
+import com.hereliesaz.graffitixr.nativebridge.SlamManager
+import org.opencv.core.Mat
+import org.opencv.core.MatOfDMatch
+import org.opencv.core.MatOfKeyPoint
+import org.opencv.features2d.DescriptorMatcher
+import org.opencv.features2d.ORB
+
+/**
+ * Builds a wall fingerprint from two camera keyframes by triangulation — the depth-off path. Detects
+ * ORB on both views, matches with a Lowe ratio test, triangulates the matches into metric 3D via
+ * [MetricMarks] (which wraps the tested [Triangulation] core), and hands the result to the native
+ * engine through [SlamManager.restoreWallFingerprintMetric].
+ *
+ * The artist's natural step-in / step-back supplies the baseline; no second lens, no ML depth. Points
+ * land in keyframe-0's CV camera frame with the anchor pose attached, so they relocalize through the
+ * same PnP/PoseFusion path as a depth-built fingerprint.
+ *
+ * ORB (CV_8U) descriptors are used deliberately: the native reloc thread only takes the SuperPoint
+ * path when the stored descriptors are CV_32F, so CV_8U keeps both ends on ORB and consistent.
+ */
+object MetricFingerprintBuilder {
+
+    /** One captured view: grayscale image, its ARCore/GL world→camera view, and pinhole intrinsics. */
+    class Keyframe(
+        val gray: Mat,
+        val glView: FloatArray,
+        val fx: Float, val fy: Float, val cx: Float, val cy: Float,
+    )
+
+    /**
+     * Detect, match, triangulate, and ingest. Returns the number of metric points committed (0 if the
+     * geometry was too weak — too few matches survived triangulation/reprojection filtering).
+     *
+     * @param anchorModel the anchor's world pose (column-major 4x4) at keyframe-0's time.
+     */
+    fun build(
+        slam: SlamManager,
+        kf0: Keyframe,
+        kf1: Keyframe,
+        anchorModel: FloatArray,
+        minPoints: Int = 20,
+        ratio: Float = 0.75f,
+    ): Int {
+        val matched = detectAndMatch(kf0.gray, kf1.gray, ratio) ?: return 0
+        val cv0 = MetricMarks.glViewToCv(kf0.glView)
+        val cv1 = MetricMarks.glViewToCv(kf1.glView)
+        val tri = MetricMarks.triangulate(matched.corrs, cv0, cv1, kf0.fx, kf0.fy, kf0.cx, kf0.cy)
+        if (tri.count < minPoints) return 0
+
+        // Keep only the rows of frame-0's descriptors whose match survived triangulation.
+        val keptDesc = Mat(tri.count, matched.descriptors.cols(), matched.descriptors.type())
+        for ((dst, src) in tri.kept.withIndex()) {
+            matched.descriptors.row(src).copyTo(keptDesc.row(dst))
+        }
+        val bytes = ByteArray(keptDesc.rows() * keptDesc.cols() * keptDesc.elemSize().toInt())
+        keptDesc.get(0, 0, bytes)
+
+        slam.restoreWallFingerprintMetric(
+            bytes, keptDesc.rows(), keptDesc.cols(), keptDesc.type(),
+            tri.pointsCam0, anchorModel,
+            floatArrayOf(kf0.fx, kf0.fy, kf0.cx, kf0.cy),
+        )
+        keptDesc.release()
+        return tri.count
+    }
+
+    private class Matched(val corrs: List<MetricMarks.Corr>, val descriptors: Mat)
+
+    /** ORB detect + ratio-tested BF-Hamming match. descriptors[i] is frame-0's descriptor for corrs[i]. */
+    private fun detectAndMatch(gray0: Mat, gray1: Mat, ratio: Float): Matched? {
+        val orb = ORB.create(1500)
+        val kp0 = MatOfKeyPoint(); val kp1 = MatOfKeyPoint()
+        val d0 = Mat(); val d1 = Mat()
+        try {
+            orb.detectAndCompute(gray0, Mat(), kp0, d0)
+            orb.detectAndCompute(gray1, Mat(), kp1, d1)
+            if (d0.empty() || d1.empty()) return null
+
+            val matcher = DescriptorMatcher.create(DescriptorMatcher.BRUTEFORCE_HAMMING)
+            val knn = ArrayList<MatOfDMatch>()
+            matcher.knnMatch(d0, d1, knn, 2)
+
+            val pts0 = kp0.toArray()
+            val pts1 = kp1.toArray()
+            val corrs = ArrayList<MetricMarks.Corr>(knn.size)
+            val rows = ArrayList<Int>(knn.size)
+            for (mm in knn) {
+                val m = mm.toArray()
+                if (m.size < 2) continue
+                if (m[0].distance < ratio * m[1].distance) {
+                    val p0 = pts0[m[0].queryIdx].pt
+                    val p1 = pts1[m[0].trainIdx].pt
+                    corrs.add(MetricMarks.Corr(p0.x.toFloat(), p0.y.toFloat(), p1.x.toFloat(), p1.y.toFloat()))
+                    rows.add(m[0].queryIdx)
+                }
+            }
+            if (corrs.isEmpty()) return null
+
+            val desc = Mat(corrs.size, d0.cols(), d0.type())
+            for ((dst, src) in rows.withIndex()) d0.row(src).copyTo(desc.row(dst))
+            return Matched(corrs, desc)
+        } finally {
+            kp0.release(); kp1.release(); d0.release(); d1.release()
+        }
+    }
+}
+</content>

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/MetricFingerprintBuilder.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/MetricFingerprintBuilder.kt
@@ -1,11 +1,16 @@
 package com.hereliesaz.graffitixr.feature.ar.anchor
 
+import android.graphics.Bitmap
+import com.hereliesaz.graffitixr.common.model.Fingerprint
 import com.hereliesaz.graffitixr.nativebridge.SlamManager
+import org.opencv.android.Utils
+import org.opencv.core.KeyPoint
 import org.opencv.core.Mat
 import org.opencv.core.MatOfDMatch
 import org.opencv.core.MatOfKeyPoint
 import org.opencv.features2d.DescriptorMatcher
 import org.opencv.features2d.ORB
+import org.opencv.imgproc.Imgproc
 
 /**
  * Builds a wall fingerprint from two camera keyframes by triangulation — the depth-off path. Detects
@@ -30,8 +35,9 @@ object MetricFingerprintBuilder {
     )
 
     /**
-     * Detect, match, triangulate, and ingest. Returns the number of metric points committed (0 if the
-     * geometry was too weak — too few matches survived triangulation/reprojection filtering).
+     * Detect, match, triangulate, and ingest. Returns a persistable [Fingerprint] (descriptors +
+     * keyframe-0-frame 3D points), or null if the geometry was too weak — too few matches survived
+     * triangulation/reprojection filtering. The result is also committed to the live native engine.
      *
      * @param anchorModel the anchor's world pose (column-major 4x4) at keyframe-0's time.
      */
@@ -42,28 +48,67 @@ object MetricFingerprintBuilder {
         anchorModel: FloatArray,
         minPoints: Int = 20,
         ratio: Float = 0.75f,
-    ): Int {
-        val matched = detectAndMatch(kf0.gray, kf1.gray, ratio) ?: return 0
-        val cv0 = MetricMarks.glViewToCv(kf0.glView)
-        val cv1 = MetricMarks.glViewToCv(kf1.glView)
-        val tri = MetricMarks.triangulate(matched.corrs, cv0, cv1, kf0.fx, kf0.fy, kf0.cx, kf0.cy)
-        if (tri.count < minPoints) return 0
+    ): Fingerprint? {
+        val matched = detectAndMatch(kf0.gray, kf1.gray, ratio) ?: return null
+        try {
+            val cv0 = MetricMarks.glViewToCv(kf0.glView)
+            val cv1 = MetricMarks.glViewToCv(kf1.glView)
+            val tri = MetricMarks.triangulate(matched.corrs, cv0, cv1, kf0.fx, kf0.fy, kf0.cx, kf0.cy)
+            if (tri.count < minPoints) return null
 
-        // Keep only the rows of frame-0's descriptors whose match survived triangulation.
-        val keptDesc = Mat(tri.count, matched.descriptors.cols(), matched.descriptors.type())
-        for ((dst, src) in tri.kept.withIndex()) {
-            matched.descriptors.row(src).copyTo(keptDesc.row(dst))
+            // Keep the rows of frame-0's descriptors (and the frame-0 keypoints) whose match survived.
+            val keptDesc = Mat(tri.count, matched.descriptors.cols(), matched.descriptors.type())
+            val keypoints = ArrayList<KeyPoint>(tri.count)
+            for ((dst, src) in tri.kept.withIndex()) {
+                matched.descriptors.row(src).copyTo(keptDesc.row(dst))
+                val c = matched.corrs[src]
+                keypoints.add(KeyPoint(c.u0, c.v0, 7f))
+            }
+            val bytes = ByteArray(keptDesc.rows() * keptDesc.cols() * keptDesc.elemSize().toInt())
+            keptDesc.get(0, 0, bytes)
+            val rows = keptDesc.rows(); val cols = keptDesc.cols(); val type = keptDesc.type()
+            keptDesc.release()
+
+            slam.restoreWallFingerprintMetric(
+                bytes, rows, cols, type, tri.pointsCam0, anchorModel,
+                floatArrayOf(kf0.fx, kf0.fy, kf0.cx, kf0.cy),
+            )
+            return Fingerprint(keypoints, tri.pointsCam0.toList(), bytes, rows, cols, type)
+        } finally {
+            matched.descriptors.release()
         }
-        val bytes = ByteArray(keptDesc.rows() * keptDesc.cols() * keptDesc.elemSize().toInt())
-        keptDesc.get(0, 0, bytes)
+    }
 
-        slam.restoreWallFingerprintMetric(
-            bytes, keptDesc.rows(), keptDesc.cols(), keptDesc.type(),
-            tri.pointsCam0, anchorModel,
-            floatArrayOf(kf0.fx, kf0.fy, kf0.cx, kf0.cy),
-        )
-        keptDesc.release()
-        return tri.count
+    /**
+     * Bitmap convenience overload: converts each view to grayscale and builds. The two intrinsics
+     * (fx,fy,cx,cy) must describe the same pixel frame as the bitmaps; pass the two views' ARCore
+     * world→camera matrices and the anchor's world pose at keyframe-0's time.
+     */
+    fun build(
+        slam: SlamManager,
+        bitmap0: Bitmap, glView0: FloatArray, intr0: FloatArray,
+        bitmap1: Bitmap, glView1: FloatArray, intr1: FloatArray,
+        anchorModel: FloatArray,
+        minPoints: Int = 20,
+    ): Fingerprint? {
+        val gray0 = toGray(bitmap0)
+        val gray1 = toGray(bitmap1)
+        try {
+            val kf0 = Keyframe(gray0, glView0, intr0[0], intr0[1], intr0[2], intr0[3])
+            val kf1 = Keyframe(gray1, glView1, intr1[0], intr1[1], intr1[2], intr1[3])
+            return build(slam, kf0, kf1, anchorModel, minPoints)
+        } finally {
+            gray0.release(); gray1.release()
+        }
+    }
+
+    private fun toGray(bitmap: Bitmap): Mat {
+        val rgba = Mat()
+        Utils.bitmapToMat(bitmap, rgba)
+        val gray = Mat()
+        Imgproc.cvtColor(rgba, gray, Imgproc.COLOR_RGBA2GRAY)
+        rgba.release()
+        return gray
     }
 
     private class Matched(val corrs: List<MetricMarks.Corr>, val descriptors: Mat)

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/MetricFingerprintBuilder.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/MetricFingerprintBuilder.kt
@@ -151,4 +151,3 @@ object MetricFingerprintBuilder {
         }
     }
 }
-</content>

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/MetricMarks.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/MetricMarks.kt
@@ -1,0 +1,85 @@
+package com.hereliesaz.graffitixr.feature.ar.anchor
+
+import kotlin.math.hypot
+
+/**
+ * Assembles metric 3D marks from two camera views via [Triangulation], for building a wall
+ * fingerprint when no depth source is available (the artist's natural step-in/step-back supplies the
+ * baseline). Pure math — no Android/OpenCV — so it's unit-testable; the OpenCV keypoint
+ * detection/matching that produces the [Corr] list and the native ingest of the result live outside.
+ *
+ * Output points are in **keyframe-0's camera frame, CV convention** (camera looks +Z, depth
+ * positive) — the same frame `MobileGS::generateFingerprint` stores depth-built points in, so the
+ * result drops straight into the existing reloc PnP (objPts = these points).
+ *
+ * Conventions: view matrices are column-major 4x4. [Triangulation] expects **CV-convention** views
+ * (camera looks +Z); ARCore/OpenGL views look −Z, so convert them with [glViewToCv] first.
+ */
+object MetricMarks {
+
+    /** A matched mark: pixel (u,v) in view 0 and view 1, same intrinsics. */
+    data class Corr(val u0: Float, val v0: Float, val u1: Float, val v1: Float)
+
+    /** kept[i] indexes the input list; pointsCam0 is flat [x,y,z,...] in keyframe-0's CV camera frame. */
+    data class Result(val kept: IntArray, val pointsCam0: FloatArray) {
+        val count: Int get() = kept.size
+        override fun equals(other: Any?) = this === other
+        override fun hashCode() = System.identityHashCode(this)
+    }
+
+    /**
+     * Convert an OpenGL/ARCore world→camera view (camera looks −Z) to CV convention (camera looks
+     * +Z) by negating the camera Y and Z axes — i.e. rows 1 and 2 of the matrix.
+     */
+    fun glViewToCv(view: FloatArray): FloatArray {
+        val v = view.copyOf()
+        for (col in 0 until 4) {              // element (row,col) = v[col*4+row], column-major
+            v[col * 4 + 1] = -v[col * 4 + 1]  // row 1 (camera Y)
+            v[col * 4 + 2] = -v[col * 4 + 2]  // row 2 (camera Z)
+        }
+        return v
+    }
+
+    /**
+     * Triangulate matched marks into keyframe-0's CV camera frame, keeping only those that are
+     * non-degenerate, in front of both cameras, and reproject within [maxReprojPx] in both views.
+     * Returns an empty result if the baseline is below [minBaselineM] (geometry too weak to trust).
+     *
+     * @param cvView0 / cvView1 CV-convention world→camera views (see [glViewToCv]).
+     */
+    fun triangulate(
+        corrs: List<Corr>,
+        cvView0: FloatArray, cvView1: FloatArray,
+        fx: Float, fy: Float, cx: Float, cy: Float,
+        maxReprojPx: Float = 2f,
+        minBaselineM: Float = 0.03f,
+    ): Result {
+        if (Triangulation.baselineMeters(cvView0, cvView1) < minBaselineM) {
+            return Result(IntArray(0), FloatArray(0))
+        }
+        val p0 = Triangulation.projectionFromView(cvView0, fx, fy, cx, cy)
+        val p1 = Triangulation.projectionFromView(cvView1, fx, fy, cx, cy)
+        val kept = ArrayList<Int>(corrs.size)
+        val pts = ArrayList<Float>(corrs.size * 3)
+        for ((i, c) in corrs.withIndex()) {
+            val w = Triangulation.triangulate(p0, p1, c.u0, c.v0, c.u1, c.v1) ?: continue
+            val r0 = Triangulation.project(p0, w[0], w[1], w[2]) ?: continue   // cheirality view 0
+            val r1 = Triangulation.project(p1, w[0], w[1], w[2]) ?: continue   // cheirality view 1
+            if (hypot((r0[0] - c.u0).toDouble(), (r0[1] - c.v0).toDouble()) > maxReprojPx) continue
+            if (hypot((r1[0] - c.u1).toDouble(), (r1[1] - c.v1).toDouble()) > maxReprojPx) continue
+            val cam0 = transformPoint(cvView0, w[0], w[1], w[2])
+            if (cam0[2] <= 0f) continue
+            kept.add(i)
+            pts.add(cam0[0]); pts.add(cam0[1]); pts.add(cam0[2])
+        }
+        return Result(kept.toIntArray(), pts.toFloatArray())
+    }
+
+    /** Apply a column-major 4x4 to a point (w=1). */
+    private fun transformPoint(m: FloatArray, x: Float, y: Float, z: Float) = floatArrayOf(
+        m[0] * x + m[4] * y + m[8] * z + m[12],
+        m[1] * x + m[5] * y + m[9] * z + m[13],
+        m[2] * x + m[6] * y + m[10] * z + m[14],
+    )
+}
+</content>

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/MetricMarks.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/MetricMarks.kt
@@ -82,4 +82,3 @@ object MetricMarks {
         m[2] * x + m[6] * y + m[10] * z + m[14],
     )
 }
-</content>

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/PoseFusion.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/PoseFusion.kt
@@ -1,17 +1,48 @@
 package com.hereliesaz.graffitixr.feature.ar.anchor
 
 /**
- * Fuses the ARCore-consensus backbone with smoothed, confidence-weighted mark-PnP corrections into a
- * single rendered anchor model matrix (ARCore world frame). Stateful only across frames (last seq +
- * current smoothed pose); the geometry is pure (see [composeCorrected]/[blend]).
+ * Fuses the ARCore-consensus backbone with mark-PnP relocalization into a single rendered anchor
+ * model matrix (ARCore world frame).
+ *
+ * The PnP fix is modelled as a **persistent world-frame drift correction** `D = corrected ∘
+ * backbone⁻¹`, held between snaps and re-applied to the live backbone every frame
+ * (`fused = D ∘ backbone`). So the overlay stays locked to the PnP-corrected world location even as
+ * ARCore's frame drifts and even on frames where no new snap arrives — the previous design reset to
+ * the raw backbone each non-snap frame, which washed out every correction.
+ *
+ * Correction strength is driven by the **PnP inlier ratio** (not splat confidence, which is ~0 when
+ * the depth API is off and would otherwise zero the correction). A confident relock that is *cold*
+ * — the first lock, or one that diverges far from where we're currently drawing (the pocket case) —
+ * **hard-snaps** (D replaced outright) for instant relocalization; otherwise D is smoothed toward
+ * the new fix.
+ *
+ * Stateful only across frames (last seq + current correction); the geometry is pure.
  */
 class PoseFusion {
     private var lastSeq = 0f
-    private var smoothed: FloatArray? = null
+    private var correction: FloatArray? = null
 
     companion object {
+        /** Minimum inlier ratio for a snap to be trusted at all. */
         const val MIN_INLIER_RATIO = 0.5f
+        /** Base smoothing rate for a (non-cold) correction update. */
         const val BASE_ALPHA = 0.25f
+        /**
+         * Splat-confidence floor. Effective confidence = CONF_FLOOR + (1-CONF_FLOOR)*confGlobal, so
+         * map maturity can *raise* trust toward 1.0 but can never drop it below the floor — depth-off
+         * (confGlobal≈0) still corrects, driven by the inlier ratio.
+         */
+        const val CONF_FLOOR = 0.5f
+        /** A cold (hard) snap requires at least this inlier ratio … */
+        const val COLD_SNAP_INLIER_RATIO = 0.7f
+        /** … and at least this many absolute inliers — guards against a confident-but-tiny match. */
+        const val COLD_SNAP_MIN_INLIERS = 20f
+        /** Translation gap (m) between where we draw now and the new fix that counts as a relock. */
+        const val COLD_SNAP_DIST_M = 0.20f
+        /** Rotation gap (deg) that counts as a relock. */
+        const val COLD_SNAP_ANGLE_DEG = 15f
+
+        private fun identity() = floatArrayOf(1f,0f,0f,0f, 0f,1f,0f,0f, 0f,0f,1f,0f, 0f,0f,0f,1f)
 
         /** Corrected anchor model matrix in the CURRENT world frame. All inputs rigid. */
         fun composeCorrected(vCurrent: FloatArray, pnpMat: FloatArray, fpAnchor: FloatArray): FloatArray =
@@ -23,6 +54,17 @@ class PoseFusion {
             val q = PoseMath.nlerpQuat(PoseMath.matrixToQuaternion(current), PoseMath.matrixToQuaternion(target), alpha)
             return PoseMath.fromQuaternionTranslation(q, t)
         }
+
+        /** True if two rigid poses differ in translation or rotation beyond the cold-snap thresholds. */
+        fun diverged(a: FloatArray, b: FloatArray): Boolean {
+            val ta = PoseMath.translationOf(a); val tb = PoseMath.translationOf(b)
+            val dx = ta[0] - tb[0]; val dy = ta[1] - tb[1]; val dz = ta[2] - tb[2]
+            if (kotlin.math.sqrt(dx * dx + dy * dy + dz * dz) >= COLD_SNAP_DIST_M) return true
+            val qa = PoseMath.matrixToQuaternion(a); val qb = PoseMath.matrixToQuaternion(b)
+            val dot = kotlin.math.abs(qa[0]*qb[0] + qa[1]*qb[1] + qa[2]*qb[2] + qa[3]*qb[3]).coerceIn(0f, 1f)
+            val angleDeg = Math.toDegrees(2.0 * kotlin.math.acos(dot.toDouble())).toFloat()
+            return angleDeg >= COLD_SNAP_ANGLE_DEG
+        }
     }
 
     /**
@@ -30,7 +72,7 @@ class PoseFusion {
      * @param vCurrent current ARCore view matrix (fresh, GL thread)
      * @param reloc    FloatArray(19): [0..15]=pnpMat, [16]=inlierCount, [17]=matchCount, [18]=seq
      * @param fpAnchor fingerprint-frame anchor model matrix
-     * @param confGlobal global splat confidence in [0,1] — map maturity, scales correction strength
+     * @param confGlobal global splat confidence in [0,1] — map maturity; only ever raises trust
      */
     fun currentAnchor(
         backbone: FloatArray,
@@ -41,20 +83,31 @@ class PoseFusion {
     ): FloatArray {
         val seq = reloc[18]
         val matchCount = reloc[17]
-        val inlierRatio = if (matchCount > 0f) reloc[16] / matchCount else 0f
+        val inliers = reloc[16]
+        val inlierRatio = if (matchCount > 0f) inliers / matchCount else 0f
         val isNew = seq > 0f && seq != lastSeq
-        val base = smoothed ?: backbone
 
-        if (!isNew || inlierRatio < MIN_INLIER_RATIO) {
-            smoothed = backbone.copyOf()
-            return backbone
+        if (isNew && inlierRatio >= MIN_INLIER_RATIO) {
+            lastSeq = seq
+            val corrected = composeCorrected(vCurrent, reloc.copyOf(16), fpAnchor)
+            // World-frame drift correction such that D ∘ backbone == corrected at snap time.
+            val newD = PoseMath.multiply(corrected, PoseMath.rigidInverse(backbone))
+
+            val applied = correction?.let { PoseMath.multiply(it, backbone) }
+            val cold = applied == null || diverged(applied, corrected)
+            val highConf = inlierRatio >= COLD_SNAP_INLIER_RATIO && inliers >= COLD_SNAP_MIN_INLIERS
+
+            correction = if (cold && highConf) {
+                newD // instant relock
+            } else {
+                val effConf = (CONF_FLOOR + (1f - CONF_FLOOR) * confGlobal.coerceIn(0f, 1f))
+                val alpha = (BASE_ALPHA * inlierRatio * effConf).coerceIn(0f, 1f)
+                blend(correction ?: identity(), newD, alpha)
+            }
         }
-        lastSeq = seq
-        val pnpMat = reloc.copyOf(16)
-        val corrected = composeCorrected(vCurrent, pnpMat, fpAnchor)
-        val alpha = (BASE_ALPHA * inlierRatio * confGlobal.coerceIn(0f, 1f)).coerceIn(0f, 1f)
-        val out = blend(base, corrected, alpha)
-        smoothed = out
-        return out
+
+        // Hold the correction between snaps and re-apply to the live backbone (world-locked).
+        return correction?.let { PoseMath.multiply(it, backbone) } ?: backbone
     }
 }
+</content>

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/PoseFusion.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/PoseFusion.kt
@@ -110,4 +110,3 @@ class PoseFusion {
         return correction?.let { PoseMath.multiply(it, backbone) } ?: backbone
     }
 }
-</content>

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/MetricMarksTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/MetricMarksTest.kt
@@ -70,4 +70,3 @@ class MetricMarksTest {
         assertTrue("kept the consistent correspondence", r.kept[0] == 0)
     }
 }
-</content>

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/MetricMarksTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/MetricMarksTest.kt
@@ -1,0 +1,73 @@
+package com.hereliesaz.graffitixr.feature.ar.anchor
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MetricMarksTest {
+    private val fx = 500f; private val fy = 500f; private val cx = 320f; private val cy = 320f
+
+    private fun identity() = floatArrayOf(1f,0f,0f,0f, 0f,1f,0f,0f, 0f,0f,1f,0f, 0f,0f,0f,1f)
+    // CV-convention world→camera with identity rotation, camera centered at C: t = -C.
+    private fun viewWithCenter(x: Float, y: Float, z: Float) =
+        identity().also { it[12] = -x; it[13] = -y; it[14] = -z }
+
+    private fun proj(view: FloatArray, x: Float, y: Float, z: Float): FloatArray {
+        val p = Triangulation.projectionFromView(view, fx, fy, cx, cy)
+        return Triangulation.project(p, x, y, z)!!
+    }
+
+    @Test fun `glViewToCv negates the Y and Z rows`() {
+        val gl = floatArrayOf(1f,2f,3f,4f, 5f,6f,7f,8f, 9f,10f,11f,12f, 13f,14f,15f,16f)
+        val cv = MetricMarks.glViewToCv(gl)
+        for (col in 0 until 4) {
+            assertEquals(gl[col*4+0], cv[col*4+0], 0f)     // row 0 unchanged
+            assertEquals(-gl[col*4+1], cv[col*4+1], 0f)    // row 1 negated
+            assertEquals(-gl[col*4+2], cv[col*4+2], 0f)    // row 2 negated
+            assertEquals(gl[col*4+3], cv[col*4+3], 0f)     // row 3 unchanged
+        }
+    }
+
+    @Test fun `recovers camera-frame points from a step-aside baseline`() {
+        val v0 = viewWithCenter(0f, 0f, 0f)   // keyframe 0 at origin -> cam0 frame == world
+        val v1 = viewWithCenter(0.2f, 0f, 0f) // stepped 20cm aside
+        val gt = listOf(
+            floatArrayOf(0.05f, 0.1f, 2f),
+            floatArrayOf(-0.3f, 0.2f, 1.5f),
+            floatArrayOf(0.0f, -0.1f, 3f),
+        )
+        val corrs = gt.map { g ->
+            val a = proj(v0, g[0], g[1], g[2]); val b = proj(v1, g[0], g[1], g[2])
+            MetricMarks.Corr(a[0], a[1], b[0], b[1])
+        }
+        val r = MetricMarks.triangulate(corrs, v0, v1, fx, fy, cx, cy)
+        assertEquals(3, r.count)
+        for (i in gt.indices) {
+            assertEquals(gt[i][0], r.pointsCam0[i*3+0], 1e-2f)
+            assertEquals(gt[i][1], r.pointsCam0[i*3+1], 1e-2f)
+            assertEquals(gt[i][2], r.pointsCam0[i*3+2], 1e-2f)
+        }
+    }
+
+    @Test fun `rejects a near-zero baseline as degenerate`() {
+        val v = viewWithCenter(0f, 0f, 0f)
+        val a = proj(v, 0.05f, 0.1f, 2f)
+        val r = MetricMarks.triangulate(
+            listOf(MetricMarks.Corr(a[0], a[1], a[0], a[1])), v, v, fx, fy, cx, cy)
+        assertEquals(0, r.count)
+    }
+
+    @Test fun `drops a correspondence that reprojects badly (mismatch)`() {
+        val v0 = viewWithCenter(0f, 0f, 0f); val v1 = viewWithCenter(0.2f, 0f, 0f)
+        val good = floatArrayOf(0.05f, 0.1f, 2f)
+        val a = proj(v0, good[0], good[1], good[2]); val b = proj(v1, good[0], good[1], good[2])
+        val corrs = listOf(
+            MetricMarks.Corr(a[0], a[1], b[0], b[1]),          // consistent
+            MetricMarks.Corr(a[0], a[1], b[0] + 150f, b[1] + 150f), // view-1 pixel is a wrong match
+        )
+        val r = MetricMarks.triangulate(corrs, v0, v1, fx, fy, cx, cy)
+        assertEquals(1, r.count)
+        assertTrue("kept the consistent correspondence", r.kept[0] == 0)
+    }
+}
+</content>

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/PoseFusionTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/PoseFusionTest.kt
@@ -1,12 +1,19 @@
 package com.hereliesaz.graffitixr.feature.ar.anchor
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class PoseFusionTest {
     private fun identity() = floatArrayOf(1f,0f,0f,0f, 0f,1f,0f,0f, 0f,0f,1f,0f, 0f,0f,0f,1f)
     private fun trans(x: Float, y: Float, z: Float) =
         floatArrayOf(1f,0f,0f,0f, 0f,1f,0f,0f, 0f,0f,1f,0f, x,y,z,1f)
+
+    /** reloc payload with vCurrent=I, fpAnchor=I so composeCorrected(reloc)=target. */
+    private fun reloc(target: FloatArray, inliers: Float, matches: Float, seq: Float) =
+        FloatArray(19).also {
+            System.arraycopy(target, 0, it, 0, 16); it[16] = inliers; it[17] = matches; it[18] = seq
+        }
 
     @Test fun `composeCorrected with V=pnp and fpAnchor=I yields identity`() {
         val v = trans(2f, 0f, 0f)
@@ -21,30 +28,72 @@ class PoseFusionTest {
         assertEquals(5f, PoseFusion.blend(cur, tgt, 0.5f)[12], 1e-4f)
     }
 
-    @Test fun `fusion returns backbone when no new reloc result`() {
+    @Test fun `returns backbone when no new reloc result`() {
         val f = PoseFusion()
         val backbone = trans(1f,1f,1f)
-        val out = f.currentAnchor(backbone, identity(), reloc = FloatArray(19), fpAnchor = identity(), confGlobal = 1f)
+        val out = f.currentAnchor(backbone, identity(), FloatArray(19), identity(), confGlobal = 1f)
         backbone.forEachIndexed { i, e -> assertEquals(e, out[i], 1e-4f) }
     }
 
-    @Test fun `fusion ignores low-inlier-ratio snaps`() {
+    @Test fun `ignores low-inlier-ratio snaps`() {
         val f = PoseFusion()
-        val backbone = trans(0f,0f,0f)
-        val reloc = FloatArray(19).also {
-            System.arraycopy(trans(99f,0f,0f), 0, it, 0, 16); it[16] = 1f; it[17] = 100f; it[18] = 1f
-        }
-        val out = f.currentAnchor(backbone, identity(), reloc, fpAnchor = identity(), confGlobal = 1f)
+        val out = f.currentAnchor(trans(0f,0f,0f), identity(),
+            reloc(trans(99f,0f,0f), inliers = 1f, matches = 100f, seq = 1f), identity(), confGlobal = 1f)
         assertEquals(0f, out[12], 1e-3f)
     }
 
-    @Test fun `fusion moves toward correction on a confident new snap`() {
+    @Test fun `first confident snap hard-snaps to correction`() {
         val f = PoseFusion()
-        val backbone = trans(0f,0f,0f)
-        val reloc = FloatArray(19).also {
-            System.arraycopy(trans(10f,0f,0f), 0, it, 0, 16); it[16] = 90f; it[17] = 100f; it[18] = 1f
-        }
-        val out = f.currentAnchor(backbone, identity(), reloc, fpAnchor = identity(), confGlobal = 1f)
-        assert(out[12] > 0f && out[12] < 10f) { "expected partial move, got ${out[12]}" }
+        val out = f.currentAnchor(trans(0f,0f,0f), identity(),
+            reloc(trans(10f,0f,0f), inliers = 90f, matches = 100f, seq = 1f), identity(), confGlobal = 1f)
+        assertEquals(10f, out[12], 1e-3f)
+    }
+
+    @Test fun `moderate-confidence first snap partially corrects`() {
+        val f = PoseFusion()
+        // ratio 0.6: above MIN_INLIER_RATIO but below COLD_SNAP_INLIER_RATIO -> smooth, not snap.
+        val out = f.currentAnchor(trans(0f,0f,0f), identity(),
+            reloc(trans(10f,0f,0f), inliers = 60f, matches = 100f, seq = 1f), identity(), confGlobal = 1f)
+        assertTrue("expected partial move, got ${out[12]}", out[12] > 0f && out[12] < 10f)
+    }
+
+    @Test fun `depth-off (confGlobal 0) still corrects via inlier ratio`() {
+        val f = PoseFusion()
+        // The old design multiplied alpha by confGlobal, so conf=0 froze the overlay. The floor fixes it.
+        val out = f.currentAnchor(trans(0f,0f,0f), identity(),
+            reloc(trans(10f,0f,0f), inliers = 60f, matches = 100f, seq = 1f), identity(), confGlobal = 0f)
+        assertTrue("expected non-zero correction with depth off, got ${out[12]}", out[12] > 0f)
+    }
+
+    @Test fun `correction persists and stays world-locked between snaps`() {
+        val f = PoseFusion()
+        // Confident cold snap establishes D = +10x at backbone origin.
+        f.currentAnchor(trans(0f,0f,0f), identity(),
+            reloc(trans(10f,0f,0f), inliers = 90f, matches = 100f, seq = 1f), identity(), confGlobal = 1f)
+        // No new snap, but ARCore's frame drifts the backbone by +1z: D must still apply.
+        val out = f.currentAnchor(trans(0f,0f,1f), identity(), FloatArray(19), identity(), confGlobal = 1f)
+        assertEquals(10f, out[12], 1e-3f)
+        assertEquals(1f, out[14], 1e-3f)
+    }
+
+    @Test fun `confident relock that diverges far hard-snaps (pocket case)`() {
+        val f = PoseFusion()
+        f.currentAnchor(trans(0f,0f,0f), identity(),
+            reloc(trans(10f,0f,0f), inliers = 90f, matches = 100f, seq = 1f), identity(), confGlobal = 1f)
+        // New confident snap puts the anchor 10m away -> beyond COLD_SNAP_DIST_M -> instant relock.
+        val out = f.currentAnchor(trans(0f,0f,0f), identity(),
+            reloc(trans(20f,0f,0f), inliers = 90f, matches = 100f, seq = 2f), identity(), confGlobal = 1f)
+        assertEquals(20f, out[12], 1e-3f)
+    }
+
+    @Test fun `small confident relock smooths instead of teleporting`() {
+        val f = PoseFusion()
+        f.currentAnchor(trans(0f,0f,0f), identity(),
+            reloc(trans(10f,0f,0f), inliers = 90f, matches = 100f, seq = 1f), identity(), confGlobal = 1f)
+        // 5cm move (< COLD_SNAP_DIST_M) -> not cold -> smoothed, lands just past 10, not snapped to 10.05.
+        val out = f.currentAnchor(trans(0f,0f,0f), identity(),
+            reloc(trans(10.05f,0f,0f), inliers = 90f, matches = 100f, seq = 2f), identity(), confGlobal = 1f)
+        assertTrue("expected smoothed move, got ${out[12]}", out[12] > 10f && out[12] < 10.05f)
     }
 }
+</content>

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/PoseFusionTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/PoseFusionTest.kt
@@ -96,4 +96,3 @@ class PoseFusionTest {
         assertTrue("expected smoothed move, got ${out[12]}", out[12] > 10f && out[12] < 10.05f)
     }
 }
-</content>


### PR DESCRIPTION
Follow-on to #1529 (which merged the distortion-head spec + training pipeline). These 7 commits landed on the branch after that merge, so they need their own PR. They make the depth-off relocalization path work end-to-end.

## What

**Fusion + reloc were structurally broken; this fixes the chain and adds the depth-off path.**

1. **`fix(ar): persistent, inlier-driven pose fusion with cold hard-snap`** — `PoseFusion` reset to the raw backbone every non-snap frame (corrections washed out next frame) and multiplied `alpha` by splat confidence (≈0 with depth off → overlay never corrected). Reworked to a persistent world-frame drift correction `D = corrected ∘ backbone⁻¹`, inlier-ratio driven with a confidence floor, plus an instant cold hard-snap on first/diverged confident relock. Tests rewritten.
2. **`fix(slam): actually run live relocalization + real PnP intrinsics`** — `scheduleRelocCheck` was an empty stub, so the reloc thread never got a frame and live PnP relocalization never ran at all. Implemented it (throttled). Also fixed the reloc camera matrix: a `Mat_<double>(3,3)` initialized with only 6 of 9 values, hardcoded to a resolution guess — now uses the fingerprint's real intrinsics.
3. **`feat(slam): IPPE planar refine + flip-resolution`** — refine the RANSAC inlier pose with `SOLVEPNP_IPPE`, resolving the planar two-fold ambiguity by reprojection; adopted only if it strictly beats the RANSAC pose, so it can't regress.
4. **`feat(ar): MetricMarks`** — tested two-view → metric-3D geometry (depth-off fingerprint), wrapping the tested `Triangulation` core with baseline/cheirality/reprojection filtering and GL→CV conversion.
5. **`feat(slam): native ingest for triangulated metric fingerprints`** — `restoreWallFingerprintMetric` (native + JNI + Kotlin) sets descriptors + 3D + anchor + intrinsics together.
6. **`feat(ar): MetricFingerprintBuilder`** — ORB detect/match → triangulate → persistable `Fingerprint` + native ingest.
7. **`feat(ar): depth-off target creation via two-keyframe triangulation`** — `onConfirmTargetCreation` branches on depth: with none, a two-tap capture (step aside) triangulates the marks. Previously depth-off target creation produced no fingerprint at all.

## Testing
Pure-math units are unit-tested (`PoseFusion`, `MetricMarks`; `Triangulation` already was). Native + OpenCV-Java paths compile-verified by review; CI build validation in progress.

## Not included (genuinely blocked)
- Distortion-head device integration — needs the trained `distortion_head.onnx`.
- Teleological promotion (stages 2–4) — needs the stage-1 target validator.

https://claude.ai/code/session_0113WPtR3s4xfLPpVSEDjm8o

---
_Generated by [Claude Code](https://claude.ai/code/session_0113WPtR3s4xfLPpVSEDjm8o)_