### PR TITLE
fix(design): remove scan indicator; Add works w/o preloaded project; hide empty Layers

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -1246,7 +1246,12 @@ class MainActivity : ComponentActivity() {
                 onClick = {
                     // From a Mode, tapping Design navigates to the dedicated Design screen. In Design it
                     // just expands the design tools below (this onClick is a no-op there).
-                    if (!isDesignMode) navController.navigate(EditorMode.DESIGN.name) { launchSingleTop = true }
+                    if (!isDesignMode) {
+                        // Design needs an active project or every Add silently no-ops — create+open one
+                        // if the user jumped straight into Design without loading a project.
+                        if (editorUiState.projectId == null) dashboardViewModel.createAndOpenProject()
+                        navController.navigate(EditorMode.DESIGN.name) { launchSingleTop = true }
+                    }
                 }
             )
 
@@ -1275,8 +1280,8 @@ class MainActivity : ComponentActivity() {
                     }
                 }
 
-                // LAYERS SUB-FOLDER
-                azRailSubItem(
+                // LAYERS SUB-FOLDER — only when layers exist (an empty "Layers" folder is confusing)
+                if (editorUiState.layers.isNotEmpty()) azRailSubItem(
                     id = "sub.design.layers",
                     hostId = "host.design",
                     text = "Layers",

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/BackgroundRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/BackgroundRenderer.kt
@@ -264,28 +264,10 @@ class BackgroundRenderer : GlReleasable {
             }
 
             void main() {
-                vec4 cam = texture(u_Texture, v_TexCoord);
-                if (u_ScanActive < 0.5) { FragColor = cam; return; }
-
-                float yawOffset = atan(v_NdcXy.x * tan(u_HalfFovHRad));
-                float yaw = u_CameraYawRad + yawOffset;
-                float u = fract(yaw / TWO_PI);
-                if (u < 0.0) u += 1.0;
-                float coverage = texture(u_MaskTex, vec2(u, 0.5)).r; // 0 unmapped .. 1 mapped
-
-                // Newspaper halftone of the camera luminance: darker -> larger ink dot.
-                float L = dot(cam.rgb, vec3(0.299, 0.587, 0.114));
-                vec2 cell = gl_FragCoord.xy / u_DotSizePx;
-                float dotd = length(fract(cell) - 0.5) * 2.0;
-                float dotR = sqrt(clamp(1.0 - L, 0.0, 1.0));
-                float inkDot = smoothstep(dotR + 0.08, dotR - 0.08, dotd);
-                vec3 bw = vec3(1.0 - inkDot); // paper-white with black halftone dots
-
-                // Full colour/tone bleeds in organically as coverage rises (spreads like ink).
-                float nf = vnoise(gl_FragCoord.xy / 90.0);
-                float reveal = smoothstep(nf - 0.12, nf + 0.12, coverage);
-
-                FragColor = vec4(mix(bw, cam.rgb, reveal), 1.0);
+                // Plain camera pass-through. The screen-space halftone->colour "develop" reveal was
+                // removed: it was a flat 2D effect (same failing as the pink fog). A real scan indicator
+                // must spread on the actual 3D surfaces being mapped, not across the whole frame.
+                FragColor = texture(u_Texture, v_TexCoord);
             }
         """.trimIndent()
     }

--- a/feature/dashboard/src/main/java/com/hereliesaz/graffitixr/feature/dashboard/DashboardViewModel.kt
+++ b/feature/dashboard/src/main/java/com/hereliesaz/graffitixr/feature/dashboard/DashboardViewModel.kt
@@ -52,6 +52,20 @@ class DashboardViewModel @Inject constructor(
         _uiState.update { it.copy(showNewProjectDialog = true) }
     }
 
+    /**
+     * Create a project AND load it, so the editor gets a non-null projectId immediately. Used when the
+     * user jumps straight into Design with no active project — otherwise every Add silently no-ops
+     * because the add handlers require a projectId.
+     */
+    fun createAndOpenProject(name: String = "Untitled", isRightHanded: Boolean = true) {
+        viewModelScope.launch {
+            val p = repository.createProject(name)
+            repository.updateProject(p.copy(isRightHanded = isRightHanded))
+            repository.loadProject(p.id)
+            loadAvailableProjects()
+        }
+    }
+
     fun onCreateProject(name: String, isRightHanded: Boolean) {
         viewModelScope.launch {
             val p = repository.createProject(name)


### PR DESCRIPTION
Three cleanup fixes:

1. **Scan indicator removed.** The screen-space halftone→colour "develop" reveal was a flat 2D effect — the same failing as the pink fog. `BackgroundRenderer` is now a plain camera pass-through. (A real indicator must spread on the actual mapped **3D surfaces**, which needs depth/mesh — not available in the depth-off config; noted for later.)
2. **Add was broken.** Entering Design with no active project left `projectId == null`, so `onAddLayer`/`onAddBlankLayer`/`onAddTextLayer` all silently no-opped. The Design rail tap now **creates and opens** a project (`createAndOpenProject`) when none is active, so Add works immediately.
3. **Layers folder** only shows when layers actually exist (an empty "Layers" folder was confusing).

`:app:assembleDebug` SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)