### PR TITLE
feat(ar): run distortion head at reloc — coverage→progress + matchability

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainViewModel.kt
@@ -281,6 +281,9 @@ class MainViewModel @Inject constructor(
             // (Teleological artwork base is registered from the live design composite via
             // ArViewModel.updatePaintingGuide — the design-only overlay, not blended with wall texture.)
 
+            // Canonical patch (the captured marks) for the distortion head — inert unless its model is bundled.
+            slamManager.setWallPatch(sensorBmp)
+
             projectManager.saveProject(
                 context = context,
                 projectData = currentProject.copy(fingerprint = fp),
@@ -351,6 +354,9 @@ class MainViewModel @Inject constructor(
             }
             // (Teleological artwork base is registered from the live design composite via
             // ArViewModel.updatePaintingGuide — see the depth path above.)
+
+            // Canonical patch (keyframe of the marks) for the distortion head — inert unless model bundled.
+            slamManager.setWallPatch(bitmap)
 
             projectManager.saveProject(
                 context = context,

--- a/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
+++ b/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
@@ -184,6 +184,13 @@ Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeGetWallKeypointCou
 }
 
 JNIEXPORT void JNICALL
+Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeSetWallPatch(JNIEnv* env, jobject thiz, jobject bitmap) {
+    if (!gSlamEngine || !bitmap) return;
+    cv::Mat img; bitmapToMat(env, bitmap, img);
+    gSlamEngine->setWallPatch(img);
+}
+
+JNIEXPORT void JNICALL
 Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeSetVoxelSize(JNIEnv* env, jobject thiz, jfloat size) {
     if (gSlamEngine) gSlamEngine->setVoxelSize(size);
 }

--- a/core/nativebridge/src/main/cpp/MobileGS.cpp
+++ b/core/nativebridge/src/main/cpp/MobileGS.cpp
@@ -380,6 +380,31 @@ void MobileGS::relocThreadFunc() {
             }
         }
 
+        // Distortion head (optional, docs/DISTORTION_HEAD.md): when the model + canonical patch are
+        // present, compare the live view (cropped around the coarse match centroid) against the
+        // fingerprint patch -> matchability (relock confidence) + coverage (= painting-progress). The
+        // corners/H -> IPPE prior is a later increment; here we consume the cheap signals. Inert unless
+        // the distortion_head.onnx asset is bundled. Uses RAW gray (the head's SuperPoint expects it).
+        if (mDistortionHead.isLoaded() && !mWallPatch.empty() && !imgPts.empty()) {
+            float cxs = 0, cys = 0;
+            for (const auto& p : imgPts) { cxs += p.x; cys += p.y; }
+            cxs /= (float)imgPts.size(); cys /= (float)imgPts.size();
+            cv::Mat headGray;
+            cv::cvtColor(workFrame, headGray, cv::COLOR_RGB2GRAY);
+            int side = std::min(headGray.cols, headGray.rows);
+            int x0 = std::max(0, std::min((int)cxs - side / 2, headGray.cols - side));
+            int y0 = std::max(0, std::min((int)cys - side / 2, headGray.rows - side));
+            cv::Mat crop = headGray(cv::Rect(x0, y0, side, side)).clone();
+            cv::Mat patch; { std::lock_guard<std::mutex> lock(mMutex); patch = mWallPatch.clone(); }
+            std::array<float, 13> dist{};
+            if (mDistortionHead.run(crop, patch, dist)) {
+                const float matchability = dist[11], coverage = dist[12];
+                if (matchability > 0.5f) mPaintingProgress.store(coverage, std::memory_order_relaxed);
+                LOGI("DistortionHead: match %.2f coverage %.2f tilt %.0f log2scale %.2f",
+                     matchability, coverage, dist[8], dist[9]);
+            }
+        }
+
         // Lowered floors so a close-up PARTIAL view (only a corner of the marks visible) can still
         // localize: PnP needs only a handful of correspondences. The inlier RATIO (published below) is
         // the quality gate PoseFusion actually trusts, so being permissive here is safe.
@@ -549,7 +574,9 @@ void MobileGS::tryUpdateFingerprint(const cv::Mat& grayClean) {
             validQuery.push_back(m[0].queryIdx);
         }
     }
-    if (artDescs.rows > 0)
+    // The distortion head's coverage is the principled progress signal; only fall back to this
+    // descriptor-corroboration ratio when the head isn't present.
+    if (artDescs.rows > 0 && !mDistortionHead.isLoaded())
         mPaintingProgress.store((float)matched / (float)artDescs.rows, std::memory_order_relaxed);
 
     // --- Teleological self-grow (opt-in) ---------------------------------------------------------
@@ -854,6 +881,18 @@ void MobileGS::setArtworkFingerprint(const cv::Mat& composite, const uint8_t* de
     }
     LOGI("setArtworkFingerprint: stored %d validator features (%zu with 3D)",
          mArtworkDescriptors.rows, (size_t)mArtworkKeypoints3D.size());
