### PR TITLE
feat(ar): dev-overlay FP pts — live wall-fingerprint size

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -1966,6 +1966,7 @@ private fun EvalOverlay(
         DiagnosticRow("Avail", "%.0f%%".format(metrics.availability * 100), androidx.compose.ui.graphics.Color.White)
         DiagnosticRow("Recovery", metrics.recoveryMs?.let { "${it}ms" } ?: "—", androidx.compose.ui.graphics.Color.White)
         DiagnosticRow("Stage ms", metrics.stageMs.joinToString(" ") { "%.1f".format(it) }, androidx.compose.ui.graphics.Color.Yellow)
+        DiagnosticRow("FP pts", metrics.wallCount.toString(), androidx.compose.ui.graphics.Color.Green)
         DiagnosticRow("Batt", "%.0fmA".format(metrics.batteryMa), androidx.compose.ui.graphics.Color.White)
         androidx.compose.foundation.layout.Row {
             androidx.compose.material3.TextButton(onClick = onStartLog) { androidx.compose.material3.Text("Log▶") }

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/UiState.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/UiState.kt
@@ -16,6 +16,7 @@ data class EvalLiveMetrics(
     val recoveryMs: Long? = null,
     val stageMs: FloatArray = FloatArray(5),
     val batteryMa: Float = 0f,
+    val wallCount: Int = 0, // live wall-fingerprint point count (reloc health / self-grow watch)
 )
 
 /** A tapped wall mark: normalized screen coords (0..1) plus the camera→point range in meters

--- a/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
+++ b/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
@@ -178,6 +178,11 @@ Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeSetSelfGrowEnabled
     if (gSlamEngine) gSlamEngine->setSelfGrowEnabled(enabled);
 }
 
+JNIEXPORT jint JNICALL
+Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeGetWallKeypointCount(JNIEnv* env, jobject thiz) {
+    return gSlamEngine ? gSlamEngine->getWallKeypointCount() : 0;
+}
+
 JNIEXPORT void JNICALL
 Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeSetVoxelSize(JNIEnv* env, jobject thiz, jfloat size) {
     if (gSlamEngine) gSlamEngine->setVoxelSize(size);

--- a/core/nativebridge/src/main/cpp/include/MobileGS.h
+++ b/core/nativebridge/src/main/cpp/include/MobileGS.h
@@ -50,6 +50,8 @@ public:
     void getFingerprintKeypoints(const cv::Mat& image, const cv::Mat& mask, std::vector<cv::Point2f>& out);
     // Teleological self-grow (default OFF — mutates the live reloc fingerprint, so opt-in only).
     void setSelfGrowEnabled(bool e) { mSelfGrowEnabled.store(e, std::memory_order_relaxed); }
+    // Live wall-fingerprint size — diagnostic for relocalization health and watching self-grow.
+    int getWallKeypointCount() const { std::lock_guard<std::mutex> lock(mMutex); return (int)mWallKeypoints3D.size(); }
     // SuperPoint detect+describe for one image (gray + CLAHE applied inside, matching the reloc path) so
     // the depth-off triangulated fingerprint can be built from SuperPoint (CV_32F) instead of ORB. False
     // if the model isn't loaded or nothing was found.

--- a/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
+++ b/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
@@ -127,6 +127,9 @@ class SlamManager @Inject constructor(
      * found. Caller unpacks (kept here as a raw array to avoid an OpenCV dependency in this module).
      */
     fun detectSuperPoint(bitmap: Bitmap): FloatArray? = nativeDetectSuperPoint(bitmap)
+
+    /** Live wall-fingerprint point count — diagnostic for reloc health / watching self-grow. */
+    fun getWallKeypointCount(): Int = nativeGetWallKeypointCount()
     fun setVoxelSize(size: Float) = nativeSetVoxelSize(size)
     fun setMappingPaused(paused: Boolean) = nativeSetMappingPaused(paused)
 
@@ -437,6 +440,7 @@ class SlamManager @Inject constructor(
     private external fun nativeSetRelocEnabled(enabled: Boolean)
     private external fun nativeSetSelfGrowEnabled(enabled: Boolean)
     private external fun nativeDetectSuperPoint(bitmap: Bitmap): FloatArray?
+    private external fun nativeGetWallKeypointCount(): Int
     private external fun nativeSetVoxelSize(size: Float)
     private external fun nativeSetMappingPaused(paused: Boolean)
     private external fun nativeFeedPointCloud(points: FloatArray)

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -894,7 +894,9 @@ class ArViewModel @Inject constructor(
                 visibleSplatConfidenceAvg = visConf,
                 globalSplatConfidenceAvg = globConf,
                 trackingFailed = trackingFailed,
-                evalLiveMetrics = if (evalLogging) evalProbe.lastMetrics else state.evalLiveMetrics
+                evalLiveMetrics = if (evalLogging)
+                    evalProbe.lastMetrics.copy(wallCount = slamManager.getWallKeypointCount())
+                else state.evalLiveMetrics
             )
         }
     }


### PR DESCRIPTION
## What
Adds an **"FP pts"** row to the diagnostic overlay showing the live wall-fingerprint point count — so relocalization health is visible and the teleological **self-grow** can be watched (the count rises as validated marks are promoted; flat = nothing promoted).

`getWallKeypointCount` (native + JNI + SlamManager) → `ArViewModel` copies it into the eval metrics → overlay row.

## Verification
- `:app:assembleDebug` → BUILD SUCCESSFUL.
- On-device (eval logging on): "FP pts" shows the fingerprint size; toggle "Grow ON" and watch it climb as you paint matching marks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)