### PR TITLE
fix(ar): self-heal broken forced-stereo (in-session →mono) + clear stale SLAM map

### DIFF
--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -995,21 +995,24 @@ class ArViewModel @Inject constructor(
             sessionMutex.withLock {
                 val s = session
                 if (s == null || isDestroying) return@withLock
+                val wasResumed = isSessionResumed
+                if (wasResumed) pauseArSessionInternal()
                 try {
-                    val wasResumed = isSessionResumed
-                    if (wasResumed) pauseArSessionInternal()
                     val monoConfigs = s.getSupportedCameraConfigs(CameraConfigFilter(s).apply {
                         facingDirection = CameraConfig.FacingDirection.BACK
                         targetFps = EnumSet.of(CameraConfig.TargetFps.TARGET_FPS_30)
                     })
                     if (monoConfigs.isNotEmpty()) s.cameraConfig = monoConfigs[0]
                     _uiState.update { it.copy(isDualLensActive = false, isHardwareStereoActive = false) }
-                    if (isActivityResumed && isInArMode && !isDestroying) resumeArSessionInternal()
-                    // Treat the reconfigure as a fresh start so the fast detector doesn't re-fire.
-                    lastTrackingTimestampMs = System.currentTimeMillis()
                     Timber.w("ARDIAG dual-lens: forced stereo broken -> reconfigured LIVE session to mono")
                 } catch (e: Exception) {
                     Timber.e(e, "ARDIAG stereo->mono live reconfigure failed")
+                } finally {
+                    // Always attempt to resume — a throw during the config swap must not leave the
+                    // session permanently paused (black camera, no recovery).
+                    if (isActivityResumed && isInArMode && !isDestroying) resumeArSessionInternal()
+                    // Treat the reconfigure as a fresh start so the fast detector doesn't re-fire.
+                    lastTrackingTimestampMs = System.currentTimeMillis()
                 }
             }
             stereoRecoveryInFlight.set(false)

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -398,6 +398,9 @@ class ArViewModel @Inject constructor(
     @Volatile private var arEntryTimestampMs: Long = 0L
     @Volatile private var lastTrackingTimestampMs: Long = 0L
     private val trackingFailureGraceMs: Long = 10_000L
+    // Forced-stereo "stuck" detection must beat the 5s input-timeout ANR, so it's much shorter
+    // than the general tracking-failure grace.
+    private val STEREO_STUCK_GRACE_MS: Long = 3_000L
 
     private val isSaving = AtomicBoolean(false)
     private val lastSavedSplatCount = AtomicInteger(0)
@@ -836,6 +839,14 @@ class ArViewModel @Inject constructor(
                 }
                 Timber.d("Atomic persistence complete: Loaded available mapping components for $projectId")
             }
+        } else {
+            // No saved map for this project — clear any lingering SLAM map left over in native
+            // state from a previous session, so a new AR session doesn't get stuck trying to
+            // relocalize a stale map (kMapTracking with 0 structure matches -> black camera).
+            viewModelScope.launch(Dispatchers.IO) {
+                slamManager.clearMap()
+                lastSavedSplatCount.set(0)
+            }
         }
     }
 
@@ -949,22 +960,59 @@ class ArViewModel @Inject constructor(
             )
         }
 
