### PR TITLE
feat(ar): self-healing runtime fallback when forced stereo is broken (ANR)

### DIFF
--- a/core/data/src/main/java/com/hereliesaz/graffitixr/data/repository/SettingsRepositoryImpl.kt
+++ b/core/data/src/main/java/com/hereliesaz/graffitixr/data/repository/SettingsRepositoryImpl.kt
@@ -30,6 +30,7 @@ class SettingsRepositoryImpl @Inject constructor(
     private val AR_SCAN_MODE = stringPreferencesKey("ar_scan_mode")
     private val MURAL_METHOD = stringPreferencesKey("mural_method")
     private val SHOW_ANCHOR_BOUNDARY = booleanPreferencesKey("show_anchor_boundary")
+    private val FORCED_STEREO_UNSTABLE = booleanPreferencesKey("forced_stereo_unstable")
     private val IS_IMPERIAL_UNITS = booleanPreferencesKey("is_imperial_units")
     private val BACKGROUND_COLOR = intPreferencesKey("background_color")
     private val COMPLETED_TUTORIALS = stringSetPreferencesKey("completed_tutorials")
@@ -93,6 +94,16 @@ class SettingsRepositoryImpl @Inject constructor(
     override val showAnchorBoundary: Flow<Boolean> = context.dataStore.data
         .catch { if (it is IOException) emit(emptyPreferences()) else throw it }
         .map { preferences -> preferences[SHOW_ANCHOR_BOUNDARY] ?: false }
+
+    override val forcedStereoUnstable: Flow<Boolean> = context.dataStore.data
+        .catch { if (it is IOException) emit(emptyPreferences()) else throw it }
+        .map { preferences -> preferences[FORCED_STEREO_UNSTABLE] ?: false }
+
+    override suspend fun setForcedStereoUnstable(unstable: Boolean) {
+        context.dataStore.edit { preferences ->
+            preferences[FORCED_STEREO_UNSTABLE] = unstable
+        }
+    }
 
     override suspend fun setShowAnchorBoundary(show: Boolean) {
         context.dataStore.edit { preferences ->

--- a/core/domain/src/main/java/com/hereliesaz/graffitixr/domain/repository/SettingsRepository.kt
+++ b/core/domain/src/main/java/com/hereliesaz/graffitixr/domain/repository/SettingsRepository.kt
@@ -47,6 +47,15 @@ interface SettingsRepository {
 
     suspend fun setShowAnchorBoundary(show: Boolean)
 
+    /**
+     * Set once a device proves it can't run forced hardware-stereo (ARCore motion-stereo disparity
+     * fails / VIO never tracks): future sessions skip the stereo config and stay on Canvas, so the
+     * broken path can't thrash the device. Cleared when the user explicitly re-selects Mural.
+     */
+    val forcedStereoUnstable: Flow<Boolean>
+
+    suspend fun setForcedStereoUnstable(unstable: Boolean)
+
     /** Whether distances are displayed in imperial (ft) rather than metric (m/cm). */
     val isImperialUnits: Flow<Boolean>
 

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -454,6 +454,15 @@ class ArViewModel @Inject constructor(
             }
         }
         viewModelScope.launch {
+            settingsRepository.forcedStereoUnstable.collect { unstable ->
+                forcedStereoUnstable = unstable
+                if (unstable) {
+                    deviceCanDoMural = false
+                    _uiState.update { it.copy(arScanMode = it.arScanMode.coerceToCapability()) }
+                }
+            }
+        }
+        viewModelScope.launch {
             settingsRepository.isRightHanded.collect { isRight ->
                 _uiState.update { it.copy(isRightHanded = isRight) }
             }
@@ -474,11 +483,22 @@ class ArViewModel @Inject constructor(
     // triangulation; set from the session's hardware-stereo support. Defaults true until known.
     @Volatile private var deviceCanDoMural: Boolean = true
 
+    // Sticky: a device proved its forced hardware-stereo path is broken (ARCore motion-stereo
+    // disparity fails / VIO never tracks). Persisted; once set, sessions skip the stereo config.
+    @Volatile private var forcedStereoUnstable: Boolean = false
+
     // MURAL requires depth; on devices that can't do it, fall back to Canvas (CLOUD_POINTS).
     private fun ArScanMode.coerceToCapability(): ArScanMode =
         if (!deviceCanDoMural && this == ArScanMode.MURAL) ArScanMode.CLOUD_POINTS else this
 
     fun setArScanMode(mode: ArScanMode) {
+        // A user explicitly choosing Mural is a retry: clear the sticky stereo-unstable flag and let
+        // the next session re-evaluate hardware stereo (recovers from any false positive).
+        if (mode == ArScanMode.MURAL && forcedStereoUnstable) {
+            forcedStereoUnstable = false
+            deviceCanDoMural = true
+            viewModelScope.launch { settingsRepository.setForcedStereoUnstable(false) }
+        }
         _uiState.update { it.copy(arScanMode = mode.coerceToCapability()) }
     }
 
@@ -610,7 +630,9 @@ class ArViewModel @Inject constructor(
             }
 
             val stereoActive: Boolean
-            if (stereoConfigs.isNotEmpty()) {
+            // Skip forced stereo if this device previously proved it can't run it (ARCore
+            // motion-stereo disparity fails / VIO never tracks) — stay on the safe mono path.
+            if (stereoConfigs.isNotEmpty() && !forcedStereoUnstable) {
                 s.cameraConfig = stereoConfigs[0]
                 stereoActive = true
                 Timber.i("dual-lens: HARDWARE STEREO selected — cameraId=${stereoConfigs[0].cameraId} imageSize=${stereoConfigs[0].imageSize} (${stereoConfigs.size} stereo config(s))")
@@ -918,6 +940,24 @@ class ArViewModel @Inject constructor(
                     evalProbe.lastMetrics.copy(wallCount = slamManager.getWallKeypointCount())
                 else state.evalLiveMetrics
             )
+        }
+
+        // Runtime fallback: forced hardware-stereo that never lets VIO track in MURAL (the broken
+        // ComputeDisparity / spherical_rectifier case) → persist the unstable flag so the next
+        // session skips stereo and stays on Canvas. The current bad session is handled by the
+        // existing tracking-failed flow; re-entry comes up clean (self-healing).
+        if (!forcedStereoUnstable &&
+            isInArMode &&
+            isHardwareStereo &&
+            trackingFailed &&
+            splatCount == 0 &&
+            _uiState.value.arScanMode == ArScanMode.MURAL
+        ) {
+            forcedStereoUnstable = true
+            deviceCanDoMural = false
+            _uiState.update { it.copy(arScanMode = it.arScanMode.coerceToCapability()) }
+            viewModelScope.launch { settingsRepository.setForcedStereoUnstable(true) }
+            Timber.w("dual-lens: forced stereo never tracked in MURAL — falling back to Canvas + mono on next session")
         }
     }
 


### PR DESCRIPTION
## What (approach A — runtime fallback for the ANR)

Some devices **pass** the hardware-stereo check but ARCore's motion-stereo disparity (`spherical_rectifier.cc`) fails on their camera model (`kUnrectifiedPinhole`), thrashing VIO and starving the main thread → **input-timeout ANR**. The static `stereoActive` gate (#1587) can't catch these — they have the lens, the *depth* just doesn't work.

This adds a self-healing runtime fallback:

- **Detect:** in `setTrackingState`, if forced hardware-stereo is active in **Mural** and VIO **never tracks** (`trackingFailed` after the 10s grace, `splatCount == 0`), conclude the stereo path is broken.
- **Persist:** set a sticky `forcedStereoUnstable` preference.
- **Skip stereo:** `initArSessionLocked` now selects stereo only when `stereoConfigs.isNotEmpty() && !forcedStereoUnstable` — flagged devices come up **mono**, and `deviceCanDoMural` follows `stereoActive`, so Mural coerces to **Canvas**.
- **Self-heal & recover:** the current bad session is handled by the existing tracking-failed flow; **re-entry comes up clean**. If the user explicitly re-selects **Mural**, the flag is cleared so a false positive can retry.

No mid-session camera reconfigure (too risky), so dual-lens stays intact for devices where ARCore stereo actually works.

## Files
- `SettingsRepository` (+ impl): `forcedStereoUnstable` flag.
- `ArViewModel`: collector, detection, session-config gate, retry-on-Mural reset.

## Verification
No SDK here — verified interface/impl consistency (only `SettingsRepositoryImpl` implements it; tests use mocks), references, and brackets. **This is the AR path and I can't reproduce the ANR — please validate on the affected device:** confirm it ANRs once, then re-entry runs Canvas+mono cleanly, and a true dual-lens device still gets Mural.

One tunable to flag: detection uses `trackingFailed` (10s no-track) + `splatCount == 0`. A genuinely-good stereo device that can't track for 10s (pitch black / blank wall) could false-positive; that's why re-selecting Mural clears the flag. Happy to lengthen the grace or require N consecutive failures if you'd rather be more conservative.

https://claude.ai/code/session_01GxdoXFy5ewQGEwdJ3Aj7Si

---
_Generated by [Claude Code](https://claude.ai/code/session_01GxdoXFy5ewQGEwdJ3Aj7Si)_

## Summary by Sourcery

Introduce a runtime self-healing fallback that disables forced hardware stereo on devices where ARCore never achieves tracking in Mural, defaulting subsequent sessions to mono Canvas while allowing users to retry Mural to clear false positives.

New Features:
- Persist a forced-stereo instability flag in settings to remember devices whose hardware stereo path is broken.
- Gate AR session stereo configuration and Mural availability on the persisted instability flag so affected devices automatically fall back to mono Canvas.

Enhancements:
- Wire the new stereo instability flag through ArViewModel to dynamically adjust AR scan mode and device capabilities based on runtime tracking failures.