### PR TITLE
feat(ar): DistortionHead native loader (foundation for the Kaggle model)

### DIFF
--- a/core/nativebridge/src/main/cpp/CMakeLists.txt
+++ b/core/nativebridge/src/main/cpp/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(graffitixr SHARED
     SurfaceUnroller.cpp
     StereoProcessor.cpp
     SuperPointDetector.cpp
+    DistortionHead.cpp
     LowLightEnhancer.cpp
     ImageWarper.cpp
 )

--- a/core/nativebridge/src/main/cpp/DistortionHead.cpp
+++ b/core/nativebridge/src/main/cpp/DistortionHead.cpp
@@ -1,0 +1,48 @@
+#include "include/DistortionHead.h"
+#include <android/log.h>
+
+#define LOGD(...) __android_log_print(ANDROID_LOG_DEBUG, "DistortionHead", __VA_ARGS__)
+#define LOGE(...) __android_log_print(ANDROID_LOG_ERROR, "DistortionHead", __VA_ARGS__)
+
+bool DistortionHead::load(const std::vector<uchar>& onnxBytes) {
+    std::lock_guard<std::mutex> lock(mMutex);
+    mLoaded = false;
+    try {
+        mNet = cv::dnn::readNetFromONNX(onnxBytes);
+        mNet.setPreferableBackend(cv::dnn::DNN_BACKEND_DEFAULT);
+        if (cv::ocl::haveOpenCL()) mNet.setPreferableTarget(cv::dnn::DNN_TARGET_OPENCL);
+        else                       mNet.setPreferableTarget(cv::dnn::DNN_TARGET_CPU);
+        mLoaded = !mNet.empty();
+        if (mLoaded) LOGD("DistortionHead: loaded");
+        return mLoaded;
+    } catch (...) {
+        LOGE("DistortionHead: failed to load ONNX");
+        return false;
+    }
+}
+
+bool DistortionHead::run(const cv::Mat& grayCur, const cv::Mat& grayFp, std::array<float, 13>& out) {
+    if (!mLoaded || grayCur.empty() || grayFp.empty()) return false;
+
+    cv::Mat cur, fp;
+    cv::resize(grayCur, cur, cv::Size(kPatch, kPatch));
+    cv::resize(grayFp, fp, cv::Size(kPatch, kPatch));
+    cur.convertTo(cur, CV_32F, 1.0 / 255.0);
+    fp.convertTo(fp, CV_32F, 1.0 / 255.0);
+    cv::Mat blobCur = cv::dnn::blobFromImage(cur); // [1,1,256,256]
+    cv::Mat blobFp  = cv::dnn::blobFromImage(fp);
+
+    try {
+        std::lock_guard<std::mutex> lock(mMutex);
+        mNet.setInput(blobCur, "image_cur");
+        mNet.setInput(blobFp, "image_fp");
+        cv::Mat o = mNet.forward("distortion");
+        if ((int)o.total() < 13) { LOGE("DistortionHead: bad output size %d", (int)o.total()); return false; }
+        const float* p = o.ptr<float>(0);
+        for (int i = 0; i < 13; ++i) out[i] = p[i];
+        return true;
+    } catch (const cv::Exception& e) {
+        LOGE("DistortionHead: forward failed: %s", e.what());
+        return false;
+    }
+}

--- a/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
+++ b/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
@@ -456,6 +456,24 @@ Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeLoadSuperPoint(
     return ok ? JNI_TRUE : JNI_FALSE;
 }
 
