### PR TITLE
Tutorial flow + instant drawing for all paint tools

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -646,7 +646,7 @@ class MainActivity : ComponentActivity() {
                                 OnboardingCoachOverlay(
                                     step = coachStep,
                                     gestureInProgress = editorUiState.gestureInProgress,
-                                    targetBounds = coachStep.targetId?.let { railItemBounds[it] },
+                                    boundsFor = { railItemBounds[it] },
                                     onSeen = {
                                         coachSeenThisSession.add(key)
                                         if (!replayCoaching) mainViewModel.markTutorialCompletePersistent(key)

--- a/app/src/main/java/com/hereliesaz/graffitixr/OnboardingCoach.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/OnboardingCoach.kt
@@ -21,8 +21,20 @@ import kotlinx.coroutines.delay
  * state. [targetId] is the rail item the pointer aims at (null = text only). [lines] are revealed
  * one at a time. [key] is stable per situation, so the same step is never re-derived as "new" and is
  * remembered as shown once it has been seen.
+ *
+ * [lineTargets], when present, gives a per-line target id so a single step's pointer can move between
+ * rail items as the user pages through its lines (e.g. walking Open → Sketch → Text after the Design
+ * menu opens). An entry of null — or running past the list — falls back to [targetId].
  */
-data class CoachStep(val key: String, val targetId: String?, val lines: List<String>)
+data class CoachStep(
+    val key: String,
+    val targetId: String?,
+    val lines: List<String>,
+    val lineTargets: List<String?>? = null,
+) {
+    /** The rail item the pointer should aim at for [lineIdx]: per-line override, else [targetId]. */
+    fun targetForLine(lineIdx: Int): String? = lineTargets?.getOrNull(lineIdx) ?: targetId
+}
 
 /**
  * Derives the current coaching step purely from app state — the coach adapts to the user, it never
@@ -54,6 +66,7 @@ fun rememberCoachStep(editor: EditorUiState, ar: ArUiState): CoachStep? {
         }
 
         val design = arr(DesignR.array.onboarding_design)
+        val designLayers = arr(DesignR.array.onboarding_design_layers)
         val arLines = arr(DesignR.array.onboarding_ar)
         val overlay = arr(DesignR.array.onboarding_overlay)
         val mockup = arr(DesignR.array.onboarding_mockup)
@@ -61,7 +74,14 @@ fun rememberCoachStep(editor: EditorUiState, ar: ArUiState): CoachStep? {
 
         when (editor.editorMode) {
             EditorMode.DESIGN -> when {
-                !hasLayers -> CoachStep("coach.design.add", "host.design", lines(design, 0, 1))
+                // Intro on 'Design', then — once the user presses it open — walk the pointer across
+                // the layer sources (Open / Sketch / Text), explaining each in turn before they pick.
+                !hasLayers -> CoachStep(
+                    key = "coach.design.add",
+                    targetId = "host.design",
+                    lines = listOf(design.getOrNull(0).orEmpty()) + designLayers,
+                    lineTargets = listOf("host.design", "design.addImg", "design.addDraw", "design.addText"),
+                )
                 activeLayer == null -> CoachStep("coach.design.select", firstLayerTarget, lines(design, 2))
                 else -> CoachStep("coach.design.use", "host.modes", lines(design, 3))
             }
@@ -101,7 +121,7 @@ fun rememberCoachStep(editor: EditorUiState, ar: ArUiState): CoachStep? {
 fun OnboardingCoachOverlay(
     step: CoachStep,
     gestureInProgress: Boolean,
-    targetBounds: Rect?,
+    boundsFor: (String) -> Rect?,
     onSeen: () -> Unit,
 ) {
     var settled by remember(step.key) { mutableStateOf(false) }
@@ -115,6 +135,10 @@ fun OnboardingCoachOverlay(
     if (gestureInProgress || !settled) return
 
     var lineIdx by rememberSaveable(step.key) { mutableStateOf(0) }
+    // Resolve the pointer target for the line currently showing — for a multi-target step this moves
+    // the arrow from item to item as the user pages through (e.g. Open → Sketch → Text). Reading the
+    // bounds here keeps the arrow live as the rail reports positions (the Design menu opening, etc.).
+    val targetBounds = step.targetForLine(lineIdx)?.let(boundsFor)
     ModeOnboardingOverlay(
         positionKey = step.key,
         step = lineIdx,

--- a/core/design/src/main/res/values/strings.xml
+++ b/core/design/src/main/res/values/strings.xml
@@ -636,6 +636,13 @@
         <item>Tap a layer to open its tools — grouped into Paint, Retouch, Adjust and Effects folders. Pinch and drag on the canvas to size and place it.</item>
         <item>When it looks right, choose how to use it: \'Trace\' to turn your phone into a lightbox, \'Mockup\' to preview on a photo, or \'AR\' to project it onto a wall.</item>
     </string-array>
+    <!-- Sub-item walkthrough shown after the Design menu is opened: one line per layer source,
+         each pointing at its own rail button (Open / Sketch / Text). -->
+    <string-array name="onboarding_design_layers">
+        <item>Open — import a photo or artwork; it lands as a new layer.</item>
+        <item>Sketch — start a blank layer and draw your own marks.</item>
+        <item>Text — type words and style them as their own layer.</item>
+    </string-array>
 
     <!-- Additional Tutorial Strings from TutorialDefinitions.kt -->
     <string name="tut_create_anchor_title">Create Anchor</string>


### PR DESCRIPTION
This branch contains two changes (kept together per the session's branch constraint).

---

## 1. Onboarding advances to Open/Sketch/Text when Design is opened

The coach used to park on the **Design** button and never explain the layer sources that appear when the menu opens.

- `CoachStep` gains optional per-line targets (`lineTargets`); the Design no-layers step intros on **Design**, then walks the pointer across `design.addImg` → `design.addDraw` → `design.addText` (Open / Sketch / Text) as the user pages forward.
- `OnboardingCoachOverlay` resolves the pointer target for the *current* line via a `boundsFor` resolver.
- New `onboarding_design_layers` string array (separate from `onboarding_design` so existing index slices and whole-array consumers stay untouched).

## 2. Brush / eraser / all paint tools draw instantly

Drawing lagged because every drag point rasterized into the layer bitmap and re-uploaded the whole texture to the GPU, and the first dab waited on a background full-bitmap copy.

- The in-progress stroke is now a **live vector overlay** (`EditorUiState.liveStrokePoints`) — no per-point bitmap work, no texture re-upload — rasterized into the layer **once**, on finger-up.
- `MainScreen` draws the committed layer + live stroke into one **offscreen-composited group**, so destructive tools (eraser `CLEAR`, burn `DARKEN`, dodge `LIGHTEN`) composite against the layer and reveal what's beneath — matching the final raster.
- `ImageProcessor.buildToolPaint` is the single source of truth for each tool's stroke paint, shared by the preview and the commit so they look identical.
- Liquify keeps its baked-bitmap path (it warps pixels and can't be drawn as a path).

### Verification notes
- No Android SDK in this environment, so nothing was compiled here — needs on-device verification.
- Pixel-exact for the common case (drawing on a screen-sized sketch layer at default transform). Two known edge cases to eyeball: live preview doesn't apply the layer's colour adjustments mid-stroke (snaps in on commit), and eraser alignment on a letterboxed image layer under a non-identity transform may be slightly off.

https://claude.ai/code/session_011d9PsCWgTxCPR7nP6CgxEi