+}
+
+void MobileGS::setWallPatch(const cv::Mat& img) {
+    if (img.empty()) return;
+    cv::Mat gray;
+    if (img.channels() == 4)      cv::cvtColor(img, gray, cv::COLOR_RGBA2GRAY);
+    else if (img.channels() == 3) cv::cvtColor(img, gray, cv::COLOR_RGB2GRAY);
+    else                          gray = img;
+    cv::Mat patch;
+    cv::resize(gray, patch, cv::Size(DistortionHead::kPatch, DistortionHead::kPatch));
+    std::lock_guard<std::mutex> lock(mMutex);
+    mWallPatch = patch.clone(); // raw gray, no CLAHE (the head's SuperPoint was trained on raw gray)
 }
 
 bool MobileGS::getSuperPointFeatures(const cv::Mat& image, std::vector<cv::KeyPoint>& kps, cv::Mat& descs) {

--- a/core/nativebridge/src/main/cpp/include/MobileGS.h
+++ b/core/nativebridge/src/main/cpp/include/MobileGS.h
@@ -67,6 +67,9 @@ public:
 
     bool loadSuperPoint(const std::vector<uchar>& onnxBytes);
     bool loadDistortionHead(const std::vector<uchar>& onnxBytes) { return mDistortionHead.load(onnxBytes); }
+    // Canonical fingerprint patch (the marks) the distortion head compares the live crop against.
+    // Stored as a raw 256x256 gray (NO CLAHE — the head's frozen SuperPoint was trained on raw gray).
+    void setWallPatch(const cv::Mat& img);
     bool loadLowLightEnhancer(const std::vector<uchar>& onnxBytes);
     void clearMap();
     void pruneByConfidence(float threshold);
@@ -181,6 +184,7 @@ private:
     // confident relock so promoted marks are placed with a current pose, never a stale one).
     std::atomic<bool> mSelfGrowEnabled{false};
     long mLastGrowSeq = 0;
+    cv::Mat mWallPatch; // raw 256x256 gray canonical patch for the distortion head (desc_fp source)
     // VIO view snapshot captured alongside the reloc frame, so the rectifying warp matches that frame.
     float mRelocViewMatrix[16] = {1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1};
     uint64_t mFrameCounter = 0;

--- a/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
+++ b/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
@@ -130,6 +130,9 @@ class SlamManager @Inject constructor(
 
     /** Live wall-fingerprint point count — diagnostic for reloc health / watching self-grow. */
     fun getWallKeypointCount(): Int = nativeGetWallKeypointCount()
+
+    /** Store the canonical fingerprint patch (the captured marks) for the distortion head. */
+    fun setWallPatch(bitmap: Bitmap) = nativeSetWallPatch(bitmap)
     fun setVoxelSize(size: Float) = nativeSetVoxelSize(size)
     fun setMappingPaused(paused: Boolean) = nativeSetMappingPaused(paused)
 
@@ -444,6 +447,7 @@ class SlamManager @Inject constructor(
     private external fun nativeSetSelfGrowEnabled(enabled: Boolean)
     private external fun nativeDetectSuperPoint(bitmap: Bitmap): FloatArray?
     private external fun nativeGetWallKeypointCount(): Int
+    private external fun nativeSetWallPatch(bitmap: Bitmap)
     private external fun nativeSetVoxelSize(size: Float)
     private external fun nativeSetMappingPaused(paused: Boolean)
     private external fun nativeFeedPointCloud(points: FloatArray)


### PR DESCRIPTION
## What
Second increment of the distortion-head wiring (`docs/DISTORTION_HEAD.md` §5–6), **inert until `distortion_head.onnx` is bundled**:

- **Canonical patch**: `setWallPatch` (native + JNI + SlamManager) stores the captured marks as a raw **256×256 gray** (the head's frozen SuperPoint expects raw gray, not CLAHE); `MainViewModel` sets it at both capture paths (depth + depth-off).
- **relocThreadFunc**: when head + patch are present, crop the live frame (raw gray) around the coarse match centroid and run the head vs. the patch → **matchability** (logged confidence) + **coverage**. Coverage is the principled painting-progress signal, so it drives `mPaintingProgress`; the teleological gatekeeper's descriptor-ratio fallback yields to it when the head is loaded.

## Deferred (next increment)
`corners`/H → IPPE pose prior + adaptive thresholds (the geometry), and persisting the patch on `Fingerprint` (survives reload).

## Verification
- `:core:nativebridge` + `:app:assembleDebug` → BUILD SUCCESSFUL.
- On-device (with the Kaggle `distortion_head.onnx` in assets): logcat `DistortionHead: match … coverage …`; painting-progress reflects coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)