### PR TITLE
fix(ar): stop forcing hardware stereo (ANR/black camera); restore mode knobs

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -83,7 +83,6 @@ import com.hereliesaz.graffitixr.common.model.CaptureStep
 import com.hereliesaz.graffitixr.common.model.ScanPhase
 import com.hereliesaz.graffitixr.common.model.EditorMode
 import com.hereliesaz.graffitixr.common.model.EditorUiState
-import com.hereliesaz.graffitixr.common.model.ModeAdjustment
 import com.hereliesaz.graffitixr.onboarding.ArUnavailableOverlay
 import com.hereliesaz.graffitixr.onboarding.ModeOnboarding
 import com.hereliesaz.graffitixr.onboarding.ModeOnboardingOverlay
@@ -428,8 +427,6 @@ class MainActivity : ComponentActivity() {
                 val navStrings = strings.nav
                 var showFontPicker by remember { mutableStateOf(false) }
                 var fontPickerLayerId by remember { mutableStateOf<String?>(null) }
-                // Non-null while the per-mode whole-design tone panel is open for that mode.
-                var modeAdjustPanelMode by remember { mutableStateOf<EditorMode?>(null) }
                 val layerMenusOpen = remember { mutableStateMapOf<String, Boolean>() }
 
                 val context = LocalContext.current
@@ -516,7 +513,7 @@ class MainActivity : ComponentActivity() {
                                     permissionLauncher.launch(arrayOf(Manifest.permission.CAMERA, Manifest.permission.ACCESS_FINE_LOCATION))
                                 }
                             },
-                            onOpenModeAdjust = { modeAdjustPanelMode = it }
+                            onOpenModeAdjust = { }
                         )
                     }
 
@@ -1099,22 +1096,6 @@ class MainActivity : ComponentActivity() {
                                     },
                                     strings = strings
                                 )
