### PR TITLE
fix(ar): repair botched PoseFusion merge that broke the build

### DIFF
--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/PoseFusion.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/PoseFusion.kt
@@ -20,10 +20,12 @@ package com.hereliesaz.graffitixr.feature.ar.anchor
  */
 class PoseFusion {
     private var lastSeq = 0f
-    private var smoothed: FloatArray? = null
-    // True until the first confident relocalization after a (re)start or tracking loss. The first
-    // confident snap is applied HARD (no smoothing) so a cold relock — out of a pocket, screen back on —
-    // is instantaneous; subsequent in-session corrections are smoothed to avoid jitter.
+    // Persistent world-frame drift correction D such that fused = D ∘ backbone. Held between snaps and
+    // re-applied every frame so the overlay stays locked to the PnP-corrected world location even on
+    // frames with no new snap. Null until the first trusted relocalization.
+    private var correction: FloatArray? = null
+    // True until the first HARD relock after a (re)start or tracking loss, so a cold relock — out of a
+    // pocket, screen back on — snaps instantly instead of easing in.
     private var coldStart = true
 
     /** Re-arm the cold (hard) snap — call on session resume / tracking loss so the next relock is instant. */
@@ -96,16 +98,19 @@ class PoseFusion {
         val isNew = seq > 0f && seq != lastSeq
 
         if (isNew && inlierRatio >= MIN_INLIER_RATIO) {
-            lastSeq = seq
             val corrected = composeCorrected(vCurrent, reloc.copyOf(16), fpAnchor)
             // World-frame drift correction such that D ∘ backbone == corrected at snap time.
             val newD = PoseMath.multiply(corrected, PoseMath.rigidInverse(backbone))
 
+            // Cold = first lock after (re)start/tracking-loss, no prior correction, or a fix that
+            // diverges far from where we currently draw (the pocket case). A confident cold fix snaps
+            // hard for instant relock; everything else eases in by inlier-ratio-scaled alpha.
             val applied = correction?.let { PoseMath.multiply(it, backbone) }
-            val cold = applied == null || diverged(applied, corrected)
+            val cold = coldStart || applied == null || diverged(applied, corrected)
             val highConf = inlierRatio >= COLD_SNAP_INLIER_RATIO && inliers >= COLD_SNAP_MIN_INLIERS
 
             correction = if (cold && highConf) {
+                coldStart = false
                 newD // instant relock
             } else {
                 val effConf = (CONF_FLOOR + (1f - CONF_FLOOR) * confGlobal.coerceIn(0f, 1f))
@@ -114,13 +119,7 @@ class PoseFusion {
             }
         }
         lastSeq = seq
-        val pnpMat = reloc.copyOf(16)
-        val corrected = composeCorrected(vCurrent, pnpMat, fpAnchor)
-        // Cold relock snaps hard (instant); warm corrections ease in by inlier-ratio-scaled alpha.
-        val alpha = if (coldStart) 1f else (BASE_ALPHA * inlierRatio).coerceIn(0f, 1f)
-        coldStart = false
-        val out = blend(base, corrected, alpha)
-        smoothed = out
-        return out
+        // fused = D ∘ backbone, re-applied every frame (identity drift until the first trusted snap).
+        return PoseMath.multiply(correction ?: identity(), backbone)
     }
 }


### PR DESCRIPTION
## Problem
`origin/main` does not compile. The #1537 merge spliced two `PoseFusion` implementations together — the function references a `correction` field that was never declared **and** a `base` parameter that doesn't exist:

```
e: PoseFusion.kt:104 Unresolved reference 'correction'.
e: PoseFusion.kt:122 Unresolved reference 'base'.
```

This breaks `:app:assembleDebug`, so on-device testing can't build.

## Fix
Reconcile to the single persistent-drift model the existing `PoseFusionTest` already specifies:
- `D = corrected ∘ backbone⁻¹`, held between snaps, re-applied each frame as `fused = D ∘ backbone`.
- Cold-start hard-snap folded into the `cold` decision, gated by high confidence so moderate first snaps still ease in.
- Dropped the leftover `base`/`smoothed` block.

## Verification
- All `*PoseFusionTest` cases pass.
- `:app:assembleDebug` → BUILD SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix pose fusion drift correction so AR builds and runs again by reconciling to a single persistent correction model and always deriving the fused pose from it.

Bug Fixes:
- Resolve unresolved references and broken pose fusion logic that prevented the AR module from compiling.

Enhancements:
- Unify pose fusion around a persistent world-frame drift correction applied each frame, with cold-start handling based on relock confidence.