### PR TITLE
feat(ar): SuperPoint wall fingerprint (depth-off) with ORB fallback

### DIFF
--- a/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
+++ b/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
@@ -646,6 +646,32 @@ Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeAnnotateKeypoints(
 }
 
 JNIEXPORT jfloatArray JNICALL
+Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeDetectSuperPoint(
+        JNIEnv* env, jobject thiz, jobject bitmap) {
+    if (!gSlamEngine) return nullptr;
+    cv::Mat image; bitmapToMat(env, bitmap, image);
+    if (image.empty()) return nullptr;
+    std::vector<cv::KeyPoint> kps; cv::Mat descs;
+    {
+        std::lock_guard<std::mutex> lock(gSlamEngine->getMutex());
+        if (!gSlamEngine->getSuperPointFeatures(image, kps, descs)) return nullptr;
+    }
+    const int n = (int)kps.size();
+    const int d = descs.cols;
+    if (n <= 0 || d <= 0) return nullptr;
+    cv::Mat dc = descs.isContinuous() ? descs : descs.clone();
+    // Packed layout: [n, d, (u,v) * n, descriptors row-major (n*d)].
+    jfloatArray result = env->NewFloatArray(2 + 2 * n + n * d);
+    if (!result) return nullptr;
+    jfloat* ptr = env->GetFloatArrayElements(result, nullptr);
+    ptr[0] = (float)n; ptr[1] = (float)d;
+    for (int i = 0; i < n; ++i) { ptr[2 + 2*i] = kps[i].pt.x; ptr[2 + 2*i + 1] = kps[i].pt.y; }
+    std::memcpy(ptr + 2 + 2*n, dc.ptr<float>(0), (size_t)n * d * sizeof(float));
+    env->ReleaseFloatArrayElements(result, ptr, 0);
+    return result;
+}
+
+JNIEXPORT jfloatArray JNICALL
 Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeGetFingerprintKeypoints(
         JNIEnv* env, jobject thiz, jobject bitmap, jobject mask) {
     if (!gSlamEngine) return nullptr;

--- a/core/nativebridge/src/main/cpp/MobileGS.cpp
+++ b/core/nativebridge/src/main/cpp/MobileGS.cpp
@@ -856,6 +856,17 @@ void MobileGS::setArtworkFingerprint(const cv::Mat& composite, const uint8_t* de
          mArtworkDescriptors.rows, (size_t)mArtworkKeypoints3D.size());
 }
 
