### PR TITLE
feat(ar): Canvas label + auto-fall-back from Mural when unsupported

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -772,17 +772,8 @@ class MainActivity : ComponentActivity() {
                                 )
                             }
 
-                            val showDepthWarning = editorUiState.editorMode == EditorMode.AR
-                                    && arUiState.arScanMode == ArScanMode.MURAL
-                                    && !arUiState.isDepthApiSupported
-                                    && arUiState.splatCount == 0
-                            if (showDepthWarning && !showLibrary && !showSettings) {
-                                DepthApiUnsupportedBanner(
-                                    modifier = Modifier
-                                        .align(Alignment.TopCenter)
-                                        .padding(top = 16.dp)
-                                )
-                            }
+                            // Depth-unsupported devices auto-fall-back to Canvas (handled in
+                            // ArViewModel), so the old "switch to Canvas in Settings" banner is gone.
 
                             if (editorUiState.editorMode == EditorMode.AR
                                 && !arUiState.isArCoreAvailable
@@ -2018,21 +2009,6 @@ private fun WallSourceDialog(
             AzButton(text = stringResource(DesignR.string.choose_from_gallery), onClick = onGallery, shape = AzButtonShape.RECTANGLE)
         }
     )
-}
-
-@Composable
-private fun DepthApiUnsupportedBanner(modifier: Modifier = Modifier) {
-    Box(
-        modifier = modifier
-            .background(Color(0xEECC4400), RoundedCornerShape(12.dp))
-            .padding(horizontal = 20.dp, vertical = 10.dp)
-    ) {
-        Text(
-            text = stringResource(DesignR.string.depth_unsupported),
-            color = HotPink,
-            textAlign = TextAlign.Center
-        )
-    }
 }
 
 @Composable

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -450,7 +450,7 @@ class ArViewModel @Inject constructor(
         }
         viewModelScope.launch {
             settingsRepository.arScanMode.collect { mode ->
-                _uiState.update { it.copy(arScanMode = mode) }
+                _uiState.update { it.copy(arScanMode = mode.coerceToCapability()) }
             }
         }
         viewModelScope.launch {
@@ -470,8 +470,16 @@ class ArViewModel @Inject constructor(
         }
     }
 
+    // Whether this device can run MURAL scanning (gated on ARCore Depth API support, the app's
+    // existing capability premise). Defaults true until a session reports otherwise.
+    @Volatile private var deviceCanDoMural: Boolean = true
+
+    // MURAL requires depth; on devices that can't do it, fall back to Canvas (CLOUD_POINTS).
+    private fun ArScanMode.coerceToCapability(): ArScanMode =
+        if (!deviceCanDoMural && this == ArScanMode.MURAL) ArScanMode.CLOUD_POINTS else this
+
     fun setArScanMode(mode: ArScanMode) {
-        _uiState.update { it.copy(arScanMode = mode) }
+        _uiState.update { it.copy(arScanMode = mode.coerceToCapability()) }
     }
 
     fun setMuralMethod(method: MuralMethod) {
@@ -574,13 +582,18 @@ class ArViewModel @Inject constructor(
             // device offers it); the wall anchor uses plane detection. Re-enabling requires first
             // solving the VIO starvation.
             val useArCoreDepthApi = false
-            if (useArCoreDepthApi && s.isDepthModeSupported(Config.DepthMode.AUTOMATIC)) {
+            // Device capability for MURAL: whether ARCore supports the Depth API here. Independent of
+            // useArCoreDepthApi (which stays off for VIO reasons) — this is the device's true support.
+            deviceCanDoMural = s.isDepthModeSupported(Config.DepthMode.AUTOMATIC)
+            if (useArCoreDepthApi && deviceCanDoMural) {
                 config.depthMode = Config.DepthMode.AUTOMATIC
                 _uiState.update { it.copy(isDepthApiSupported = true) }
             } else {
                 config.depthMode = Config.DepthMode.DISABLED
                 _uiState.update { it.copy(isDepthApiSupported = false) }
             }
+            // Auto-fall-back to Canvas if this device can't do MURAL.
+            _uiState.update { it.copy(arScanMode = it.arScanMode.coerceToCapability()) }
             renderer?.depthApiEnabled = useArCoreDepthApi
 
             s.configure(config)

--- a/feature/dashboard/src/main/java/com/hereliesaz/graffitixr/feature/dashboard/SettingsScreen.kt
+++ b/feature/dashboard/src/main/java/com/hereliesaz/graffitixr/feature/dashboard/SettingsScreen.kt
@@ -218,7 +218,7 @@ fun SettingsScreen(
                             val modes = ArScanMode.entries
                             val nextMode = modes[(arScanMode.ordinal + 1) % modes.size]
                             val scanModeValue = when (arScanMode) {
-                                ArScanMode.CLOUD_POINTS -> strings.settings.pointCloud
+                                ArScanMode.CLOUD_POINTS -> strings.nav.canvas
                                 ArScanMode.MURAL -> strings.nav.mural
                             }
                             SettingsItem(


### PR DESCRIPTION
## What

Two scan-mode fixes:

1. **Label consistency** — the scan-mode setting now shows **"Canvas"** for `CLOUD_POINTS` (was "Point Cloud"), matching **"Mural"** for the other mode.
2. **Auto-fallback** — devices that can't do Mural automatically fall back to **Canvas**.

## How (fallback)

Mural's capability gate is ARCore Depth API support (the app's existing premise — that's what the old "switch to Canvas" prompt keyed off). At session config we now read the device's true capability (`session.isDepthModeSupported(AUTOMATIC)`, independent of the `useArCoreDepthApi` toggle which stays off for VIO reasons) into `deviceCanDoMural`, and coerce `MURAL → CLOUD_POINTS` at every entry point — the settings collector, `setArScanMode`, and session config — so an incapable device can never get stuck on Mural. The renderer reads `arScanMode` straight from state, so it follows automatically.

Removed the now-redundant **DepthApiUnsupportedBanner** ("switch to Canvas in Settings") — the fallback replaces the manual instruction (and that banner was firing for everyone in Mural anyway, since `isDepthApiSupported` is always false while the Depth API is disabled).

## Notes
- No SDK in the session container; verified imports, references, and brackets. CI compiles.
- The capability premise is the ARCore Depth API, matching the app's existing model. If "can't do Mural" should key off a different signal (e.g. hardware stereo / VIO quality), say so and I'll adjust the gate.

https://claude.ai/code/session_01GxdoXFy5ewQGEwdJ3Aj7Si

---
_Generated by [Claude Code](https://claude.ai/code/session_01GxdoXFy5ewQGEwdJ3Aj7Si)_