### PR TITLE
fix(ar): gate Mural fallback on hardware stereo (dual-lens), not Depth API

### DIFF
--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -623,12 +623,16 @@ class ArViewModel @Inject constructor(
                 stereoActive = false
                 Timber.i("dual-lens: no hardware-stereo config on this device — using mono")
             }
-            _uiState.update { it.copy(isDualLensActive = stereoActive, isHardwareStereoActive = stereoActive) }
-
             // MURAL needs dual-lens (hardware-stereo) depth triangulation. Devices without a second
             // rear lens (e.g. Pixel 5) can't do it, so auto-fall-back to Canvas.
             deviceCanDoMural = stereoActive
-            _uiState.update { it.copy(arScanMode = it.arScanMode.coerceToCapability()) }
+            _uiState.update {
+                it.copy(
+                    isDualLensActive = stereoActive,
+                    isHardwareStereoActive = stereoActive,
+                    arScanMode = it.arScanMode.coerceToCapability()
+                )
+            }
 
             session = s
             _isCameraInUseByAr.value = true

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -470,8 +470,8 @@ class ArViewModel @Inject constructor(
         }
     }
 
-    // Whether this device can run MURAL scanning (gated on ARCore Depth API support, the app's
-    // existing capability premise). Defaults true until a session reports otherwise.
+    // Whether this device can run MURAL scanning. MURAL needs dual-lens (hardware-stereo) depth
+    // triangulation; set from the session's hardware-stereo support. Defaults true until known.
     @Volatile private var deviceCanDoMural: Boolean = true
 
     // MURAL requires depth; on devices that can't do it, fall back to Canvas (CLOUD_POINTS).
@@ -582,18 +582,13 @@ class ArViewModel @Inject constructor(
             // device offers it); the wall anchor uses plane detection. Re-enabling requires first
             // solving the VIO starvation.
             val useArCoreDepthApi = false
-            // Device capability for MURAL: whether ARCore supports the Depth API here. Independent of
-            // useArCoreDepthApi (which stays off for VIO reasons) — this is the device's true support.
-            deviceCanDoMural = s.isDepthModeSupported(Config.DepthMode.AUTOMATIC)
-            if (useArCoreDepthApi && deviceCanDoMural) {
+            if (useArCoreDepthApi && s.isDepthModeSupported(Config.DepthMode.AUTOMATIC)) {
                 config.depthMode = Config.DepthMode.AUTOMATIC
                 _uiState.update { it.copy(isDepthApiSupported = true) }
             } else {
                 config.depthMode = Config.DepthMode.DISABLED
                 _uiState.update { it.copy(isDepthApiSupported = false) }
             }
-            // Auto-fall-back to Canvas if this device can't do MURAL.
-            _uiState.update { it.copy(arScanMode = it.arScanMode.coerceToCapability()) }
             renderer?.depthApiEnabled = useArCoreDepthApi
 
             s.configure(config)
@@ -629,6 +624,11 @@ class ArViewModel @Inject constructor(
                 Timber.i("dual-lens: no hardware-stereo config on this device — using mono")
             }
             _uiState.update { it.copy(isDualLensActive = stereoActive, isHardwareStereoActive = stereoActive) }
+
+            // MURAL needs dual-lens (hardware-stereo) depth triangulation. Devices without a second
+            // rear lens (e.g. Pixel 5) can't do it, so auto-fall-back to Canvas.
+            deviceCanDoMural = stereoActive
+            _uiState.update { it.copy(arScanMode = it.arScanMode.coerceToCapability()) }
 
             session = s
             _isCameraInUseByAr.value = true


### PR DESCRIPTION
## What

Correct the Mural→Canvas auto-fallback to gate on **hardware-stereo (dual-lens) support** instead of ARCore Depth-API support.

## Why

Mural needs **dual-lens depth triangulation**. Devices with a single rear lens (e.g. **Pixel 5**) can't do it — but they *do* support the ARCore Depth API, so the previous gate (`isDepthModeSupported`) wouldn't have triggered the fallback for them.

## How

The session already detects hardware stereo by querying `getSupportedCameraConfigs(... StereoCameraUsage.REQUIRE_AND_USE)` → `stereoActive`. `deviceCanDoMural` is now set to `stereoActive` (right after stereo is determined), and the scan mode is coerced `MURAL → CLOUD_POINTS` from there. The Depth-API config block is reverted to standing on its own. So a no-stereo device (Pixel 5) lands on Canvas automatically; a dual-lens device keeps Mural.

Single file, +8/−8.

https://claude.ai/code/session_01GxdoXFy5ewQGEwdJ3Aj7Si

---
_Generated by [Claude Code](https://claude.ai/code/session_01GxdoXFy5ewQGEwdJ3Aj7Si)_

## Summary by Sourcery

Gate Mural-to-Canvas AR scan mode fallback on hardware stereo (dual-lens) support instead of ARCore Depth API support, updating device capability detection and UI state accordingly.

Bug Fixes:
- Fix incorrect Mural capability detection by basing it on hardware stereo availability rather than Depth API support so single-lens devices fall back to Canvas as intended.

Enhancements:
- Consolidate hardware stereo detection with AR scan mode coercion so the active scan mode always reflects the device's dual-lens capability.