### PR TITLE
chore(ar): ARDIAG instrumentation for black-camera-with-layer bug

### DIFF
--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -536,6 +536,7 @@ class ArViewModel @Inject constructor(
             return
         }
         isInArMode = enabled
+        Timber.i("ARDIAG setArMode(enabled=$enabled) layers=${projectRepository.currentProject.value?.layers?.size ?: 0} scanMode=${_uiState.value.arScanMode} sessionExists=${session != null}")
         if (enabled) {
             val now = System.currentTimeMillis()
             arEntryTimestampMs = now
@@ -586,6 +587,7 @@ class ArViewModel @Inject constructor(
 
     private fun initArSessionLocked(context: Context) {
         if (session != null || isDestroying) return
+        Timber.i("ARDIAG initArSessionLocked: creating session")
         try {
             val s = Session(context)
             val config = Config(s)
@@ -658,11 +660,12 @@ class ArViewModel @Inject constructor(
 
             session = s
             _isCameraInUseByAr.value = true
-            
+            Timber.i("ARDIAG initArSessionLocked: session created OK (stereoActive=$stereoActive rendererAttached=${renderer != null})")
+
             // Critical: if the renderer is already attached, update it with the new session
             renderer?.attachSession(s)
         } catch (e: Exception) {
-            Timber.e(e, "Failed to create ARCore session")
+            Timber.e(e, "ARDIAG Failed to create ARCore session -> camera black")
             // Surface the failure instead of leaving the user on a frozen black AR screen.
             _isCameraInUseByAr.value = false
             _feedback.tryEmit(

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -241,6 +241,8 @@ class ArRenderer(
         planeRenderer.createOnGlThread(context)
         isSurfaceCreated = true
 
+        Timber.i("ARDIAG onSurfaceCreated: bgTexture=${backgroundRenderer.textureId}")
+
         sessionLock.withLock {
             session?.setCameraTextureName(backgroundRenderer.textureId)
         }
@@ -262,7 +264,11 @@ class ArRenderer(
         frameCount++
 
         sessionLock.withLock {
-            val activeSession = session ?: return
+            val activeSession = session
+            if (activeSession == null) {
+                if (frameCount % 120 == 0) Timber.w("ARDIAG onDrawFrame: session null -> camera black")
+                return
+            }
 
             activeSession.setCameraTextureName(backgroundRenderer.textureId)
             displayRotationHelper.updateSessionIfNeeded(activeSession)
@@ -270,9 +276,10 @@ class ArRenderer(
             val frame: Frame = try {
                 activeSession.update()
             } catch (e: SessionPausedException) {
+                if (frameCount % 120 == 0) Timber.w("ARDIAG onDrawFrame: SessionPaused -> camera black")
                 return
             } catch (e: Exception) {
-                Timber.e(e, "ARCore session update failed")
+                Timber.e(e, "ARDIAG ARCore session update failed -> camera black")
                 return
             }
 
@@ -282,6 +289,7 @@ class ArRenderer(
             val scanActive = !anchorEstablished && scanMode == ArScanMode.MURAL && scanPhase == ScanPhase.AMBIENT
             if (scanActive) backgroundRenderer.updateScanMask(visitedSectorsMask)
             backgroundRenderer.draw(frame, scanActive)
+            if (frameCount % 60 == 0) Timber.i("ARDIAG drawFrame f=$frameCount tracking=${frame.camera.trackingState} anchor=$anchorEstablished scanMode=$scanMode scanActive=$scanActive")
 
             // Scan/world-mapping indicator: ink develops on ARCore's detected planes (real 3D surfaces
             // that track with the world), so it reads as colour soaking into the wall/floor — not a flat

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/BackgroundRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/BackgroundRenderer.kt
@@ -30,6 +30,7 @@ class BackgroundRenderer : GlReleasable {
     private var uMask: Int = 0
     private var uDotSize: Int = 0
     private var hasTransformed = false
+    private var diagFrame = 0
 
     // 36-sector scan-coverage mask (for the world-mapping "ink develop" reveal).
     private var maskTextureId = 0
@@ -124,7 +125,12 @@ class BackgroundRenderer : GlReleasable {
      * organically (like spreading ink) as each yaw sector is mapped. Otherwise it's a plain pass-through.
      */
     fun draw(frame: Frame, scanActive: Boolean = false) {
-        if (backgroundProgram == 0) return
+        diagFrame++
+        if (backgroundProgram == 0) {
+            if (diagFrame % 120 == 0) Log.w("ARDIAG", "BackgroundRenderer.draw: shader not ready -> camera black")
+            return
+        }
+        if (diagFrame % 120 == 0) Log.i("ARDIAG", "BackgroundRenderer.draw: drawing camera quad (scanActive=$scanActive)")
 
         if (frame.hasDisplayGeometryChanged() || !hasTransformed) {
             frame.transformCoordinates2d(


### PR DESCRIPTION
## Purpose

**Diagnostic build** for the "AR camera is black when ≥1 Design layer is loaded" bug. Static analysis ruled out every layer-dependent AR-entry path, so this adds temporary `ARDIAG`-tagged logging along the camera pipeline to localize where it diverges.

## What it logs (tag `ARDIAG`)
- `setArMode(enabled=…)` — entry, **layer count**, scan mode, whether a session already exists.
- `initArSessionLocked` — session creation start, **success** (with `stereoActive`, renderer attached), or **failure** (exception → camera black).
- `onSurfaceCreated` — GL/shader init + camera texture id.
- `onDrawFrame` — the **early-return** paths (session null / `SessionPaused` / `update()` failed → camera black) and a throttled "reached camera draw" line with `tracking / anchor / scanMode`.
- `BackgroundRenderer.draw` — shader-not-ready (→ black) vs actually drawing the camera quad.

## How to use
1. Install this build (CI APK).
2. `adb logcat -s ARDIAG` (or grep `ARDIAG`).
3. Enter AR **with a layer** (black) and **without a layer** (works). Capture both.
4. Paste the two logs — the divergence point tells us the cause: no session, session paused, `update()` failing, or shader/surface not ready.

Pure logging, no behavior change. I'll revert it once we have the answer.

https://claude.ai/code/session_01GxdoXFy5ewQGEwdJ3Aj7Si

---
_Generated by [Claude Code](https://claude.ai/code/session_01GxdoXFy5ewQGEwdJ3Aj7Si)_

## Summary by Sourcery

Add temporary ARDIAG logging along the AR session and rendering pipeline to diagnose black camera issues when layers are present.

New Features:
- Introduce detailed ARDIAG log points around AR mode entry, session initialization, and camera usage state changes in ArViewModel.
- Add ARDIAG logging in ArRenderer to trace surface creation, frame update failures, and camera draw state.
- Add ARDIAG logging in BackgroundRenderer to distinguish shader-not-ready cases from successful camera quad rendering.