### PR TITLE
feat(ar): persist the distortion-head canonical patch on Fingerprint

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainViewModel.kt
@@ -281,12 +281,14 @@ class MainViewModel @Inject constructor(
             // (Teleological artwork base is registered from the live design composite via
             // ArViewModel.updatePaintingGuide — the design-only overlay, not blended with wall texture.)
 
-            // Canonical patch (the captured marks) for the distortion head — inert unless its model is bundled.
-            slamManager.setWallPatch(sensorBmp)
+            // Canonical patch (the captured marks) for the distortion head — fed live AND persisted on the
+            // fingerprint so the head survives reload. Inert unless its model is bundled.
+            val patch = grayPatchBytes(sensorBmp)
+            slamManager.setWallPatchBytes(patch, PATCH_SIZE)
 
             projectManager.saveProject(
                 context = context,
-                projectData = currentProject.copy(fingerprint = fp),
+                projectData = currentProject.copy(fingerprint = fp.copy(patchData = patch)),
                 targetImages = listOf(bitmap)
             )
 
@@ -296,6 +298,25 @@ class MainViewModel @Inject constructor(
                 Toast.makeText(context, "Target Saved & Locked", Toast.LENGTH_SHORT).show()
             }
         }
+    }
+
+    /**
+     * The canonical distortion-head patch as a raw [PATCH_SIZE]x[PATCH_SIZE] gray byte buffer (row-major
+     * luma). Computed in Kotlin so the exact bytes are both fed to native and persisted on the
+     * Fingerprint — keeping the capture-time and reload-time patch identical.
+     */
+    private fun grayPatchBytes(bitmap: Bitmap, size: Int = PATCH_SIZE): ByteArray {
+        val scaled = Bitmap.createScaledBitmap(bitmap, size, size, true)
+        val px = IntArray(size * size)
+        scaled.getPixels(px, 0, size, 0, 0, size, size)
+        if (scaled != bitmap) scaled.recycle()
+        val out = ByteArray(size * size)
+        for (i in px.indices) {
+            val p = px[i]
+            val r = (p ushr 16) and 0xFF; val g = (p ushr 8) and 0xFF; val b = p and 0xFF
+            out[i] = ((r * 299 + g * 587 + b * 114) / 1000).toByte() // BT.601 luma
+        }
+        return out
     }
 
     private fun resetCaptureUi() {
@@ -355,12 +376,13 @@ class MainViewModel @Inject constructor(
             // (Teleological artwork base is registered from the live design composite via
             // ArViewModel.updatePaintingGuide — see the depth path above.)
 
-            // Canonical patch (keyframe of the marks) for the distortion head — inert unless model bundled.
-            slamManager.setWallPatch(bitmap)
+            // Canonical patch (keyframe of the marks) for the distortion head — fed live AND persisted.
+            val patch = grayPatchBytes(bitmap)
+            slamManager.setWallPatchBytes(patch, PATCH_SIZE)
 
             projectManager.saveProject(
                 context = context,
-                projectData = currentProject.copy(fingerprint = fp),
+                projectData = currentProject.copy(fingerprint = fp.copy(patchData = patch)),
                 targetImages = listOf(bitmap)
             )
             projectRepository.loadProject(currentProject.id)
@@ -388,5 +410,9 @@ class MainViewModel @Inject constructor(
                 tutorialCompleted = currentState.tutorialCompleted + (tutorialId to true)
             )
         }
+    }
+
+    private companion object {
+        const val PATCH_SIZE = 256 // distortion-head canonical patch is 256x256 gray
     }
 }

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/Fingerprint.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/Fingerprint.kt
@@ -15,7 +15,10 @@ data class Fingerprint(
     val descriptorsData: ByteArray,
     val descriptorsRows: Int,
     val descriptorsCols: Int,
-    val descriptorsType: Int
+    val descriptorsType: Int,
+    // Canonical 256x256 raw-gray patch of the marks (row-major) for the distortion head. Empty when
+    // the head isn't in use. Defaulted so older saved projects deserialize unchanged.
+    val patchData: ByteArray = ByteArray(0),
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -27,6 +30,7 @@ data class Fingerprint(
         if (descriptorsRows != other.descriptorsRows) return false
         if (descriptorsCols != other.descriptorsCols) return false
         if (descriptorsType != other.descriptorsType) return false
+        if (!patchData.contentEquals(other.patchData)) return false
         return true
     }
 
@@ -37,6 +41,7 @@ data class Fingerprint(
         result = 31 * result + descriptorsRows
         result = 31 * result + descriptorsCols
         result = 31 * result + descriptorsType
+        result = 31 * result + patchData.contentHashCode()
         return result
     }
 }

