### PR TITLE
feat(design): Photoshop-style custom vector icons for the design tools

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -1266,13 +1266,13 @@ class MainActivity : ComponentActivity() {
                     content = Icons.Default.Add,
                     color = navItemColor
                 ) {
-                    azRailItem(id = "design.addImg", text = navStrings.image, content = Icons.Default.Image, color = navItemColor) {
+                    azRailItem(id = "design.addImg", text = navStrings.image, content = DesignR.drawable.ic_ps_image, color = navItemColor) {
                         overlayPicker.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
                     }
-                    azRailItem(id = "design.addDraw", text = navStrings.draw, content = Icons.Default.Brush, color = navItemColor) {
+                    azRailItem(id = "design.addDraw", text = navStrings.draw, content = DesignR.drawable.ic_ps_pencil, color = navItemColor) {
                         editorViewModel.onAddBlankLayer()
                     }
-                    azRailItem(id = "design.addText", text = navStrings.text, content = Icons.Default.TextFields, color = navItemColor) {
+                    azRailItem(id = "design.addText", text = navStrings.text, content = DesignR.drawable.ic_ps_text, color = navItemColor) {
                         editorViewModel.onAddTextLayer()
                     }
                     azRailItem(id = "design.wall", text = navStrings.wall, content = Icons.Default.Wallpaper, color = navItemColor) {
@@ -1285,7 +1285,7 @@ class MainActivity : ComponentActivity() {
                     id = "sub.design.layers",
                     hostId = "host.design",
                     text = "Layers",
-                    content = Icons.Default.Layers,
+                    content = DesignR.drawable.ic_ps_layers,
                     color = if (activeLayer != null) Cyan else navItemColor
                 ) {
                     editorUiState.layers.reversed().forEach { layer ->
@@ -1337,16 +1337,16 @@ class MainActivity : ComponentActivity() {
                         content = Icons.Default.Construction,
                         color = if (activeTool != Tool.NONE) Cyan else navItemColor
                     ) {
-                        azRailItem(id = "tool.brush", text = "Brush", content = Icons.Default.Brush, color = if (activeTool == Tool.BRUSH) Cyan else navItemColor) {
+                        azRailItem(id = "tool.brush", text = "Brush", content = DesignR.drawable.ic_ps_brush, color = if (activeTool == Tool.BRUSH) Cyan else navItemColor) {
                             editorViewModel.setActiveTool(Tool.BRUSH)
                         }
-                        azRailItem(id = "tool.eraser", text = navStrings.eraser, content = Icons.Default.AutoFixNormal, color = if (activeTool == Tool.ERASER) Cyan else navItemColor) {
+                        azRailItem(id = "tool.eraser", text = navStrings.eraser, content = DesignR.drawable.ic_ps_eraser, color = if (activeTool == Tool.ERASER) Cyan else navItemColor) {
                             editorViewModel.setActiveTool(Tool.ERASER)
                         }
-                        azRailItem(id = "tool.blur", text = navStrings.blur, content = Icons.Default.BlurOn, color = if (activeTool == Tool.BLUR) Cyan else navItemColor) {
+                        azRailItem(id = "tool.blur", text = navStrings.blur, content = DesignR.drawable.ic_ps_blur, color = if (activeTool == Tool.BLUR) Cyan else navItemColor) {
                             editorViewModel.setActiveTool(Tool.BLUR)
                         }
-                        azRailItem(id = "tool.liquify", text = navStrings.liquify, content = Icons.Default.Waves, color = if (activeTool == Tool.LIQUIFY) Cyan else navItemColor) {
+                        azRailItem(id = "tool.liquify", text = navStrings.liquify, content = DesignR.drawable.ic_ps_liquify, color = if (activeTool == Tool.LIQUIFY) Cyan else navItemColor) {
                             editorViewModel.setActiveTool(Tool.LIQUIFY)
                         }
                     }

--- a/core/design/src/main/res/drawable/ic_ps_blur.xml
+++ b/core/design/src/main/res/drawable/ic_ps_blur.xml
@@ -1,0 +1,8 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24"
+    android:tint="?android:attr/colorControlNormal">
+    <!-- Photoshop-style blur: a teardrop with a soft (half-tone) edge. -->
+    <path android:fillColor="@android:color/white"
+        android:pathData="M12,2.5c0,0 6.5,7 6.5,11.5c0,3.6 -2.9,6.5 -6.5,6.5s-6.5,-2.9 -6.5,-6.5C5.5,9.5 12,2.5 12,2.5zM12,18.5c2.5,0 4.5,-2 4.5,-4.5h-9C7.5,16.5 9.5,18.5 12,18.5z"/>
+</vector>

--- a/core/design/src/main/res/drawable/ic_ps_brush.xml
+++ b/core/design/src/main/res/drawable/ic_ps_brush.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24"
+    android:tint="?android:attr/colorControlNormal">
+    <!-- Photoshop-style brush: slanted ferrule/handle with a bristle tip. -->
+    <path android:fillColor="@android:color/white"
+        android:pathData="M18.4,2.9l2.7,2.7c0.4,0.4 0.4,1 0,1.4l-8.1,8.1l-4.1,-4.1l8.1,-8.1C17.4,2.5 18,2.5 18.4,2.9z"/>
+    <path android:fillColor="@android:color/white"
+        android:pathData="M7.7,12.1l4.2,4.2c-0.3,2.2 -2.2,3.9 -4.5,3.9c-1.7,0 -3.2,-0.9 -4.1,-2.2c1,0 1.9,-0.6 2.3,-1.5c0.3,-0.7 0.2,-1.4 0.5,-2.1C6.5,13.1 7,12.4 7.7,12.1z"/>
+</vector>

--- a/core/design/src/main/res/drawable/ic_ps_eraser.xml
+++ b/core/design/src/main/res/drawable/ic_ps_eraser.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24"
+    android:tint="?android:attr/colorControlNormal">
+    <!-- Photoshop-style eraser: angled rubber block sliding on a baseline. -->
+    <path android:fillColor="@android:color/white"
+        android:pathData="M15.1,3.6l5.3,5.3c0.8,0.8 0.8,2 0,2.8l-7,7H9.5l-4.6,-4.6c-0.8,-0.8 -0.8,-2 0,-2.8l7.4,-7.7C13.1,2.8 14.3,2.8 15.1,3.6zM10.9,17.3l5.6,-5.6l-4.2,-4.2l-5.6,5.6L10.9,17.3z"/>
+    <path android:fillColor="@android:color/white"
+        android:pathData="M3,20h18v1.6H3z"/>
+</vector>

--- a/core/design/src/main/res/drawable/ic_ps_image.xml
+++ b/core/design/src/main/res/drawable/ic_ps_image.xml
@@ -1,0 +1,8 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24"
+    android:tint="?android:attr/colorControlNormal">
+    <!-- Photoshop-style "place image": framed photo with sun + mountains. -->
+    <path android:fillColor="@android:color/white"
+        android:pathData="M21,3H3C2.4,3 2,3.4 2,4v16c0,0.6 0.4,1 1,1h18c0.6,0 1,-0.4 1,-1V4C22,3.4 21.6,3 21,3zM20,19H4l4.5,-5.5l2.5,3l3.5,-4.5L20,19zM8,9.5C8,10.3 7.3,11 6.5,11S5,10.3 5,9.5S5.7,8 6.5,8S8,8.7 8,9.5z"/>
+</vector>

--- a/core/design/src/main/res/drawable/ic_ps_layers.xml
+++ b/core/design/src/main/res/drawable/ic_ps_layers.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24"
+    android:tint="?android:attr/colorControlNormal">
+    <!-- Photoshop-style layers: stacked sheets. -->
+    <path android:fillColor="@android:color/white"
+        android:pathData="M12,2L2,8l10,6l10,-6L12,2zM12,4.3L18.1,8L12,11.7L5.9,8L12,4.3z"/>
+    <path android:fillColor="@android:color/white"
+        android:pathData="M4.2,11.4L2,12.7l10,6l10,-6l-2.2,-1.3L12,15.1L4.2,11.4z"/>
+    <path android:fillColor="@android:color/white"
+        android:pathData="M4.2,15.4L2,16.7l10,6l10,-6l-2.2,-1.3L12,19.1L4.2,15.4z"/>
+</vector>

--- a/core/design/src/main/res/drawable/ic_ps_liquify.xml
+++ b/core/design/src/main/res/drawable/ic_ps_liquify.xml
@@ -1,0 +1,8 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24"
+    android:tint="?android:attr/colorControlNormal">
+    <!-- Photoshop-style liquify: a warped swirl/finger-smudge spiral. -->
+    <path android:fillColor="@android:color/white"
+        android:pathData="M12,3C7,3 3,7 3,12c0,4.4 3.6,8 8,8c3.9,0 7,-3.1 7,-7c0,-3.3 -2.7,-6 -6,-6c-2.8,0 -5,2.2 -5,5c0,2.2 1.8,4 4,4c1.7,0 3,-1.3 3,-3c0,-1.1 -0.9,-2 -2,-2v2c0,0.6 -0.4,1 -1,1c-1.1,0 -2,-0.9 -2,-2c0,-1.7 1.3,-3 3,-3c2.2,0 4,1.8 4,4c0,2.8 -2.2,5 -5,5c-3.3,0 -6,-2.7 -6,-6c0,-3.9 3.1,-7 7,-7c4.4,0 8,3.6 8,8h2C20,6.5 16.4,3 12,3z"/>
+</vector>

--- a/core/design/src/main/res/drawable/ic_ps_pencil.xml
+++ b/core/design/src/main/res/drawable/ic_ps_pencil.xml
@@ -1,0 +1,8 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24"
+    android:tint="?android:attr/colorControlNormal">
+    <!-- Photoshop-style pencil: sharpened tip on a diagonal shaft. -->
+    <path android:fillColor="@android:color/white"
+        android:pathData="M3,17.25V21h3.75L17.81,9.94l-3.75,-3.75L3,17.25zM20.71,7.04c0.39,-0.39 0.39,-1.02 0,-1.41l-2.34,-2.34c-0.39,-0.39 -1.02,-0.39 -1.41,0l-1.83,1.83l3.75,3.75L20.71,7.04z"/>
+</vector>

--- a/core/design/src/main/res/drawable/ic_ps_text.xml
+++ b/core/design/src/main/res/drawable/ic_ps_text.xml
@@ -1,0 +1,8 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24"
+    android:tint="?android:attr/colorControlNormal">
+    <!-- Photoshop-style type tool: a serif capital T. -->
+    <path android:fillColor="@android:color/white"
+        android:pathData="M5,4h14v4h-1.6V6.6h-4.6V18h1.9v1.6H9.3V18h1.9V6.6H6.6V8H5V4z"/>
+</vector>


### PR DESCRIPTION
Custom hand-authored vector-drawable set in `core/design/res/drawable`, wired to the core design tools (the AzNavRail `content` param accepts drawable resource IDs):

- **Tools**: Brush, Eraser, Blur (teardrop), Liquify (smudge swirl)
- **Add**: Image (place/photo), Draw (pencil), Text (serif T)
- **Layers** (stacked sheets)

Replaces the Material glyphs on those items. Tinted via `?colorControlNormal` so the rail's active/inactive colors still apply.

Remaining design items (Adjust: blend/invert/filters/balance; Wall; the Add "+" / Design folder) still use Material — say the word and I'll extend the set.

`:app:assembleDebug` SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Replace Material icons in the design tool rail with custom Photoshop-style vector icons from the shared design module.

Enhancements:
- Introduce a custom set of Photoshop-style vector drawables for core design tools, including brush, eraser, blur, liquify, image, draw, text, and layers.
- Wire the new design module icons into the main design navigation rail so design tools and layer controls use the custom iconography.