+JNIEXPORT jboolean JNICALL
+Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeLoadDistortionHead(
+        JNIEnv* env, jobject thiz, jobject assetManager) {
+    if (!gSlamEngine) return JNI_FALSE;
+    AAssetManager* mgr = AAssetManager_fromJava(env, assetManager);
+    AAsset* asset = AAssetManager_open(mgr, "distortion_head.onnx", AASSET_MODE_BUFFER);
+    if (!asset) {
+        __android_log_print(ANDROID_LOG_WARN, "GraffitiJNI", "distortion_head.onnx not in assets — head disabled");
+        return JNI_FALSE; // optional model: absent => head stays inert
+    }
+    size_t size = (size_t)AAsset_getLength(asset);
+    std::vector<uchar> buf(size);
+    AAsset_read(asset, buf.data(), (off_t)size);
+    AAsset_close(asset);
+    bool ok = gSlamEngine->loadDistortionHead(buf);
+    return ok ? JNI_TRUE : JNI_FALSE;
+}
+
 JNIEXPORT void JNICALL
 Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeLoadLowLightEnhancer(
         JNIEnv* env, jobject thiz, jobject assetManager) {

--- a/core/nativebridge/src/main/cpp/include/DistortionHead.h
+++ b/core/nativebridge/src/main/cpp/include/DistortionHead.h
@@ -1,0 +1,37 @@
+#pragma once
+#include <opencv2/opencv.hpp>
+#include <opencv2/dnn.hpp>
+#include <opencv2/core/ocl.hpp>
+#include <array>
+#include <atomic>
+#include <mutex>
+#include <vector>
+
+/**
+ * Distortion head (design: docs/DISTORTION_HEAD.md). A small learned head on a frozen SuperPoint
+ * backbone, exported self-contained to ONNX: two gray views in (current crop + canonical fingerprint
+ * patch), one tensor out:
+ *
+ *   distortion[13] = [corners(8), pose(3 = tilt°, log2(scale), roll°), matchability(1), coverage(1)]
+ *
+ * corners = the planar homography between the views (the viewpoint distortion); matchability gates
+ * relocalization; coverage drives painting-progress. OpenCV-DNN compatible (opset-12, plain ops).
+ * Optional: inert unless the distortion_head.onnx asset is present.
+ */
+class DistortionHead {
+public:
+    DistortionHead() = default;
+
+    bool load(const std::vector<uchar>& onnxBytes);
+    bool isLoaded() const { return mLoaded; }
+
+    /** Two gray images → distortion[13]. Images are resized to kPatch and scaled to [0,1] inside. */
+    bool run(const cv::Mat& grayCur, const cv::Mat& grayFp, std::array<float, 13>& out);
+
+    static constexpr int kPatch = 256;
+
+private:
+    cv::dnn::Net      mNet;
+    std::mutex        mMutex;
+    std::atomic<bool> mLoaded{false};
+};

--- a/core/nativebridge/src/main/cpp/include/MobileGS.h
+++ b/core/nativebridge/src/main/cpp/include/MobileGS.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <opencv2/opencv.hpp>
 #include "SuperPointDetector.h"
+#include "DistortionHead.h"
 #include "LowLightEnhancer.h"
 #include <mutex>
 #include <vector>
@@ -65,6 +66,7 @@ public:
     FingerprintData generateFingerprint(const cv::Mat& image, const cv::Mat& mask, const uint8_t* depthData, int depthW, int depthH, int depthStride, const float* intrinsics, const float* viewMat);
 
     bool loadSuperPoint(const std::vector<uchar>& onnxBytes);
+    bool loadDistortionHead(const std::vector<uchar>& onnxBytes) { return mDistortionHead.load(onnxBytes); }
     bool loadLowLightEnhancer(const std::vector<uchar>& onnxBytes);
     void clearMap();
     void pruneByConfidence(float threshold);
@@ -147,6 +149,7 @@ private:
     cv::Ptr<cv::DescriptorMatcher> mMatcher;    // BruteForce-Hamming for ORB (CV_8U)
     cv::Ptr<cv::DescriptorMatcher> mL2Matcher;  // BruteForce-L2 for SuperPoint (CV_32F)
     SuperPointDetector mSuperPoint;
+    DistortionHead mDistortionHead;
     LowLightEnhancer mEnhancer;
     static constexpr float kLowLightThreshold = 0.35f;
 

--- a/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
+++ b/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
@@ -221,6 +221,8 @@ class SlamManager @Inject constructor(
     }
 
     fun loadSuperPoint(assetManager: AssetManager): Boolean = nativeLoadSuperPoint(assetManager)
+    /** Optional distortion head (docs/DISTORTION_HEAD.md). False (inert) if the asset isn't bundled. */
+    fun loadDistortionHead(assetManager: AssetManager): Boolean = nativeLoadDistortionHead(assetManager)
     fun loadLowLightEnhancer(assetManager: AssetManager) = nativeLoadLowLightEnhancer(assetManager)
 
     fun setArScanMode(mode: Int) = nativeSetArScanMode(mode)
@@ -403,6 +405,7 @@ class SlamManager @Inject constructor(
     private external fun nativeLoadModel(path: String)
     private external fun nativeImportModel3D(path: String): Boolean
     private external fun nativeLoadSuperPoint(assetManager: AssetManager): Boolean
+    private external fun nativeLoadDistortionHead(assetManager: AssetManager): Boolean
     private external fun nativeLoadLowLightEnhancer(assetManager: AssetManager)
     private external fun nativeUpdateAnchorTransform(transform: FloatArray)
     private external fun nativeUpdateDeviceMotion(angularVel: FloatArray, linearVel: FloatArray)

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -418,6 +418,7 @@ class ArViewModel @Inject constructor(
         NativeLibLoader.loadAll()
         viewModelScope.launch(Dispatchers.IO) {
             slamManager.loadSuperPoint(appContext.assets)
+            slamManager.loadDistortionHead(appContext.assets) // optional; inert if asset absent
             slamManager.loadLowLightEnhancer(appContext.assets)
         }
         viewModelScope.launch {


### PR DESCRIPTION
## What
Device wiring (foundation) for your trained **distortion head** (`docs/DISTORTION_HEAD.md` / the Kaggle SuperPoint model): a learned head on frozen SuperPoint that takes the live crop + the canonical fingerprint patch and emits `distortion[13] = [corners(8), pose(3), matchability(1), coverage(1)]` — the planar viewpoint distortion, relock confidence, and **coverage (= painting-progress)**.

This increment is the **inference plumbing, inert until the model asset is present**:
- `DistortionHead` (cpp/h): cv::dnn ONNX, two gray inputs (`image_cur`/`image_fp`, 256×256) → `distortion[13]`; mirrors `SuperPointDetector`.
- `MobileGS.loadDistortionHead` + JNI `nativeLoadDistortionHead` (reads `assets/distortion_head.onnx`, returns false / stays inert if absent) + `SlamManager.loadDistortionHead` + `ArViewModel` loads it beside SuperPoint.
- CMake builds `DistortionHead.cpp`.

## To activate
Drop the Kaggle-trained **`distortion_head.onnx`** into `core/nativebridge/src/main/assets/`.

## Next increments (spec §5–6)
Store the canonical patch on `Fingerprint`, then run the head in `relocThreadFunc`: matchability gate → H-prior for IPPE → `coverage → mPaintingProgress`.

## Verification
- `:core:nativebridge` + `:app:assembleDebug` → BUILD SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)