-        // Runtime fallback: forced hardware-stereo that never lets VIO track in MURAL (the broken
-        // ComputeDisparity / spherical_rectifier case) → persist the unstable flag so the next
-        // session skips stereo and stays on Canvas. The current bad session is handled by the
-        // existing tracking-failed flow; re-entry comes up clean (self-healing).
+        // Forced hardware-stereo that never lets VIO track in MURAL is broken on this device
+        // (ARCore motion-stereo ComputeDisparity / spherical_rectifier fails). Detect it FAST —
+        // well before the 5s input-timeout ANR — and reconfigure the LIVE session to mono so the
+        // first AR entry recovers instead of crashing. Persisted so future sessions skip stereo too.
         if (!forcedStereoUnstable &&
             isInArMode &&
             isHardwareStereo &&
-            trackingFailed &&
+            !isTracking &&
             splatCount == 0 &&
-            _uiState.value.arScanMode == ArScanMode.MURAL
+            _uiState.value.arScanMode == ArScanMode.MURAL &&
+            arEntryTimestampMs > 0L &&
+            (nowMs - lastTrackingTimestampMs) > STEREO_STUCK_GRACE_MS
         ) {
-            forcedStereoUnstable = true
-            deviceCanDoMural = false
-            _uiState.update { it.copy(arScanMode = it.arScanMode.coerceToCapability()) }
-            viewModelScope.launch { settingsRepository.setForcedStereoUnstable(true) }
-            Timber.w("dual-lens: forced stereo never tracked in MURAL — falling back to Canvas + mono on next session")
+            recoverFromBrokenStereo()
+        }
+    }
+
+    private val stereoRecoveryInFlight = java.util.concurrent.atomic.AtomicBoolean(false)
+
+    /**
+     * The forced hardware-stereo path is broken on this device — switch the LIVE session to the
+     * mono camera config (pause → set mono → resume) so the broken motion-stereo disparity stops
+     * thrashing the tracker, and persist the flag so future sessions skip stereo entirely.
+     * Recoverable: the user re-selecting Mural clears the flag (see setArScanMode).
+     */
+    private fun recoverFromBrokenStereo() {
+        if (!stereoRecoveryInFlight.compareAndSet(false, true)) return
+        forcedStereoUnstable = true
+        deviceCanDoMural = false
+        _uiState.update { it.copy(arScanMode = it.arScanMode.coerceToCapability(), trackingFailed = false) }
+        viewModelScope.launch { settingsRepository.setForcedStereoUnstable(true) }
+        viewModelScope.launch {
+            sessionMutex.withLock {
+                val s = session
+                if (s == null || isDestroying) return@withLock
+                try {
+                    val wasResumed = isSessionResumed
+                    if (wasResumed) pauseArSessionInternal()
+                    val monoConfigs = s.getSupportedCameraConfigs(CameraConfigFilter(s).apply {
+                        facingDirection = CameraConfig.FacingDirection.BACK
+                        targetFps = EnumSet.of(CameraConfig.TargetFps.TARGET_FPS_30)
+                    })
+                    if (monoConfigs.isNotEmpty()) s.cameraConfig = monoConfigs[0]
+                    _uiState.update { it.copy(isDualLensActive = false, isHardwareStereoActive = false) }
+                    if (isActivityResumed && isInArMode && !isDestroying) resumeArSessionInternal()
+                    // Treat the reconfigure as a fresh start so the fast detector doesn't re-fire.
+                    lastTrackingTimestampMs = System.currentTimeMillis()
+                    Timber.w("ARDIAG dual-lens: forced stereo broken -> reconfigured LIVE session to mono")
+                } catch (e: Exception) {
+                    Timber.e(e, "ARDIAG stereo->mono live reconfigure failed")
+                }
+            }
+            stereoRecoveryInFlight.set(false)
         }
     }
 

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -536,6 +536,7 @@ class ArViewModel @Inject constructor(
             return
         }
         isInArMode = enabled
