### PR TITLE
fix(ar): separate overlapping diagnostic overlays + knobs vs target dialog

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -872,9 +872,14 @@ class MainActivity : ComponentActivity() {
                                     uiState = arUiState,
                                     modifier = Modifier.align(Alignment.TopStart).padding(top = 100.dp, start = 16.dp)
                                 )
+                                // Keep the diag-log readout clear of the stats panel above (both were
+                                // pinned TopStart and overlapped into an unreadable mess). Sit it in the
+                                // empty band below the panel and above the adjustment knobs.
                                 DiagPopup(
                                     diagLog = arUiState.diagLog,
-                                    modifier = Modifier.align(Alignment.TopStart),
+                                    modifier = Modifier
+                                        .align(Alignment.BottomStart)
+                                        .padding(start = 16.dp, end = 16.dp, bottom = 220.dp),
                                     strings = strings
                                 )
                             }

--- a/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/EditorUi.kt
+++ b/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/EditorUi.kt
@@ -111,8 +111,10 @@ fun EditorUi(
                     showUndoRedo = !inMode
                 ),
                 // In a Mode the adjust knobs are the off-rail tools (opacity/saturation/…); in Design
-                // they're rail-triggered via the Adjust panel.
-                showKnobs = uiState.activePanel == EditorPanel.ADJUST || (inMode && uiState.layers.isNotEmpty()),
+                // they're rail-triggered via the Adjust panel. Hidden while capturing a target so they
+                // don't overlap the target-creation dialog.
+                showKnobs = !isCapturingTarget &&
+                    (uiState.activePanel == EditorPanel.ADJUST || (inMode && uiState.layers.isNotEmpty())),
                 showColorBalance = uiState.activePanel == EditorPanel.COLOR,
                 isLandscape = isLandscape,
                 screenHeight = screenHeight,


### PR DESCRIPTION
## What

Two UI overlap fixes, both minimal/reversible (no overlays removed or consolidated — just moved/gated):

1. **Diagnostic overlays no longer overlap.** `DiagnosticOverlay` (stats panel) and `DiagPopup` (the diag-log/`render:` readout) were both pinned to `TopStart` and stacked on top of each other, unreadable. Moved the diag-log popup to the empty band below the panel and above the knobs.

2. **Adjustment knobs no longer block the target-creation dialog.** The off-rail opacity/brightness/contrast/saturation knobs render at the bottom in AR whenever layers exist, overlapping the target-capture UI. Gated them off while `isCapturingTarget` (transient state — they return after capture).

## Why this approach
Per your call: move/gate the overlapping elements rather than consolidate or delete them — whichever change is least permanent.

https://claude.ai/code/session_01GxdoXFy5ewQGEwdJ3Aj7Si

---
_Generated by [Claude Code](https://claude.ai/code/session_01GxdoXFy5ewQGEwdJ3Aj7Si)_