--- a/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
+++ b/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
@@ -191,6 +191,17 @@ Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeSetWallPatch(JNIEn
 }
 
 JNIEXPORT void JNICALL
+Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeSetWallPatchBytes(
+        JNIEnv* env, jobject thiz, jbyteArray data, jint size) {
+    if (!gSlamEngine || !data || size <= 0) return;
+    if (env->GetArrayLength(data) < size * size) return; // expect a size x size single-channel gray buffer
+    jbyte* p = env->GetByteArrayElements(data, nullptr);
+    cv::Mat gray(size, size, CV_8UC1, reinterpret_cast<uchar*>(p));
+    gSlamEngine->setWallPatch(gray); // clones internally; safe to release after
+    env->ReleaseByteArrayElements(data, p, JNI_ABORT);
+}
+
+JNIEXPORT void JNICALL
 Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeSetVoxelSize(JNIEnv* env, jobject thiz, jfloat size) {
     if (gSlamEngine) gSlamEngine->setVoxelSize(size);
 }

--- a/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
+++ b/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
@@ -133,6 +133,8 @@ class SlamManager @Inject constructor(
 
     /** Store the canonical fingerprint patch (the captured marks) for the distortion head. */
     fun setWallPatch(bitmap: Bitmap) = nativeSetWallPatch(bitmap)
+    /** Store the canonical patch from a raw [size]x[size] gray byte buffer (persisted on Fingerprint). */
+    fun setWallPatchBytes(data: ByteArray, size: Int) = nativeSetWallPatchBytes(data, size)
     fun setVoxelSize(size: Float) = nativeSetVoxelSize(size)
     fun setMappingPaused(paused: Boolean) = nativeSetMappingPaused(paused)
 
@@ -448,6 +450,7 @@ class SlamManager @Inject constructor(
     private external fun nativeDetectSuperPoint(bitmap: Bitmap): FloatArray?
     private external fun nativeGetWallKeypointCount(): Int
     private external fun nativeSetWallPatch(bitmap: Bitmap)
+    private external fun nativeSetWallPatchBytes(data: ByteArray, size: Int)
     private external fun nativeSetVoxelSize(size: Float)
     private external fun nativeSetMappingPaused(paused: Boolean)
     private external fun nativeFeedPointCloud(points: FloatArray)

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -752,6 +752,12 @@ class ArViewModel @Inject constructor(
                     fp.descriptorsType,
                     fp.points3d.toFloatArray()
                 )
+                // Restore the distortion-head canonical patch so the head works after reload, not only
+                // in the capture session. 256x256 raw gray (= sqrt(len)); inert if absent/head unloaded.
+                if (fp.patchData.isNotEmpty()) {
+                    val s = kotlin.math.sqrt(fp.patchData.size.toDouble()).toInt()
+                    if (s * s == fp.patchData.size) slamManager.setWallPatchBytes(fp.patchData, s)
+                }
             }
         }
     }

--- a/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/EditorViewModel.kt
+++ b/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/EditorViewModel.kt
@@ -186,6 +186,11 @@ class EditorViewModel @Inject constructor(
                                     fp.descriptorsType,
                                     fp.points3d.toFloatArray()
                                 )
+                                // Restore the distortion-head canonical patch (256x256 raw gray).
+                                if (fp.patchData.isNotEmpty()) {
+                                    val s = kotlin.math.sqrt(fp.patchData.size.toDouble()).toInt()
+                                    if (s * s == fp.patchData.size) slamManager.setWallPatchBytes(fp.patchData, s)
+                                }
                             }
                         }
 


### PR DESCRIPTION
## What
The head's canonical patch (`mWallPatch`) was **session-only** — it went inert after an app restart / project reload until re-capture. Persist it:

- `Fingerprint` gains `patchData` (256×256 raw-gray, **defaulted** so old saved projects deserialize unchanged; the serializer just delegates, so it's automatic).
- Capture computes the exact patch bytes in Kotlin (`grayPatchBytes`, BT.601 luma) and **both** feeds native (`setWallPatchBytes`/`nativeSetWallPatchBytes`) **and** stores them on the `Fingerprint`, so capture-time and reload-time patches are byte-identical.
- Project restore (`ArViewModel` + `EditorViewModel`) feeds `fp.patchData` back to native after `restoreWallFingerprint`.

Inert unless `distortion_head.onnx` is bundled.

## Verification
- `:core:nativebridge` + `:app:assembleDebug` → BUILD SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)