### PR TITLE
feat(ar): perspective-robust matching design + partial-view inlier floor

### DIFF
--- a/core/nativebridge/src/main/cpp/MobileGS.cpp
+++ b/core/nativebridge/src/main/cpp/MobileGS.cpp
@@ -332,7 +332,7 @@ void MobileGS::relocThreadFunc() {
             cv::Mat intr = (cv::Mat_<double>(3,3) << fx, 0, cx, 0, fy, cy, 0, 0, 1);
             StageTimer _pnpTimer(&mStageAccumMs[4], &mStageSamples[4]);
             if (cv::solvePnPRansac(objPts, imgPts, intr, cv::Mat(), rvec, tvec, false, 100, 8.0, 0.99, inliers)) {
-                if (inliers.size() >= 12) {
+                if (inliers.size() >= 6) {
                     // Refine on the RANSAC inliers. The marks lie on the wall plane, so resolve the
                     // planar two-fold (flip) ambiguity with IPPE and keep whichever pose reprojects
                     // best — but only adopt it if it strictly beats the RANSAC pose, so a non-coplanar

--- a/docs/superpowers/specs/2026-06-03-perspective-robust-matching-design.md
+++ b/docs/superpowers/specs/2026-06-03-perspective-robust-matching-design.md
@@ -1,0 +1,97 @@
+# Perspective- & Distortion-Robust Relocalization Matching
+
+**Status:** design (2026-06-03). Extends `2026-06-02-relocalization-first-design.md`.
+**Driver:** Up-close and *off-to-the-side* viewing distorts the wall marks (perspective
+foreshortening) and shifts their light/color. The app must (a) still recognize the fingerprint under
+that distortion and from partial views, and (b) *know* it is at an oblique angle so it can adapt and
+inform the user.
+
+## Where we are (main, post-#1537/#1541)
+
+Reloc pipeline in `MobileGS::relocThreadFunc` (`MobileGS.cpp:278–387`):
+- Detector/descriptor: **SuperPoint** (learned) with **ORB** fallback.
+- Matching: `knnMatch(k=2)` + Lowe ratio 0.75.
+- Pose: `solvePnPRansac` → **IPPE planar refine + flip-resolution** (adopt only if it strictly beats
+  the RANSAC reprojection). Real fingerprint intrinsics (`mFingerprintIntrinsics`).
+- Publishes `mPnpCamFromFpWorld` + inlier/match counts + seq → `PoseFusion` (D-drift + cold-snap).
+
+**Robustness today:** *moderate.* SuperPoint is fairly viewpoint/illumination-robust, and PnP+IPPE
+handles the planar geometry — but the bottleneck is the **2D match**, not the pose solve. Under steep
+oblique + light change, descriptor matching degrades and the relock fails. Nothing currently uses the
+*known* viewing angle, even though it is derivable from the pose.
+
+## Key insight: the distortion is a homography we can pre-cancel
+
+The marks lie on a **known plane**, and ARCore VIO gives a **pose** every frame (it drifts, but it is
+continuous while tracking). The appearance difference between the stored frontal fingerprint and the
+current oblique view of a planar target is therefore a **homography**. We can **rectify** (warp) the
+live frame toward the fingerprint's canonical frontal view *before* matching, neutralizing the
+perspective geometrically. Learned descriptors (SuperPoint, already used) absorb most of the
+illumination change. So: **rectify (geometry) + learned features (appearance)** — no custom model
+training required.
+
+This also breaks the chicken-and-egg: rectification does **not** need matches first — the VIO pose
+supplies the warp; PnP then refines on the rectified matches.
+
+## Decision: do NOT train a custom model
+
+What "recognize an image/parts under perspective + light/color change" needs is **learned local
+features + a learned matcher**, which exist pretrained and already encode that invariance:
+- **SuperPoint + LightGlue** (LightGlue = modern, mobile-friendly matcher), or **XFeat**
+  (lightweight, built for constrained devices).
+Training a bespoke perspective/illumination-invariant model needs large augmented data and would only
+re-derive what these give for free. Use pretrained; spend effort on rectification + the multi-view
+fingerprint instead.
+
+## Staged design
+
+### Stage 1 — Plane-guided rectification (rectify-then-match)  ← next build
+Data already present: `mViewMatrix` (current VIO view), `mFingerprintAnchorMatrix` (wall anchor at
+capture), `mFingerprintIntrinsics`, `mWallKeypoints3D` (define the plane in the fingerprint-camera
+frame). **Add** `mFingerprintViewMatrix` (capture-time VIO view — `generateFingerprint` already
+*receives* `viewMat` but ignores it).
+
+1. Fit a plane to `mWallKeypoints3D` (normal `n_fp`, offset `d_fp`) in the fingerprint-camera frame.
+2. Relative pose fingerprint-camera → current-camera ≈ `view_cur · inverse(view_fp)` (valid while VIO
+   tracks; both share the VIO world).
+3. Plane-induced homography `H = K_fp · (R − t·nᵀ/d) · K_cur⁻¹` mapping current image → fingerprint
+   image. Warp the current gray by `H` (frontal-equivalent), then detect+match against the stored
+   fingerprint descriptors in fingerprint-image coordinates; un-warp matched 2D back for PnP.
+4. **Obliquity gate:** only rectify when the angle between `n` (current camera frame) and the camera
+   axis exceeds ~25° (frontal views need no warp), and only when VIO is tracking.
+5. **Never-worse fallback:** if VIO isn't tracking, or rectified matching yields fewer good matches
+   than the plain path, keep the plain result. Extra cost = one warp + one SuperPoint inference when
+   oblique — acceptable (accuracy ≫ compute here).
+
+### Stage 2 — Multi-viewpoint / multi-scale fingerprint
+The fingerprint "looks different up-close vs far" (scale) and from the side (perspective). Store
+descriptors captured at several distances/angles and match against the union. The **teleological
+self-growing fingerprint** (`tryUpdateFingerprint`, currently a stub at `MobileGS.cpp:389`) is the
+natural accumulator: as the artist paints from different spots, validated new marks enter the
+fingerprint with their viewpoint, widening coverage over time.
+
+### Stage 3 — Learned matcher (LightGlue / XFeat) — optional upgrade
+Replace knn+Lowe with a learned matcher for wide-baseline robustness. Pretrained ONNX, no training;
+larger integration, deferred until Stages 1–2 are validated on-device.
+
+## "Does it know the angle?" — yes, and it should act on it
+
+Obliquity = angle(plane-normal-in-camera, camera forward), computable each frame from `view · anchor`.
+Use it to (a) trigger rectification, (b) scale/gate relock confidence, (c) optionally inform the user
+("steep angle — move around to lock"). This is the "ML recognizing and informing" the user asked for,
+achieved with geometry + the existing learned descriptor.
+
+## Concrete change shipped with this spec
+
+`MobileGS.cpp:335` — lower the published-match floor `inliers.size() >= 12 → >= 6`. The comment above
+the block already promises permissiveness for **partial** close-up views, and `PoseFusion` is the real
+gate: a small match can only *smooth-correct* (hard-snap still needs ratio ≥ 0.7 **and** ≥ 20
+inliers), so a 6-inlier partial nudges the overlay without risking a teleport to a bad pose.
+
+## Verification
+
+- Stage 1: unit-test the homography/obliquity math (pure, JVM-testable if mirrored in Kotlin, or a
+  native gtest); on-device A/B with the existing Fusion ON/OFF dev overlay — relock success rate from
+  oblique/partial positions vs. frontal.
+- Floor change: on-device — confirm partial close-up relocks now nudge the overlay and that no false
+  teleports appear (they can't, per the PoseFusion gate).


### PR DESCRIPTION
## Design (spec)
`docs/superpowers/specs/2026-06-03-perspective-robust-matching-design.md` — robust relocalization under perspective distortion + light/color change, and from partial views:
- **Plane-guided rectify-then-match**: the marks lie on a known plane and VIO gives a pose, so the oblique↔frontal distortion is a homography we can pre-cancel before matching. Obliquity-gated, never-worse fallback.
- **Multi-viewpoint/scale fingerprint** via the teleological self-grow (handles up-close vs far).
- **Learned matcher (LightGlue/XFeat)** optional upgrade — pretrained, no custom training.
- Use the viewing angle to gate confidence and inform the user.

## Code change
Lower the published-reloc inlier floor `12 → 6` (`MobileGS.cpp`) so close-up **partial** views can localize. `PoseFusion` stays the real gate — a hard-snap still needs ratio ≥ 0.7 **and** ≥ 20 inliers — so a small partial match only smooth-corrects, never teleports.

## Verification
- `:core:nativebridge` native build SUCCESSFUL.
- On-device A/B (Fusion ON/OFF overlay): partial/oblique relock rate — to be validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Lower the relocalization inlier threshold to better support partial close-up views and document the design for perspective- and distortion-robust matching.

Enhancements:
- Relax the PnP inlier count threshold used to publish relocalization results to allow partial-view matches to contribute pose corrections.

Documentation:
- Add a design spec describing a plane-guided rectification approach, multi-view fingerprints, and optional learned matching for perspective-robust relocalization.