### PR TITLE
feat(ar): probe hardware stereo in an isolated process before adopting dual-lens

### DIFF
--- a/core/data/src/main/java/com/hereliesaz/graffitixr/data/repository/SettingsRepositoryImpl.kt
+++ b/core/data/src/main/java/com/hereliesaz/graffitixr/data/repository/SettingsRepositoryImpl.kt
@@ -31,6 +31,7 @@ class SettingsRepositoryImpl @Inject constructor(
     private val MURAL_METHOD = stringPreferencesKey("mural_method")
     private val SHOW_ANCHOR_BOUNDARY = booleanPreferencesKey("show_anchor_boundary")
     private val FORCED_STEREO_UNSTABLE = booleanPreferencesKey("forced_stereo_unstable")
+    private val STEREO_CAPABILITY = intPreferencesKey("stereo_capability")
     private val IS_IMPERIAL_UNITS = booleanPreferencesKey("is_imperial_units")
     private val BACKGROUND_COLOR = intPreferencesKey("background_color")
     private val COMPLETED_TUTORIALS = stringSetPreferencesKey("completed_tutorials")
@@ -102,6 +103,16 @@ class SettingsRepositoryImpl @Inject constructor(
     override suspend fun setForcedStereoUnstable(unstable: Boolean) {
         context.dataStore.edit { preferences ->
             preferences[FORCED_STEREO_UNSTABLE] = unstable
+        }
+    }
+
+    override val stereoCapability: Flow<Int> = context.dataStore.data
+        .catch { if (it is IOException) emit(emptyPreferences()) else throw it }
+        .map { preferences -> preferences[STEREO_CAPABILITY] ?: -1 }
+
+    override suspend fun setStereoCapability(value: Int) {
+        context.dataStore.edit { preferences ->
+            preferences[STEREO_CAPABILITY] = value
         }
     }
 

--- a/core/domain/src/main/java/com/hereliesaz/graffitixr/domain/repository/SettingsRepository.kt
+++ b/core/domain/src/main/java/com/hereliesaz/graffitixr/domain/repository/SettingsRepository.kt
@@ -56,6 +56,16 @@ interface SettingsRepository {
 
     suspend fun setForcedStereoUnstable(unstable: Boolean)
 
+    /**
+     * Cached result of the one-time hardware-stereo capability probe:
+     * -1 = not yet probed, 0 = device can't run forced stereo (use mono), 1 = stereo tracks (use it).
+     * Probing runs a short throwaway stereo session on a worker thread the first time AR is entered,
+     * so we only adopt the dual-lens path on a device whose motion-stereo actually tracks.
+     */
+    val stereoCapability: Flow<Int>
+
+    suspend fun setStereoCapability(value: Int)
+
     /** Whether distances are displayed in imperial (ft) rather than metric (m/cm). */
     val isImperialUnits: Flow<Boolean>
 

--- a/feature/ar/src/main/AndroidManifest.xml
+++ b/feature/ar/src/main/AndroidManifest.xml
@@ -6,6 +6,15 @@
     <uses-feature android:name="android.hardware.camera" android:required="true" />
     <uses-feature android:name="android.hardware.camera.ar" android:required="false" />
     <application>
+        <!--
+          Hardware-stereo capability probe, isolated in its own ":probe" process so a device whose
+          ARCore motion-stereo thrashes the CPU can be tested without ever risking an ANR in the main
+          UI process. Not exported: only the app itself binds it.
+        -->
+        <service
+            android:name="com.hereliesaz.graffitixr.feature.ar.StereoProbeService"
+            android:exported="false"
+            android:process=":probe" />
     </application>
 
 </manifest>

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -512,6 +512,9 @@ class ArViewModel @Inject constructor(
     // SettingsRepository.stereoCapability so the probe only runs once per install.
     @Volatile private var stereoCapable: Boolean? = null
     private val stereoProbeInFlight = java.util.concurrent.atomic.AtomicBoolean(false)
+    // The in-flight session-state update (probe + init/resume/pause). Cancelled on the next update so
+    // a running probe stops and releases the camera immediately when the activity pauses or AR exits.
+    private var sessionUpdateJob: kotlinx.coroutines.Job? = null
 
     // MURAL requires depth; on devices that can't do it, fall back to Canvas (CLOUD_POINTS).
     private fun ArScanMode.coerceToCapability(): ArScanMode =
@@ -587,6 +590,9 @@ class ArViewModel @Inject constructor(
     fun exitArMode() {
         isInArMode = false
         isDestroying = true
+        // Cancel any in-flight session update (including a running stereo probe) so it stops pumping
+        // the camera and releases the session mutex before cleanup tries to acquire it.
+        sessionUpdateJob?.cancel()
         if (_uiState.value.trackingFailed) {
             _uiState.update { it.copy(trackingFailed = false) }
         }
@@ -596,15 +602,19 @@ class ArViewModel @Inject constructor(
     }
 
     private fun updateSessionStateLocked(context: Context? = null) {
-        viewModelScope.launch {
-            // First-ever AR entry on an unprobed device: while the camera is still free (no live
-            // session yet), run a short throwaway stereo session on a worker thread to see whether
-            // dual-lens VIO actually tracks. Capped at a few seconds and off the main thread, so a
-            // device whose motion-stereo thrashes can't ANR — and we only adopt stereo if it works.
-            if (context != null && isInArMode && session == null && !isDestroying && stereoCapable == null) {
-                probeStereoCapability(context)
-            }
+        sessionUpdateJob?.cancel()
+        sessionUpdateJob = viewModelScope.launch {
             sessionMutex.withLock {
+                // First-ever AR entry on an unprobed device: while the camera is still free (no live
+                // session yet), run a short throwaway stereo session on a worker thread to see whether
+                // dual-lens VIO actually tracks. Done inside the session mutex so no concurrent state
+                // update can open the live session while the probe still holds the camera. Capped at a
+                // few seconds and off the main thread, so a device whose motion-stereo thrashes can't
+                // ANR — and we only adopt stereo if it works. Cancelling this job (AR exit / pause)
+                // cancels the probe too.
+                if (context != null && isInArMode && session == null && !isDestroying && stereoCapable == null) {
+                    probeStereoCapability(context)
+                }
                 if (isInArMode && session == null && context != null && !isDestroying) {
                     initArSessionLocked(context)
                 }
@@ -719,11 +729,14 @@ class ArViewModel @Inject constructor(
         if (stereoCapable != null) return
         if (!stereoProbeInFlight.compareAndSet(false, true)) return
         try {
-            val capable = withContext(Dispatchers.Default) { runStereoProbe(context) }
+            val capable = withContext(Dispatchers.Default) { runStereoProbe(context) { isActive } }
             stereoCapable = capable
             settingsRepository.setStereoCapability(if (capable) 1 else 0)
             Timber.i("ARDIAG stereo probe complete: capable=$capable")
         } catch (e: Exception) {
+            // A cancelled probe (AR exit / pause) must NOT be cached as a permanent mono verdict —
+            // let cancellation propagate so the device stays "unprobed" and re-probes next entry.
+            if (e is kotlinx.coroutines.CancellationException) throw e
             stereoCapable = false
             settingsRepository.setStereoCapability(0)
             Timber.w(e, "ARDIAG stereo probe threw -> treating device as mono")
@@ -733,8 +746,9 @@ class ArViewModel @Inject constructor(
     }
 
     /** Blocking stereo probe; runs entirely on the caller's (background) thread. Returns true iff a
-     *  forced-stereo session reaches TRACKING within [STEREO_PROBE_TIMEOUT_MS]. */
-    private fun runStereoProbe(context: Context): Boolean {
+     *  forced-stereo session reaches TRACKING within [STEREO_PROBE_TIMEOUT_MS]. [isActive] is polled
+     *  so the loop bails and releases the camera immediately when the coroutine is cancelled. */
+    private fun runStereoProbe(context: Context, isActive: () -> Boolean): Boolean {
         var egl: ProbeEgl? = null
         var probe: Session? = null
         try {
@@ -760,8 +774,10 @@ class ArViewModel @Inject constructor(
             probe.setCameraTextureName(egl.cameraTextureId)
             probe.resume()
 
-            val deadline = System.currentTimeMillis() + STEREO_PROBE_TIMEOUT_MS
-            while (System.currentTimeMillis() < deadline) {
+            // Monotonic clock: a wall-clock jump (NTP sync, user change) must not extend or truncate
+            // the probe window.
+            val deadline = android.os.SystemClock.elapsedRealtime() + STEREO_PROBE_TIMEOUT_MS
+            while (android.os.SystemClock.elapsedRealtime() < deadline && isActive()) {
                 val frame = try {
                     probe.update()
                 } catch (e: Exception) {
@@ -793,9 +809,14 @@ class ArViewModel @Inject constructor(
         val cameraTextureId: Int
 
         init {
+            // Validate every EGL step: a failure on an odd device/emulator must surface as an
+            // exception (probe falls back to mono) rather than running GL on an invalid context.
             display = android.opengl.EGL14.eglGetDisplay(android.opengl.EGL14.EGL_DEFAULT_DISPLAY)
+            if (display == android.opengl.EGL14.EGL_NO_DISPLAY) throw RuntimeException("eglGetDisplay failed")
             val version = IntArray(2)
-            android.opengl.EGL14.eglInitialize(display, version, 0, version, 1)
+            if (!android.opengl.EGL14.eglInitialize(display, version, 0, version, 1)) {
+                throw RuntimeException("eglInitialize failed")
+            }
             val cfgAttribs = intArrayOf(
                 android.opengl.EGL14.EGL_RENDERABLE_TYPE, android.opengl.EGL14.EGL_OPENGL_ES2_BIT,
                 android.opengl.EGL14.EGL_SURFACE_TYPE, android.opengl.EGL14.EGL_PBUFFER_BIT,
@@ -803,12 +824,19 @@ class ArViewModel @Inject constructor(
             )
             val configs = arrayOfNulls<android.opengl.EGLConfig>(1)
             val numConfig = IntArray(1)
-            android.opengl.EGL14.eglChooseConfig(display, cfgAttribs, 0, configs, 0, 1, numConfig, 0)
+            if (!android.opengl.EGL14.eglChooseConfig(display, cfgAttribs, 0, configs, 0, 1, numConfig, 0) ||
+                numConfig[0] <= 0 || configs[0] == null) {
+                throw RuntimeException("eglChooseConfig failed")
+            }
             val ctxAttribs = intArrayOf(android.opengl.EGL14.EGL_CONTEXT_CLIENT_VERSION, 2, android.opengl.EGL14.EGL_NONE)
             ctx = android.opengl.EGL14.eglCreateContext(display, configs[0], android.opengl.EGL14.EGL_NO_CONTEXT, ctxAttribs, 0)
+            if (ctx == android.opengl.EGL14.EGL_NO_CONTEXT) throw RuntimeException("eglCreateContext failed")
             val surfAttribs = intArrayOf(android.opengl.EGL14.EGL_WIDTH, 1, android.opengl.EGL14.EGL_HEIGHT, 1, android.opengl.EGL14.EGL_NONE)
             surface = android.opengl.EGL14.eglCreatePbufferSurface(display, configs[0], surfAttribs, 0)
-            android.opengl.EGL14.eglMakeCurrent(display, surface, surface, ctx)
+            if (surface == android.opengl.EGL14.EGL_NO_SURFACE) throw RuntimeException("eglCreatePbufferSurface failed")
+            if (!android.opengl.EGL14.eglMakeCurrent(display, surface, surface, ctx)) {
+                throw RuntimeException("eglMakeCurrent failed")
+            }
             val tex = IntArray(1)
             android.opengl.GLES20.glGenTextures(1, tex, 0)
             android.opengl.GLES20.glBindTexture(android.opengl.GLES11Ext.GL_TEXTURE_EXTERNAL_OES, tex[0])

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -44,6 +44,7 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.sync.Mutex

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -1,9 +1,17 @@
 // FILE: feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
 package com.hereliesaz.graffitixr.feature.ar
 
+import android.content.ComponentName
 import android.content.Context
+import android.content.Intent
+import android.content.ServiceConnection
 import android.graphics.Bitmap
 import android.graphics.PointF
+import android.os.Handler
+import android.os.IBinder
+import android.os.Looper
+import android.os.Message
+import android.os.Messenger
 import androidx.camera.core.ImageProxy
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Path
@@ -44,9 +52,7 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import com.hereliesaz.graffitixr.domain.repository.ProjectRepository
@@ -402,9 +408,6 @@ class ArViewModel @Inject constructor(
     // Forced-stereo "stuck" detection must beat the 5s input-timeout ANR, so it's much shorter
     // than the general tracking-failure grace.
     private val STEREO_STUCK_GRACE_MS: Long = 3_000L
-    // How long the one-time worker-thread stereo probe waits for VIO to reach TRACKING before
-    // concluding the device can't run dual-lens. Off the main thread, so it can't ANR.
-    private val STEREO_PROBE_TIMEOUT_MS: Long = 3_000L
 
     private val isSaving = AtomicBoolean(false)
     private val lastSavedSplatCount = AtomicInteger(0)
@@ -730,7 +733,7 @@ class ArViewModel @Inject constructor(
         if (stereoCapable != null) return
         if (!stereoProbeInFlight.compareAndSet(false, true)) return
         try {
-            val capable = withContext(Dispatchers.Default) { runStereoProbe(context) { isActive } }
+            val capable = runProbeViaService(context)
             stereoCapable = capable
             settingsRepository.setStereoCapability(if (capable) 1 else 0)
             Timber.i("ARDIAG stereo probe complete: capable=$capable")
@@ -746,114 +749,56 @@ class ArViewModel @Inject constructor(
         }
     }
 
-    /** Blocking stereo probe; runs entirely on the caller's (background) thread. Returns true iff a
-     *  forced-stereo session reaches TRACKING within [STEREO_PROBE_TIMEOUT_MS]. [isActive] is polled
-     *  so the loop bails and releases the camera immediately when the coroutine is cancelled. */
-    private fun runStereoProbe(context: Context, isActive: () -> Boolean): Boolean {
-        var egl: ProbeEgl? = null
-        var probe: Session? = null
-        try {
-            probe = Session(context)
-            val cfg = Config(probe).apply {
-                focusMode = Config.FocusMode.AUTO
-                updateMode = Config.UpdateMode.LATEST_CAMERA_IMAGE
-                depthMode = Config.DepthMode.DISABLED
-                planeFindingMode = Config.PlaneFindingMode.DISABLED
-            }
-            probe.configure(cfg)
-            val stereoConfigs = probe.getSupportedCameraConfigs(CameraConfigFilter(probe).apply {
-                facingDirection = CameraConfig.FacingDirection.BACK
-                stereoCameraUsage = EnumSet.of(CameraConfig.StereoCameraUsage.REQUIRE_AND_USE)
-            })
-            if (stereoConfigs.isEmpty()) {
-                Timber.i("ARDIAG stereo probe: device exposes no hardware-stereo config")
-                return false
-            }
-            probe.cameraConfig = stereoConfigs[0]
-
-            egl = ProbeEgl()
-            probe.setCameraTextureName(egl.cameraTextureId)
-            probe.resume()
-
-            // Monotonic clock: a wall-clock jump (NTP sync, user change) must not extend or truncate
-            // the probe window.
-            val deadline = android.os.SystemClock.elapsedRealtime() + STEREO_PROBE_TIMEOUT_MS
-            while (android.os.SystemClock.elapsedRealtime() < deadline && isActive()) {
-                val frame = try {
-                    probe.update()
+    /**
+     * Drives [StereoProbeService] in the isolated ":probe" process and returns its verdict. The broken
+     * forced-stereo thrash (if any) happens entirely in that throwaway background process, so it can
+     * never starve this UI process into an ANR. If the probe process dies, the binding can't be made,
+     * or no reply arrives within the timeout, we conservatively return false (stay on mono).
+     */
+    private suspend fun runProbeViaService(context: Context): Boolean {
+        val appCtx = context.applicationContext
+        val result = kotlinx.coroutines.CompletableDeferred<Boolean>()
+        val replyMessenger = Messenger(Handler(Looper.getMainLooper()) { msg ->
+            if (msg.what == StereoProbeService.MSG_RESULT) result.complete(msg.arg1 == 1)
+            true
+        })
+        val conn = object : ServiceConnection {
+            override fun onServiceConnected(name: ComponentName?, binder: IBinder?) {
+                try {
+                    val m = Message.obtain(null, StereoProbeService.MSG_RUN_PROBE).apply {
+                        replyTo = replyMessenger
+                    }
+                    Messenger(binder).send(m)
                 } catch (e: Exception) {
-                    Timber.w(e, "ARDIAG stereo probe: update() failed")
-                    return false
+                    result.complete(false)
                 }
-                if (frame.camera.trackingState == com.google.ar.core.TrackingState.TRACKING) {
-                    return true
-                }
-                Thread.sleep(33)
             }
-            return false
-        } catch (e: Exception) {
-            Timber.w(e, "ARDIAG stereo probe: setup failed")
-            return false
-        } finally {
-            try { probe?.pause() } catch (_: Exception) {}
-            try { probe?.close() } catch (_: Exception) {}
-            egl?.release()
+
+            override fun onServiceDisconnected(name: ComponentName?) {
+                // The :probe process died (e.g. killed after a hang) -> treat the device as mono.
+                result.complete(false)
+            }
         }
-    }
-
-    /** Minimal offscreen EGL context (1x1 pbuffer) with a single GL_TEXTURE_EXTERNAL_OES texture, so
-     *  the probe session has somewhere to bind camera frames while we pump [Session.update]. */
-    private class ProbeEgl {
-        private var display: android.opengl.EGLDisplay = android.opengl.EGL14.EGL_NO_DISPLAY
-        private var ctx: android.opengl.EGLContext = android.opengl.EGL14.EGL_NO_CONTEXT
-        private var surface: android.opengl.EGLSurface = android.opengl.EGL14.EGL_NO_SURFACE
-        val cameraTextureId: Int
-
-        init {
-            // Validate every EGL step: a failure on an odd device/emulator must surface as an
-            // exception (probe falls back to mono) rather than running GL on an invalid context.
-            display = android.opengl.EGL14.eglGetDisplay(android.opengl.EGL14.EGL_DEFAULT_DISPLAY)
-            if (display == android.opengl.EGL14.EGL_NO_DISPLAY) throw RuntimeException("eglGetDisplay failed")
-            val version = IntArray(2)
-            if (!android.opengl.EGL14.eglInitialize(display, version, 0, version, 1)) {
-                throw RuntimeException("eglInitialize failed")
-            }
-            val cfgAttribs = intArrayOf(
-                android.opengl.EGL14.EGL_RENDERABLE_TYPE, android.opengl.EGL14.EGL_OPENGL_ES2_BIT,
-                android.opengl.EGL14.EGL_SURFACE_TYPE, android.opengl.EGL14.EGL_PBUFFER_BIT,
-                android.opengl.EGL14.EGL_NONE
+        val bound = try {
+            appCtx.bindService(
+                Intent(appCtx, StereoProbeService::class.java),
+                conn,
+                Context.BIND_AUTO_CREATE
             )
-            val configs = arrayOfNulls<android.opengl.EGLConfig>(1)
-            val numConfig = IntArray(1)
-            if (!android.opengl.EGL14.eglChooseConfig(display, cfgAttribs, 0, configs, 0, 1, numConfig, 0) ||
-                numConfig[0] <= 0 || configs[0] == null) {
-                throw RuntimeException("eglChooseConfig failed")
-            }
-            val ctxAttribs = intArrayOf(android.opengl.EGL14.EGL_CONTEXT_CLIENT_VERSION, 2, android.opengl.EGL14.EGL_NONE)
-            ctx = android.opengl.EGL14.eglCreateContext(display, configs[0], android.opengl.EGL14.EGL_NO_CONTEXT, ctxAttribs, 0)
-            if (ctx == android.opengl.EGL14.EGL_NO_CONTEXT) throw RuntimeException("eglCreateContext failed")
-            val surfAttribs = intArrayOf(android.opengl.EGL14.EGL_WIDTH, 1, android.opengl.EGL14.EGL_HEIGHT, 1, android.opengl.EGL14.EGL_NONE)
-            surface = android.opengl.EGL14.eglCreatePbufferSurface(display, configs[0], surfAttribs, 0)
-            if (surface == android.opengl.EGL14.EGL_NO_SURFACE) throw RuntimeException("eglCreatePbufferSurface failed")
-            if (!android.opengl.EGL14.eglMakeCurrent(display, surface, surface, ctx)) {
-                throw RuntimeException("eglMakeCurrent failed")
-            }
-            val tex = IntArray(1)
-            android.opengl.GLES20.glGenTextures(1, tex, 0)
-            android.opengl.GLES20.glBindTexture(android.opengl.GLES11Ext.GL_TEXTURE_EXTERNAL_OES, tex[0])
-            cameraTextureId = tex[0]
+        } catch (e: Exception) {
+            false
         }
-
-        fun release() {
-            if (display != android.opengl.EGL14.EGL_NO_DISPLAY) {
-                android.opengl.EGL14.eglMakeCurrent(
-                    display, android.opengl.EGL14.EGL_NO_SURFACE,
-                    android.opengl.EGL14.EGL_NO_SURFACE, android.opengl.EGL14.EGL_NO_CONTEXT
-                )
-                if (surface != android.opengl.EGL14.EGL_NO_SURFACE) android.opengl.EGL14.eglDestroySurface(display, surface)
-                if (ctx != android.opengl.EGL14.EGL_NO_CONTEXT) android.opengl.EGL14.eglDestroyContext(display, ctx)
-                android.opengl.EGL14.eglTerminate(display)
-            }
+        if (!bound) {
+            try { appCtx.unbindService(conn) } catch (_: Exception) {}
+            return false
+        }
+        return try {
+            // Bound process startup + the probe's own timeout, with headroom; never block forever.
+            kotlinx.coroutines.withTimeoutOrNull(StereoProbeService.PROBE_TIMEOUT_MS + 4_000L) {
+                result.await()
+            } ?: false
+        } finally {
+            try { appCtx.unbindService(conn) } catch (_: Exception) {}
         }
     }
 

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -401,6 +401,9 @@ class ArViewModel @Inject constructor(
     // Forced-stereo "stuck" detection must beat the 5s input-timeout ANR, so it's much shorter
     // than the general tracking-failure grace.
     private val STEREO_STUCK_GRACE_MS: Long = 3_000L
+    // How long the one-time worker-thread stereo probe waits for VIO to reach TRACKING before
+    // concluding the device can't run dual-lens. Off the main thread, so it can't ANR.
+    private val STEREO_PROBE_TIMEOUT_MS: Long = 3_000L
 
     private val isSaving = AtomicBoolean(false)
     private val lastSavedSplatCount = AtomicInteger(0)
@@ -466,6 +469,20 @@ class ArViewModel @Inject constructor(
             }
         }
         viewModelScope.launch {
+            settingsRepository.stereoCapability.collect { cap ->
+                stereoCapable = when (cap) {
+                    1 -> true
+                    0 -> false
+                    else -> null
+                }
+                // A device whose stereo can't track can't do MURAL — fall its scan mode back to Canvas.
+                if (stereoCapable == false) {
+                    deviceCanDoMural = false
+                    _uiState.update { it.copy(arScanMode = it.arScanMode.coerceToCapability()) }
+                }
+            }
+        }
+        viewModelScope.launch {
             settingsRepository.isRightHanded.collect { isRight ->
                 _uiState.update { it.copy(isRightHanded = isRight) }
             }
@@ -489,6 +506,12 @@ class ArViewModel @Inject constructor(
     // Sticky: a device proved its forced hardware-stereo path is broken (ARCore motion-stereo
     // disparity fails / VIO never tracks). Persisted; once set, sessions skip the stereo config.
     @Volatile private var forcedStereoUnstable: Boolean = false
+
+    // One-time hardware-stereo probe result: null = not yet probed, true = stereo tracks (adopt
+    // dual-lens), false = stereo thrashes / never tracks (stay mono). Persisted via
+    // SettingsRepository.stereoCapability so the probe only runs once per install.
+    @Volatile private var stereoCapable: Boolean? = null
+    private val stereoProbeInFlight = java.util.concurrent.atomic.AtomicBoolean(false)
 
     // MURAL requires depth; on devices that can't do it, fall back to Canvas (CLOUD_POINTS).
     private fun ArScanMode.coerceToCapability(): ArScanMode =
@@ -574,6 +597,13 @@ class ArViewModel @Inject constructor(
 
     private fun updateSessionStateLocked(context: Context? = null) {
         viewModelScope.launch {
+            // First-ever AR entry on an unprobed device: while the camera is still free (no live
+            // session yet), run a short throwaway stereo session on a worker thread to see whether
+            // dual-lens VIO actually tracks. Capped at a few seconds and off the main thread, so a
+            // device whose motion-stereo thrashes can't ANR — and we only adopt stereo if it works.
+            if (context != null && isInArMode && session == null && !isDestroying && stereoCapable == null) {
+                probeStereoCapability(context)
+            }
             sessionMutex.withLock {
                 if (isInArMode && session == null && context != null && !isDestroying) {
                     initArSessionLocked(context)
@@ -618,34 +648,52 @@ class ArViewModel @Inject constructor(
 
             s.configure(config)
 
-            // Always use the plain mono 30 FPS back camera config. Forcing a hardware-stereo config
-            // (StereoCameraUsage.REQUIRE_AND_USE) made ARCore run motion-stereo (spherical_rectifier)
-            // on devices that list a "stereo" config but can't actually compute disparity — it pegged
-            // the CPU, starved VIO into permanent kNotTracking, and blocked the main thread into a
-            // 5s input-dispatch ANR with a black camera. The reactive in-session recovery couldn't win
-            // that race because the main thread was already dead. Mono is the only camera path that
-            // tracks reliably here; metric depth comes from VIO-baseline triangulation.
-            val monoConfigs = s.getSupportedCameraConfigs(CameraConfigFilter(s).apply {
-                facingDirection = CameraConfig.FacingDirection.BACK
-                targetFps = EnumSet.of(CameraConfig.TargetFps.TARGET_FPS_30)
-            })
-            if (monoConfigs.isNotEmpty()) s.cameraConfig = monoConfigs[0]
-            Timber.i("ARDIAG dual-lens: forced stereo disabled — using mono camera config")
+            // Camera config selection. Forcing a hardware-stereo config makes ARCore run motion-stereo
+            // (spherical_rectifier); on devices that list a "stereo" config but can't actually compute
+            // disparity that pegs the CPU, starves VIO into kNotTracking, and ANRs the main thread with
+            // a black camera. So we only select stereo when the one-time worker-thread probe has proven
+            // this device's stereo actually tracks (stereoCapable == true) and it hasn't since been
+            // marked unstable. Everything else stays on the safe mono 30 FPS back config.
+            val useStereo = stereoCapable == true && !forcedStereoUnstable
+            var stereoActive = false
+            if (useStereo) {
+                val stereoConfigs = try {
+                    s.getSupportedCameraConfigs(CameraConfigFilter(s).apply {
+                        facingDirection = CameraConfig.FacingDirection.BACK
+                        stereoCameraUsage = EnumSet.of(CameraConfig.StereoCameraUsage.REQUIRE_AND_USE)
+                    })
+                } catch (e: Exception) {
+                    Timber.w(e, "dual-lens: stereo config query failed")
+                    emptyList()
+                }
+                if (stereoConfigs.isNotEmpty()) {
+                    s.cameraConfig = stereoConfigs[0]
+                    stereoActive = true
+                    Timber.i("ARDIAG dual-lens: HARDWARE STEREO selected (probe-confirmed) cameraId=${stereoConfigs[0].cameraId}")
+                }
+            }
+            if (!stereoActive) {
+                val monoConfigs = s.getSupportedCameraConfigs(CameraConfigFilter(s).apply {
+                    facingDirection = CameraConfig.FacingDirection.BACK
+                    targetFps = EnumSet.of(CameraConfig.TargetFps.TARGET_FPS_30)
+                })
+                if (monoConfigs.isNotEmpty()) s.cameraConfig = monoConfigs[0]
+                Timber.i("ARDIAG dual-lens: using mono camera config (stereoCapable=$stereoCapable)")
+            }
 
-            // No hardware stereo means no dual-lens depth triangulation, so MURAL auto-falls back to
-            // Canvas.
-            deviceCanDoMural = false
+            // MURAL needs dual-lens depth triangulation; without hardware stereo it falls back to Canvas.
+            deviceCanDoMural = stereoActive
             _uiState.update {
                 it.copy(
-                    isDualLensActive = false,
-                    isHardwareStereoActive = false,
+                    isDualLensActive = stereoActive,
+                    isHardwareStereoActive = stereoActive,
                     arScanMode = it.arScanMode.coerceToCapability()
                 )
             }
 
             session = s
             _isCameraInUseByAr.value = true
-            Timber.i("ARDIAG initArSessionLocked: session created OK (mono camera, rendererAttached=${renderer != null})")
+            Timber.i("ARDIAG initArSessionLocked: session created OK (stereoActive=$stereoActive rendererAttached=${renderer != null})")
 
             // Critical: if the renderer is already attached, update it with the new session
             renderer?.attachSession(s)
@@ -656,6 +704,127 @@ class ArViewModel @Inject constructor(
             _feedback.tryEmit(
                 com.hereliesaz.graffitixr.common.model.FeedbackEvent.Error("Couldn't start AR — your camera may be in use by another app", e)
             )
+        }
+    }
+
+    /**
+     * One-time hardware-stereo capability probe. Runs a short throwaway ARCore session configured for
+     * forced hardware stereo on a worker thread (its own offscreen EGL context), pumps [Session.update]
+     * for a few seconds and adopts dual-lens only if VIO reaches TRACKING. A device whose motion-stereo
+     * is broken never tracks (and thrashes), so we cap the probe and treat any failure as "mono". The
+     * result is cached in settings so this only runs once per install. Must be called while no live
+     * session holds the camera.
+     */
+    private suspend fun probeStereoCapability(context: Context) {
+        if (stereoCapable != null) return
+        if (!stereoProbeInFlight.compareAndSet(false, true)) return
+        try {
+            val capable = withContext(Dispatchers.Default) { runStereoProbe(context) }
+            stereoCapable = capable
+            settingsRepository.setStereoCapability(if (capable) 1 else 0)
+            Timber.i("ARDIAG stereo probe complete: capable=$capable")
+        } catch (e: Exception) {
+            stereoCapable = false
+            settingsRepository.setStereoCapability(0)
+            Timber.w(e, "ARDIAG stereo probe threw -> treating device as mono")
+        } finally {
+            stereoProbeInFlight.set(false)
+        }
+    }
+
+    /** Blocking stereo probe; runs entirely on the caller's (background) thread. Returns true iff a
+     *  forced-stereo session reaches TRACKING within [STEREO_PROBE_TIMEOUT_MS]. */
+    private fun runStereoProbe(context: Context): Boolean {
+        var egl: ProbeEgl? = null
+        var probe: Session? = null
+        try {
+            probe = Session(context)
+            val cfg = Config(probe).apply {
+                focusMode = Config.FocusMode.AUTO
+                updateMode = Config.UpdateMode.LATEST_CAMERA_IMAGE
+                depthMode = Config.DepthMode.DISABLED
+                planeFindingMode = Config.PlaneFindingMode.DISABLED
+            }
+            probe.configure(cfg)
+            val stereoConfigs = probe.getSupportedCameraConfigs(CameraConfigFilter(probe).apply {
+                facingDirection = CameraConfig.FacingDirection.BACK
+                stereoCameraUsage = EnumSet.of(CameraConfig.StereoCameraUsage.REQUIRE_AND_USE)
+            })
+            if (stereoConfigs.isEmpty()) {
+                Timber.i("ARDIAG stereo probe: device exposes no hardware-stereo config")
+                return false
+            }
+            probe.cameraConfig = stereoConfigs[0]
+
+            egl = ProbeEgl()
+            probe.setCameraTextureName(egl.cameraTextureId)
+            probe.resume()
+
+            val deadline = System.currentTimeMillis() + STEREO_PROBE_TIMEOUT_MS
+            while (System.currentTimeMillis() < deadline) {
+                val frame = try {
+                    probe.update()
+                } catch (e: Exception) {
+                    Timber.w(e, "ARDIAG stereo probe: update() failed")
+                    return false
+                }
+                if (frame.camera.trackingState == com.google.ar.core.TrackingState.TRACKING) {
+                    return true
+                }
+                Thread.sleep(33)
+            }
+            return false
+        } catch (e: Exception) {
+            Timber.w(e, "ARDIAG stereo probe: setup failed")
+            return false
+        } finally {
+            try { probe?.pause() } catch (_: Exception) {}
+            try { probe?.close() } catch (_: Exception) {}
+            egl?.release()
+        }
+    }
+
+    /** Minimal offscreen EGL context (1x1 pbuffer) with a single GL_TEXTURE_EXTERNAL_OES texture, so
+     *  the probe session has somewhere to bind camera frames while we pump [Session.update]. */
+    private class ProbeEgl {
+        private var display: android.opengl.EGLDisplay = android.opengl.EGL14.EGL_NO_DISPLAY
+        private var ctx: android.opengl.EGLContext = android.opengl.EGL14.EGL_NO_CONTEXT
+        private var surface: android.opengl.EGLSurface = android.opengl.EGL14.EGL_NO_SURFACE
+        val cameraTextureId: Int
+
+        init {
+            display = android.opengl.EGL14.eglGetDisplay(android.opengl.EGL14.EGL_DEFAULT_DISPLAY)
+            val version = IntArray(2)
+            android.opengl.EGL14.eglInitialize(display, version, 0, version, 1)
+            val cfgAttribs = intArrayOf(
+                android.opengl.EGL14.EGL_RENDERABLE_TYPE, android.opengl.EGL14.EGL_OPENGL_ES2_BIT,
+                android.opengl.EGL14.EGL_SURFACE_TYPE, android.opengl.EGL14.EGL_PBUFFER_BIT,
+                android.opengl.EGL14.EGL_NONE
+            )
+            val configs = arrayOfNulls<android.opengl.EGLConfig>(1)
+            val numConfig = IntArray(1)
+            android.opengl.EGL14.eglChooseConfig(display, cfgAttribs, 0, configs, 0, 1, numConfig, 0)
+            val ctxAttribs = intArrayOf(android.opengl.EGL14.EGL_CONTEXT_CLIENT_VERSION, 2, android.opengl.EGL14.EGL_NONE)
+            ctx = android.opengl.EGL14.eglCreateContext(display, configs[0], android.opengl.EGL14.EGL_NO_CONTEXT, ctxAttribs, 0)
+            val surfAttribs = intArrayOf(android.opengl.EGL14.EGL_WIDTH, 1, android.opengl.EGL14.EGL_HEIGHT, 1, android.opengl.EGL14.EGL_NONE)
+            surface = android.opengl.EGL14.eglCreatePbufferSurface(display, configs[0], surfAttribs, 0)
+            android.opengl.EGL14.eglMakeCurrent(display, surface, surface, ctx)
+            val tex = IntArray(1)
+            android.opengl.GLES20.glGenTextures(1, tex, 0)
+            android.opengl.GLES20.glBindTexture(android.opengl.GLES11Ext.GL_TEXTURE_EXTERNAL_OES, tex[0])
+            cameraTextureId = tex[0]
+        }
+
+        fun release() {
+            if (display != android.opengl.EGL14.EGL_NO_DISPLAY) {
+                android.opengl.EGL14.eglMakeCurrent(
+                    display, android.opengl.EGL14.EGL_NO_SURFACE,
+                    android.opengl.EGL14.EGL_NO_SURFACE, android.opengl.EGL14.EGL_NO_CONTEXT
+                )
+                if (surface != android.opengl.EGL14.EGL_NO_SURFACE) android.opengl.EGL14.eglDestroySurface(display, surface)
+                if (ctx != android.opengl.EGL14.EGL_NO_CONTEXT) android.opengl.EGL14.eglDestroyContext(display, ctx)
+                android.opengl.EGL14.eglTerminate(display)
+            }
         }
     }
 

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/StereoProbeService.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/StereoProbeService.kt
@@ -1,0 +1,183 @@
+package com.hereliesaz.graffitixr.feature.ar
+
+import android.app.Service
+import android.content.Intent
+import android.os.Handler
+import android.os.HandlerThread
+import android.os.IBinder
+import android.os.Looper
+import android.os.Message
+import android.os.Messenger
+import android.os.RemoteException
+import com.google.ar.core.CameraConfig
+import com.google.ar.core.CameraConfigFilter
+import com.google.ar.core.Config
+import com.google.ar.core.Session
+import com.google.ar.core.TrackingState
+import timber.log.Timber
+import java.util.EnumSet
+
+/**
+ * Runs the hardware-stereo capability probe in an isolated ":probe" process (declared in the
+ * manifest). On a device whose ARCore motion-stereo is broken, the native VIO threads thrash the CPU
+ * and never converge; isolating that work in a throwaway background process keeps the foreground UI
+ * process responsive (the scheduler favours the foreground app over this background one), so a hang
+ * here can never ANR the app — at worst Android kills this process and the client falls back to mono.
+ *
+ * Protocol: bind, then send [MSG_RUN_PROBE] with `replyTo` set. The service runs a short forced-stereo
+ * session on a worker thread and replies with [MSG_RESULT] whose `arg1` is 1 (stereo tracks) or 0
+ * (it doesn't / setup failed).
+ */
+class StereoProbeService : Service() {
+
+    companion object {
+        const val MSG_RUN_PROBE = 1
+        const val MSG_RESULT = 2
+        /** How long to wait for VIO to reach TRACKING before declaring the device stereo-incapable. */
+        const val PROBE_TIMEOUT_MS = 3_000L
+    }
+
+    private lateinit var worker: HandlerThread
+    private lateinit var workerHandler: Handler
+
+    private val incoming = Messenger(Handler(Looper.getMainLooper()) { msg ->
+        if (msg.what == MSG_RUN_PROBE) {
+            val reply = msg.replyTo
+            // Run the probe off this process's main thread so even this sacrificial process can't ANR.
+            workerHandler.post {
+                val capable = runStereoProbe()
+                try {
+                    reply?.send(Message.obtain(null, MSG_RESULT, if (capable) 1 else 0, 0))
+                } catch (e: RemoteException) {
+                    // Client already gone (timed out / unbound). Nothing to do.
+                }
+            }
+            true
+        } else {
+            false
+        }
+    })
+
+    override fun onCreate() {
+        super.onCreate()
+        worker = HandlerThread("StereoProbe").apply { start() }
+        workerHandler = Handler(worker.looper)
+    }
+
+    override fun onBind(intent: Intent?): IBinder = incoming.binder
+
+    override fun onDestroy() {
+        worker.quitSafely()
+        super.onDestroy()
+    }
+
+    /** Blocking probe. Returns true iff a forced-stereo session reaches TRACKING within the timeout. */
+    private fun runStereoProbe(): Boolean {
+        var egl: ProbeEgl? = null
+        var probe: Session? = null
+        try {
+            probe = Session(this)
+            val cfg = Config(probe).apply {
+                focusMode = Config.FocusMode.AUTO
+                updateMode = Config.UpdateMode.LATEST_CAMERA_IMAGE
+                depthMode = Config.DepthMode.DISABLED
+                planeFindingMode = Config.PlaneFindingMode.DISABLED
+            }
+            probe.configure(cfg)
+            val stereoConfigs = probe.getSupportedCameraConfigs(CameraConfigFilter(probe).apply {
+                facingDirection = CameraConfig.FacingDirection.BACK
+                stereoCameraUsage = EnumSet.of(CameraConfig.StereoCameraUsage.REQUIRE_AND_USE)
+            })
+            if (stereoConfigs.isEmpty()) {
+                Timber.i("ARDIAG stereo probe: device exposes no hardware-stereo config")
+                return false
+            }
+            probe.cameraConfig = stereoConfigs[0]
+
+            egl = ProbeEgl()
+            probe.setCameraTextureName(egl.cameraTextureId)
+            probe.resume()
+
+            // Monotonic clock: a wall-clock jump (NTP sync) must not extend or truncate the window.
+            val deadline = android.os.SystemClock.elapsedRealtime() + PROBE_TIMEOUT_MS
+            while (android.os.SystemClock.elapsedRealtime() < deadline) {
+                val frame = try {
+                    probe.update()
+                } catch (e: Exception) {
+                    Timber.w(e, "ARDIAG stereo probe: update() failed")
+                    return false
+                }
+                if (frame.camera.trackingState == TrackingState.TRACKING) {
+                    Timber.i("ARDIAG stereo probe: TRACKING -> device is stereo-capable")
+                    return true
+                }
+                Thread.sleep(33)
+            }
+            Timber.i("ARDIAG stereo probe: never reached TRACKING -> stereo-incapable")
+            return false
+        } catch (e: Exception) {
+            Timber.w(e, "ARDIAG stereo probe: setup failed -> stereo-incapable")
+            return false
+        } finally {
+            try { probe?.pause() } catch (_: Exception) {}
+            try { probe?.close() } catch (_: Exception) {}
+            egl?.release()
+        }
+    }
+
+    /** Minimal offscreen EGL context (1x1 pbuffer) with one GL_TEXTURE_EXTERNAL_OES texture, so the
+     *  probe session has somewhere to bind camera frames while we pump [Session.update]. */
+    private class ProbeEgl {
+        private var display: android.opengl.EGLDisplay = android.opengl.EGL14.EGL_NO_DISPLAY
+        private var ctx: android.opengl.EGLContext = android.opengl.EGL14.EGL_NO_CONTEXT
+        private var surface: android.opengl.EGLSurface = android.opengl.EGL14.EGL_NO_SURFACE
+        val cameraTextureId: Int
+
+        init {
+            // Validate every EGL step: a failure on an odd device/emulator surfaces as an exception
+            // (probe falls back to mono) rather than running GL on an invalid context.
+            display = android.opengl.EGL14.eglGetDisplay(android.opengl.EGL14.EGL_DEFAULT_DISPLAY)
+            if (display == android.opengl.EGL14.EGL_NO_DISPLAY) throw RuntimeException("eglGetDisplay failed")
+            val version = IntArray(2)
+            if (!android.opengl.EGL14.eglInitialize(display, version, 0, version, 1)) {
+                throw RuntimeException("eglInitialize failed")
+            }
+            val cfgAttribs = intArrayOf(
+                android.opengl.EGL14.EGL_RENDERABLE_TYPE, android.opengl.EGL14.EGL_OPENGL_ES2_BIT,
+                android.opengl.EGL14.EGL_SURFACE_TYPE, android.opengl.EGL14.EGL_PBUFFER_BIT,
+                android.opengl.EGL14.EGL_NONE
+            )
+            val configs = arrayOfNulls<android.opengl.EGLConfig>(1)
+            val numConfig = IntArray(1)
+            if (!android.opengl.EGL14.eglChooseConfig(display, cfgAttribs, 0, configs, 0, 1, numConfig, 0) ||
+                numConfig[0] <= 0 || configs[0] == null) {
+                throw RuntimeException("eglChooseConfig failed")
+            }
+            val ctxAttribs = intArrayOf(android.opengl.EGL14.EGL_CONTEXT_CLIENT_VERSION, 2, android.opengl.EGL14.EGL_NONE)
+            ctx = android.opengl.EGL14.eglCreateContext(display, configs[0], android.opengl.EGL14.EGL_NO_CONTEXT, ctxAttribs, 0)
+            if (ctx == android.opengl.EGL14.EGL_NO_CONTEXT) throw RuntimeException("eglCreateContext failed")
+            val surfAttribs = intArrayOf(android.opengl.EGL14.EGL_WIDTH, 1, android.opengl.EGL14.EGL_HEIGHT, 1, android.opengl.EGL14.EGL_NONE)
+            surface = android.opengl.EGL14.eglCreatePbufferSurface(display, configs[0], surfAttribs, 0)
+            if (surface == android.opengl.EGL14.EGL_NO_SURFACE) throw RuntimeException("eglCreatePbufferSurface failed")
+            if (!android.opengl.EGL14.eglMakeCurrent(display, surface, surface, ctx)) {
+                throw RuntimeException("eglMakeCurrent failed")
+            }
+            val tex = IntArray(1)
+            android.opengl.GLES20.glGenTextures(1, tex, 0)
+            android.opengl.GLES20.glBindTexture(android.opengl.GLES11Ext.GL_TEXTURE_EXTERNAL_OES, tex[0])
+            cameraTextureId = tex[0]
+        }
+
+        fun release() {
+            if (display != android.opengl.EGL14.EGL_NO_DISPLAY) {
+                android.opengl.EGL14.eglMakeCurrent(
+                    display, android.opengl.EGL14.EGL_NO_SURFACE,
+                    android.opengl.EGL14.EGL_NO_SURFACE, android.opengl.EGL14.EGL_NO_CONTEXT
+                )
+                if (surface != android.opengl.EGL14.EGL_NO_SURFACE) android.opengl.EGL14.eglDestroySurface(display, surface)
+                if (ctx != android.opengl.EGL14.EGL_NO_CONTEXT) android.opengl.EGL14.eglDestroyContext(display, ctx)
+                android.opengl.EGL14.eglTerminate(display)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What

Restores dual-lens (hardware-stereo) depth on devices that genuinely support it, while making the capability test **impossible to ANR the app**.

## Why the worker-thread approach wasn't enough

A device ANR log showed the broken-stereo thrash lives in ARCore's **native** VIO threads (`MTC_vio`, `MTC_mapping`, `MTC_triangulati`). They peg the CPU process-wide and starve the main thread **regardless of which Kotlin/coroutine thread drives `update()`** — so an in-process probe could still ANR on a truly-broken device.

## The fix: sacrificial `:probe` process

`StereoProbeService` runs the forced-stereo capability test in an **isolated `:probe` process** (`android:process=":probe"`). The native thread storm now happens in a throwaway **background** process; the scheduler favors the foreground UI process over it, so a hang can never ANR the app. If the probe process is killed, the binding drops and the client falls back to mono.

Flow:
- First-ever AR entry on an unprobed device (inside `sessionMutex`, camera free): `ArViewModel` binds `StereoProbeService`, sends `MSG_RUN_PROBE` with a reply `Messenger`.
- The service runs a short forced-stereo ARCore session on a worker thread (its own offscreen EGL pbuffer context), pumps `Session.update()` up to 3s, and replies `MSG_RESULT` = 1 iff VIO reaches TRACKING.
- The client awaits the reply with a timeout (probe timeout + headroom), unbinds, and caches the tri-state verdict (`stereoCapability`: `-1` unknown / `0` mono / `1` stereo). Cancellation (AR exit) is **not** cached, so it re-probes next entry.
- `initArSessionLocked` selects the stereo camera config only when the probe confirmed it; otherwise mono, with MURAL falling back to Canvas. The reactive in-session recovery remains as a backstop.

## Files
- `feature/ar/.../StereoProbeService.kt` — isolated-process probe (Messenger IPC, ARCore session, offscreen EGL)
- `feature/ar/src/main/AndroidManifest.xml` — service declared `android:process=":probe"`, not exported
- `feature/ar/.../ArViewModel.kt` — bind/await/cache client; capability-gated camera-config selection
- `core/domain` + `core/data` — `stereoCapability` tri-state setting

## Notes
- One-time cost on the very first AR entry while the verdict is fetched; cached thereafter.
- A capable device pointed at a featureless scene during the one-time probe could be cached as mono; re-selecting Mural clears the unstable flag.

https://claude.ai/code/session_01GxdoXFy5ewQGEwdJ3Aj7Si