### PR TITLE
Restore missing Export (Project) and Light (AR/Overlay) rail buttons

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/HelpItemsBuilder.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/HelpItemsBuilder.kt
@@ -24,6 +24,8 @@ internal fun buildHelpItems(strings: AppStrings, layers: List<Layer>): Map<Strin
         "mode.mockup" to strings.help.mockup,
         "mode.trace" to strings.help.trace,
         "target.create" to strings.help.create,
+        "mode.ar.light" to strings.help.flashlight,
+        "mode.overlay.light" to strings.help.flashlight,
         "mode.mockup.wall" to strings.help.wall,
 
         // Design menu
@@ -51,6 +53,7 @@ internal fun buildHelpItems(strings: AppStrings, layers: List<Layer>): Map<Strin
         "host.project" to strings.help.projectHost,
         "proj.new" to strings.help.newProject,
         "proj.save" to strings.help.saveProject,
+        "proj.export" to strings.help.exportImage,
         "proj.load" to strings.help.loadProject,
         "proj.settings" to strings.help.appSettings,
 

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -1913,11 +1913,21 @@ class MainActivity : ComponentActivity() {
                     azRailSubItem(id = "target.create", hostId = "mode.ar", text = navStrings.grid, color = navItemColor, shape = AzButtonShape.RECTANGLE) {
                         if (hasCameraPermission) mainViewModel.startTargetCapture() else requestPermissions()
                     }
+                    // Flashlight — illuminate the wall in low light while tracking.
+                    azRailSubItem(id = "mode.ar.light", hostId = "mode.ar", text = navStrings.light, color = if (arUiState.isFlashlightOn) Cyan else navItemColor, shape = AzButtonShape.NONE) {
+                        arViewModel.toggleFlashlight()
+                    }
                 }
                 modeLayerSubHost("mode.ar", EditorMode.AR, editorUiState, editorViewModel, navStrings, navItemColor, onOpenModeAdjust)
             }
 
             azRailSubHostItem(id = "mode.overlay", hostId = "host.modes", text = navStrings.overlay, route = EditorMode.OVERLAY.name, color = navItemColor, shape = AzButtonShape.NONE)
+            // Flashlight — illuminate the wall in low light while overlaying.
+            if (editorUiState.editorMode == EditorMode.OVERLAY) {
+                azRailSubItem(id = "mode.overlay.light", hostId = "mode.overlay", text = navStrings.light, color = if (arUiState.isFlashlightOn) Cyan else navItemColor, shape = AzButtonShape.NONE) {
+                    arViewModel.toggleFlashlight()
+                }
+            }
             modeLayerSubHost("mode.overlay", EditorMode.OVERLAY, editorUiState, editorViewModel, navStrings, navItemColor, onOpenModeAdjust)
 
             // Mockup ▸ Wall ▸ { Photo (take a photo), File (pick an image) }
@@ -1947,6 +1957,9 @@ class MainActivity : ComponentActivity() {
             azRailSubItem(id = "proj.new", hostId = "host.project", text = navStrings.new, color = navItemColor, shape = AzButtonShape.NONE) {                dashboardViewModel.onNewProjectTriggered()
             }
             azRailSubItem(id = "proj.save", hostId = "host.project", text = navStrings.save, color = navItemColor, shape = AzButtonShape.NONE) {                showSaveDialog = true
+            }
+            azRailSubItem(id = "proj.export", hostId = "host.project", text = navStrings.export, color = navItemColor, shape = AzButtonShape.NONE) {
+                editorViewModel.exportImage()
             }
             azRailSubItem(id = "proj.load", hostId = "host.project", text = navStrings.load, color = navItemColor, shape = AzButtonShape.NONE) {                navController.navigate(LIBRARY_ROUTE) { launchSingleTop = true }
             }

--- a/app/src/main/java/com/hereliesaz/graffitixr/RailIdEnumerator.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/RailIdEnumerator.kt
@@ -41,6 +41,10 @@ internal fun enumerateRailItemIdRegistrations(layers: List<Layer>, mode: EditorM
     )
     if (mode == EditorMode.AR) {
         ids += "target.create"
+        ids += "mode.ar.light"
+    }
+    if (mode == EditorMode.OVERLAY) {
+        ids += "mode.overlay.light"
     }
 
     // Design menu
@@ -50,7 +54,7 @@ internal fun enumerateRailItemIdRegistrations(layers: List<Layer>, mode: EditorM
 
     // Project menu
     ids += listOf(
-        "host.project", "proj.new", "proj.save", "proj.load", "proj.settings"
+        "host.project", "proj.new", "proj.save", "proj.export", "proj.load", "proj.settings"
     )
 
     // Global tools


### PR DESCRIPTION
## Why

Two rail buttons had gone missing even though their handlers (and strings) still existed:
- **Export** under the **Project** folder
- **Light** (flashlight) under **AR** / **Overlay**

## What

Restored both as rail items and wired them to the existing handlers:

- `proj.export` → `editorViewModel.exportImage()` — renders all visible layers into a flat PNG saved to the photo gallery (matches the `nav_export` description). Placed between Save and Load.
- `mode.ar.light` / `mode.overlay.light` → `arViewModel.toggleFlashlight()` — shown while in that mode (same gating as Target capture), tinted cyan when on.

Also registered all three IDs in `buildHelpItems` (help-overlay text via the existing `help.exportImage` / `help.flashlight` strings) and in `RailIdEnumerator` so the debug `RailIntegrityCheck` and `RailIdUniquenessTest` stay consistent.

## Verification

- Project ▸ Export saves a merged image to the gallery (toast confirms).
- In AR or Overlay, the Light button appears under the mode and toggles the device torch (cyan when on).
- `./gradlew :app:testDebugUnitTest` (RailIdUniquenessTest / HelpItemsBuilderTest) + `assembleDebug`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014yRGTczfd3E8jvNSH2b3gi

---
_Generated by [Claude Code](https://claude.ai/code/session_014yRGTczfd3E8jvNSH2b3gi)_

## Summary by Sourcery

Restore missing rail buttons for project export and AR/overlay flashlight and register them in navigation metadata.

New Features:
- Add Project ▸ Export rail item wired to image export functionality.
- Add Light rail item in AR mode to toggle the device flashlight.
- Add Light rail item in Overlay mode to reuse the AR flashlight toggle.

Enhancements:
- Register new rail IDs in the rail ID enumerator to keep integrity checks and uniqueness tests in sync.
- Hook new rail items into the help overlay with existing export and flashlight help strings.