### PR TITLE
perf(design): memoize per-layer color filter + gate offscreen compositing

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
@@ -302,47 +302,67 @@ fun MainScreen(
                     }
             ) {
                 uiState.layers.filter { it.isVisible }.forEach { layer ->
-                    val isLive = layer.id == uiState.liveStrokeLayerId
-                    val bmp = if (isLive) uiState.liveStrokeBitmap ?: layer.bitmap else layer.bitmap
-                    bmp?.let { displayBmp ->
-                        val imageBitmap = if (isLive) {
-                            val version = uiState.liveStrokeVersion
-                            remember(version) { displayBmp.asImageBitmap() }
-                        } else {
-                            remember(displayBmp) { displayBmp.asImageBitmap() }
-                        }
-                        Image(
-                            bitmap = imageBitmap,
-                            contentDescription = null,
-                            colorFilter = ColorFilter.colorMatrix(
-                                createColorMatrix(
-                                    saturation = layer.saturation * modeAdj.saturation,
-                                    contrast = layer.contrast * modeAdj.contrast,
-                                    brightness = layer.brightness + modeAdj.brightness,
-                                    colorBalanceR = layer.colorBalanceR,
-                                    colorBalanceG = layer.colorBalanceG,
-                                    colorBalanceB = layer.colorBalanceB,
-                                    isInverted = layer.isInverted != modeAdj.isInverted
+                    androidx.compose.runtime.key(layer.id) {
+                        val isLive = layer.id == uiState.liveStrokeLayerId
+                        val bmp = if (isLive) uiState.liveStrokeBitmap ?: layer.bitmap else layer.bitmap
+                        bmp?.let { displayBmp ->
+                            val imageBitmap = if (isLive) {
+                                val version = uiState.liveStrokeVersion
+                                remember(version) { displayBmp.asImageBitmap() }
+                            } else {
+                                remember(displayBmp) { displayBmp.asImageBitmap() }
+                            }
+                            // Memoize the colour filter. createColorMatrix() was rebuilt on EVERY
+                            // recomposition for EVERY layer — a per-frame allocation storm that makes
+                            // the whole screen lag. Recompute only when the inputs actually change.
+                            val colorFilter = remember(
+                                layer.saturation, layer.contrast, layer.brightness,
+                                layer.colorBalanceR, layer.colorBalanceG, layer.colorBalanceB,
+                                layer.isInverted, modeAdj.saturation, modeAdj.contrast,
+                                modeAdj.brightness, modeAdj.isInverted
+                            ) {
+                                ColorFilter.colorMatrix(
+                                    createColorMatrix(
+                                        saturation = layer.saturation * modeAdj.saturation,
+                                        contrast = layer.contrast * modeAdj.contrast,
+                                        brightness = layer.brightness + modeAdj.brightness,
+                                        colorBalanceR = layer.colorBalanceR,
+                                        colorBalanceG = layer.colorBalanceG,
+                                        colorBalanceB = layer.colorBalanceB,
+                                        isInverted = layer.isInverted != modeAdj.isInverted
+                                    )
                                 )
-                            ),
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .graphicsLayer {
-                                    translationX = layer.offset.x
-                                    translationY = layer.offset.y
-                                    scaleX = layer.scale
-                                    scaleY = layer.scale
-                                    rotationX = layer.rotationX
-                                    rotationY = layer.rotationY
-                                    rotationZ = layer.rotationZ
-                                    alpha = layer.opacity
-                                    transformOrigin = TransformOrigin.Center
-                                    blendMode = layer.blendMode
-                                    compositingStrategy =
-                                        androidx.compose.ui.graphics.CompositingStrategy.Offscreen
-                                },
-                            contentScale = ContentScale.Fit
-                        )
+                            }
+                            // Offscreen compositing forces a full-screen offscreen buffer + extra pass
+                            // per layer, every frame. It's only needed to isolate a non-default blend
+                            // mode; for normal (SrcOver) layers, Auto avoids that cost.
+                            val needsOffscreen =
+                                layer.blendMode != androidx.compose.ui.graphics.BlendMode.SrcOver
+                            Image(
+                                bitmap = imageBitmap,
+                                contentDescription = null,
+                                colorFilter = colorFilter,
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .graphicsLayer {
+                                        translationX = layer.offset.x
+                                        translationY = layer.offset.y
+                                        scaleX = layer.scale
+                                        scaleY = layer.scale
+                                        rotationX = layer.rotationX
+                                        rotationY = layer.rotationY
+                                        rotationZ = layer.rotationZ
+                                        alpha = layer.opacity
+                                        transformOrigin = TransformOrigin.Center
+                                        blendMode = layer.blendMode
+                                        compositingStrategy = if (needsOffscreen)
+                                            androidx.compose.ui.graphics.CompositingStrategy.Offscreen
+                                        else
+                                            androidx.compose.ui.graphics.CompositingStrategy.Auto
+                                    },
+                                contentScale = ContentScale.Fit
+                            )
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Symptom

Opened images don't render — **even in Design mode** (no AR/camera) — and the whole app is "laggy as fuck."

## Most likely cause found

The design canvas rebuilt a `ColorMatrix` via `createColorMatrix()` + `ColorFilter.colorMatrix()` **on every recomposition, for every visible layer**, and forced an `Offscreen` compositing pass **per layer, every frame**. When the screen recomposes frequently, that's a per-frame allocation + GPU storm — it makes the whole app lag, and a frame that never settles can present as "images not rendering."

## Fix
- **Memoize** the per-layer color filter with `remember(...)` keyed on its actual inputs, so it only recomputes on change instead of every frame.
- Wrap each layer in `key(layer.id)` for stable composition identity.
- Use `Offscreen` compositing **only** when a non-default (`!= SrcOver`) blend mode needs the isolation; normal layers use `Auto` and skip the offscreen buffer.

## Honesty / what still needs confirming
Statically, the render path otherwise looks correct (opened images get a real non-null bitmap; Design uses an identity transform; layers draw over the background). I could not find a code reason images would be *fully invisible* — which is why I think the lag is choking rendering. To pin it down I need one on-device data point: **on a fresh app launch, going straight to Design (without ever entering AR), do images render?** If yes-after-AR-only, the real cause is the AR session not tearing down and I'll fix that next.

https://claude.ai/code/session_01GxdoXFy5ewQGEwdJ3Aj7Si

---
_Generated by [Claude Code](https://claude.ai/code/session_01GxdoXFy5ewQGEwdJ3Aj7Si)_