### PR TITLE
refactor(ar): register teleological base from the live design composite (option A)

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainViewModel.kt
@@ -3,7 +3,6 @@ package com.hereliesaz.graffitixr
 
 import android.content.Context
 import android.graphics.Bitmap
-import com.hereliesaz.graffitixr.common.util.ImageUtils
 import android.widget.Toast
 import java.nio.ByteBuffer
 import androidx.lifecycle.ViewModel
@@ -279,25 +278,8 @@ class MainViewModel @Inject constructor(
                 return@launch
             }
 
-            // Teleological base: register the design composited over the captured wall as the "base
-            // understanding" the clean camera frame is validated against (drives painting-progress and
-            // the staged self-grow). Built from the same capture frame/depth/intrinsics as the wall
-            // fingerprint, so the artwork 3D coordinates align. No overlay yet => gatekeeper stays inert.
-            currentProject.overlayImageUri?.let { overlayUri ->
-                val design = ImageUtils.loadBitmapSync(context, overlayUri)
-                if (design != null) {
-                    val composite = sensorBmp.copy(Bitmap.Config.ARGB_8888, true)
-                    android.graphics.Canvas(composite).drawBitmap(
-                        design,
-                        null,
-                        android.graphics.Rect(0, 0, composite.width, composite.height),
-                        android.graphics.Paint().apply { alpha = 180; isFilterBitmap = true }
-                    )
-                    slamManager.setArtworkFingerprint(
-                        composite, safeDepth, depthW, depthH, depthStride, safeIntr, safeView
-                    )
-                }
-            }
+            // (Teleological artwork base is registered from the live design composite via
+            // ArViewModel.updatePaintingGuide — the design-only overlay, not blended with wall texture.)
 
             projectManager.saveProject(
                 context = context,
@@ -367,21 +349,8 @@ class MainViewModel @Inject constructor(
                 }
                 return@launch
             }
-            // Teleological base (depth-off path): register the design composited over the captured wall.
-            // No depth buffer here => descriptors-only base, which is enough to drive painting-progress.
-            currentProject.overlayImageUri?.let { overlayUri ->
-                val design = ImageUtils.loadBitmapSync(context, overlayUri)
-                if (design != null) {
-                    val composite = bitmap.copy(Bitmap.Config.ARGB_8888, true)
-                    android.graphics.Canvas(composite).drawBitmap(
-                        design,
-                        null,
-                        android.graphics.Rect(0, 0, composite.width, composite.height),
-                        android.graphics.Paint().apply { alpha = 180; isFilterBitmap = true }
-                    )
-                    slamManager.setArtworkFingerprint(composite, null, 0, 0, 0, intr, view)
-                }
-            }
+            // (Teleological artwork base is registered from the live design composite via
+            // ArViewModel.updatePaintingGuide — see the depth path above.)
 
             projectManager.saveProject(
                 context = context,

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -896,8 +896,25 @@ class ArViewModel @Inject constructor(
         }
     }
 
+    private val artworkRegInFlight = java.util.concurrent.atomic.AtomicBoolean(false)
+
     fun updatePaintingGuide(bitmap: Bitmap) {
-        // Future: feed to PnP engine if needed
+        // The design composite (design layers only — NO wall texture) is the teleological "base
+        // understanding": the registered overlay the clean wall frame is validated against. Re-register
+        // it as the artwork base whenever the design changes so painting-progress (and the staged
+        // self-grow) track the current design. Descriptors-only here (no capture depth); the
+        // 3D-dependent promotion step is staged. compareAndSet drops overlapping registrations — the
+        // next stable design state registers once the in-flight one finishes.
+        if (!artworkRegInFlight.compareAndSet(false, true)) return
+        val intr = _uiState.value.targetIntrinsics ?: FloatArray(4)
+        val view = _uiState.value.targetCaptureViewMatrix ?: FloatArray(16)
+        viewModelScope.launch(Dispatchers.IO) {
+            try {
+                slamManager.setArtworkFingerprint(bitmap, null, 0, 0, 0, intr, view)
+            } finally {
+                artworkRegInFlight.set(false)
+            }
+        }
     }
 
     fun onFreezeRequested(bitmap: Bitmap) {


### PR DESCRIPTION
## What
Switches the teleological artwork base from a **wall-blended** composite (option B) to the **design-only** composite the Design refactor already produces (option A). Blending wall texture let painting-progress score off wall features the design never had; the gatekeeper must fire only on real design content.

The refactor builds `compositeLayersForAr(visibleLayers)` and routes it to the AR overlay **and** to the previously-stubbed `ArViewModel.updatePaintingGuide(bitmap)` (commented *"Future: feed to PnP engine if needed"*). That bitmap is the design layers alone — the true base understanding.

- **Implement `updatePaintingGuide`**: register the design composite as the artwork base (descriptors-only; 3D-dependent promotion stays staged), refreshed whenever the design changes; `compareAndSet` drops overlapping registrations.
- **Drop** the `MainViewModel` `overlayImageUri` registration in both target-creation paths + the now-unused `ImageUtils` import.

## Verification
- `:app:assembleDebug` → BUILD SUCCESSFUL.
- On-device: with a design overlaid in AR, logcat `setArtworkFingerprint: stored N target validator features`; painting-progress should now rise only as the wall matches the **design**, not from wall texture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)