+bool MobileGS::getSuperPointFeatures(const cv::Mat& image, std::vector<cv::KeyPoint>& kps, cv::Mat& descs) {
+    if (!mSuperPoint.isLoaded() || image.empty()) return false;
+    cv::Mat gray;
+    if (image.channels() == 4)      cv::cvtColor(image, gray, cv::COLOR_RGBA2GRAY);
+    else if (image.channels() == 3) cv::cvtColor(image, gray, cv::COLOR_RGB2GRAY);
+    else                            gray = image;
+    normalizeForFeatures(gray); // CLAHE, identical to the reloc path so descriptors stay comparable
+    if (!mSuperPoint.detect(gray, kps, descs)) return false;
+    return !kps.empty() && !descs.empty();
+}
+
 void MobileGS::getFingerprintKeypoints(const cv::Mat& image, const cv::Mat& mask,
                                        std::vector<cv::Point2f>& out) {
     out.clear();

--- a/core/nativebridge/src/main/cpp/include/MobileGS.h
+++ b/core/nativebridge/src/main/cpp/include/MobileGS.h
@@ -50,6 +50,10 @@ public:
     void getFingerprintKeypoints(const cv::Mat& image, const cv::Mat& mask, std::vector<cv::Point2f>& out);
     // Teleological self-grow (default OFF — mutates the live reloc fingerprint, so opt-in only).
     void setSelfGrowEnabled(bool e) { mSelfGrowEnabled.store(e, std::memory_order_relaxed); }
+    // SuperPoint detect+describe for one image (gray + CLAHE applied inside, matching the reloc path) so
+    // the depth-off triangulated fingerprint can be built from SuperPoint (CV_32F) instead of ORB. False
+    // if the model isn't loaded or nothing was found.
+    bool getSuperPointFeatures(const cv::Mat& image, std::vector<cv::KeyPoint>& kps, cv::Mat& descs);
 
     struct FingerprintData {
         std::vector<cv::KeyPoint> keypoints;

--- a/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
+++ b/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
@@ -120,6 +120,13 @@ class SlamManager @Inject constructor(
     fun setRelocEnabled(enabled: Boolean) = nativeSetRelocEnabled(enabled)
     /** Teleological self-grow (default OFF): promote validated new marks into the live fingerprint. */
     fun setSelfGrowEnabled(enabled: Boolean) = nativeSetSelfGrowEnabled(enabled)
+
+    /**
+     * SuperPoint detect+describe on [bitmap] (gray + CLAHE applied natively). Returns the packed array
+     * [n, dim, (u,v)*n, descriptors row-major (n*dim)], or null if the model isn't loaded / nothing
+     * found. Caller unpacks (kept here as a raw array to avoid an OpenCV dependency in this module).
+     */
+    fun detectSuperPoint(bitmap: Bitmap): FloatArray? = nativeDetectSuperPoint(bitmap)
     fun setVoxelSize(size: Float) = nativeSetVoxelSize(size)
     fun setMappingPaused(paused: Boolean) = nativeSetMappingPaused(paused)
 
@@ -429,6 +436,7 @@ class SlamManager @Inject constructor(
     )
     private external fun nativeSetRelocEnabled(enabled: Boolean)
     private external fun nativeSetSelfGrowEnabled(enabled: Boolean)
+    private external fun nativeDetectSuperPoint(bitmap: Bitmap): FloatArray?
     private external fun nativeSetVoxelSize(size: Float)
     private external fun nativeSetMappingPaused(paused: Boolean)
     private external fun nativeFeedPointCloud(points: FloatArray)

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/MetricFingerprintBuilder.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/MetricFingerprintBuilder.kt
@@ -50,10 +50,20 @@ object MetricFingerprintBuilder {
         ratio: Float = 0.75f,
     ): Fingerprint? {
         val matched = detectAndMatch(kf0.gray, kf1.gray, ratio) ?: return null
+        return assemble(slam, matched, kf0.glView, kf1.glView,
+            floatArrayOf(kf0.fx, kf0.fy, kf0.cx, kf0.cy), anchorModel, minPoints)
+    }
+
+    /** Triangulate a Matched set into metric 3D, ingest it, and return the persistable Fingerprint. */
+    private fun assemble(
+        slam: SlamManager, matched: Matched,
+        glView0: FloatArray, glView1: FloatArray, intr0: FloatArray,
+        anchorModel: FloatArray, minPoints: Int,
+    ): Fingerprint? {
         try {
-            val cv0 = MetricMarks.glViewToCv(kf0.glView)
-            val cv1 = MetricMarks.glViewToCv(kf1.glView)
-            val tri = MetricMarks.triangulate(matched.corrs, cv0, cv1, kf0.fx, kf0.fy, kf0.cx, kf0.cy)
+            val cv0 = MetricMarks.glViewToCv(glView0)
+            val cv1 = MetricMarks.glViewToCv(glView1)
+            val tri = MetricMarks.triangulate(matched.corrs, cv0, cv1, intr0[0], intr0[1], intr0[2], intr0[3])
             if (tri.count < minPoints) return null
 
             // Keep the rows of frame-0's descriptors (and the frame-0 keypoints) whose match survived.
@@ -70,8 +80,7 @@ object MetricFingerprintBuilder {
             keptDesc.release()
 
             slam.restoreWallFingerprintMetric(
-                bytes, rows, cols, type, tri.pointsCam0, anchorModel,
-                floatArrayOf(kf0.fx, kf0.fy, kf0.cx, kf0.cy),
+                bytes, rows, cols, type, tri.pointsCam0, anchorModel, intr0,
             )
             return Fingerprint(keypoints, tri.pointsCam0.toList(), bytes, rows, cols, type)
         } finally {
@@ -91,6 +100,15 @@ object MetricFingerprintBuilder {
         anchorModel: FloatArray,
         minPoints: Int = 20,
     ): Fingerprint? {
+        // Prefer SuperPoint (learned, far more robust to viewpoint/illumination) so the depth-off
+        // fingerprint is CV_32F and the reloc thread runs its SuperPoint path. Falls back to ORB if the
+        // model isn't loaded or the SuperPoint match/triangulation is too weak — strictly never-worse.
+        val sp = matchSuperPoint(slam, bitmap0, bitmap1, 0.75f)
+        if (sp != null) {
+            val fp = assemble(slam, sp, glView0, glView1, intr0, anchorModel, minPoints)
+            if (fp != null) return fp
+        }
+
         val gray0 = toGray(bitmap0)
         val gray1 = toGray(bitmap1)
         try {
@@ -100,6 +118,47 @@ object MetricFingerprintBuilder {
         } finally {
             gray0.release(); gray1.release()
         }
+    }
+
+    /** SuperPoint detect (native, CLAHE'd) on both views + L2 ratio match → Matched (CV_32F descs). */
+    private fun matchSuperPoint(slam: SlamManager, bitmap0: Bitmap, bitmap1: Bitmap, ratio: Float): Matched? {
+        val sp0 = unpackSuperPoint(slam.detectSuperPoint(bitmap0)) ?: return null
+        val sp1 = unpackSuperPoint(slam.detectSuperPoint(bitmap1)) ?: return null
+        val (pos0, d0) = sp0
+        val (pos1, d1) = sp1
+        try {
+            val matcher = DescriptorMatcher.create(DescriptorMatcher.BRUTEFORCE) // L2 for float descriptors
+            val knn = ArrayList<MatOfDMatch>()
+            matcher.knnMatch(d0, d1, knn, 2)
+            val corrs = ArrayList<MetricMarks.Corr>(knn.size)
+            val rows = ArrayList<Int>(knn.size)
+            for (mm in knn) {
+                val m = mm.toArray()
+                if (m.size < 2) continue
+                if (m[0].distance < ratio * m[1].distance) {
+                    val q = m[0].queryIdx; val t = m[0].trainIdx
+                    corrs.add(MetricMarks.Corr(pos0[2 * q], pos0[2 * q + 1], pos1[2 * t], pos1[2 * t + 1]))
+                    rows.add(q)
+                }
+            }
+            if (corrs.isEmpty()) return null
+            val desc = Mat(corrs.size, d0.cols(), d0.type())
+            for ((dst, src) in rows.withIndex()) d0.row(src).copyTo(desc.row(dst))
+            return Matched(corrs, desc)
+        } finally {
+            d0.release(); d1.release()
+        }
+    }
+
+    /** Unpack the native [n, dim, (u,v)*n, descriptors] array into (positions, CV_32F descriptor Mat). */
+    private fun unpackSuperPoint(raw: FloatArray?): Pair<FloatArray, Mat>? {
+        if (raw == null || raw.size < 2) return null
+        val n = raw[0].toInt(); val d = raw[1].toInt()
+        if (n <= 0 || d <= 0 || raw.size < 2 + 2 * n + n * d) return null
+        val pos = raw.copyOfRange(2, 2 + 2 * n)
+        val descs = Mat(n, d, org.opencv.core.CvType.CV_32F)
+        descs.put(0, 0, raw.copyOfRange(2 + 2 * n, 2 + 2 * n + n * d))
+        return Pair(pos, descs)
     }
 
     private fun toGray(bitmap: Bitmap): Mat {


### PR DESCRIPTION
## What
The depth-off triangulated fingerprint used **ORB** deliberately. Switch it to **SuperPoint** (learned, far more robust to viewpoint/illumination) so the reloc thread runs its SuperPoint path and the *entire* pipeline — relocalization, teleological gatekeeper, self-grow — is CV_32F/SuperPoint and **type-consistent**. This makes every robustness feature shipped this session (oblique rectification, multi-scale, CLAHE) land on the stronger detector for your config.

- `getSuperPointFeatures` (gray + CLAHE + SuperPoint detect) + JNI `nativeDetectSuperPoint` packing `[n, dim, (u,v)*n, descriptors]` + `SlamManager.detectSuperPoint` passthrough (raw array — no OpenCV dep in that module).
- `MetricFingerprintBuilder`: extracted `assemble()`; the bitmap `build()` now tries SuperPoint (L2 ratio match → triangulate) **first** and falls back to the ORB path if the model is absent or the result is too weak — **strictly never-worse**.

## Verification
- `:app:assembleDebug` → BUILD SUCCESSFUL.
- On-device: capture a target → expect a SuperPoint (CV_32F) fingerprint and SuperPoint relocalization; ORB still used if SuperPoint can't match the two keyframes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)