### PR TITLE
Brush size/color rail items fill, and brush stroke matches the size preview

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -1480,7 +1480,7 @@ class MainActivity : ComponentActivity() {
                                                         if (abs(dragAmount.y) >= abs(dragAmount.x)) {
                                                             val currentSize = editorViewModel.uiState.value.brushSize
                                                             editorViewModel.setBrushSize(
-                                                                (currentSize - dragAmount.y * 0.5f).coerceIn(1f, itemSizePx)
+                                                                (currentSize - dragAmount.y * 0.5f).coerceIn(1f, maxOf(1f, itemSizePx))
                                                             )
                                                         } else {
                                                             val currentFeather = editorViewModel.uiState.value.brushFeathering
@@ -1493,7 +1493,7 @@ class MainActivity : ComponentActivity() {
                                             contentAlignment = Alignment.Center
                                         ) {
                                             val sizeDp = with(density) {
-                                                liveState.brushSize.coerceIn(1f, itemSizePx).toDp()
+                                                liveState.brushSize.coerceIn(1f, maxOf(1f, itemSizePx)).toDp()
                                             }
                                             val checkerModifier = Modifier.drawBehind {
                                                 val squareSize = 6.dp.toPx()
@@ -1522,7 +1522,7 @@ class MainActivity : ComponentActivity() {
                                                     )
                                                 }
                                                 val hardCoreDp = with(density) {
-                                                    (liveState.brushSize * (1f - liveState.brushFeathering * 0.7f)).coerceIn(2f, itemSizePx).toDp()
+                                                    (liveState.brushSize * (1f - liveState.brushFeathering * 0.7f)).coerceIn(2f, maxOf(2f, itemSizePx)).toDp()
                                                 }
                                                 Box(
                                                     modifier = Modifier

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -1467,12 +1467,12 @@ class MainActivity : ComponentActivity() {
                                     shape = AzButtonShape.CIRCLE,
                                     content = AzComposableContent { isEnabled ->
                                         val liveState by editorViewModel.uiState.collectAsState()
-                                        var itemRadiusPx by remember { mutableFloatStateOf(100f) }
+                                        var itemSizePx by remember { mutableFloatStateOf(100f) }
                                         val density = LocalDensity.current
                                         Box(
                                             modifier = Modifier
                                                 .fillMaxSize()
-                                                .onSizeChanged { size -> itemRadiusPx = size.width / 2f }
+                                                .onSizeChanged { size -> itemSizePx = size.width.toFloat() }
                                                 .pointerInput(isEnabled) {
                                                     if (!isEnabled) return@pointerInput
                                                     detectDragGestures { change, dragAmount ->
@@ -1480,7 +1480,7 @@ class MainActivity : ComponentActivity() {
                                                         if (abs(dragAmount.y) >= abs(dragAmount.x)) {
                                                             val currentSize = editorViewModel.uiState.value.brushSize
                                                             editorViewModel.setBrushSize(
-                                                                (currentSize - dragAmount.y * 0.5f).coerceIn(1f, itemRadiusPx)
+                                                                (currentSize - dragAmount.y * 0.5f).coerceIn(1f, itemSizePx)
                                                             )
                                                         } else {
                                                             val currentFeather = editorViewModel.uiState.value.brushFeathering
@@ -1493,7 +1493,7 @@ class MainActivity : ComponentActivity() {
                                             contentAlignment = Alignment.Center
                                         ) {
                                             val sizeDp = with(density) {
-                                                liveState.brushSize.coerceIn(1f, itemRadiusPx).toDp()
+                                                liveState.brushSize.coerceIn(1f, itemSizePx).toDp()
                                             }
                                             val checkerModifier = Modifier.drawBehind {
                                                 val squareSize = 6.dp.toPx()
@@ -1522,7 +1522,7 @@ class MainActivity : ComponentActivity() {
                                                     )
                                                 }
                                                 val hardCoreDp = with(density) {
-                                                    (liveState.brushSize * (1f - liveState.brushFeathering * 0.7f)).coerceIn(2f, itemRadiusPx).toDp()
+                                                    (liveState.brushSize * (1f - liveState.brushFeathering * 0.7f)).coerceIn(2f, itemSizePx).toDp()
                                                 }
                                                 Box(
                                                     modifier = Modifier
@@ -1609,9 +1609,11 @@ class MainActivity : ComponentActivity() {
                                                     },
                                                 contentAlignment = Alignment.Center
                                             ) {
+                                                // Fill the whole rail item with the colour swatch.
                                                 Box(
                                                     modifier = Modifier
-                                                        .size(28.dp)
+                                                        .fillMaxSize()
+                                                        .clip(CircleShape)
                                                         .background(Color(currentColor), CircleShape)
                                                         .border(1.dp, navItemColor.copy(alpha = 0.5f), CircleShape)
                                                 )

--- a/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/DrawingEngine.kt
+++ b/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/DrawingEngine.kt
@@ -45,8 +45,14 @@ internal class DrawingEngine(private val slamManager: SlamManager) {
             stroke.path, stroke.canvasSize.width, stroke.canvasSize.height, bitmap.width, bitmap.height,
             stroke.layerScale, stroke.layerOffset, stroke.layerRotationZ
         )
+        // brushSize is stored in screen px (what the rail size preview shows). Convert it to bitmap
+        // space with the same scale the coordinates use, so the painted stroke renders at exactly the
+        // previewed on-screen diameter regardless of the layer's resolution/scale.
+        val brushScale = ImageProcessor.screenToBitmapScale(
+            stroke.canvasSize.width, stroke.canvasSize.height, bitmap.width, bitmap.height, stroke.layerScale
+        )
         return ImageProcessor.applyToolToBitmap(
-            bitmap, mapped, stroke.tool, stroke.brushSize, stroke.brushColor, stroke.intensity,
+            bitmap, mapped, stroke.tool, stroke.brushSize * brushScale, stroke.brushColor, stroke.intensity,
             replaceExisting, stroke.feathering
         )
     }

--- a/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/EditorViewModel.kt
+++ b/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/EditorViewModel.kt
@@ -1262,7 +1262,12 @@ class EditorViewModel @Inject constructor(
         viewModelScope.launch(dispatchers.default) {
             val workBitmap = originalBitmap.copy(Bitmap.Config.ARGB_8888, true)
             val workCanvas = Canvas(workBitmap)
-            val paint = buildStrokePaint(tool, argb, brushSize, feathering)
+            // Match the rail size preview exactly: brushSize is screen px; scale it into this layer's
+            // bitmap space (1f for an unscaled sketch) so the painted dab is the previewed diameter.
+            val brushScale = ImageProcessor.screenToBitmapScale(
+                canvasSize.width, canvasSize.height, workBitmap.width, workBitmap.height, strokeLayerScale
+            )
+            val paint = buildStrokePaint(tool, argb, brushSize * brushScale, feathering)
 
             // Snapshot the collected points at this moment — may include points that arrived
             // during the bitmap-copy phase.

--- a/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/EditorViewModel.kt
+++ b/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/EditorViewModel.kt
@@ -1262,10 +1262,15 @@ class EditorViewModel @Inject constructor(
         viewModelScope.launch(dispatchers.default) {
             val workBitmap = originalBitmap.copy(Bitmap.Config.ARGB_8888, true)
             val workCanvas = Canvas(workBitmap)
+            // Read the transform off the captured immutable `layer` (not the mutable stroke* members,
+            // which a quick second stroke could overwrite before this coroutine runs).
+            val layerScale = layer.scale
+            val layerOffset = layer.offset
+            val layerRotationZ = layer.rotationZ
             // Match the rail size preview exactly: brushSize is screen px; scale it into this layer's
             // bitmap space (1f for an unscaled sketch) so the painted dab is the previewed diameter.
             val brushScale = ImageProcessor.screenToBitmapScale(
-                canvasSize.width, canvasSize.height, workBitmap.width, workBitmap.height, strokeLayerScale
+                canvasSize.width, canvasSize.height, workBitmap.width, workBitmap.height, layerScale
             )
             val paint = buildStrokePaint(tool, argb, brushSize * brushScale, feathering)
 
@@ -1274,7 +1279,7 @@ class EditorViewModel @Inject constructor(
             val catchUpPoints = strokeCollectedPoints.toList()
             val mappedAll = ImageProcessor.mapScreenToBitmap(
                 catchUpPoints, canvasSize.width, canvasSize.height, workBitmap.width, workBitmap.height,
-                strokeLayerScale, strokeLayerOffset, strokeLayerRotationZ
+                layerScale, layerOffset, layerRotationZ
             )
 
             if (mappedAll.size == 1) {

--- a/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/util/ImageProcessor.kt
+++ b/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/util/ImageProcessor.kt
@@ -28,6 +28,29 @@ object ImageProcessor {
     }
 
         /**
+         * The linear scale that [mapScreenToBitmap] applies to a *length* (e.g. a brush diameter):
+         * screen_px * scale = bitmap_px. It is the same `fitScaleX / layerScale` used for coordinates
+         * (ContentScale.Fit is uniform, so X and Y scales are equal). Drawing a stroke whose width is
+         * `brushSize * scale` in bitmap space therefore renders at exactly `brushSize` screen px,
+         * matching the size preview shown in the rail item. Returns 1f for a 1:1, unscaled layer.
+         */
+        fun screenToBitmapScale(
+            screenWidth: Int,
+            screenHeight: Int,
+            bitmapWidth: Int,
+            bitmapHeight: Int,
+            layerScale: Float,
+        ): Float {
+            if (screenWidth <= 0 || screenHeight <= 0 || bitmapWidth <= 0 || bitmapHeight <= 0) return 1f
+            val imageAspect = bitmapWidth.toFloat() / bitmapHeight.toFloat()
+            val screenAspect = screenWidth.toFloat() / screenHeight.toFloat()
+            val renderWidth = if (imageAspect > screenAspect) screenWidth.toFloat() else screenHeight * imageAspect
+            val fitScaleX = if (renderWidth > 0f) bitmapWidth / renderWidth else 1f
+            val safeLayerScale = if (layerScale > 0.0001f) layerScale else 1f
+            return fitScaleX / safeLayerScale
+        }
+
+        /**
              * Maps screen-space touch coordinates to pixel-space bitmap coordinates,
                   * accounting for Compose's ContentScale.Fit logic used in the UI.
                        */


### PR DESCRIPTION
## Why

Two issues with the brush **Size** and **Color** rail tools:
1. They didn't fill their rail item — the size preview circle could only ever grow to half the button, and the colour swatch was a small fixed dot.
2. The painted brush stroke wasn't the same size as the circle shown in the size rail item.

## What

**1. Fill the rail item** (`MainActivity`)
- **Size:** the preview circle was capped at the item *radius* (`size.width / 2f`), so it filled at most half the button. Now capped at the full item size, so the circle grows to fill the item and the drag range maps to the full diameter.
- **Colour:** the swatch was a fixed 28dp dot; it now fills the whole rail item (clipped circle + border).

**2. Stroke matches the preview** (`ImageProcessor`, `DrawingEngine`, `EditorViewModel`)
`brushSize` is a screen-px value (exactly what the rail circle renders), but strokes were painted at that width in *bitmap* space. On a 1:1 sketch layer (created at screen resolution) those already match, but on scaled/imported layers the stroke was off by the same `fitScale / layerScale` factor that `mapScreenToBitmap` applies to coordinates. Added `ImageProcessor.screenToBitmapScale(...)` and multiply the paint width by it in both the live paint and the `DrawingEngine` replay, so the painted dab renders at exactly the previewed on-screen diameter on every layer. The factor is `1f` for an unscaled sketch, so sketch drawing is unchanged.

## Verification

- Open the brush Size tool: the preview circle now grows to fill the rail item; the colour swatch fills its item.
- Paint on a sketch layer: stroke diameter matches the rail circle.
- Paint/retouch on a scaled or high-res imported image layer: stroke diameter now also matches the rail circle (previously thinner/thicker).
- `./gradlew :app:assembleDebug :feature:editor:testDebugUnitTest`.

> Note: no Android SDK in the build env here, so this needs an on-device check — particularly the scaled-layer size match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014yRGTczfd3E8jvNSH2b3gi

---
_Generated by [Claude Code](https://claude.ai/code/session_014yRGTczfd3E8jvNSH2b3gi)_

## Summary by Sourcery

Align brush size and color rail previews with actual stroke rendering and fill the rail items with their respective previews.

New Features:
- Expand brush size rail preview to use the full rail item diameter.
- Fill the brush color rail item with a circular color swatch and border matching the control size.

Bug Fixes:
- Ensure brush strokes render at the same on-screen diameter as the brush size rail preview across all layer scales and resolutions.
- Use layer-local transform values when replaying strokes to avoid mismatches caused by mutable state changes.

Enhancements:
- Introduce a reusable ImageProcessor.screenToBitmapScale helper to convert screen-space brush sizes into bitmap-space widths for consistent rendering.