### PR TITLE
fix(ar): stereo probe must use BLOCKING update mode too

### DIFF
--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/StereoProbeService.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/StereoProbeService.kt
@@ -79,7 +79,10 @@ class StereoProbeService : Service() {
             probe = Session(this)
             val cfg = Config(probe).apply {
                 focusMode = Config.FocusMode.AUTO
-                updateMode = Config.UpdateMode.LATEST_CAMERA_IMAGE
+                // BLOCKING, matching the live session: LATEST_CAMERA_IMAGE drops frames the init-time
+                // depth provider needs, which jams VIO into kNotTracking. With it, the probe would
+                // never reach TRACKING and would falsely classify every device as stereo-incapable.
+                updateMode = Config.UpdateMode.BLOCKING
                 depthMode = Config.DepthMode.DISABLED
                 planeFindingMode = Config.PlaneFindingMode.DISABLED
             }


### PR DESCRIPTION
## What

Follow-up to #1595. That PR switched the **live** AR session to `UpdateMode.BLOCKING` to fix the stuck-VIO black camera, but `StereoProbeService` (the isolated `:probe` process) was still on `LATEST_CAMERA_IMAGE`.

## Why it matters

The probe checks whether VIO reaches `TRACKING` to decide if a device can do dual-lens. With `LATEST_CAMERA_IMAGE`, the same frame-drop that jams VIO (ARCore's init-time depth provider can't find the frames it needs) means the probe would **never reach TRACKING within its timeout** — so it would classify **every** device as stereo-incapable and write `0` to settings permanently, disabling dual-lens even on devices that genuinely support it.

This matches the probe's config to the live session (`UpdateMode.BLOCKING`) so its verdict is accurate. Caught in review by gemini-code-assist on #1595.

https://claude.ai/code/session_01GxdoXFy5ewQGEwdJ3Aj7Si

---
_Generated by [Claude Code](https://claude.ai/code/session_01GxdoXFy5ewQGEwdJ3Aj7Si)_

## Summary by Sourcery

Bug Fixes:
- Ensure the stereo probe uses BLOCKING update mode so VIO can reach TRACKING instead of getting stuck and disabling dual-lens on capable devices.