### PR TITLE
feat: Implement illumination normalization for robust AR feature matc…

### DIFF
--- a/core/nativebridge/src/main/cpp/MobileGS.cpp
+++ b/core/nativebridge/src/main/cpp/MobileGS.cpp
@@ -17,6 +17,17 @@
 #define LOGE(...) __android_log_print(ANDROID_LOG_ERROR, "MobileGS", __VA_ARGS__)
 
 namespace {
+// Normalize illumination so feature matching survives light/color changes: CLAHE on the luma. MUST be
+// applied identically to BOTH fingerprint build and live reloc detection or descriptors stop matching.
+// thread_local so the reloc/map/UI threads each keep their own reusable instance.
+inline void normalizeForFeatures(cv::Mat& gray) {
+    if (gray.empty() || gray.type() != CV_8UC1) return;
+    static thread_local cv::Ptr<cv::CLAHE> clahe = cv::createCLAHE(2.0, cv::Size(8, 8));
+    cv::Mat tmp;
+    clahe->apply(gray, tmp);   // not in-place, and never aliases a caller's source bitmap
+    gray = tmp;
+}
+
 // C++17-compatible atomic double add via CAS loop.
 inline void atomicAddDouble(std::atomic<double>* a, double v) {
     double old = a->load(std::memory_order_relaxed);
@@ -290,6 +301,7 @@ void MobileGS::relocThreadFunc() {
         }
         cv::Mat gray;
         cv::cvtColor(workFrame, gray, cv::COLOR_RGB2GRAY);
+        normalizeForFeatures(gray); // illumination-normalize to match the (also-normalized) fingerprint
 
         // SuperPoint usable when loaded and the wall fingerprint is float-typed (or empty).
         const bool spOk = mSuperPoint.isLoaded() &&
@@ -708,6 +720,7 @@ void MobileGS::setArtworkFingerprint(const cv::Mat& composite, const uint8_t* de
     if (composite.channels() == 4)      cv::cvtColor(composite, gray, cv::COLOR_RGBA2GRAY);
     else if (composite.channels() == 3) cv::cvtColor(composite, gray, cv::COLOR_RGB2GRAY);
     else                                gray = composite;
+    normalizeForFeatures(gray); // match the live frame's illumination normalization
 
     std::vector<cv::KeyPoint> kps;
     cv::Mat descs;
@@ -777,6 +790,7 @@ void MobileGS::getFingerprintKeypoints(const cv::Mat& image, const cv::Mat& mask
     if (workFrame.channels() == 4)      cv::cvtColor(workFrame, gray, cv::COLOR_RGBA2GRAY);
     else if (workFrame.channels() == 3) cv::cvtColor(workFrame, gray, cv::COLOR_RGB2GRAY);
     else                                gray = workFrame;
+    normalizeForFeatures(gray); // same normalization as generateFingerprint, so the overlay is truthful
 
     cv::Mat orbMask;
     if (!mask.empty()) {
@@ -818,6 +832,7 @@ MobileGS::FingerprintData MobileGS::generateFingerprint(
         cv::cvtColor(workFrame, gray, cv::COLOR_RGB2GRAY);
     else
         gray = workFrame;
+    normalizeForFeatures(gray); // illumination-normalize to match the live reloc frame
 
     cv::Mat orbMask;
     if (!mask.empty()) {

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/MetricFingerprintBuilder.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/MetricFingerprintBuilder.kt
@@ -116,11 +116,18 @@ object MetricFingerprintBuilder {
     /** ORB detect + ratio-tested BF-Hamming match. descriptors[i] is frame-0's descriptor for corrs[i]. */
     private fun detectAndMatch(gray0: Mat, gray1: Mat, ratio: Float): Matched? {
         val orb = ORB.create(1500)
+        // Illumination-normalize identically to the native reloc path (CLAHE 2.0 / 8x8) so this
+        // triangulated fingerprint's descriptors match the live frame's under light/color changes.
+        // CLAHE doesn't move pixels, so keypoint positions (used for triangulation) are unaffected.
+        val clahe = Imgproc.createCLAHE(2.0, org.opencv.core.Size(8.0, 8.0))
+        val n0 = Mat(); val n1 = Mat()
+        clahe.apply(gray0, n0); clahe.apply(gray1, n1)
         val kp0 = MatOfKeyPoint(); val kp1 = MatOfKeyPoint()
         val d0 = Mat(); val d1 = Mat()
         try {
-            orb.detectAndCompute(gray0, Mat(), kp0, d0)
-            orb.detectAndCompute(gray1, Mat(), kp1, d1)
+            orb.detectAndCompute(n0, Mat(), kp0, d0)
+            orb.detectAndCompute(n1, Mat(), kp1, d1)
+            n0.release(); n1.release()
             if (d0.empty() || d1.empty()) return null
 
             val matcher = DescriptorMatcher.create(DescriptorMatcher.BRUTEFORCE_HAMMING)


### PR DESCRIPTION
…hing

- Introduces CLAHE-based (2.0 clip limit, 8x8 grid) illumination normalization to both Kotlin and C++ feature detection paths
- Updates `MetricFingerprintBuilder` to normalize grayscale frames before ORB descriptor computation to ensure consistency with native relocation
- Adds a `thread_local` `normalizeForFeatures` utility in `MobileGS.cpp` to provide efficient, thread-safe normalization across relocation, mapping, and UI threads
- Synchronizes normalization logic between fingerprint generation and live frame processing to improve matching reliability under varying light and color conditions
- Updates native diagnostic and overlay paths to use normalized frames for consistent visual debugging