+        Timber.i("ARDIAG setArMode(enabled=$enabled) layers=${projectRepository.currentProject.value?.layers?.size ?: 0} scanMode=${_uiState.value.arScanMode} sessionExists=${session != null}")
         if (enabled) {
             val now = System.currentTimeMillis()
             arEntryTimestampMs = now
@@ -586,6 +587,7 @@ class ArViewModel @Inject constructor(
 
     private fun initArSessionLocked(context: Context) {
         if (session != null || isDestroying) return
+        Timber.i("ARDIAG initArSessionLocked: creating session")
         try {
             val s = Session(context)
             val config = Config(s)
@@ -658,11 +660,12 @@ class ArViewModel @Inject constructor(
 
             session = s
             _isCameraInUseByAr.value = true
-            
+            Timber.i("ARDIAG initArSessionLocked: session created OK (stereoActive=$stereoActive rendererAttached=${renderer != null})")
+
             // Critical: if the renderer is already attached, update it with the new session
             renderer?.attachSession(s)
         } catch (e: Exception) {
-            Timber.e(e, "Failed to create ARCore session")
+            Timber.e(e, "ARDIAG Failed to create ARCore session -> camera black")
             // Surface the failure instead of leaving the user on a frozen black AR screen.
             _isCameraInUseByAr.value = false
             _feedback.tryEmit(

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -241,6 +241,8 @@ class ArRenderer(
         planeRenderer.createOnGlThread(context)
         isSurfaceCreated = true
 
+        Timber.i("ARDIAG onSurfaceCreated: bgTexture=${backgroundRenderer.textureId}")
+
         sessionLock.withLock {
             session?.setCameraTextureName(backgroundRenderer.textureId)
         }
@@ -262,7 +264,11 @@ class ArRenderer(
         frameCount++
 
         sessionLock.withLock {
-            val activeSession = session ?: return
+            val activeSession = session
+            if (activeSession == null) {
+                if (frameCount % 120 == 0) Timber.w("ARDIAG onDrawFrame: session null -> camera black")
+                return
+            }
 
             activeSession.setCameraTextureName(backgroundRenderer.textureId)
             displayRotationHelper.updateSessionIfNeeded(activeSession)
@@ -270,9 +276,10 @@ class ArRenderer(
             val frame: Frame = try {
                 activeSession.update()
             } catch (e: SessionPausedException) {
+                if (frameCount % 120 == 0) Timber.w("ARDIAG onDrawFrame: SessionPaused -> camera black")
                 return
             } catch (e: Exception) {
-                Timber.e(e, "ARCore session update failed")
+                Timber.e(e, "ARDIAG ARCore session update failed -> camera black")
                 return
             }
 
@@ -282,6 +289,7 @@ class ArRenderer(
             val scanActive = !anchorEstablished && scanMode == ArScanMode.MURAL && scanPhase == ScanPhase.AMBIENT
             if (scanActive) backgroundRenderer.updateScanMask(visitedSectorsMask)
             backgroundRenderer.draw(frame, scanActive)
+            if (frameCount % 60 == 0) Timber.i("ARDIAG drawFrame f=$frameCount tracking=${frame.camera.trackingState} anchor=$anchorEstablished scanMode=$scanMode scanActive=$scanActive")
 
             // Scan/world-mapping indicator: ink develops on ARCore's detected planes (real 3D surfaces
             // that track with the world), so it reads as colour soaking into the wall/floor — not a flat

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/BackgroundRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/BackgroundRenderer.kt
@@ -30,6 +30,7 @@ class BackgroundRenderer : GlReleasable {
     private var uMask: Int = 0
     private var uDotSize: Int = 0
     private var hasTransformed = false
+    private var diagFrame = 0
 
     // 36-sector scan-coverage mask (for the world-mapping "ink develop" reveal).
     private var maskTextureId = 0
@@ -124,7 +125,12 @@ class BackgroundRenderer : GlReleasable {
      * organically (like spreading ink) as each yaw sector is mapped. Otherwise it's a plain pass-through.
      */
     fun draw(frame: Frame, scanActive: Boolean = false) {
-        if (backgroundProgram == 0) return
+        diagFrame++
+        if (backgroundProgram == 0) {
+            if (diagFrame % 120 == 0) Log.w("ARDIAG", "BackgroundRenderer.draw: shader not ready -> camera black")
+            return
+        }
+        if (diagFrame % 120 == 0) Log.i("ARDIAG", "BackgroundRenderer.draw: drawing camera quad (scanActive=$scanActive)")
 
         if (frame.hasDisplayGeometryChanged() || !hasTransformed) {
             frame.transformCoordinates2d(

--- a/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/EditorUi.kt
+++ b/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/EditorUi.kt
@@ -93,8 +93,10 @@ fun EditorUi(
                 )
             }
 
-            // Modes (anything but the Design screen) show the finished design with off-rail adjustment
-            // knobs and NO history controls; Design keeps undo/redo and rail-triggered knobs.
+            // Modes (anything but the Design screen) show the finished design with NO history
+            // controls; per-mode whole-design adjustment is done through the rail's Layer/Adjust
+            // panel (ModeAdjustPanel), so the legacy off-rail knobs must NOT also appear in a mode
+            // or the user sees two duplicate sets of opacity/brightness/contrast/saturation controls.
             val inMode = uiState.editorMode != EditorMode.DESIGN
             AdjustmentsPanel(
                 state = AdjustmentsState(
@@ -110,9 +112,9 @@ fun EditorUi(
                     activeLayer = overlayLayer,
                     showUndoRedo = !inMode
                 ),
-                // In a Mode the adjust knobs are the off-rail tools (opacity/saturation/…); in Design
-                // they're rail-triggered via the Adjust panel.
-                showKnobs = uiState.activePanel == EditorPanel.ADJUST || (inMode && uiState.layers.isNotEmpty()),
+                // Knobs are rail-triggered via the Adjust panel in Design only. In a Mode the
+                // per-mode ModeAdjustPanel owns adjustment, so the off-rail knobs stay hidden.
+                showKnobs = !inMode && uiState.activePanel == EditorPanel.ADJUST,
                 showColorBalance = uiState.activePanel == EditorPanel.COLOR,
                 isLandscape = isLandscape,
                 screenHeight = screenHeight,


### PR DESCRIPTION
## Problem

On devices whose camera can't actually do ARCore motion-stereo
(`spherical_rectifier` / `ComputeDisparity` on a `kUnrectifiedPinhole`
sensor — e.g. Pixel 5), forcing the hardware-stereo camera config in
MURAL never lets VIO track. The render thread stalls in `session.update()`
and the first AR entry hits a **5s input-timeout ANR** with a **black
camera**. The previous fallback (#1588) detected this too slowly (~10s),
so the app crashed before it could recover.

A second, correlated symptom: opening a **new project** (no saved map)
could still leave the camera black, because lingering native SLAM state
from a previous session made the new session get stuck relocalizing a
stale map (`kMapTracking` with 0 structure matches).

## Fix

**In-session stereo → mono self-heal.** Detect the stuck state fast —
`>3s` (`STEREO_STUCK_GRACE_MS`) with no tracking, 0 splats, MURAL +
hardware stereo, which beats the 5s ANR — and reconfigure the **live**
ARCore session in place: `pause → set mono CameraConfig → resume` via the
existing `pauseArSessionInternal`/`resumeArSessionInternal`. This recovers
on the very first AR entry instead of crashing, and keeps dual-lens for
devices where it genuinely works. The `forcedStereoUnstable` flag is
persisted so future sessions skip the stereo config, and is cleared when
the user explicitly re-selects Mural.

**Clear stale SLAM map.** When `loadMapIfExists()` finds no saved map for
the project, clear any lingering native SLAM map so the new session starts
clean instead of failing to relocalize stale geometry.

## Notes
- Recovery is guarded by an `AtomicBoolean` so it fires once per stuck
  episode.
- ARDIAG instrumentation from #1589 remains on `main`; it can be removed in
  a follow-up once this fix is confirmed on-device.

https://claude.ai/code/session_01GxdoXFy5ewQGEwdJ3Aj7Si

---
_Generated by [Claude Code](https://claude.ai/code/session_01GxdoXFy5ewQGEwdJ3Aj7Si)_

## Summary by Sourcery

Introduce fast in-session recovery for broken forced-stereo AR sessions and clear stale SLAM maps when starting projects without saved maps.

Bug Fixes:
- Detect and self-heal AR sessions stuck on hardware stereo by switching the live ARCore session to a mono camera configuration before hitting ANR timeouts.
- Clear lingering native SLAM maps when no saved map exists for a project to prevent new sessions from stalling on stale relocalization state.

Enhancements:
- Persist and reuse a forced-stereo instability flag while allowing users to re-enable Mural explicitly.
- Add diagnostic logging around AR session lifecycle, rendering, and camera texture setup to aid investigation of black-camera issues.