### PR TITLE
fix: launch crash — MetaGlassProvider touches Wearables before init

### DIFF
--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/wearable/MetaGlassProvider.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/wearable/MetaGlassProvider.kt
@@ -70,22 +70,40 @@ class MetaGlassProvider @Inject constructor(
 
     init {
         scope.launch {
-            Wearables.registrationState.collect { state ->
-                val newState = when (state) {
-                    is RegistrationState.Registered -> ConnectionState.Connected
-                    is RegistrationState.Available -> ConnectionState.Disconnected
-                    is RegistrationState.Unavailable -> {
-                        if (state.error != null) ConnectionState.Error(state.error.toString())
-                        else ConnectionState.Disconnected
-                    }
-                    else -> ConnectionState.Connecting
-                }
-                _connectionState.value = newState
+            // This @Singleton can be constructed before MainActivity calls Wearables.initialize()
+            // (which is itself permission-gated), so touching Wearables.registrationState here can throw
+            // "Wearables not initialized" and crash the app on launch. Wait + retry instead of crashing;
+            // once collect() starts it runs for the session.
+            var attempt = 0
+            while (true) {
+                try {
+                    Wearables.registrationState.collect { state ->
+                        val newState = when (state) {
+                            is RegistrationState.Registered -> ConnectionState.Connected
+                            is RegistrationState.Available -> ConnectionState.Disconnected
+                            is RegistrationState.Unavailable -> {
+                                if (state.error != null) ConnectionState.Error(state.error.toString())
+                                else ConnectionState.Disconnected
+                            }
+                            else -> ConnectionState.Connecting
+                        }
+                        _connectionState.value = newState
 
-                if (newState is ConnectionState.Connected) {
-                    startCameraStream()
-                } else if (newState is ConnectionState.Disconnected || newState is ConnectionState.Error) {
-                    stopCameraStream()
+                        if (newState is ConnectionState.Connected) {
+                            startCameraStream()
+                        } else if (newState is ConnectionState.Disconnected || newState is ConnectionState.Error) {
+                            stopCameraStream()
+                        }
+                    }
+                    break // collect completed normally
+                } catch (e: Exception) {
+                    // Most commonly WearablesException("not initialized") — back off and retry until the
+                    // SDK is initialized. Give up after ~1 min so we don't poll forever if it never is.
+                    if (++attempt >= 30) {
+                        Log.w("MetaGlassProvider", "Wearables registrationState unavailable; giving up", e)
+                        break
+                    }
+                    kotlinx.coroutines.delay(2000)
                 }
             }
         }


### PR DESCRIPTION
## Crash
`FATAL EXCEPTION: main` on launch:
```
com.meta.wearable.dat.core.types.WearablesException: Wearables not initialized. Call Wearables.initialize(context) first.
  at MetaGlassProvider$1.invokeSuspend(MetaGlassProvider.kt:73)
```
The `@Singleton MetaGlassProvider` init coroutine accesses `Wearables.registrationState` at construction — before `MainActivity.checkAndInitializeWearables()` runs `Wearables.initialize(this)`. And that init is gated on `BLUETOOTH_CONNECT`, so on first launch (permission not yet granted) it never runs, guaranteeing the crash.

## Fix
Wrap the `registrationState.collect` in a retry loop that catches the not-initialized exception and backs off (2 s, up to ~1 min) until the SDK is initialized, instead of crashing. Gives up gracefully if it's never initialized (no glasses / BT denied — common on a phone) — no crash either way.

## Verification
- `:app:assembleDebug` → BUILD SUCCESSFUL.
- On-device: app should now launch (this was blocking *all* testing, including the distortion head).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prevent app launch crashes by making MetaGlassProvider tolerate uninitialized Wearables SDK state.

Bug Fixes:
- Avoid a launch-time crash when MetaGlassProvider accesses Wearables.registrationState before the Wearables SDK is initialized.

Enhancements:
- Add a retry-with-backoff loop around Wearables.registrationState collection that logs and gives up after a bounded period if the SDK never initializes.