### PR TITLE
feat(nav): keep Modes rail minimal — Adjust is off-rail, not a rail item

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -1393,27 +1393,12 @@ class MainActivity : ComponentActivity() {
                 }
             }
 
-            // ADJUST — in-mode tweaks for the finished design (the few last-minute, in-place touchups).
-            // Lives under Modes and only while in a mode; design content editing stays in the Design screen.
-            if (!isDesignMode) {
-                azRailSubItem(
-                    id = "sub.modes.adjust",
-                    hostId = "host.modes",
-                    text = navStrings.adjust,
-                    content = Icons.Default.Tune,
-                    color = navItemColor
-                ) {
-                    if (editorUiState.editorMode == EditorMode.MOCKUP) {
-                        azRailItem(id = "adjust.wall", text = navStrings.wall, content = Icons.Default.Wallpaper, color = navItemColor) {
-                            showWallSourceDialog = true
-                        }
-                    }
-                    azRailItem(id = "adjust.dim", text = "Dim", content = Icons.Default.Opacity, color = navItemColor) {
-                        editorViewModel.updateAllLayers { it.copy(opacity = (it.opacity - 0.1f).coerceIn(0f, 1f)) }
-                    }
-                    azRailItem(id = "adjust.reset", text = "Reset", content = Icons.Default.Refresh, color = navItemColor) {
-                        editorViewModel.updateAllLayers { it.copy(scale = 1f, offset = Offset.Zero, rotationX = 0f, rotationY = 0f, rotationZ = 0f) }
-                    }
+            // Adjust for Modes is NOT a rail item — it's off-rail adjustment knobs (opacity, saturation,
+            // …) on the mode screen, like the design adjustment knobs. Keeping the rail minimal so Modes
+            // don't overwhelm. Mockup still needs to pick its surface image (not a design-content tool):
+            if (editorUiState.editorMode == EditorMode.MOCKUP) {
+                azRailSubItem(id = "mode.mockup.wall", hostId = "host.modes", text = navStrings.wall, content = Icons.Default.Wallpaper, color = navItemColor) {
+                    showWallSourceDialog = true
                 }
             }
 


### PR DESCRIPTION
Per the redesign (reduce overwhelm): Modes get **no** Adjust rail/sub-rail item — the adjust tools (opacity, saturation, …) belong **off-rail** as adjustment knobs on the mode screen. Removed the `sub.modes.adjust` folder; kept only Mockup's **Wall** under Modes (it must pick its surface; not a design-content tool). Design editing stays Design-screen only.

Next: surface the off-rail adjustment knobs in Modes + remove undo/redo there (AdjustmentsPanel/EditorUi).

`:app:assembleDebug` SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Simplify the Modes navigation rail by removing the generic Adjust sub-rail and keeping only the Mockup wall surface picker as a dedicated mode rail item under Modes.

New Features:
- Expose the Mockup mode wall surface picker as a standalone Modes rail item instead of nesting it under a generic Adjust sub-rail.

Enhancements:
- Reduce navigation rail clutter in Modes by removing the in-mode Adjust rail group in favor of off-rail adjustment controls on the mode screen.