### PR TITLE
feat(ar): keypoint curation overlay reflects erasing

### DIFF
--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -1025,6 +1025,18 @@ class ArViewModel @Inject constructor(
             }
             canvas.drawCircle(nx * copy.width, ny * copy.height, radius * copy.width, paint)
             _uiState.update { it.copy(annotatedCaptureBitmap = copy) }
+            // Reflect the erase in the keypoint overlay: re-detect within the updated mask so dots in
+            // erased regions disappear. Debounced so a drag (many erase calls) recomputes once it pauses.
+            scheduleKeypointRecompute()
+        }
+    }
+
+    private var keypointRecomputeJob: kotlinx.coroutines.Job? = null
+    private fun scheduleKeypointRecompute() {
+        keypointRecomputeJob?.cancel()
+        keypointRecomputeJob = viewModelScope.launch {
+            kotlinx.coroutines.delay(250)
+            computeTargetKeypoints()
         }
     }
 


### PR DESCRIPTION
## What
The truthful keypoint overlay (#1550) was computed once at capture, so the dots stayed put while erasing. Now `applyEraseToMask` triggers a **debounced (250 ms)** re-detection within the *updated* mask, so dots in erased regions disappear — you watch marks leave the fingerprint as you erase. The debounce coalesces a drag's many erase calls into one recompute once the gesture pauses (no SuperPoint storm).

## Verification
- `:feature:ar:compileDebugKotlin` SUCCESSFUL.
- On-device: erase over the dots → after a brief pause they vanish there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)