-                            }
-
-                            modeAdjustPanelMode?.let { panelMode ->
-                                Box(
-                                    modifier = Modifier.fillMaxSize(),
-                                    contentAlignment = Alignment.CenterEnd
-                                ) {
-                                    ModeAdjustPanel(
-                                        mode = panelMode,
-                                        adjustment = editorUiState.modeAdjustments[panelMode] ?: ModeAdjustment(),
-                                        onChange = { editorViewModel.onModeAdjustmentChanged(panelMode, it) },
-                                        onReset = { editorViewModel.onModeLayerReset(panelMode) },
-                                        onDismiss = { modeAdjustPanelMode = null },
-                                        modifier = Modifier.padding(16.dp)
-                                    )
-                                }
                             }
 
                             if (showDesignInstructionsDialog) {

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -618,52 +618,34 @@ class ArViewModel @Inject constructor(
 
             s.configure(config)
 
-            // Dual-lens mandate: use a hardware-stereo camera config whenever ARCore offers one on
-            // this device; fall back to the mono 30 FPS back config otherwise. We only select a
-            // stereo config that ARCore explicitly lists as supported, so devices that don't expose
-            // one (e.g. Pixel 5) stay exactly on the old mono path — no change, no risk. Where stereo
-            // IS selected the device gets true two-lens depth; watch for the historical caveat that
-            // some phones' VIO destabilized under forced stereo (grep logcat "dual-lens").
-            val stereoConfigs = try {
-                s.getSupportedCameraConfigs(CameraConfigFilter(s).apply {
-                    facingDirection = CameraConfig.FacingDirection.BACK
-                    stereoCameraUsage = java.util.EnumSet.of(CameraConfig.StereoCameraUsage.REQUIRE_AND_USE)
-                })
-            } catch (e: Exception) {
-                Timber.w(e, "dual-lens: stereo config query failed")
-                emptyList()
-            }
+            // Always use the plain mono 30 FPS back camera config. Forcing a hardware-stereo config
+            // (StereoCameraUsage.REQUIRE_AND_USE) made ARCore run motion-stereo (spherical_rectifier)
+            // on devices that list a "stereo" config but can't actually compute disparity — it pegged
+            // the CPU, starved VIO into permanent kNotTracking, and blocked the main thread into a
+            // 5s input-dispatch ANR with a black camera. The reactive in-session recovery couldn't win
+            // that race because the main thread was already dead. Mono is the only camera path that
+            // tracks reliably here; metric depth comes from VIO-baseline triangulation.
+            val monoConfigs = s.getSupportedCameraConfigs(CameraConfigFilter(s).apply {
+                facingDirection = CameraConfig.FacingDirection.BACK
+                targetFps = EnumSet.of(CameraConfig.TargetFps.TARGET_FPS_30)
+            })
+            if (monoConfigs.isNotEmpty()) s.cameraConfig = monoConfigs[0]
+            Timber.i("ARDIAG dual-lens: forced stereo disabled — using mono camera config")
 
-            val stereoActive: Boolean
-            // Skip forced stereo if this device previously proved it can't run it (ARCore
-            // motion-stereo disparity fails / VIO never tracks) — stay on the safe mono path.
-            if (stereoConfigs.isNotEmpty() && !forcedStereoUnstable) {
-                s.cameraConfig = stereoConfigs[0]
-                stereoActive = true
-                Timber.i("dual-lens: HARDWARE STEREO selected — cameraId=${stereoConfigs[0].cameraId} imageSize=${stereoConfigs[0].imageSize} (${stereoConfigs.size} stereo config(s))")
-            } else {
-                val monoConfigs = s.getSupportedCameraConfigs(CameraConfigFilter(s).apply {
-                    facingDirection = CameraConfig.FacingDirection.BACK
-                    targetFps = EnumSet.of(CameraConfig.TargetFps.TARGET_FPS_30)
-                })
-                if (monoConfigs.isNotEmpty()) s.cameraConfig = monoConfigs[0]
-                stereoActive = false
-                Timber.i("dual-lens: no hardware-stereo config on this device — using mono")
-            }
-            // MURAL needs dual-lens (hardware-stereo) depth triangulation. Devices without a second
-            // rear lens (e.g. Pixel 5) can't do it, so auto-fall-back to Canvas.
-            deviceCanDoMural = stereoActive
+            // No hardware stereo means no dual-lens depth triangulation, so MURAL auto-falls back to
+            // Canvas.
+            deviceCanDoMural = false
             _uiState.update {
                 it.copy(
-                    isDualLensActive = stereoActive,
-                    isHardwareStereoActive = stereoActive,
+                    isDualLensActive = false,
+                    isHardwareStereoActive = false,
                     arScanMode = it.arScanMode.coerceToCapability()
                 )
             }
 
             session = s
             _isCameraInUseByAr.value = true
-            Timber.i("ARDIAG initArSessionLocked: session created OK (stereoActive=$stereoActive rendererAttached=${renderer != null})")
+            Timber.i("ARDIAG initArSessionLocked: session created OK (mono camera, rendererAttached=${renderer != null})")
 
             // Critical: if the renderer is already attached, update it with the new session
             renderer?.attachSession(s)

--- a/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/EditorUi.kt
+++ b/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/EditorUi.kt
@@ -93,10 +93,8 @@ fun EditorUi(
                 )
             }
 
-            // Modes (anything but the Design screen) show the finished design with NO history
-            // controls; per-mode whole-design adjustment is done through the rail's Layer/Adjust
-            // panel (ModeAdjustPanel), so the legacy off-rail knobs must NOT also appear in a mode
-            // or the user sees two duplicate sets of opacity/brightness/contrast/saturation controls.
+            // Modes (anything but the Design screen) show the finished design with off-rail adjustment
+            // knobs and NO history controls; Design keeps undo/redo and rail-triggered knobs.
             val inMode = uiState.editorMode != EditorMode.DESIGN
             AdjustmentsPanel(
                 state = AdjustmentsState(
@@ -112,9 +110,9 @@ fun EditorUi(
                     activeLayer = overlayLayer,
                     showUndoRedo = !inMode
                 ),
-                // Knobs are rail-triggered via the Adjust panel in Design only. In a Mode the
-                // per-mode ModeAdjustPanel owns adjustment, so the off-rail knobs stay hidden.
-                showKnobs = !inMode && uiState.activePanel == EditorPanel.ADJUST,
+                // In a Mode the adjust knobs are the off-rail tools (opacity/saturation/…); in Design
+                // they're rail-triggered via the Adjust panel.
+                showKnobs = uiState.activePanel == EditorPanel.ADJUST || (inMode && uiState.layers.isNotEmpty()),
                 showColorBalance = uiState.activePanel == EditorPanel.COLOR,
                 isLandscape = isLandscape,
                 screenHeight = screenHeight,


### PR DESCRIPTION
## What

Two fixes the previous PR (#1590) got wrong.

### 1. ANR / black AR camera — stop forcing hardware stereo

logcat from the device showed an **input-dispatch ANR** (main thread blocked 5s) with the CPU pegged (188% app, 141% camera provider) and a black preview. Root cause: `getSupportedCameraConfigs(StereoCameraUsage.REQUIRE_AND_USE)` returns a "stereo" config on this device, so ARCore runs **motion-stereo** (`spherical_rectifier`) — which it can't actually compute here. That pegs the CPU, starves VIO into permanent `kNotTracking`, and blocks the main thread before the reactive in-session recovery from #1590 can ever run (the main thread is already dead).

Fix: always select the plain **mono** back camera config. Metric depth comes from VIO-baseline triangulation; MURAL auto-falls back to Canvas (`deviceCanDoMural = false`). This removes the motion-stereo CPU thrash entirely — the deterministic cause of the ANR.

### 2. Restore the mode adjustment knobs (revert duplicate-controls change)

#1590 hid the off-rail adjustment knobs in a Mode, but those knobs are the intended controls. This reverts that: the knobs stay visible in a Mode, and the **duplicate** per-mode `ModeAdjustPanel` ("AR · LAYER" side panel) is removed instead. The rail's mode Adjust item still toggles whole-design transform via `onModeLayerSelected`.

## Notes
- The reactive `recoverFromBrokenStereo()` path from #1590 is now inert (stereo is never selected) but left in place; can be removed in a cleanup along with the ARDIAG instrumentation once AR is confirmed good on-device.

https://claude.ai/code/session_01GxdoXFy5ewQGEwdJ3Aj7Si

---
_Generated by [Claude Code](https://claude.ai/code/session_01GxdoXFy5ewQGEwdJ3Aj7Si)_

## Summary by Sourcery

Force AR sessions to use mono back camera configs to avoid hardware-stereo-induced ANRs and restore per-mode adjustment knobs as the primary controls while removing the duplicate mode adjustment side panel.

Bug Fixes:
- Stop selecting hardware-stereo camera configs in AR, ensuring ARCore uses a stable mono camera path and preventing ANRs and black camera previews caused by motion-stereo on unsupported devices.

Enhancements:
- Always configure AR sessions with a mono 30 FPS back camera and disable dual-lens MURAL capability, simplifying camera configuration and making depth behavior deterministic.
- Restore off-rail adjustment knobs in editor modes and remove the redundant per-mode ModeAdjustPanel side panel, clarifying where users adjust whole-design tone in each mode.