### PR TITLE
fix(ar): probe dual-lens depth triangulation, not mere stereo tracking

### DIFF
--- a/core/data/src/main/java/com/hereliesaz/graffitixr/data/repository/SettingsRepositoryImpl.kt
+++ b/core/data/src/main/java/com/hereliesaz/graffitixr/data/repository/SettingsRepositoryImpl.kt
@@ -31,7 +31,10 @@ class SettingsRepositoryImpl @Inject constructor(
     private val MURAL_METHOD = stringPreferencesKey("mural_method")
     private val SHOW_ANCHOR_BOUNDARY = booleanPreferencesKey("show_anchor_boundary")
     private val FORCED_STEREO_UNSTABLE = booleanPreferencesKey("forced_stereo_unstable")
-    private val STEREO_CAPABILITY = intPreferencesKey("stereo_capability")
+    // Key intentionally renamed from "stereo_capability": the probe's meaning changed from "stereo
+    // tracks" to "dual lenses actually triangulate depth", so pre-existing verdicts must be discarded
+    // and re-probed under the stricter test. Reading the new key returns -1 (unprobed) on old installs.
+    private val STEREO_CAPABILITY = intPreferencesKey("depth_triangulation_capability")
     private val IS_IMPERIAL_UNITS = booleanPreferencesKey("is_imperial_units")
     private val BACKGROUND_COLOR = intPreferencesKey("background_color")
     private val COMPLETED_TUTORIALS = stringSetPreferencesKey("completed_tutorials")

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -472,8 +472,9 @@ class ArViewModel @Inject constructor(
         }
         viewModelScope.launch {
             settingsRepository.stereoCapability.collect { cap ->
-                // Only decides whether to adopt the stereo camera config; the MURAL scan mode stays
-                // available on mono either way.
+                // "Capable" now means the probe proved the dual lenses actually triangulate depth (not
+                // merely that a stereo config exists and tracks). Only decides whether to adopt the
+                // stereo camera config; the MURAL scan mode stays available on mono either way.
                 stereoCapable = when (cap) {
                     1 -> true
                     0 -> false
@@ -502,9 +503,9 @@ class ArViewModel @Inject constructor(
     // disparity fails / VIO never tracks). Persisted; once set, sessions skip the stereo config.
     @Volatile private var forcedStereoUnstable: Boolean = false
 
-    // One-time hardware-stereo probe result: null = not yet probed, true = stereo tracks (adopt
-    // dual-lens), false = stereo thrashes / never tracks (stay mono). Persisted via
-    // SettingsRepository.stereoCapability so the probe only runs once per install.
+    // One-time dual-lens depth-triangulation probe result: null = not yet probed, true = the lenses
+    // produce a real depth map (adopt the stereo config), false = no usable depth / thrashes / never
+    // tracks (stay mono). Persisted via SettingsRepository.stereoCapability so it runs once per install.
     @Volatile private var stereoCapable: Boolean? = null
     private val stereoProbeInFlight = java.util.concurrent.atomic.AtomicBoolean(false)
     // The in-flight session-state update (probe + init/resume/pause). Cancelled on the next update so
@@ -604,8 +605,8 @@ class ArViewModel @Inject constructor(
         sessionUpdateJob = viewModelScope.launch {
             sessionMutex.withLock {
                 // First-ever AR entry on an unprobed device: while the camera is still free (no live
-                // session yet), run a short throwaway stereo session on a worker thread to see whether
-                // dual-lens VIO actually tracks. Done inside the session mutex so no concurrent state
+                // session yet), run a short throwaway stereo session in an isolated process to see
+                // whether the dual lenses actually triangulate depth. Done inside the session mutex so no concurrent state
                 // update can open the live session while the probe still holds the camera. Capped at a
                 // few seconds and off the main thread, so a device whose motion-stereo thrashes can't
                 // ANR — and we only adopt stereo if it works. Cancelling this job (AR exit / pause)
@@ -665,8 +666,8 @@ class ArViewModel @Inject constructor(
             // (spherical_rectifier); on devices that list a "stereo" config but can't actually compute
             // disparity that pegs the CPU, starves VIO into kNotTracking, and ANRs the main thread with
             // a black camera. So we only select stereo when the one-time worker-thread probe has proven
-            // this device's stereo actually tracks (stereoCapable == true) and it hasn't since been
-            // marked unstable. Everything else stays on the safe mono 30 FPS back config.
+            // this device's dual lenses actually triangulate depth (stereoCapable == true) and it hasn't
+            // since been marked unstable. Everything else stays on the safe mono 30 FPS back config.
             val useStereo = stereoCapable == true && !forcedStereoUnstable
             var stereoActive = false
             if (useStereo) {
@@ -720,12 +721,13 @@ class ArViewModel @Inject constructor(
     }
 
     /**
-     * One-time hardware-stereo capability probe. Runs a short throwaway ARCore session configured for
-     * forced hardware stereo on a worker thread (its own offscreen EGL context), pumps [Session.update]
-     * for a few seconds and adopts dual-lens only if VIO reaches TRACKING. A device whose motion-stereo
-     * is broken never tracks (and thrashes), so we cap the probe and treat any failure as "mono". The
-     * result is cached in settings so this only runs once per install. Must be called while no live
-     * session holds the camera.
+     * One-time dual-lens depth-triangulation probe. Runs a short throwaway ARCore session configured
+     * for forced hardware stereo with the Depth API enabled, in an isolated ":probe" process, and
+     * adopts dual-lens only if it both reaches TRACKING and hands back a populated depth image — proof
+     * the two lenses actually triangulate depth. A device that merely lists a stereo config but can't
+     * compute disparity returns an empty depth map (or thrashes and never tracks), so we cap the probe
+     * and treat any failure as "mono". The result is cached in settings so this only runs once per
+     * install. Must be called while no live session holds the camera.
      */
     private suspend fun probeStereoCapability(context: Context) {
         if (stereoCapable != null) return
@@ -734,14 +736,14 @@ class ArViewModel @Inject constructor(
             val capable = runProbeViaService(context)
             stereoCapable = capable
             settingsRepository.setStereoCapability(if (capable) 1 else 0)
-            Timber.i("ARDIAG stereo probe complete: capable=$capable")
+            Timber.i("ARDIAG depth-triangulation probe complete: capable=$capable")
         } catch (e: Exception) {
             // A cancelled probe (AR exit / pause) must NOT be cached as a permanent mono verdict —
             // let cancellation propagate so the device stays "unprobed" and re-probes next entry.
             if (e is kotlinx.coroutines.CancellationException) throw e
             stereoCapable = false
             settingsRepository.setStereoCapability(0)
-            Timber.w(e, "ARDIAG stereo probe threw -> treating device as mono")
+            Timber.w(e, "ARDIAG depth-triangulation probe threw -> treating device as mono")
         } finally {
             stereoProbeInFlight.set(false)
         }

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -1007,6 +1007,7 @@ class ArViewModel @Inject constructor(
         // `renderer`, resurrecting a reference to an already-destroyed renderer.
         renderer = r
         renderer?.stereoProvider = stereoProvider
+        renderer?.onCameraNotFeeding = { onCameraNotFeeding() }
         renderer?.attachSession(session)
         loadCloudPointsIfExists()
     }
@@ -1102,6 +1103,23 @@ class ArViewModel @Inject constructor(
         }
     }
 
+    /**
+     * The render watchdog reports ARCore is getting no camera frames — either update() stalled on the
+     * GL thread or the camera timestamp stayed 0 for seconds. The only non-default camera config we
+     * ever force is hardware-stereo, and on a device wrongly classified depth-capable that config can
+     * fail to stream. Because update() stalls *before* any tracking callback fires, the callback-driven
+     * detector in onTrackingUpdated (recoverFromBrokenStereo) can never run for this case. This hook is
+     * driven from the side watchdog thread — alive while the GL thread is blocked — so it can still
+     * self-heal: reconfigure the LIVE session to mono. No-op when we're already on mono (then the black
+     * camera is some other fault and must not be mis-blamed on stereo) or when recovery already ran.
+     */
+    private fun onCameraNotFeeding() {
+        if (forcedStereoUnstable) return
+        if (!_uiState.value.isHardwareStereoActive) return
+        Timber.w("ARDIAG dual-lens: camera not feeding ARCore under forced stereo -> self-heal to mono")
+        recoverFromBrokenStereo()
+    }
+
     private val stereoRecoveryInFlight = java.util.concurrent.atomic.AtomicBoolean(false)
 
     /**
@@ -1128,6 +1146,9 @@ class ArViewModel @Inject constructor(
                     })
                     if (monoConfigs.isNotEmpty()) s.cameraConfig = monoConfigs[0]
                     _uiState.update { it.copy(isDualLensActive = false, isHardwareStereoActive = false) }
+                    // Re-arm the streaming verdict so the mono config earns a fresh CAMERA STREAMING /
+                    // STALL readout (and the self-heal hook doesn't stay latched from the stereo run).
+                    renderer?.resetCameraStreamWatchdog()
                     Timber.w("ARDIAG dual-lens: forced stereo broken -> reconfigured LIVE session to mono")
                 } catch (e: Exception) {
                     Timber.e(e, "ARDIAG stereo->mono live reconfigure failed")

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/StereoProbeService.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/StereoProbeService.kt
@@ -136,8 +136,10 @@ class StereoProbeService : Service() {
                     Timber.w(e, "ARDIAG depth-triangulation probe: update() failed")
                     return false
                 }
+                // No Thread.sleep here: UpdateMode.BLOCKING already paces update() to the camera frame
+                // rate, so the loop runs at full ~30fps. An explicit sleep would halve that and shrink
+                // the depth-convergence budget inside the timeout.
                 if (frame.camera.trackingState != TrackingState.TRACKING) {
-                    Thread.sleep(33)
                     continue
                 }
                 reachedTracking = true
@@ -155,7 +157,6 @@ class StereoProbeService : Service() {
                 } catch (e: Exception) {
                     Timber.w(e, "ARDIAG depth-triangulation probe: depth acquire failed")
                 }
-                Thread.sleep(33)
             }
             Timber.i(
                 "ARDIAG depth-triangulation probe: tracking=$reachedTracking but no valid depth map " +

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/StereoProbeService.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/StereoProbeService.kt
@@ -14,6 +14,8 @@ import com.google.ar.core.CameraConfigFilter
 import com.google.ar.core.Config
 import com.google.ar.core.Session
 import com.google.ar.core.TrackingState
+import com.google.ar.core.exceptions.NotYetAvailableException
+import com.hereliesaz.graffitixr.feature.ar.eval.DepthLookup
 import timber.log.Timber
 import java.util.EnumSet
 
@@ -25,16 +27,27 @@ import java.util.EnumSet
  * here can never ANR the app — at worst Android kills this process and the client falls back to mono.
  *
  * Protocol: bind, then send [MSG_RUN_PROBE] with `replyTo` set. The service runs a short forced-stereo
- * session on a worker thread and replies with [MSG_RESULT] whose `arg1` is 1 (stereo tracks) or 0
- * (it doesn't / setup failed).
+ * session on a worker thread and replies with [MSG_RESULT] whose `arg1` is 1 (the dual lenses actually
+ * triangulate depth) or 0 (they don't / setup failed).
+ *
+ * The verdict deliberately tests *depth triangulation*, not just dual-lens presence or tracking: a
+ * device can expose a hardware-stereo camera config and even reach VIO TRACKING while its two lenses
+ * never produce a usable depth map. Adopting stereo on such a device buys nothing (and historically
+ * pegged the CPU into an ANR). So we only call a device stereo-capable once it has handed us a real,
+ * populated depth image with the Depth API enabled under the forced-stereo config.
  */
 class StereoProbeService : Service() {
 
     companion object {
         const val MSG_RUN_PROBE = 1
         const val MSG_RESULT = 2
-        /** How long to wait for VIO to reach TRACKING before declaring the device stereo-incapable. */
-        const val PROBE_TIMEOUT_MS = 3_000L
+        /**
+         * Total window to reach TRACKING *and* hand back a valid depth image. Depth needs a second or
+         * two to converge after tracking starts, so this is larger than a tracking-only probe.
+         */
+        const val PROBE_TIMEOUT_MS = 6_000L
+        /** Fraction of a sampled grid that must carry valid metric depth to count as triangulation. */
+        private const val MIN_VALID_DEPTH_FRACTION = 0.25f
     }
 
     private lateinit var worker: HandlerThread
@@ -71,19 +84,31 @@ class StereoProbeService : Service() {
         super.onDestroy()
     }
 
-    /** Blocking probe. Returns true iff a forced-stereo session reaches TRACKING within the timeout. */
+    /**
+     * Blocking probe. Returns true iff a forced-stereo session both reaches TRACKING *and* produces a
+     * populated depth image within the timeout — i.e. the dual lenses actually triangulate depth.
+     * Tracking alone is the weak signal we used to trust; it let through devices that list a stereo
+     * config but never compute disparity.
+     */
     private fun runStereoProbe(): Boolean {
         var egl: ProbeEgl? = null
         var probe: Session? = null
         try {
             probe = Session(this)
+            // No Depth API support means there is no depth to triangulate from the lenses, period.
+            if (!probe.isDepthModeSupported(Config.DepthMode.AUTOMATIC)) {
+                Timber.i("ARDIAG depth-triangulation probe: Depth API unsupported -> incapable")
+                return false
+            }
             val cfg = Config(probe).apply {
                 focusMode = Config.FocusMode.AUTO
                 // BLOCKING, matching the live session: LATEST_CAMERA_IMAGE drops frames the init-time
                 // depth provider needs, which jams VIO into kNotTracking. With it, the probe would
-                // never reach TRACKING and would falsely classify every device as stereo-incapable.
+                // never reach TRACKING and would falsely classify every device as incapable.
                 updateMode = Config.UpdateMode.BLOCKING
-                depthMode = Config.DepthMode.DISABLED
+                // Enable depth: this is the capability under test. The probe lives in a throwaway
+                // ":probe" process, so even if AUTOMATIC depth thrashes here it can't starve the UI.
+                depthMode = Config.DepthMode.AUTOMATIC
                 planeFindingMode = Config.PlaneFindingMode.DISABLED
             }
             probe.configure(cfg)
@@ -92,7 +117,7 @@ class StereoProbeService : Service() {
                 stereoCameraUsage = EnumSet.of(CameraConfig.StereoCameraUsage.REQUIRE_AND_USE)
             })
             if (stereoConfigs.isEmpty()) {
-                Timber.i("ARDIAG stereo probe: device exposes no hardware-stereo config")
+                Timber.i("ARDIAG depth-triangulation probe: no hardware-stereo config -> incapable")
                 return false
             }
             probe.cameraConfig = stereoConfigs[0]
@@ -103,29 +128,73 @@ class StereoProbeService : Service() {
 
             // Monotonic clock: a wall-clock jump (NTP sync) must not extend or truncate the window.
             val deadline = android.os.SystemClock.elapsedRealtime() + PROBE_TIMEOUT_MS
+            var reachedTracking = false
             while (android.os.SystemClock.elapsedRealtime() < deadline) {
                 val frame = try {
                     probe.update()
                 } catch (e: Exception) {
-                    Timber.w(e, "ARDIAG stereo probe: update() failed")
+                    Timber.w(e, "ARDIAG depth-triangulation probe: update() failed")
                     return false
                 }
-                if (frame.camera.trackingState == TrackingState.TRACKING) {
-                    Timber.i("ARDIAG stereo probe: TRACKING -> device is stereo-capable")
-                    return true
+                if (frame.camera.trackingState != TrackingState.TRACKING) {
+                    Thread.sleep(33)
+                    continue
+                }
+                reachedTracking = true
+                // Tracking is reached; now demand a real depth map. acquireDepthImage16Bits throws
+                // NotYetAvailableException until depth has converged, so keep pumping until then.
+                try {
+                    frame.acquireDepthImage16Bits().use { depth ->
+                        if (depthMapHasValidTriangulation(depth)) {
+                            Timber.i("ARDIAG depth-triangulation probe: valid depth map -> capable")
+                            return true
+                        }
+                    }
+                } catch (e: NotYetAvailableException) {
+                    // Depth not converged yet — keep going until the deadline.
+                } catch (e: Exception) {
+                    Timber.w(e, "ARDIAG depth-triangulation probe: depth acquire failed")
                 }
                 Thread.sleep(33)
             }
-            Timber.i("ARDIAG stereo probe: never reached TRACKING -> stereo-incapable")
+            Timber.i(
+                "ARDIAG depth-triangulation probe: tracking=$reachedTracking but no valid depth map " +
+                    "within ${PROBE_TIMEOUT_MS}ms -> incapable"
+            )
             return false
         } catch (e: Exception) {
-            Timber.w(e, "ARDIAG stereo probe: setup failed -> stereo-incapable")
+            Timber.w(e, "ARDIAG depth-triangulation probe: setup failed -> incapable")
             return false
         } finally {
             try { probe?.pause() } catch (_: Exception) {}
             try { probe?.close() } catch (_: Exception) {}
             egl?.release()
         }
+    }
+
+    /**
+     * True if [depth] carries enough valid metric samples to count as real dual-lens triangulation. A
+     * device that lists a stereo config but can't compute disparity hands back an empty/all-zero map,
+     * so we sample an 11x11 grid across the frame and require at least [MIN_VALID_DEPTH_FRACTION] of
+     * the cells to read back a plausible distance (the per-cell patch median rejects stray pixels).
+     */
+    private fun depthMapHasValidTriangulation(depth: android.media.Image): Boolean {
+        val plane = depth.planes.firstOrNull() ?: return false
+        val w = depth.width
+        val h = depth.height
+        if (w <= 0 || h <= 0) return false
+        val grid = 11
+        var valid = 0
+        for (gy in 0 until grid) {
+            for (gx in 0 until grid) {
+                val u = (gx + 0.5f) / grid
+                val v = (gy + 0.5f) / grid
+                if (DepthLookup.depthMetersAtPatch(plane.buffer, plane.rowStride, w, h, u, v, radius = 1) > 0f) {
+                    valid++
+                }
+            }
+        }
+        return valid >= grid * grid * MIN_VALID_DEPTH_FRACTION
     }
 
     /** Minimal offscreen EGL context (1x1 pbuffer) with one GL_TEXTURE_EXTERNAL_OES texture, so the

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -150,6 +150,11 @@ class ArRenderer(
     @Volatile private var lastTickMs = 0L
     @Volatile private var lastStep = "init"
     @Volatile private var stallReported = false
+    // Self-heal hook. Fired at most once (off the GL thread) the moment ARCore stops receiving camera
+    // frames — i.e. the live session's camera config isn't streaming. Lets the ViewModel reconfigure to
+    // a mono config even while the GL thread is blocked in update() and no tracking callback can fire.
+    @Volatile private var cameraNotFeedingReported = false
+    var onCameraNotFeeding: (() -> Unit)? = null
     private var watchdog: Thread? = null
     private var sensorOrientation = 90
     private var isSurfaceCreated = false
@@ -183,6 +188,7 @@ class ArRenderer(
                 // Reset so the per-frame startup heartbeat fires on every (re)attach/resume, not just
                 // the first session — resume is a common spot for camera/GL init stalls.
                 frameCount = 0
+                resetCameraStreamWatchdog()
                 displayRotationHelper.onResume()
                 if (isSurfaceCreated) {
                     session.setCameraTextureName(backgroundRenderer.textureId)
@@ -296,9 +302,29 @@ class ArRenderer(
                 if (age > 2500 && !stallReported && !camStreamReported) {
                     stallReported = true
                     onDiag("RENDER STALLED f=$frameCount step=$lastStep for ${age}ms -> camera not feeding ARCore")
+                    reportCameraNotFeeding()
                 }
             }
         }.apply { isDaemon = true; name = "ArStallWatchdog"; start() }
+    }
+
+    /** Fire the camera-not-feeding self-heal hook at most once. Called from the side watchdog thread
+     *  (GL thread blocked in update()) or the draw thread's "no frame after Nf" check — both mean the
+     *  selected camera config isn't streaming into ARCore. */
+    private fun reportCameraNotFeeding() {
+        if (cameraNotFeedingReported) return
+        cameraNotFeedingReported = true
+        onCameraNotFeeding?.invoke()
+    }
+
+    /** Clears the camera-streaming/stall verdict so a freshly attached or reconfigured session earns a
+     *  fresh on-screen verdict and the self-heal hook re-arms for the new camera config. */
+    fun resetCameraStreamWatchdog() {
+        camStreamReported = false
+        camStallWarned = false
+        stallReported = false
+        cameraNotFeedingReported = false
+        lastTickMs = android.os.SystemClock.elapsedRealtime()
     }
 
     override fun onSurfaceChanged(gl: GL10?, width: Int, height: Int) {
@@ -360,6 +386,7 @@ class ArRenderer(
                 // feeding ARCore (resume() succeeded but no frames) — distinct from a slow converge.
                 camStallWarned = true
                 onDiag("CAMERA STALL: no frame after ${frameCount}f (ts still 0) -> camera not streaming")
+                reportCameraNotFeeding()
             }
             // During the AMBIENT scan, the camera background renders as a newspaper halftone with full
             // colour bleeding in (like ink) as each yaw sector is mapped — the world-mapping indicator.


### PR DESCRIPTION
## Problem

The hardware-stereo probe declared a device **dual-lens capable as soon as a forced-stereo session reached VIO `TRACKING`**. That is exactly the weak signal the camera-config selection comments already warn about: a device can expose a hardware-stereo camera config and even track while its two lenses never compute disparity. We'd then adopt the stereo config for nothing — and historically that pegged the CPU into a black-camera ANR.

We don't actually want "has a dual-lens config." We want "the dual lenses can **triangulate depth**."

## Change

- **`StereoProbeService` now verifies depth triangulation, not tracking.** It enables the Depth API (`DepthMode.AUTOMATIC`) under the forced-stereo config and only returns *capable* once the session both reaches `TRACKING` **and** hands back a populated depth image — a sampled 11×11 grid with at least 25% of cells carrying a plausible metric distance (per-cell patch median rejects stray pixels). A device that lists a stereo config but can't compute disparity returns an empty/all-zero depth map and is correctly classified as mono.
  - The probe still runs in the isolated `:probe` process, so enabling `AUTOMATIC` depth there cannot starve the UI process even if it thrashes.
  - Bumped `PROBE_TIMEOUT_MS` 3s → 6s so depth has time to converge after tracking starts.
  - Reuses the existing `DepthLookup.depthMetersAtPatch` DEPTH16 parser (same convention as `ArRenderer`).
- **Stale verdicts are invalidated** by renaming the persisted DataStore key (`stereo_capability` → `depth_triangulation_capability`). Installs cached under the old "stereo tracks" test read back as unprobed and re-run the stricter test once.
- Updated the surrounding comments/log strings in `ArViewModel` so the cached flag and camera-config gate read as the depth-triangulation capability they now represent. The mono/MURAL paths are unchanged.

## Verification

No Android SDK is available in this environment, so this was verified by review rather than a compile. The depth-image parsing reuses the same `DepthLookup` helper already used by the working renderer path. Worth a real device run to confirm the 25% / 6s thresholds classify correctly.

https://claude.ai/code/session_01GxdoXFy5ewQGEwdJ3Aj7Si

---
_Generated by [Claude Code](https://claude.ai/code/session_01GxdoXFy5ewQGEwdJ3Aj7Si)_

## Summary by Sourcery

Tighten the AR stereo capability probe to require actual dual‑lens depth triangulation rather than mere tracking, and invalidate old cached results accordingly.

New Features:
- Detect dual‑lens capability by verifying that the Depth API produces a populated depth map under the forced stereo configuration.

Enhancements:
- Extend the stereo probe timeout and use a sampled depth‑map grid to decide whether depth triangulation is reliable.
- Clarify AR logging and comments so the cached capability flag is explicitly defined in terms of depth triangulation instead of tracking.
- Rename the stored stereo capability preference key so existing installs are re‑probed under the stricter depth‑based test.