### PR TITLE
fix(ar): BLOCKING update mode for stuck VIO + on-screen render diagnostics

### DIFF
--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -639,7 +639,13 @@ class ArViewModel @Inject constructor(
             val s = Session(context)
             val config = Config(s)
             config.focusMode = Config.FocusMode.AUTO
-            config.updateMode = Config.UpdateMode.LATEST_CAMERA_IMAGE
+            // BLOCKING (not LATEST_CAMERA_IMAGE): ARCore's init-time visual-feature-track depth
+            // provider requests camera images at specific past timestamps. LATEST_CAMERA_IMAGE drops
+            // intermediate frames, so on some device profiles the provider can't find them
+            // ("image_buffer.cc: Failed to find an image with the requested timestamp"), which jams
+            // VIO into permanent kNotTracking and never publishes a camera texture -> black passthrough.
+            // BLOCKING processes frames in order without dropping, so the provider finds its images.
+            config.updateMode = Config.UpdateMode.BLOCKING
             // Detect walls so the overlay can anchor to the real surface at its true distance. Without
             // this, hit-tests only return sparse feature points and the overlay lands short of the wall.
             config.planeFindingMode = Config.PlaneFindingMode.HORIZONTAL_AND_VERTICAL

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -266,7 +266,10 @@ class ArRenderer(
         sessionLock.withLock {
             val activeSession = session
             if (activeSession == null) {
-                if (frameCount % 120 == 0) Timber.w("ARDIAG onDrawFrame: session null -> camera black")
+                if (frameCount % 120 == 0) {
+                    Timber.w("ARDIAG onDrawFrame: session null -> camera black")
+                    onDiag("render: session null -> black")
+                }
                 return
             }
 
@@ -276,10 +279,14 @@ class ArRenderer(
             val frame: Frame = try {
                 activeSession.update()
             } catch (e: SessionPausedException) {
-                if (frameCount % 120 == 0) Timber.w("ARDIAG onDrawFrame: SessionPaused -> camera black")
+                if (frameCount % 120 == 0) {
+                    Timber.w("ARDIAG onDrawFrame: SessionPaused -> camera black")
+                    onDiag("render: session paused -> black")
+                }
                 return
             } catch (e: Exception) {
                 Timber.e(e, "ARDIAG ARCore session update failed -> camera black")
+                if (frameCount % 120 == 0) onDiag("render: update() failed: ${e.javaClass.simpleName} -> black")
                 return
             }
 
@@ -289,7 +296,12 @@ class ArRenderer(
             val scanActive = !anchorEstablished && scanMode == ArScanMode.MURAL && scanPhase == ScanPhase.AMBIENT
             if (scanActive) backgroundRenderer.updateScanMask(visitedSectorsMask)
             backgroundRenderer.draw(frame, scanActive)
-            if (frameCount % 60 == 0) Timber.i("ARDIAG drawFrame f=$frameCount tracking=${frame.camera.trackingState} anchor=$anchorEstablished scanMode=$scanMode scanActive=$scanActive")
+            if (frameCount % 60 == 0) {
+                Timber.i("ARDIAG drawFrame f=$frameCount tracking=${frame.camera.trackingState} anchor=$anchorEstablished scanMode=$scanMode scanActive=$scanActive")
+                // On-screen heartbeat: if this is updating, the camera IS being drawn and any black
+                // is something painting over it; if it's stuck, the render loop is the problem.
+                onDiag("render: drawing f=$frameCount track=${frame.camera.trackingState}")
+            }
 
             // Scan/world-mapping indicator: ink develops on ARCore's detected planes (real 3D surfaces
             // that track with the world), so it reads as colour soaking into the wall/floor — not a flat


### PR DESCRIPTION
## Diagnosis (from device logcat)

On-device AR with a layer loaded: no ANR, mono camera, Canvas mode — all correct. But:

- Camera hardware streams fine — `[Camera][0] Accumulative count` climbs steadily.
- VIO never initializes — `VisualInertialState is kNotTracking. Wait.` forever.
- Every frame: `feature_track_ml_depth_provider … NOT_FOUND: Not able to find any depth measurements` and **`Failed to find an image with the requested timestamp`** (`image_buffer.cc:50`).

ARCore's init-time visual-feature-track depth provider keeps asking for a past camera frame that has **already been dropped**, so VIO can't converge and ARCore never publishes a usable camera texture → black passthrough.

## Fix

The session was configured with `UpdateMode.LATEST_CAMERA_IMAGE`, which drops intermediate frames by design — exactly the frames the provider asks for. Switch to **`UpdateMode.BLOCKING`** (ARCore's standard non-dropping mode) so frames are processed in order and the provider can find its images.

## Plus: on-screen render diagnostics

I've twice asked for the render-loop state and gotten only native ARCore spam. So this also routes the `onDrawFrame` camera-black reasons (`session null` / `paused` / `update() failed`) and a periodic `drawing f=N track=…` heartbeat to `onDiag`, which surfaces in the existing **Diagnostic Overlay** (Settings toggle). If `BLOCKING` doesn't fully fix it, the next run shows—on screen, no logcat needed—whether the camera is drawing (so something opaque covers it) or the render loop is stuck.

## How to verify
1. Install this build.
2. Settings → enable **Diagnostic Overlay**.
3. Enter AR with a layer. Either the camera comes up, or the on-screen overlay shows the exact render state.

https://claude.ai/code/session_01GxdoXFy5ewQGEwdJ3Aj7Si

---
_Generated by [Claude Code](https://claude.ai/code/session_01GxdoXFy5ewQGEwdJ3Aj7Si)_