### PR TITLE
feat(ar): teleological self-grow promotion (opt-in)

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -856,6 +856,7 @@ class MainActivity : ComponentActivity() {
                                     onStopLog = { arViewModel.evalStopLog() },
                                     onInduceLoss = { arViewModel.evalInduceLoss() },
                                     onToggleFusion = { arViewModel.evalSetFusionEnabled(it) },
+                                    onToggleSelfGrow = { arViewModel.evalSetSelfGrowEnabled(it) },
                                 )
                             }
 
@@ -1949,9 +1950,12 @@ private fun EvalOverlay(
     onStopLog: () -> Unit,
     onInduceLoss: () -> Unit,
     onToggleFusion: (Boolean) -> Unit,
+    onToggleSelfGrow: (Boolean) -> Unit,
 ) {
     // Local UI state for the A/B switch; defaults to true to match ArRenderer.fusionEnabled.
     val fusionOn = androidx.compose.runtime.remember { androidx.compose.runtime.mutableStateOf(true) }
+    // Teleological self-grow defaults OFF to match the native default (mutates the reloc fingerprint).
+    val selfGrowOn = androidx.compose.runtime.remember { androidx.compose.runtime.mutableStateOf(false) }
     androidx.compose.foundation.layout.Column(
         androidx.compose.ui.Modifier
             .background(androidx.compose.ui.graphics.Color(0xAA000000))
@@ -1974,6 +1978,12 @@ private fun EvalOverlay(
                 onToggleFusion(fusionOn.value)
             }) {
                 androidx.compose.material3.Text(if (fusionOn.value) "Fusion ON" else "Fusion OFF")
+            }
+            androidx.compose.material3.TextButton(onClick = {
+                selfGrowOn.value = !selfGrowOn.value
+                onToggleSelfGrow(selfGrowOn.value)
+            }) {
+                androidx.compose.material3.Text(if (selfGrowOn.value) "Grow ON" else "Grow OFF")
             }
         }
     }

--- a/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
+++ b/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
@@ -174,6 +174,11 @@ Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeSetRelocEnabled(JN
 }
 
 JNIEXPORT void JNICALL
+Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeSetSelfGrowEnabled(JNIEnv* env, jobject thiz, jboolean enabled) {
+    if (gSlamEngine) gSlamEngine->setSelfGrowEnabled(enabled);
+}
+
+JNIEXPORT void JNICALL
 Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeSetVoxelSize(JNIEnv* env, jobject thiz, jfloat size) {
     if (gSlamEngine) gSlamEngine->setVoxelSize(size);
 }

