### PR TITLE
fix: crash navigating to DESIGN — register the missing nav destination

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -690,6 +690,10 @@ class MainActivity : ComponentActivity() {
                                     TraceScreen(editorViewModel, showLibrary, arUiState)
                                     EditorOverlay(editorViewModel, mainUiState, strings)
                                 }
+                                composable(EditorMode.DESIGN.name) {
+                                    DesignScreen(editorUiState, editorViewModel)
+                                    EditorOverlay(editorViewModel, mainUiState, strings)
+                                }
                             }
 
                             if (mainUiState.isTouchLocked) {


### PR DESCRIPTION
## Crash
Tapping the **Design** nav-rail button:
```
java.lang.IllegalArgumentException: Navigation destination that matches route DESIGN
cannot be found in the navigation graph ... startDestination={route=library}
```
The Design-mode refactor added `EditorMode.DESIGN` + a rail item routing to it, but never registered `composable(EditorMode.DESIGN.name)` in the `AzNavHost` (only AR/OVERLAY/MOCKUP/TRACE/LIBRARY existed).

## Fix
Register the `DESIGN` destination, rendering `DesignScreen(editorUiState, editorViewModel)` + `EditorOverlay` like the other modes. Cross-checked: every rail-routed mode now has a destination (STENCIL isn't rail-routed, so no gap remains).

## Verification
- `:app:assembleDebug` → BUILD SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Fix a crash when tapping the Design navigation-rail item by adding its corresponding navigation destination.