### PR TITLE
AR battery savings, action-driven onboarding, and full-bleed project cards

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/onboarding/ModeOnboardingOverlay.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/onboarding/ModeOnboardingOverlay.kt
@@ -45,7 +45,6 @@ import kotlin.math.cos
 import kotlin.math.hypot
 import kotlin.math.sin
 import kotlin.random.Random
-import kotlinx.coroutines.delay
 
 @Composable
 fun ModeOnboardingOverlay(
@@ -65,8 +64,8 @@ fun ModeOnboardingOverlay(
 
 /**
  * Generic onboarding overlay over arbitrary [lines]. The current [step] is controlled by the
- * caller so any tap source — the non-consuming screen observer below, the per-step timer, or an
- * external rail tap — can drive advancement through the same [onAdvance]. [positionKey] seeds the
+ * caller so any tap source — the non-consuming screen observer below or an external rail tap — can
+ * drive advancement through the same [onAdvance]. [positionKey] seeds the
  * popup zone and resets the tap observer when the context changes.
  *
  * The overlay never consumes pointer events, so taps fall through to the canvas/editor underneath
@@ -92,16 +91,11 @@ fun ModeOnboardingOverlay(
         return
     }
 
-    // Keep advance current without restarting the pointer loop on every step.
+    // Advancement is entirely user-driven. A screen tap (observed below, non-consuming) pages
+    // through a step's explanatory lines, and performing the actual action changes app state, which
+    // swaps in the next step. There is deliberately NO timer — the coach waits on the user and never
+    // auto-advances on its own.
     val advance by rememberUpdatedState(onAdvance)
-
-    // Idle safety-net timer: longer lines linger longer. With the do-it-to-advance walkthrough the
-    // user is expected to perform the targeted interaction, so this only fires when they don't —
-    // hence the doubled durations. Restarts whenever the step (from any source) or context changes.
-    LaunchedEffect(positionKey, step) {
-        delay(stepDurationMs(line))
-        advance()
-    }
 
     // Pointer geometry: the overlay's own window origin (to convert the target's window-space
     // bounds into local draw coords) and the instruction card's bounds (the pointer's tail).
@@ -176,9 +170,6 @@ fun ModeOnboardingOverlay(
         }
     }
 }
-
-private fun stepDurationMs(line: String): Long =
-    (6000L + 100L * line.length).coerceIn(6000L, 20000L)
 
 /**
  * Draws a pointer from the instruction [cardLocal] to the [targetLocal] rail item: a pulsing

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -1780,10 +1780,11 @@ class ArViewModel @Inject constructor(
     private val BATTERY_TIER_LOW = 15
 
     /**
-     * Folds device-stress signals into the AR rate policy. The coarse perception floor
-     * (perceptionSystemThrottle) is unchanged; the battery *level* additionally degrades the
-     * adaptive-rate ceilings in tiers, and at the low tier also forces the perception floor and a
-     * 30fps-capped camera on the next AR entry. All gated by the existing throttleOnLowBattery toggle.
+     * Folds device-stress signals into the AR rate policy. The existing perception floor (15fps via
+     * perceptionSystemThrottle) is the "super battery saver" and is left exactly as-is — thermal,
+     * OS power-save mode, and the coarse low-battery warning. The battery *level* tiers added here do
+     * NOT touch that floor: a merely low level keeps perception at the full 30fps and only tightens
+     * the adaptive idle/active rate ceilings (and caps the camera to 30fps on the next AR entry).
      */
     private fun recomputeSystemThrottle() {
         val saver = powerManager?.isPowerSaveMode == true
@@ -1794,10 +1795,11 @@ class ArViewModel @Inject constructor(
             batteryPct <= BATTERY_TIER_MED -> 1
             else -> 0
         }
+        // Unchanged super-saver floor (15fps). The battery-level tier is intentionally NOT a trigger
+        // here — it only drives the rate ceilings below.
         val throttle = (s.throttleOnThermal && thermalHot) ||
             (s.throttleOnPowerSave && saver) ||
-            (s.throttleOnLowBattery && batteryLow) ||
-            tier >= 2
+            (s.throttleOnLowBattery && batteryLow)
         val idleCeiling = when (tier) { 2 -> 8; 1 -> 10; else -> 12 }
         val activeCeiling = when (tier) { 2 -> 24; 1 -> 30; else -> 0 }
         if (s.perceptionSystemThrottle != throttle || s.batteryTier != tier ||

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -1787,32 +1787,29 @@ class ArViewModel @Inject constructor(
      * the adaptive idle/active rate ceilings (and caps the camera to 30fps on the next AR entry).
      */
     private fun recomputeSystemThrottle() {
-        val saver = powerManager?.isPowerSaveMode == true
-        val s = _uiState.value
-        val tier = when {
-            !s.throttleOnLowBattery || batteryPct !in 0..100 -> 0
-            batteryPct <= BATTERY_TIER_LOW -> 2
-            batteryPct <= BATTERY_TIER_MED -> 1
-            else -> 0
-        }
-        // Unchanged super-saver floor (15fps). The battery-level tier is intentionally NOT a trigger
-        // here — it only drives the rate ceilings below.
-        val throttle = (s.throttleOnThermal && thermalHot) ||
-            (s.throttleOnPowerSave && saver) ||
-            (s.throttleOnLowBattery && batteryLow)
-        val idleCeiling = when (tier) { 2 -> 8; 1 -> 10; else -> 12 }
-        val activeCeiling = when (tier) { 2 -> 24; 1 -> 30; else -> 0 }
-        if (s.perceptionSystemThrottle != throttle || s.batteryTier != tier ||
-            s.idleRateCeilingFps != idleCeiling || s.activeRateCeilingFps != activeCeiling
-        ) {
-            _uiState.update {
-                it.copy(
-                    perceptionSystemThrottle = throttle,
-                    batteryTier = tier,
-                    idleRateCeilingFps = idleCeiling,
-                    activeRateCeilingFps = activeCeiling,
-                )
+        // Read + check + write atomically inside update {} — this is called from broadcast/thermal
+        // listener threads, so the lambda re-runs on CAS contention with a fresh snapshot.
+        _uiState.update { s ->
+            val saver = powerManager?.isPowerSaveMode == true
+            val tier = when {
+                !s.throttleOnLowBattery || batteryPct !in 0..100 -> 0
+                batteryPct <= BATTERY_TIER_LOW -> 2
+                batteryPct <= BATTERY_TIER_MED -> 1
+                else -> 0
             }
+            // Unchanged super-saver floor (15fps). The battery-level tier is intentionally NOT a
+            // trigger here — it only drives the rate ceilings below.
+            val throttle = (s.throttleOnThermal && thermalHot) ||
+                (s.throttleOnPowerSave && saver) ||
+                (s.throttleOnLowBattery && batteryLow)
+            val idleCeiling = when (tier) { 2 -> 8; 1 -> 10; else -> 12 }
+            val activeCeiling = when (tier) { 2 -> 24; 1 -> 30; else -> 0 }
+            s.copy(
+                perceptionSystemThrottle = throttle,
+                batteryTier = tier,
+                idleRateCeilingFps = idleCeiling,
+                activeRateCeilingFps = activeCeiling,
+            )
         }
     }
 

--- a/feature/dashboard/src/main/java/com/hereliesaz/graffitixr/feature/dashboard/ProjectLibraryScreen.kt
+++ b/feature/dashboard/src/main/java/com/hereliesaz/graffitixr/feature/dashboard/ProjectLibraryScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -20,6 +21,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
@@ -34,6 +36,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.hereliesaz.aznavrail.AzButton
@@ -142,59 +145,80 @@ fun ProjectLibraryScreen(
                 ) {
                     items(projects) { project ->
                         Card(
-                            modifier = Modifier.fillMaxWidth()
-                                .border(1.dp, Color.White.copy(alpha = 0.15f), CardDefaults.shape),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .aspectRatio(16f / 9f)
+                                .border(1.dp, Color.White.copy(alpha = 0.15f), CardDefaults.shape)
+                                .clickable { onLoadProject(project) },
                             colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
                         ) {
-                            Row(
-                                modifier = Modifier
-                                    .clickable { onLoadProject(project) }
-                                    .padding(16.dp),
-                                verticalAlignment = Alignment.CenterVertically
-                            ) {
-                                // Thumbnail or Default Icon
+                            // The project's design imagery fills the whole box (full-bleed); the
+                            // name, date and delete control are overlaid over a bottom scrim so they
+                            // stay legible over any artwork.
+                            Box(modifier = Modifier.fillMaxSize().background(Color.Black)) {
                                 if (project.thumbnailUri != null) {
                                     coil.compose.AsyncImage(
                                         model = project.thumbnailUri,
                                         contentDescription = strings.lib.projectThumbnail,
-                                        modifier = Modifier
-                                            .size(96.dp)
-                                            .background(Color.Black)
-                                            .padding(1.dp),
+                                        modifier = Modifier.fillMaxSize(),
                                         contentScale = androidx.compose.ui.layout.ContentScale.Crop
                                     )
                                 } else {
                                     Icon(
                                         Icons.Default.Folder,
                                         contentDescription = null,
-                                        tint = Color.White,
-                                        modifier = Modifier.size(96.dp).padding(12.dp)
-                                    )
-                                }
-                                Spacer(Modifier.width(16.dp))
-
-                                // Project Info
-                                Column(modifier = Modifier.weight(1f)) {
-                                    Text(
-                                        text = project.name,
-                                        style = MaterialTheme.typography.titleMedium,
-                                        color = Color.White
-                                    )
-                                    Text(
-                                        text = SimpleDateFormat("MMM dd, yyyy HH:mm", Locale.getDefault())
-                                            .format(Date(project.lastModified)),
-                                        style = MaterialTheme.typography.bodySmall,
-                                        color = Color.LightGray
+                                        tint = Color.White.copy(alpha = 0.35f),
+                                        modifier = Modifier.size(72.dp).align(Alignment.Center)
                                     )
                                 }
 
-                                // Delete Action
-                                IconButton(onClick = { onDeleteProject(project.id) }) {
-                                    Icon(
-                                        Icons.Default.Delete,
-                                        contentDescription = strings.lib.deleteProjectDesc(project.name),
-                                        tint = MaterialTheme.colorScheme.error
-                                    )
+                                // Bottom-up gradient scrim for text contrast.
+                                Box(
+                                    modifier = Modifier
+                                        .align(Alignment.BottomCenter)
+                                        .fillMaxWidth()
+                                        .height(110.dp)
+                                        .background(
+                                            Brush.verticalGradient(
+                                                colors = listOf(
+                                                    Color.Transparent,
+                                                    Color.Black.copy(alpha = 0.8f)
+                                                )
+                                            )
+                                        )
+                                )
+
+                                Row(
+                                    modifier = Modifier
+                                        .align(Alignment.BottomStart)
+                                        .fillMaxWidth()
+                                        .padding(horizontal = 16.dp, vertical = 12.dp),
+                                    verticalAlignment = Alignment.CenterVertically
+                                ) {
+                                    Column(modifier = Modifier.weight(1f)) {
+                                        Text(
+                                            text = project.name,
+                                            style = MaterialTheme.typography.titleMedium,
+                                            color = Color.White,
+                                            fontWeight = FontWeight.Bold,
+                                            maxLines = 1,
+                                            overflow = TextOverflow.Ellipsis
+                                        )
+                                        Text(
+                                            text = SimpleDateFormat("MMM dd, yyyy HH:mm", Locale.getDefault())
+                                                .format(Date(project.lastModified)),
+                                            style = MaterialTheme.typography.bodySmall,
+                                            color = Color.White.copy(alpha = 0.85f)
+                                        )
+                                    }
+
+                                    IconButton(onClick = { onDeleteProject(project.id) }) {
+                                        Icon(
+                                            Icons.Default.Delete,
+                                            contentDescription = strings.lib.deleteProjectDesc(project.name),
+                                            tint = Color.White
+                                        )
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
Three related UX/efficiency changes from one session.

## 1. AR battery reduction (no perceptible loss)
- **Idle frame-rate gating** (`ArRenderer`): when the anchor is locked and the phone is still (reusing the existing camera pose-delta signal), the heavy native SLAM/VIO and perception draws are gated to a low idle rate while `session.update()` + the cheap scene redraw keep running every vsync. Snaps back to full rate instantly on motion. Asymmetric hysteresis + a not-TRACKING guard prevent oscillation and tracking-loss compounding.
- **Battery-percentage-aware degradation** (`ArViewModel`): real `BATTERY_PROPERTY_CAPACITY` read folded into the throttle plumbing. Low battery *level* tiers only tighten the idle/active rate ceilings and cap the camera to 30fps at the next AR entry. **The 15fps "super-saver" perception floor is unchanged** — it stays reserved for stress conditions (thermal / OS power-save / coarse low-battery warning) and is never the usual cap; normal stays 30fps. `recomputeSystemThrottle()` now reads+writes atomically.
- **Conditional touch-lock brightness** (`MainActivity`): max brightness only in TRACE (lightbox); other modes keep system brightness while holding the screen on; capped at the lowest battery tier even in TRACE.
- Gated behind an `adaptiveRateEnabled` setting (default on).

## 2. Action-driven onboarding
The coach paged its explanatory lines on a 6–20s auto-advance **timer** regardless of what the user did. Removed it (`ModeOnboardingOverlay`): a screen tap pages a step's lines, and performing the actual action changes app state — which swaps in the next step. The coach waits on the user and never auto-advances on its own. Step selection was already state-derived; now everything is.

## 3. Full-bleed project cards
Each project box in the library is now a full-bleed 16:9 card showing the project's composite design imagery (`ContentScale.Crop`) instead of a small thumbnail beside text. Name/date/delete are overlaid over a bottom gradient scrim for legibility (`ProjectLibraryScreen`).

## Verification
- AR: lock anchor, hold still → tracking holds while idle-gated; moving snaps back ~1 frame. `adb shell dumpsys battery set level 25/10` → ceilings tighten, camera caps 30fps on entry, perception stays 30 (only thermal/power-save floor it to 15). Touch-lock brightness per-mode.
- Onboarding: new project → coach appears; it advances only when you tap or perform the action, never on a timer.
- Library: each project row shows its artwork filling the card.
- `./gradlew assembleDebug` + unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014yRGTczfd3E8jvNSH2b3gi

## Summary by Sourcery

Improve AR battery-aware throttling, make onboarding progression fully user-driven, and redesign project library cards as full-bleed imagery.

Enhancements:
- Adjust AR system throttle to treat low battery levels as ceiling-only constraints while keeping the existing super-saver perception floor behavior unchanged.
- Make onboarding overlays advance only in response to user taps or state changes by removing the auto-advance timer.
- Redesign project library cards as 16:9 full-bleed image tiles with overlaid metadata for improved visual presentation.