--- a/core/nativebridge/src/main/cpp/MobileGS.cpp
+++ b/core/nativebridge/src/main/cpp/MobileGS.cpp
@@ -539,16 +539,90 @@ void MobileGS::tryUpdateFingerprint(const cv::Mat& grayClean) {
     matcher->knnMatch(descs, artDescs, matches, 2);
 
     std::vector<char> hit(artDescs.rows, 0);
+    std::vector<int> validQuery;   // clean keypoints that corroborate the artwork (self-grow candidates)
     int matched = 0;
     for (auto& m : matches) {
         if (m.size() < 2) continue;
         if (m[0].distance < 0.75f * m[1].distance) {
             int a = m[0].trainIdx;
             if (a >= 0 && a < (int)hit.size() && !hit[a]) { hit[a] = 1; matched++; }
+            validQuery.push_back(m[0].queryIdx);
         }
     }
     if (artDescs.rows > 0)
         mPaintingProgress.store((float)matched / (float)artDescs.rows, std::memory_order_relaxed);
+
+    // --- Teleological self-grow (opt-in) ---------------------------------------------------------
+    // Promote validated NEW marks into the live reloc fingerprint so it self-grows from real painting
+    // that matches the target — surviving the original marks being painted over. Depth-free: each new
+    // feature is placed on the wall plane via the current relocalized pose. Guarded hard (fresh +
+    // confident relock, gatekeeper-validated, capped, deduped) and RANSAC in the reloc PnP is the
+    // backstop, but it still mutates the authoritative set, so it stays OFF unless explicitly enabled.
+    if (!mSelfGrowEnabled.load(std::memory_order_relaxed) || validQuery.empty()) return;
+
+    cv::Matx33d R; cv::Vec3d t; double fx, fy, cx, cy; int inliers; long seq;
+    std::vector<cv::Point3f> wall;
+    {
+        std::lock_guard<std::mutex> lock(mMutex);
+        seq = mPnpResultSeq.load(std::memory_order_relaxed);
+        if (seq == mLastGrowSeq) return;          // no fresh relock this tick — pose would be stale
+        inliers = mPnpInlierCount.load(std::memory_order_relaxed);
+        const float* M = mPnpCamFromFpWorld;      // camera_from_fpWorld, column-major (OpenCV frame)
+        R = cv::Matx33d(M[0], M[4], M[8], M[1], M[5], M[9], M[2], M[6], M[10]);
+        t = cv::Vec3d(M[12], M[13], M[14]);
+        fx = mFingerprintIntrinsics[0]; fy = mFingerprintIntrinsics[1];
+        cx = mFingerprintIntrinsics[2]; cy = mFingerprintIntrinsics[3];
+        wall = mWallKeypoints3D;
+        if (inliers >= 20) mLastGrowSeq = seq;    // claim this relock (whether or not it yields points)
+    }
+    if (inliers < 20 || fx <= 0 || fy <= 0 || wall.size() < 12 || wall.size() > 5000) return;
+
+    // Wall plane (n·X = pdist, pdist>0) in the fingerprint frame, fit to the existing marks.
+    cv::Mat data((int)wall.size(), 3, CV_32F);
+    for (int i = 0; i < (int)wall.size(); ++i) {
+        data.at<float>(i,0) = wall[i].x; data.at<float>(i,1) = wall[i].y; data.at<float>(i,2) = wall[i].z;
+    }
+    cv::PCA pca(data, cv::Mat(), cv::PCA::DATA_AS_ROW);
+    cv::Vec3d n(pca.eigenvectors.at<float>(2,0), pca.eigenvectors.at<float>(2,1), pca.eigenvectors.at<float>(2,2));
+    cv::Vec3d cen(pca.mean.at<float>(0,0), pca.mean.at<float>(0,1), pca.mean.at<float>(0,2));
+    double nn = cv::norm(n); if (nn < 1e-6) return; n /= nn;
+    double pdist = n.dot(cen); if (pdist < 0) { n = -n; pdist = -pdist; } if (pdist < 1e-3) return;
+
+    // fp_from_cam = [R^T | -R^T t]: camera centre and per-pixel ray in the fingerprint frame.
+    cv::Matx33d Rt = R.t();
+    cv::Vec3d C = -(Rt * t);
+    double nDotC = n.dot(C);
+
+    std::vector<cv::Point3f> newPts; cv::Mat newDescs;
+    for (int q : validQuery) {
+        if (q < 0 || q >= (int)kps.size()) continue;
+        cv::Point2f p = kps[q].pt;
+        cv::Vec3d dir = Rt * cv::Vec3d((p.x - cx) / fx, (p.y - cy) / fy, 1.0);
+        double denom = n.dot(dir);
+        if (std::abs(denom) < 1e-6) continue;
+        double lambda = (pdist - nDotC) / denom;
+        if (lambda <= 0) continue;                // intersection behind the camera
+        cv::Vec3d X = C + lambda * dir;
+        cv::Point3f Xp((float)X[0], (float)X[1], (float)X[2]);
+        bool dup = false;
+        for (const auto& w : wall)
+            if (std::abs(w.x-Xp.x) < 0.01f && std::abs(w.y-Xp.y) < 0.01f && std::abs(w.z-Xp.z) < 0.01f) { dup = true; break; }
+        if (dup) continue;
+        newPts.push_back(Xp);
+        newDescs.push_back(descs.row(q));
+        if (newPts.size() >= 30) break;           // cap per relock
+    }
+    if (newPts.empty()) return;
+
+    {
+        std::lock_guard<std::mutex> lock(mMutex);
+        if (mWallDescriptors.type() != newDescs.type() || mWallKeypoints3D.size() > 5000) return;
+        for (int i = 0; i < (int)newPts.size(); ++i) {
+            mWallKeypoints3D.push_back(newPts[i]);
+            mWallDescriptors.push_back(newDescs.row(i));
+        }
+    }
+    LOGI("Teleological self-grow: promoted %zu marks (wall now %zu)", newPts.size(), mWallKeypoints3D.size());
 }
 void MobileGS::interpolateAnchorStep() {}
 void MobileGS::setArCoreTrackingState(bool t) { mIsArCoreTracking = t; }
