### PR TITLE
perf(ar): adaptive idle frame-rate to cut battery without perceptible loss

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -362,14 +362,22 @@ class MainActivity : ComponentActivity() {
                     }
                 }
 
-                LaunchedEffect(mainUiState.isTouchLocked) {
+                LaunchedEffect(mainUiState.isTouchLocked, editorUiState.editorMode, arUiState.batteryTier) {
+                    val params = window.attributes
                     if (mainUiState.isTouchLocked) {
-                        val params = window.attributes
-                        params.screenBrightness = 1.0f
+                        // Keep the screen on in every mode while locked, but force MAX brightness only
+                        // where it's functionally needed — the TRACE lightbox. Other modes keep system
+                        // brightness (AR touch-lock at max brightness was pure waste). Even in TRACE,
+                        // cap brightness once battery is low.
+                        params.screenBrightness = when {
+                            editorUiState.editorMode != EditorMode.TRACE ->
+                                WindowManager.LayoutParams.BRIGHTNESS_OVERRIDE_NONE
+                            arUiState.batteryTier >= 2 -> 0.85f
+                            else -> 1.0f
+                        }
                         window.attributes = params
                         window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
                     } else {
-                        val params = window.attributes
                         params.screenBrightness = WindowManager.LayoutParams.BRIGHTNESS_OVERRIDE_NONE
                         window.attributes = params
                         window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
@@ -1180,6 +1188,8 @@ class MainActivity : ComponentActivity() {
                                     onThrottleOnLowBatteryChanged = { arViewModel.setThrottleOnLowBattery(it) },
                                     throttleOnLag = arUiState.throttleOnLag,
                                     onThrottleOnLagChanged = { arViewModel.setThrottleOnLag(it) },
+                                    adaptiveRateEnabled = arUiState.adaptiveRateEnabled,
+                                    onAdaptiveRateEnabledChanged = { arViewModel.setAdaptiveRateEnabled(it) },
                                     arScanMode = arUiState.arScanMode,
                                     onArScanModeChanged = { arViewModel.setArScanMode(it) },
                                     showAnchorBoundary = arUiState.showAnchorBoundary,

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
@@ -246,6 +246,12 @@ fun MainScreen(
                                 // trigger's enable flag (evaluated renderer-side).
                                 r.systemThrottle = arUiState.perceptionSystemThrottle
                                 r.lagThrottleEnabled = arUiState.throttleOnLag
+                                // Adaptive idle rate: policy ceilings from the VM + the live
+                                // interaction flag (so a gesture instantly forces full rate).
+                                r.adaptiveRateEnabled = arUiState.adaptiveRateEnabled
+                                r.idleRateCeilingFps = arUiState.idleRateCeilingFps
+                                r.activeRateCeilingFps = arUiState.activeRateCeilingFps
+                                r.gestureInProgress = uiState.gestureInProgress
                             }
                         },
                         onRelease = { view ->

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/UiState.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/UiState.kt
@@ -116,6 +116,18 @@ data class ArUiState(
     val throttleOnLag: Boolean = true,
     /** Derived: any enabled thermal/power-save/low-battery trigger is currently active. */
     val perceptionSystemThrottle: Boolean = false,
+    /**
+     * Master toggle for the adaptive AR frame-rate coach. When on (default), the renderer gates the
+     * heavy native SLAM/VIO work while the projection is locked and the phone is held still, snapping
+     * back to full rate instantly on motion — a still scene looks identical, so it's imperceptible.
+     */
+    val adaptiveRateEnabled: Boolean = true,
+    /** Heavy-work cadence (fps) while idle. Tightened under battery/thermal pressure. */
+    val idleRateCeilingFps: Int = 12,
+    /** Heavy-work cadence cap (fps) while active; 0 = uncapped. Set >0 only under battery pressure. */
+    val activeRateCeilingFps: Int = 0,
+    /** Battery pressure tier: 0 = normal, 1 = medium (≤30%), 2 = low (≤15%). Drives degradation. */
+    val batteryTier: Int = 0,
 
     // Teleological SLAM — fraction [0,1] of locked artwork guide features currently visible
     // on the wall.  0 until addLayerFeaturesToSLAM has been called (layers locked as guide).

--- a/core/data/src/main/java/com/hereliesaz/graffitixr/data/repository/SettingsRepositoryImpl.kt
+++ b/core/data/src/main/java/com/hereliesaz/graffitixr/data/repository/SettingsRepositoryImpl.kt
@@ -44,6 +44,7 @@ class SettingsRepositoryImpl @Inject constructor(
     private val THROTTLE_ON_POWER_SAVE = booleanPreferencesKey("throttle_on_power_save")
     private val THROTTLE_ON_LOW_BATTERY = booleanPreferencesKey("throttle_on_low_battery")
     private val THROTTLE_ON_LAG = booleanPreferencesKey("throttle_on_lag")
+    private val ADAPTIVE_RATE_ENABLED = booleanPreferencesKey("adaptive_rate_enabled")
     private val COMPLETED_TUTORIALS = stringSetPreferencesKey("completed_tutorials")
 
     override val language: Flow<AppLanguage> = context.dataStore.data
@@ -195,6 +196,11 @@ class SettingsRepositoryImpl @Inject constructor(
     override val throttleOnLag: Flow<Boolean> = throttleFlow(THROTTLE_ON_LAG)
     override suspend fun setThrottleOnLag(on: Boolean) {
         context.dataStore.edit { it[THROTTLE_ON_LAG] = on }
+    }
+
+    override val adaptiveRateEnabled: Flow<Boolean> = throttleFlow(ADAPTIVE_RATE_ENABLED)
+    override suspend fun setAdaptiveRateEnabled(on: Boolean) {
+        context.dataStore.edit { it[ADAPTIVE_RATE_ENABLED] = on }
     }
 
     override val completedTutorials: Flow<Set<String>> = context.dataStore.data

--- a/core/domain/src/main/java/com/hereliesaz/graffitixr/domain/repository/SettingsRepository.kt
+++ b/core/domain/src/main/java/com/hereliesaz/graffitixr/domain/repository/SettingsRepository.kt
@@ -93,6 +93,13 @@ interface SettingsRepository {
     val throttleOnLag: Flow<Boolean>
     suspend fun setThrottleOnLag(on: Boolean)
 
+    /**
+     * Master toggle for the adaptive AR frame-rate coach (gates heavy SLAM work while idle, plus the
+     * battery-tier degradation). Default on. Off = always full rate (more drain, no behaviour change).
+     */
+    val adaptiveRateEnabled: Flow<Boolean>
+    suspend fun setAdaptiveRateEnabled(on: Boolean)
+
     /** Set of tutorial keys the user has completed. Keys: "tut_ar", "tut_overlay", "tut_mockup", "tut_trace", "tut_design", "tut_project". */
     val completedTutorials: Flow<Set<String>>
 

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -508,6 +508,12 @@ class ArViewModel @Inject constructor(
             }
         }
         viewModelScope.launch {
+            // Master adaptive-rate toggle; the renderer reads it to enable/disable idle gating.
+            settingsRepository.adaptiveRateEnabled.collect { on ->
+                _uiState.update { it.copy(adaptiveRateEnabled = on) }
+            }
+        }
+        viewModelScope.launch {
             settingsRepository.forcedStereoUnstable.collect { unstable ->
                 // Only controls whether to use the stereo *camera config* next session — does not
                 // disable the MURAL scan mode (which works on mono).
@@ -608,6 +614,10 @@ class ArViewModel @Inject constructor(
 
     fun setThrottleOnLag(on: Boolean) {
         viewModelScope.launch { settingsRepository.setThrottleOnLag(on) }
+    }
+
+    fun setAdaptiveRateEnabled(on: Boolean) {
+        viewModelScope.launch { settingsRepository.setAdaptiveRateEnabled(on) }
     }
 
     fun setImperialUnits(imperial: Boolean) {
@@ -857,7 +867,14 @@ class ArViewModel @Inject constructor(
                 // (Matching cameraId keeps us on the camera/stream ARCore already validated; we don't
                 // also match resolution because CameraConfig doesn't expose it in this ARCore version.)
                 // If no same-cameraId fps variant exists, we leave the default untouched.
-                val targetFps = if (_uiState.value.cameraTargetFps == 60)
+                // Under battery pressure (tier ≥ medium) cap the camera to 30fps even if 60 was
+                // chosen. Done here at session build only — a mid-session CameraConfig swap resets
+                // tracking, which would be perceptible; the seamless mid-session levers are the
+                // render/SLAM rate ceilings instead.
+                val effectiveCameraFps =
+                    if (_uiState.value.adaptiveRateEnabled && _uiState.value.batteryTier >= 1) 30
+                    else _uiState.value.cameraTargetFps
+                val targetFps = if (effectiveCameraFps == 60)
                     CameraConfig.TargetFps.TARGET_FPS_60 else CameraConfig.TargetFps.TARGET_FPS_30
                 val defaultCfg = s.cameraConfig
                 val fpsConfig = try {
@@ -1749,19 +1766,51 @@ class ArViewModel @Inject constructor(
     private val powerManager by lazy {
         appContext.getSystemService(Context.POWER_SERVICE) as? android.os.PowerManager
     }
+    private val batteryManager by lazy {
+        appContext.getSystemService(Context.BATTERY_SERVICE) as? android.os.BatteryManager
+    }
     private var thermalListener: android.os.PowerManager.OnThermalStatusChangedListener? = null
     private var powerReceiver: android.content.BroadcastReceiver? = null
     @Volatile private var thermalHot = false
     @Volatile private var batteryLow = false
+    /** Live battery level [0..100], or -1 when unknown. Sampled from ACTION_BATTERY_CHANGED. */
+    @Volatile private var batteryPct = -1
+    /** Battery-level thresholds (%) for the medium / low degradation tiers. */
+    private val BATTERY_TIER_MED = 30
+    private val BATTERY_TIER_LOW = 15
 
+    /**
+     * Folds device-stress signals into the AR rate policy. The coarse perception floor
+     * (perceptionSystemThrottle) is unchanged; the battery *level* additionally degrades the
+     * adaptive-rate ceilings in tiers, and at the low tier also forces the perception floor and a
+     * 30fps-capped camera on the next AR entry. All gated by the existing throttleOnLowBattery toggle.
+     */
     private fun recomputeSystemThrottle() {
         val saver = powerManager?.isPowerSaveMode == true
         val s = _uiState.value
+        val tier = when {
+            !s.throttleOnLowBattery || batteryPct !in 0..100 -> 0
+            batteryPct <= BATTERY_TIER_LOW -> 2
+            batteryPct <= BATTERY_TIER_MED -> 1
+            else -> 0
+        }
         val throttle = (s.throttleOnThermal && thermalHot) ||
             (s.throttleOnPowerSave && saver) ||
-            (s.throttleOnLowBattery && batteryLow)
-        if (s.perceptionSystemThrottle != throttle) {
-            _uiState.update { it.copy(perceptionSystemThrottle = throttle) }
+            (s.throttleOnLowBattery && batteryLow) ||
+            tier >= 2
+        val idleCeiling = when (tier) { 2 -> 8; 1 -> 10; else -> 12 }
+        val activeCeiling = when (tier) { 2 -> 24; 1 -> 30; else -> 0 }
+        if (s.perceptionSystemThrottle != throttle || s.batteryTier != tier ||
+            s.idleRateCeilingFps != idleCeiling || s.activeRateCeilingFps != activeCeiling
+        ) {
+            _uiState.update {
+                it.copy(
+                    perceptionSystemThrottle = throttle,
+                    batteryTier = tier,
+                    idleRateCeilingFps = idleCeiling,
+                    activeRateCeilingFps = activeCeiling,
+                )
+            }
         }
     }
 
@@ -1783,6 +1832,10 @@ class ArViewModel @Inject constructor(
                 when (intent?.action) {
                     android.content.Intent.ACTION_BATTERY_LOW -> batteryLow = true
                     android.content.Intent.ACTION_BATTERY_OKAY -> batteryLow = false
+                    android.content.Intent.ACTION_BATTERY_CHANGED ->
+                        batteryPct = batteryManager
+                            ?.getIntProperty(android.os.BatteryManager.BATTERY_PROPERTY_CAPACITY)
+                            ?.takeIf { it in 0..100 } ?: batteryPct
                 }
                 recomputeSystemThrottle()
             }
@@ -1790,6 +1843,7 @@ class ArViewModel @Inject constructor(
         val filter = android.content.IntentFilter().apply {
             addAction(android.content.Intent.ACTION_BATTERY_LOW)
             addAction(android.content.Intent.ACTION_BATTERY_OKAY)
+            addAction(android.content.Intent.ACTION_BATTERY_CHANGED)
             addAction(android.os.PowerManager.ACTION_POWER_SAVE_MODE_CHANGED)
         }
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -170,6 +170,25 @@ class ArRenderer(
     private var lastPerceptionSplatCount = -1
     private var perceptionRefreshAvgMs = 0f
 
+    // --- Adaptive idle rate (pushed from ArViewModel via MainScreen) -----------------------------
+    // When the projection is locked and the phone is held still, the heavy native SLAM/VIO map
+    // integration is gated to idleRateCeilingFps; it snaps back to full rate instantly on motion or
+    // interaction. session.update() and the cheap camera+overlay draw keep running every vsync, so
+    // tracking stays healthy and a static scene looks identical — the saving is the gated SLAM work.
+    @Volatile var adaptiveRateEnabled: Boolean = true
+    @Volatile var idleRateCeilingFps: Int = 12
+    @Volatile var activeRateCeilingFps: Int = 0   // 0 = uncapped
+    @Volatile var gestureInProgress: Boolean = false
+    /** True while the pipeline is in the gated idle state. Read-only for callers (e.g. DualAnalyzer). */
+    @Volatile var isIdle: Boolean = false
+        private set
+    // GL-thread-only idle bookkeeping.
+    private val idlePose = FloatArray(16)
+    private var haveIdlePose = false
+    private var noMotionSinceMs = 0L
+    private var resumeHoldUntilMs = 0L
+    private var lastHeavyWorkMs = 0L
+
     private val anchorOrchestrator = AnchorOrchestrator()
     private val poseFusion = com.hereliesaz.graffitixr.feature.ar.anchor.PoseFusion()
     // A/B switch for the Sub-project A harness: when false, reproduce the old pre/post-anchor toggle.
@@ -529,6 +548,54 @@ class ArRenderer(
         return maxDelta > PERCEPTION_POSE_EPSILON
     }
 
+    /** True when the camera pose moved past the (coarser) idle threshold since the last heavy frame. */
+    private fun idlePoseChanged(view: FloatArray): Boolean {
+        var maxDelta = 0f
+        for (i in 0 until 16) {
+            val d = kotlin.math.abs(view[i] - idlePose[i])
+            if (d > maxDelta) maxDelta = d
+        }
+        return maxDelta > IDLE_POSE_EPSILON
+    }
+
+    /**
+     * Decides whether to run the heavy native SLAM/VIO work this frame, updating [isIdle]. Returns
+     * true on a full (heavy) frame; false on a gated idle frame. The phone is "idle" only when the
+     * anchor is established, no scan/capture/realign/gesture is active, tracking is healthy, and the
+     * pose has been still past the enter-debounce. Exit from idle is instant (first motion frame),
+     * with a brief full-rate hold so it can't oscillate at the threshold. While idle, heavy work runs
+     * at [idleRateCeilingFps]; while active it's uncapped unless [activeRateCeilingFps] > 0.
+     */
+    private fun shouldRunHeavyThisFrame(view: FloatArray, tracking: Boolean): Boolean {
+        val now = android.os.SystemClock.elapsedRealtime()
+        val active = !anchorEstablished || captureRequested || isCapturingTarget ||
+            isInPlaneRealignment || scanPhase == ScanPhase.AMBIENT || gestureInProgress || !tracking
+        val moved = !haveIdlePose || idlePoseChanged(view)
+        if (active || moved) {
+            isIdle = false
+            resumeHoldUntilMs = now + RESUME_HOLD_MS
+            noMotionSinceMs = 0L
+        } else if (now >= resumeHoldUntilMs) {
+            if (noMotionSinceMs == 0L) noMotionSinceMs = now
+            if (now - noMotionSinceMs >= IDLE_ENTER_DEBOUNCE_MS) isIdle = true
+        }
+        val targetFps = when {
+            !adaptiveRateEnabled -> 0   // master off → always full rate (no idle or battery capping)
+            isIdle -> idleRateCeilingFps.coerceAtLeast(1)
+            activeRateCeilingFps > 0 -> activeRateCeilingFps
+            else -> 0
+        }
+        val heavy = targetFps <= 0 || (now - lastHeavyWorkMs) >= (1000L / targetFps)
+        if (heavy) {
+            lastHeavyWorkMs = now
+            // Re-baseline the idle pose only on heavy frames, so slow drift accumulates across gated
+            // frames and eventually trips idlePoseChanged() rather than being silently tracked away.
+            System.arraycopy(view, 0, idlePose, 0, 16)
+            haveIdlePose = true
+        }
+        return heavy
+    }
+
     override fun onDrawFrame(gl: GL10?) {
         GLES30.glClear(GLES30.GL_COLOR_BUFFER_BIT or GLES30.GL_DEPTH_BUFFER_BIT)
         // Mode-exit was requested: stop driving ARCore so teardown is effectively
@@ -724,15 +791,21 @@ class ArRenderer(
             mappingProjMatrix[15] = 0.0f
 
             lastStep = "slamCamera"
-            slamManager.updateCamera(viewMatrix, projMatrix, mappingViewMatrix, mappingProjMatrix, frame.timestamp)
+            val isTracking = camera.trackingState == TrackingState.TRACKING
+            // Adaptive idle gating: skip the heavy native SLAM/VIO map integration on gated idle
+            // frames (projection locked + phone still). session.update() above still ran, so ARCore's
+            // pose keeps advancing and the first heavy frame after resume re-feeds a correct pose.
+            // The not-tracking case is never gated (shouldRunHeavyThisFrame forces active), so a
+            // relocalization always re-feeds SLAM immediately.
+            if (shouldRunHeavyThisFrame(viewMatrix, isTracking)) {
+                slamManager.updateCamera(viewMatrix, projMatrix, mappingViewMatrix, mappingProjMatrix, frame.timestamp)
+            }
 
             lastStep = "light"
             val lightEstimate = frame.lightEstimate
             if (lightEstimate.state == com.google.ar.core.LightEstimate.State.VALID) {
                 onLightUpdated(lightEstimate.pixelIntensity)
             }
-
-            val isTracking = camera.trackingState == TrackingState.TRACKING
             // Re-arm the hard cold-snap whenever ARCore isn't tracking (pocket / screen-off / loss), so
             // the next confident relocalization snaps the overlay back instantly rather than easing in.
             if (!isTracking) poseFusion.markRelocalizing()
@@ -1443,6 +1516,16 @@ class ArRenderer(
         const val PERCEPTION_LAG_MS = 16f
         // Per-element view-matrix delta below which the pose is treated as unchanged (skip redraw).
         const val PERCEPTION_POSE_EPSILON = 1e-4f
+
+        // --- Adaptive idle gating ---
+        // Per-element view-matrix delta below which the phone is treated as "still" for idle. Coarser
+        // than the perception epsilon so handheld micro-jitter doesn't count as motion (≈0.09° / 1.5mm).
+        const val IDLE_POSE_EPSILON = 1.5e-3f
+        // Continuous no-motion + no-interaction time before entering idle (slow to sleep).
+        const val IDLE_ENTER_DEBOUNCE_MS = 700L
+        // After resuming from idle, hold full rate this long so a single threshold-straddling jitter
+        // frame can't immediately re-sleep (instant to wake, brief hold).
+        const val RESUME_HOLD_MS = 500L
     }
 }
 

--- a/feature/dashboard/src/main/java/com/hereliesaz/graffitixr/feature/dashboard/SettingsScreen.kt
+++ b/feature/dashboard/src/main/java/com/hereliesaz/graffitixr/feature/dashboard/SettingsScreen.kt
@@ -97,6 +97,8 @@ fun SettingsScreen(
     onThrottleOnLowBatteryChanged: (Boolean) -> Unit,
     throttleOnLag: Boolean,
     onThrottleOnLagChanged: (Boolean) -> Unit,
+    adaptiveRateEnabled: Boolean,
+    onAdaptiveRateEnabledChanged: (Boolean) -> Unit,
     arScanMode: ArScanMode,
     onArScanModeChanged: (ArScanMode) -> Unit,
     showAnchorBoundary: Boolean,
@@ -305,6 +307,14 @@ fun SettingsScreen(
                                 label = "Throttle: frame lag",
                                 value = if (throttleOnLag) strings.settings.on else strings.settings.off,
                                 modifier = Modifier.clickable { onThrottleOnLagChanged(!throttleOnLag) }
+                            )
+                            // Adaptive rate: gates heavy SLAM work while the projection is locked and
+                            // the phone is still (snaps back instantly on motion), plus battery-tier
+                            // degradation. Default on; imperceptible. Off = always full rate.
+                            SettingsItem(
+                                label = "Adaptive rate (idle)",
+                                value = if (adaptiveRateEnabled) strings.settings.on else strings.settings.off,
+                                modifier = Modifier.clickable { onAdaptiveRateEnabledChanged(!adaptiveRateEnabled) }
                             )
                             val modes = ArScanMode.entries
                             val nextMode = modes[(arScanMode.ordinal + 1) % modes.size]


### PR DESCRIPTION
## Why

The dominant battery draw is the **AR pipeline running flat-out every frame even when the projection is locked and the phone is held still**. The heavy native SLAM/VIO map integration (`slamManager.updateCamera`) ran on every vsync regardless of activity, and the existing perception throttle only governed debug visualizations — not the base loop or SLAM. Non-AR modes run no GL loop, so AR is the only meaningful target.

## What

**1. Adaptive idle frame-rate (the big win) — `ArRenderer`**
Derive an idle state on the GL thread from the existing camera pose-delta (no new sensors) + interaction flags (anchor not established, capture/realign/scan/gesture in progress, not tracking). While idle, gate `slamManager.updateCamera` to `idleRateCeilingFps` (~12). `session.update()` and the cheap camera + overlay draw keep running every vsync, so tracking stays healthy and a static scene looks identical. Asymmetric hysteresis (700ms enter, instant exit, 500ms resume-hold) prevents oscillation; a not-tracking frame always forces full work so relocalization re-feeds SLAM immediately.

**2. Battery-percentage adaptive degradation — `ArViewModel`**
Read real battery level (`BATTERY_PROPERTY_CAPACITY` via `ACTION_BATTERY_CHANGED`) and fold it into `recomputeSystemThrottle` as tiers (≤30% / ≤15%) that tighten the idle/active rate ceilings, force the perception floor at the low tier, and cap the camera to 30fps **at AR entry only**. Gated by the existing low-battery toggle + the new master toggle.

**3. Touch-lock brightness — `MainActivity`**
Force max brightness only in TRACE (the lightbox); other modes keep system brightness (AR touch-lock at max brightness was pure waste). TRACE caps under low battery. Keep-screen-on unchanged.

**4. Master Settings toggle** (`adaptiveRateEnabled`, default on); off = always full rate.

## Notes / deliberate calls
- Kept `RENDERMODE_CONTINUOUSLY` + in-frame gating rather than `WHEN_DIRTY`/skip-swap — avoids tracking instability and stale-buffer flicker; the headline saving (native SLAM gating) needs neither.
- Camera FPS cap applies at session build only — a mid-session `CameraConfig` swap resets tracking (perceptible).
- DualAnalyzer idle-gating (Change 4 in the plan) was **skipped**: it's test-only, not wired into production.

## Verification
No Android SDK in the authoring environment, so relying on CI to compile. Manual on-device: establish anchor → hold still (confirm tracking stays TRACKING while gated via diag), then move (overlay must not lag); `adb shell dumpsys battery set level 10` to exercise tiers; touch-lock brightness per mode.

https://claude.ai/code/session_014yRGTczfd3E8jvNSH2b3gi

---
_Generated by [Claude Code](https://claude.ai/code/session_014yRGTczfd3E8jvNSH2b3gi)_

## Summary by Sourcery

Introduce adaptive AR frame-rate and battery-aware throttling to reduce power usage without impacting perceived experience.

New Features:
- Gate heavy SLAM/VIO work in ArRenderer based on an adaptive idle state and configurable idle/active frame-rate ceilings.
- Drive AR frame-rate policy from live battery level tiers, including camera FPS capping under low battery.
- Expose a user-facing adaptive rate (idle) setting wired through ViewModel, settings repository, and dashboard UI.
- Adjust touch-lock brightness so only TRACE mode forces high brightness, with caps under low battery.

Enhancements:
- Unify thermal, power-save, and battery signals into a single system throttle that also configures AR idle/active rate ceilings.