### PR TITLE
fix(ar): RECTANGLE Target/Layer rail items; non-blocking camera to unstick render

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -1261,7 +1261,7 @@ class MainActivity : ComponentActivity() {
             hostId = modeId,
             text = "Layer",
             color = if (active) Cyan else navItemColor,
-            shape = AzButtonShape.NONE,
+            shape = AzButtonShape.RECTANGLE,
             onClick = { editorViewModel.onModeLayerSelected(mode) }
         )
         azRailSubItem(id = "$modeId.layer.adjust", hostId = "$modeId.layer", text = navStrings.adjust, color = navItemColor, shape = AzButtonShape.NONE) {
@@ -1921,7 +1921,7 @@ class MainActivity : ComponentActivity() {
                 azRailSubHostItem(id = "mode.ar", hostId = "host.modes", text = navStrings.arMode, route = EditorMode.AR.name, color = navItemColor, shape = AzButtonShape.NONE)
                 // Target capture — only meaningful while in AR mode.
                 if (editorUiState.editorMode == EditorMode.AR) {
-                    azRailSubItem(id = "target.create", hostId = "mode.ar", text = navStrings.grid, color = navItemColor, shape = AzButtonShape.NONE) {
+                    azRailSubItem(id = "target.create", hostId = "mode.ar", text = navStrings.grid, color = navItemColor, shape = AzButtonShape.RECTANGLE) {
                         if (hasCameraPermission) mainViewModel.startTargetCapture() else requestPermissions()
                     }
                 }

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -633,13 +633,12 @@ class ArViewModel @Inject constructor(
             val s = Session(context)
             val config = Config(s)
             config.focusMode = Config.FocusMode.AUTO
-            // BLOCKING (not LATEST_CAMERA_IMAGE): ARCore's init-time visual-feature-track depth
-            // provider requests camera images at specific past timestamps. LATEST_CAMERA_IMAGE drops
-            // intermediate frames, so on some device profiles the provider can't find them
-            // ("image_buffer.cc: Failed to find an image with the requested timestamp"), which jams
-            // VIO into permanent kNotTracking and never publishes a camera texture -> black passthrough.
-            // BLOCKING processes frames in order without dropping, so the provider finds its images.
-            config.updateMode = Config.UpdateMode.BLOCKING
+            // LATEST_CAMERA_IMAGE so session.update() never blocks the GL render thread. On this
+            // device the BLOCKING mode left the renderer stuck "Waiting for first frame" (the render
+            // heartbeat never fired) — update() hung waiting for a frame that never arrived, so the
+            // camera passthrough never drew. LATEST returns the most recent frame immediately, letting
+            // onDrawFrame tick and draw the camera even when ARCore's perception pipeline is degraded.
+            config.updateMode = Config.UpdateMode.LATEST_CAMERA_IMAGE
             // Detect walls so the overlay can anchor to the real surface at its true distance. Without
             // this, hit-tests only return sparse feature points and the overlay lands short of the wall.
             config.planeFindingMode = Config.PlaneFindingMode.HORIZONTAL_AND_VERTICAL


### PR DESCRIPTION
## What

Addresses three of the four items from the latest round:

1. **AR Target + Layer items are now `RECTANGLE`.** `target.create` and the per-mode `Layer` sub-host were `NONE`; switched to `AzButtonShape.RECTANGLE` to match the other host/sub-host items (e.g. Design ▸ Layers). (The Layer sub-host is shared across modes, so it's RECTANGLE in every mode for consistency.)

2. **Live AR session back to `UpdateMode.LATEST_CAMERA_IMAGE`.** You confirmed the AR screen stays black with the diag stuck on "Waiting for first frame" — meaning my render heartbeat never fires, i.e. the render loop produces nothing. The likely cause is `BLOCKING` `update()` hanging the GL thread waiting for a first frame that never arrives on this throttled/custom-ROM device. `LATEST` returns immediately so `onDrawFrame` keeps ticking and can draw the camera even when ARCore's perception is degraded. If it's still black after this, the heartbeat will now fire and tell us exactly why.

## Not in this PR (explained to author)
- **Expand Design host by default / auto-expand Layers on layer creation:** the AzNavRail Kotlin host-item DSL has no programmatic "expand this host" parameter — hosts only expand on tap and that state is cached inside AzNavRail. This needs a small AzNavRail API addition (a `forceExpanded`/`initiallyExpanded` flag on `azRailHostItem`/`azRailSubHostItem`, analogous to `forceHiddenMenuOpen` on reloc items).

https://claude.ai/code/session_01GxdoXFy5ewQGEwdJ3Aj7Si

---
_Generated by [Claude Code](https://claude.ai/code/session_01GxdoXFy5ewQGEwdJ3Aj7Si)_