@@ -722,9 +796,16 @@ void MobileGS::setArtworkFingerprint(const cv::Mat& composite, const uint8_t* de
     else                                gray = composite;
     normalizeForFeatures(gray); // match the live frame's illumination normalization
 
+    // Detect with the SAME descriptor type as the wall fingerprint so the gatekeeper match (clean-vs-
+    // artwork) and self-grow promotion are type-compatible: if the wall is ORB (CV_8U, the depth-off
+    // path) use ORB here too; otherwise SuperPoint. Without this, an ORB wall + SuperPoint artwork can't
+    // match and painting-progress/self-grow silently do nothing in the depth-off config.
+    bool wallIsOrb;
+    { std::lock_guard<std::mutex> lock(mMutex); wallIsOrb = !mWallDescriptors.empty() && mWallDescriptors.type() == CV_8U; }
+
     std::vector<cv::KeyPoint> kps;
     cv::Mat descs;
-    bool useSuperPoint = mSuperPoint.isLoaded();
+    bool useSuperPoint = mSuperPoint.isLoaded() && !wallIsOrb;
     if (useSuperPoint && !mSuperPoint.detect(gray, kps, descs)) useSuperPoint = false;
     if (!useSuperPoint || kps.empty()) {
         auto orb = cv::ORB::create(1500);

--- a/core/nativebridge/src/main/cpp/include/MobileGS.h
+++ b/core/nativebridge/src/main/cpp/include/MobileGS.h
@@ -48,6 +48,8 @@ public:
     // Detect the same features generateFingerprint would (SuperPoint/ORB-1000, masked) and return their
     // 2D positions in image pixels — for a truthful "what anchors the fingerprint" curation overlay.
     void getFingerprintKeypoints(const cv::Mat& image, const cv::Mat& mask, std::vector<cv::Point2f>& out);
+    // Teleological self-grow (default OFF — mutates the live reloc fingerprint, so opt-in only).
+    void setSelfGrowEnabled(bool e) { mSelfGrowEnabled.store(e, std::memory_order_relaxed); }
 
     struct FingerprintData {
         std::vector<cv::KeyPoint> keypoints;
@@ -166,6 +168,10 @@ private:
     // restored without a capture view (rectification is then skipped — plain matching still runs).
     float mFingerprintViewMatrix[16] = {1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1};
     bool mHasFingerprintView = false;
+    // Teleological self-grow: opt-in flag + the last reloc seq we grew from (only grow on a fresh,
+    // confident relock so promoted marks are placed with a current pose, never a stale one).
+    std::atomic<bool> mSelfGrowEnabled{false};
+    long mLastGrowSeq = 0;
     // VIO view snapshot captured alongside the reloc frame, so the rectifying warp matches that frame.
     float mRelocViewMatrix[16] = {1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1};
     uint64_t mFrameCounter = 0;

--- a/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
+++ b/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
@@ -118,6 +118,8 @@ class SlamManager @Inject constructor(
     fun pruneByConfidence(threshold: Float) = nativePruneByConfidence(threshold)
 
     fun setRelocEnabled(enabled: Boolean) = nativeSetRelocEnabled(enabled)
+    /** Teleological self-grow (default OFF): promote validated new marks into the live fingerprint. */
+    fun setSelfGrowEnabled(enabled: Boolean) = nativeSetSelfGrowEnabled(enabled)
     fun setVoxelSize(size: Float) = nativeSetVoxelSize(size)
     fun setMappingPaused(paused: Boolean) = nativeSetMappingPaused(paused)
 
@@ -426,6 +428,7 @@ class SlamManager @Inject constructor(
         intrinsics: FloatArray, viewMatrix: FloatArray
     )
     private external fun nativeSetRelocEnabled(enabled: Boolean)
+    private external fun nativeSetSelfGrowEnabled(enabled: Boolean)
     private external fun nativeSetVoxelSize(size: Float)
     private external fun nativeSetMappingPaused(paused: Boolean)
     private external fun nativeFeedPointCloud(points: FloatArray)

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -236,6 +236,9 @@ class ArViewModel @Inject constructor(
     /** A/B switch for the pose fusion (Sub-project B): on = corrected snap-back fusion, off = old toggle. */
     fun evalSetFusionEnabled(on: Boolean) { renderer?.fusionEnabled = on }
 
+    /** A/B switch for teleological self-grow (default OFF): promote validated new marks into the fingerprint. */
+    fun evalSetSelfGrowEnabled(on: Boolean) { slamManager.setSelfGrowEnabled(on) }
+
     // ── Glasses session lifecycle ─────────────────────────────────────────────
 
     fun startGlassesSession() {


### PR DESCRIPTION
## What
Completes the teleological vision: the fingerprint **self-grows from real painting that matches the target**, so it keeps relocalizing even as the original marks get painted over.

- **`tryUpdateFingerprint`**: on a **fresh, confident** relock (≥20 inliers, new seq), for each clean-frame feature that corroborates the artwork base, ray-cast its pixel onto the **wall plane** (PCA over existing marks) via the current relocalized pose, and promote (descriptor + 3D) into the live fingerprint. Depth-free, all in the OpenCV fingerprint frame.
- **Type-consistency keystone**: `setArtworkFingerprint` now detects with the **wall's descriptor type** (ORB depth-off, else SuperPoint), so the gatekeeper match + promotion are type-compatible — without it the ORB-wall + SuperPoint-artwork mismatch made the whole thing silently inert in the depth-off config.

## Safety (it mutates the authoritative reloc set)
**Off by default.** Guards: gatekeeper-validated only, fresh+confident pose only, **30/relock + 5000 total caps**, 1cm dedup, descriptor-type checked; reloc PnP **RANSAC** is the backstop. Toggle via the new **"Grow ON/OFF"** dev-overlay button (beside Fusion). Geometry is unvalidated on-device — enable, watch `Teleological self-grow: promoted N marks`, and confirm the overlay stays locked (not drifting) before trusting it.

## Verification
- `:app:assembleDebug` → BUILD SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)