### PR TITLE
feat(ar): truthful fingerprint-keypoint curation overlay + depth-optional artwork base

### DIFF
--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -1077,6 +1077,28 @@ class ArViewModel @Inject constructor(
 
     fun setAnnotatedCapture(bitmap: Bitmap?) {
         _uiState.update { it.copy(annotatedCaptureBitmap = bitmap) }
+        computeTargetKeypoints()
+    }
+
+    /**
+     * Detect the REAL fingerprint features on the captured target (same detector as
+     * generateFingerprint, restricted to the current mask) and publish them normalized for the
+     * refinement overlay, so the user sees exactly what will anchor and can erase the spurious ones.
+     */
+    private fun computeTargetKeypoints() {
+        val raw = _uiState.value.tempCaptureBitmap
+        if (raw == null) {
+            _uiState.update { it.copy(targetKeypoints = emptyList()) }
+            return
+        }
+        val mask = _uiState.value.annotatedCaptureBitmap
+        val w = raw.width.toFloat().coerceAtLeast(1f)
+        val h = raw.height.toFloat().coerceAtLeast(1f)
+        viewModelScope.launch(Dispatchers.IO) {
+            val pts = slamManager.getFingerprintKeypoints(raw, mask)
+                .map { androidx.compose.ui.geometry.Offset(it.first / w, it.second / h) }
+            _uiState.update { it.copy(targetKeypoints = pts) }
+        }
     }
 
 

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/TargetCreationFlow.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/TargetCreationFlow.kt
@@ -76,6 +76,7 @@ fun TargetCreationUi(
                 TargetRefinementScreen(
                     rawBitmap = uiState.tempCaptureBitmap,
                     maskBitmap = uiState.annotatedCaptureBitmap,
+                    keypoints = uiState.targetKeypoints,
                     strings = strings,
                     onNext = { mask ->
                         if (mask != null) {
@@ -336,6 +337,7 @@ private fun UnwarpOverlay(
 private fun TargetRefinementScreen(
     rawBitmap: Bitmap?,
     maskBitmap: Bitmap?,
+    keypoints: List<Offset>,
     strings: AppStrings,
     onNext: (Bitmap?) -> Unit,
     onRetake: () -> Unit,
@@ -382,6 +384,18 @@ private fun TargetRefinementScreen(
                 val imgH = bmpH * scale
                 val imgX = (boxW - imgW) / 2f
                 val imgY = (boxH - imgH) / 2f
+
+                // The actual fingerprint features (HotPink dots) overlaid where they sit on the capture,
+                // so the user sees exactly what anchors and can tap/drag to erase the spurious ones.
+                Canvas(modifier = Modifier.fillMaxSize()) {
+                    keypoints.forEach { kp ->
+                        drawCircle(
+                            color = HotPink,
+                            radius = 4f,
+                            center = Offset(imgX + kp.x * imgW, imgY + kp.y * imgH)
+                        )
+                    }
+                }
 
                 Box(
                     modifier = Modifier.fillMaxSize()


### PR DESCRIPTION
## Two things on the target-refinement step

### 1. Fix: `setArtworkFingerprint` is now depth-optional
The merged version **required** a depth buffer and bailed otherwise — so the option-A teleological base (the design composite, which has no depth) never registered and **painting-progress was silently stuck at 0**. Now: 3D from depth when present (for the staged self-grow), descriptors-only otherwise.

### 2. Feature: truthful keypoint curation overlay
Tap/drag-to-erase + mask display already exist and already remove marks from the fingerprint. The gap was *seeing* what anchors — the only keypoint API (`getKeypoints`) ran plain **ORB-500**, not the real detector. Added `getFingerprintKeypoints` (native + JNI + SlamManager) that mirrors `generateFingerprint`'s detection (**SuperPoint / ORB-1000, masked**) and returns the real 2D positions. `ArViewModel` computes them on capture → `ArUiState.targetKeypoints` (normalized); `TargetRefinementScreen` overlays them as HotPink dots via the existing image-fit transform.

So on the refinement screen you now see the **actual** fingerprint features and erase the spurious ones by tap/drag.

## Verification
- `:app:assembleDebug` → BUILD SUCCESSFUL.
- On-device: capture a target → dots appear on the real features; erasing removes them from the built fingerprint; and (fix #1) `setArtworkFingerprint: stored N validator features` now logs on the option-A path so painting-progress works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)