### PR TITLE
Make brush/eraser and all paint tools draw instantly

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
@@ -25,9 +25,14 @@ import kotlinx.coroutines.withContext
 import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.foundation.Canvas
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.ContentScale
+import com.hereliesaz.graffitixr.feature.editor.util.ImageProcessor
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import com.hereliesaz.graffitixr.design.R as DesignR
@@ -335,9 +340,14 @@ fun MainScreen(
                 uiState.layers.filter { it.isVisible }.forEach { layer ->
                     androidx.compose.runtime.key(layer.id) {
                         val isLive = layer.id == uiState.liveStrokeLayerId
-                        val bmp = if (isLive) uiState.liveStrokeBitmap ?: layer.bitmap else layer.bitmap
+                        // Liquify streams a baked bitmap; every other tool shows an instant vector
+                        // overlay (no per-point bitmap upload) composited with the layer below.
+                        val liquifyLive = isLive && uiState.liveStrokeBitmap != null
+                        val vectorLive = isLive && uiState.liveStrokeBitmap == null &&
+                            uiState.liveStrokePoints.isNotEmpty()
+                        val bmp = if (liquifyLive) uiState.liveStrokeBitmap ?: layer.bitmap else layer.bitmap
                         bmp?.let { displayBmp ->
-                            val imageBitmap = if (isLive) {
+                            val imageBitmap = if (liquifyLive) {
                                 val version = uiState.liveStrokeVersion
                                 remember(version) { displayBmp.asImageBitmap() }
                             } else {
@@ -367,32 +377,92 @@ fun MainScreen(
                             // Offscreen compositing forces a full-screen offscreen buffer + extra pass
                             // per layer, every frame. It's only needed to isolate a non-default blend
                             // mode; for normal (SrcOver) layers, Auto avoids that cost.
+                            // Offscreen compositing forces a full-screen offscreen buffer + extra pass
+                            // per layer, every frame. It's only needed to isolate a non-default blend
+                            // mode; for normal (SrcOver) layers, Auto avoids that cost.
                             val needsOffscreen =
                                 layer.blendMode != androidx.compose.ui.graphics.BlendMode.SrcOver
-                            Image(
-                                bitmap = imageBitmap,
-                                contentDescription = null,
-                                colorFilter = colorFilter,
-                                modifier = Modifier
-                                    .fillMaxSize()
-                                    .graphicsLayer {
-                                        translationX = layer.offset.x
-                                        translationY = layer.offset.y
-                                        scaleX = layer.scale
-                                        scaleY = layer.scale
-                                        rotationX = layer.rotationX
-                                        rotationY = layer.rotationY
-                                        rotationZ = layer.rotationZ
-                                        alpha = layer.opacity
-                                        transformOrigin = TransformOrigin.Center
-                                        blendMode = layer.blendMode
-                                        compositingStrategy = if (needsOffscreen)
-                                            androidx.compose.ui.graphics.CompositingStrategy.Offscreen
-                                        else
-                                            androidx.compose.ui.graphics.CompositingStrategy.Auto
-                                    },
-                                contentScale = ContentScale.Fit
-                            )
+                            if (vectorLive) {
+                                // Live stroke: draw the committed layer and the in-progress stroke into
+                                // one offscreen group so destructive tools (eraser CLEAR, burn DARKEN,
+                                // dodge LIGHTEN…) composite against the layer and reveal what's beneath —
+                                // exactly like the final raster, but with no per-point bitmap upload.
+                                val strokeColorArgb = uiState.activeColor.toArgb()
+                                val strokeTool = uiState.activeTool
+                                val brushPx = uiState.brushSize
+                                val feather = uiState.brushFeathering
+                                val pts = uiState.liveStrokePoints
+                                androidx.compose.foundation.layout.Box(
+                                    modifier = Modifier
+                                        .fillMaxSize()
+                                        .graphicsLayer {
+                                            translationX = layer.offset.x
+                                            translationY = layer.offset.y
+                                            scaleX = layer.scale
+                                            scaleY = layer.scale
+                                            rotationX = layer.rotationX
+                                            rotationY = layer.rotationY
+                                            rotationZ = layer.rotationZ
+                                            alpha = layer.opacity
+                                            transformOrigin = TransformOrigin.Center
+                                            blendMode = layer.blendMode
+                                            compositingStrategy =
+                                                androidx.compose.ui.graphics.CompositingStrategy.Offscreen
+                                        }
+                                ) {
+                                    Image(
+                                        bitmap = imageBitmap,
+                                        contentDescription = null,
+                                        colorFilter = colorFilter,
+                                        modifier = Modifier.fillMaxSize(),
+                                        contentScale = ContentScale.Fit
+                                    )
+                                    // Brush width is screen px; the enclosing group scales drawing by
+                                    // layer.scale, so divide it out so the preview matches the commit.
+                                    val localWidth = brushPx / layer.scale.coerceAtLeast(0.0001f)
+                                    Canvas(modifier = Modifier.fillMaxSize()) {
+                                        val paint = ImageProcessor.buildToolPaint(
+                                            strokeTool, strokeColorArgb, localWidth, 0.5f, feather
+                                        )
+                                        drawIntoCanvas { c ->
+                                            if (pts.size == 1) {
+                                                c.nativeCanvas.drawPoint(pts[0].x, pts[0].y, paint)
+                                            } else {
+                                                val path = android.graphics.Path().apply {
+                                                    moveTo(pts[0].x, pts[0].y)
+                                                    for (i in 1 until pts.size) lineTo(pts[i].x, pts[i].y)
+                                                }
+                                                c.nativeCanvas.drawPath(path, paint)
+                                            }
+                                        }
+                                    }
+                                }
+                            } else {
+                                Image(
+                                    bitmap = imageBitmap,
+                                    contentDescription = null,
+                                    colorFilter = colorFilter,
+                                    modifier = Modifier
+                                        .fillMaxSize()
+                                        .graphicsLayer {
+                                            translationX = layer.offset.x
+                                            translationY = layer.offset.y
+                                            scaleX = layer.scale
+                                            scaleY = layer.scale
+                                            rotationX = layer.rotationX
+                                            rotationY = layer.rotationY
+                                            rotationZ = layer.rotationZ
+                                            alpha = layer.opacity
+                                            transformOrigin = TransformOrigin.Center
+                                            blendMode = layer.blendMode
+                                            compositingStrategy = if (needsOffscreen)
+                                                androidx.compose.ui.graphics.CompositingStrategy.Offscreen
+                                            else
+                                                androidx.compose.ui.graphics.CompositingStrategy.Auto
+                                        },
+                                    contentScale = ContentScale.Fit
+                                )
+                            }
                         }
                     }
                 }

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/EditorModels.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/EditorModels.kt
@@ -174,11 +174,16 @@ data class EditorUiState(
     val showMesh: Boolean = true,           // persistent surface mesh
 
     // Real-time stroke rendering: the mutable bitmap being actively drawn into.
-    // Non-null only while a brush stroke is in progress (non-Liquify tools).
+    // Non-null only while a Liquify stroke is in progress (Liquify warps pixels and can't be
+    // previewed as a vector path, so it still streams a baked bitmap).
     val liveStrokeLayerId: String? = null,
     val liveStrokeBitmap: Bitmap? = null,
     // Incremented after each stroke segment so Compose re-reads the modified pixels.
     val liveStrokeVersion: Int = 0,
+    // Live vector preview for all non-Liquify tools: the in-progress stroke's raw screen-space points.
+    // Rendered as a cheap vector overlay (no per-point bitmap upload) so the result is instant; the
+    // stroke is rasterized into the layer bitmap once, on finger-up. Empty when no stroke is active.
+    val liveStrokePoints: List<Offset> = emptyList(),
     val canvasBackground: Color = Color.Black,
     val isSegmenting: Boolean = false,
     val segmentationInfluence: Float = 0.5f,

--- a/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/EditorViewModel.kt
+++ b/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/EditorViewModel.kt
@@ -3,12 +3,6 @@ package com.hereliesaz.graffitixr.feature.editor
 
 import android.content.Context
 import android.graphics.Bitmap
-import android.graphics.BlurMaskFilter
-import android.graphics.Canvas
-import android.graphics.Paint
-import android.graphics.Path
-import android.graphics.PorterDuff
-import android.graphics.PorterDuffXfermode
 import android.net.Uri
 import android.widget.Toast
 import androidx.compose.ui.geometry.Offset
@@ -110,10 +104,6 @@ class EditorViewModel @Inject constructor(
     private var pendingStencilProjectId: String? = null
 
     // Real-time stroke state — valid only between onStrokeStart and onStrokeEnd.
-    private var strokeWorkingBitmap: Bitmap? = null
-    private var strokeWorkingCanvas: Canvas? = null
-    private var strokePaint: Paint? = null
-    private var strokePrevBitmapPoint: Offset? = null
     private var strokeCollectedPoints: MutableList<Offset> = mutableListOf()
     private var strokeLayerId: String? = null
     private var strokeCanvasW: Int = 0
@@ -228,6 +218,8 @@ class EditorViewModel @Inject constructor(
         // callbacks would commit to the previous view's layer. Mirror the reducer's no-op guard.
         if (_uiState.value.editorMode != mode) {
             clearTransientStrokeState()
+            // Drop any in-flight live stroke overlay so it can't linger over the new mode.
+            _uiState.update { it.copy(liveStrokeLayerId = null, liveStrokeBitmap = null, liveStrokePoints = emptyList()) }
             pendingStencilSourceLayerId = null
             pendingStencilProjectId = null
         }
@@ -1226,8 +1218,12 @@ class EditorViewModel @Inject constructor(
     // Kept for interface compliance; no longer called (DrawingCanvas now uses the three-phase API).
     override fun onDrawingPathFinished(path: List<Offset>, canvasSize: IntSize) {}
 
-    /** Called when the user first touches the canvas. Prepares a mutable working bitmap for
-     *  incremental real-time rendering (all tools except Liquify). */
+    /**
+     * Called when the user first touches the canvas. For every tool except Liquify the in-progress
+     * stroke is shown as an instant vector overlay (see [EditorUiState.liveStrokePoints]) — no bitmap
+     * copy, no per-point GPU upload — and only rasterized into the layer on finger-up. Liquify warps
+     * pixels and can't be drawn as a path, so it still streams a baked bitmap.
+     */
     fun onStrokeStart(startPoint: Offset, canvasSize: IntSize) {
         val state = _uiState.value
         if (state.activeTool == Tool.NONE) return
@@ -1251,65 +1247,12 @@ class EditorViewModel @Inject constructor(
             return
         }
 
-        val tool = state.activeTool
-        val argb = state.activeColor.toArgb()
-        val brushSize = state.brushSize
-        val feathering = state.brushFeathering
-
-        // Copy the bitmap on a background thread (can be ~10-50 ms for large images).
-        // After the copy is done, replay ALL points collected so far (including any that
-        // arrived while the copy was in flight) so no input is lost.
-        viewModelScope.launch(dispatchers.default) {
-            val workBitmap = originalBitmap.copy(Bitmap.Config.ARGB_8888, true)
-            val workCanvas = Canvas(workBitmap)
-            // Read the transform off the captured immutable `layer` (not the mutable stroke* members,
-            // which a quick second stroke could overwrite before this coroutine runs).
-            val layerScale = layer.scale
-            val layerOffset = layer.offset
-            val layerRotationZ = layer.rotationZ
-            // Match the rail size preview exactly: brushSize is screen px; scale it into this layer's
-            // bitmap space (1f for an unscaled sketch) so the painted dab is the previewed diameter.
-            val brushScale = ImageProcessor.screenToBitmapScale(
-                canvasSize.width, canvasSize.height, workBitmap.width, workBitmap.height, layerScale
-            )
-            val paint = buildStrokePaint(tool, argb, brushSize * brushScale, feathering)
-
-            // Snapshot the collected points at this moment — may include points that arrived
-            // during the bitmap-copy phase.
-            val catchUpPoints = strokeCollectedPoints.toList()
-            val mappedAll = ImageProcessor.mapScreenToBitmap(
-                catchUpPoints, canvasSize.width, canvasSize.height, workBitmap.width, workBitmap.height,
-                layerScale, layerOffset, layerRotationZ
-            )
-
-            if (mappedAll.size == 1) {
-                workCanvas.drawPoint(mappedAll[0].x, mappedAll[0].y, paint)
-            } else {
-                val seg = android.graphics.Path()
-                seg.moveTo(mappedAll[0].x, mappedAll[0].y)
-                for (i in 1 until mappedAll.size) {
-                    seg.lineTo(mappedAll[i].x, mappedAll[i].y)
-                }
-                workCanvas.drawPath(seg, paint)
-            }
-
-            val lastMapped = mappedAll.last()
-
-            withContext(dispatchers.main) {
-                strokeWorkingBitmap = workBitmap
-                strokeWorkingCanvas = workCanvas
-                strokePaint = paint
-                strokePrevBitmapPoint = lastMapped
-                _uiState.update { it.copy(
-                    liveStrokeLayerId = layerId,
-                    liveStrokeBitmap = workBitmap,
-                    liveStrokeVersion = it.liveStrokeVersion + catchUpPoints.size
-                )}
-            }
-        }
+        // Instant feedback: publish the first point so the vector overlay paints under the finger
+        // on this very frame. Nothing heavy happens until onStrokeEnd.
+        _uiState.update { it.copy(liveStrokeLayerId = layerId, liveStrokePoints = listOf(startPoint)) }
     }
 
-    /** Called for every drag update. Draws only the new segment onto the working bitmap. */
+    /** Called for every drag update. Appends the point to the live vector overlay (Liquify excepted). */
     fun onStrokePoint(currentPoint: Offset) {
         strokeCollectedPoints.add(currentPoint)
 
@@ -1361,138 +1304,112 @@ class EditorViewModel @Inject constructor(
             return
         }
 
-        val canvas = strokeWorkingCanvas ?: return
-        val paint = strokePaint ?: return
-        val prev = strokePrevBitmapPoint ?: return
-        val workBitmap = strokeWorkingBitmap ?: return
-
-        val mapped = ImageProcessor.mapScreenToBitmap(
-            listOf(currentPoint), strokeCanvasW, strokeCanvasH, workBitmap.width, workBitmap.height,
-            strokeLayerScale, strokeLayerOffset, strokeLayerRotationZ
-        ).first()
-
-        val seg = Path()
-        seg.moveTo(prev.x, prev.y)
-        seg.lineTo(mapped.x, mapped.y)
-        canvas.drawPath(seg, paint)
-        strokePrevBitmapPoint = mapped
-
-        _uiState.update { it.copy(liveStrokeVersion = it.liveStrokeVersion + 1) }
+        // Vector overlay: just publish the accumulated points. No bitmap mutation, no texture
+        // re-upload — the overlay redraws as cheap lines, so the stroke tracks the finger instantly.
+        if (strokeLayerId == null) return
+        _uiState.update { it.copy(liveStrokePoints = strokeCollectedPoints.toList()) }
     }
 
     /** Called when the user lifts their finger. Finalizes the stroke into the layer and undo history. */
     fun onStrokeEnd() {
         val state = _uiState.value
+        val tool = state.activeTool
         val layerId = strokeLayerId ?: return
         val layer = state.layers.find { it.id == layerId } ?: return
         val points = strokeCollectedPoints.toList()
         val canvasW = strokeCanvasW
         val canvasH = strokeCanvasH
-
         val capturedScale = strokeLayerScale
         val capturedOffset = strokeLayerOffset
         val capturedRotationZ = strokeLayerRotationZ
+        val argb = state.activeColor.toArgb()
+        val brushSize = state.brushSize
+        val feathering = state.brushFeathering
 
-        if (state.activeTool == Tool.LIQUIFY || strokeWorkingBitmap == null) {
-            // Liquify (or a stroke so fast the background copy hadn't finished):
-            // fall back to the full whole-stroke approach.
-            val bitmap = layer.bitmap ?: return
-            
-            val finalBitmap = if (state.activeTool == Tool.LIQUIFY) {
-                // Fall back to the committed layer bitmap if the original was already cleared
-                // (e.g. a second onStrokeEnd, or a start that never populated it) rather than NPE.
-                val baked = (liquifyOriginalBitmap ?: bitmap).copy(Bitmap.Config.ARGB_8888, true)
-                slamManager.bakeLiquify(baked)
-                baked
-            } else {
-                bitmap // Should not happen for non-liquify if strokeWorkingBitmap is null but it's a safety
-            }
-
+        if (tool == Tool.LIQUIFY) {
+            // Liquify warps pixels in the native engine; bake the accumulated warp into the bitmap.
+            val bitmap = layer.bitmap ?: run { clearTransientStrokeState(); return }
+            val baked = (liquifyOriginalBitmap ?: bitmap).copy(Bitmap.Config.ARGB_8888, true)
+            slamManager.bakeLiquify(baked)
             val command = StrokeCommand(
-                path = points,
-                canvasSize = IntSize(canvasW, canvasH),
-                tool = state.activeTool,
-                brushSize = state.brushSize,
-                brushColor = state.activeColor.toArgb(),
-                intensity = 0.5f,
-                feathering = state.brushFeathering,
-                layerScale = capturedScale,
-                layerOffset = capturedOffset,
-                layerRotationZ = capturedRotationZ
+                path = points, canvasSize = IntSize(canvasW, canvasH), tool = tool,
+                brushSize = brushSize, brushColor = argb, intensity = 0.5f, feathering = feathering,
+                layerScale = capturedScale, layerOffset = capturedOffset, layerRotationZ = capturedRotationZ
             )
-
-            // Add stroke to history
             layerStore.addStroke(layerId, command)
             history.pushDraw(layerId, command)
             updateHistoryCounts()
-
             _uiState.update { s ->
                 s.copy(
-                    layers = s.layers.map { if (it.id == layerId) it.copy(bitmap = finalBitmap) else it },
-                    liveStrokeLayerId = null,
-                    liveStrokeBitmap = null
+                    layers = s.layers.map { if (it.id == layerId) it.copy(bitmap = baked) else it },
+                    liveStrokeLayerId = null, liveStrokeBitmap = null, liveStrokePoints = emptyList()
                 )
             }
-            scheduleDiskSave(layerId, finalBitmap, layer.uri)
-        } else {
-            // Real-time path: the working bitmap already contains the complete stroke.
-            val workBitmap = strokeWorkingBitmap!!
-            val command = StrokeCommand(
-                path = points,
-                canvasSize = IntSize(canvasW, canvasH),
-                tool = state.activeTool,
-                brushSize = state.brushSize,
-                brushColor = state.activeColor.toArgb(),
-                intensity = 0.5f,
-                feathering = state.brushFeathering,
-                layerScale = capturedScale,
-                layerOffset = capturedOffset,
-                layerRotationZ = capturedRotationZ
-            )
-
-            // Add stroke to history for undo/redo replay.
-            layerStore.addStroke(layerId, command)
-            history.pushDraw(layerId, command)
-            updateHistoryCounts()
-
-            // Commit: working bitmap becomes the displayed layer bitmap.
-            _uiState.update { s ->
-                s.copy(
-                    layers = s.layers.map { if (it.id == layerId) it.copy(bitmap = workBitmap) else it },
-                    liveStrokeLayerId = null,
-                    liveStrokeBitmap = null
-                )
-            }
-            scheduleDiskSave(layerId, workBitmap, layer.uri)
+            scheduleDiskSave(layerId, baked, layer.uri)
+            opEmitter.emit(Op.LayerBitmapReplace(layerId, ImageUtils.bitmapToByteArray(baked)))
+            clearTransientStrokeState()
+            return
         }
 
-        // Co-op sync: replayable brush strokes go as StrokeComplete; Liquify bakes into the
-        // bitmap and can't map to a BrushStroke, so it propagates as a whole-bitmap replace.
-        if (state.activeTool != Tool.LIQUIFY) {
-            val bitmap = layer.bitmap
-            if (bitmap != null) {
-                val mappedPoints = ImageProcessor.mapScreenToBitmap(
-                    points, canvasW, canvasH, bitmap.width, bitmap.height,
-                    capturedScale, capturedOffset, capturedRotationZ
-                )
-                val pointsFlat = mappedPoints.flatMap { listOf(it.x, it.y) }
-                val brushStroke = BrushStroke(
-                    points = pointsFlat,
-                    colorArgb = state.activeColor.toArgb().toLong() and 0xFFFFFFFFL,
-                    brushSize = state.brushSize,
-                    brushFeathering = state.brushFeathering,
-                    blendModeOrdinal = state.activeTool.ordinal
-                )
-                opEmitter.emit(Op.StrokeComplete(layerId, brushStroke))
-            }
-        } else {
-            val baked = _uiState.value.layers.find { it.id == layerId }?.bitmap
-            if (baked != null) {
-                opEmitter.emit(Op.LayerBitmapReplace(layerId, ImageUtils.bitmapToByteArray(baked)))
-            }
-        }
-
+        // All other tools: the stroke was shown live as a vector overlay; rasterize it into the layer
+        // bitmap exactly once, now. Capture-state is cleared synchronously so a fast next stroke starts
+        // clean, while the overlay (uiState.liveStrokePoints) stays up until the committed bitmap lands
+        // — so there's no flash of the un-drawn layer between finger-up and commit.
+        val base = layer.bitmap
+        val uri = layer.uri
         clearTransientStrokeState()
+        if (base == null || points.isEmpty()) {
+            _uiState.update { it.copy(liveStrokeLayerId = null, liveStrokeBitmap = null, liveStrokePoints = emptyList()) }
+            return
+        }
+
+        viewModelScope.launch(dispatchers.default) {
+            val brushScale = ImageProcessor.screenToBitmapScale(
+                canvasW, canvasH, base.width, base.height, capturedScale
+            )
+            val mapped = ImageProcessor.mapScreenToBitmap(
+                points, canvasW, canvasH, base.width, base.height,
+                capturedScale, capturedOffset, capturedRotationZ
+            )
+            val finalBitmap = ImageProcessor.applyToolToBitmap(
+                base, mapped, tool, brushSize * brushScale, argb, 0.5f, false, feathering
+            )
+            val pointsFlat = mapped.flatMap { listOf(it.x, it.y) }
+            withContext(dispatchers.main) {
+                val command = StrokeCommand(
+                    path = points, canvasSize = IntSize(canvasW, canvasH), tool = tool,
+                    brushSize = brushSize, brushColor = argb, intensity = 0.5f, feathering = feathering,
+                    layerScale = capturedScale, layerOffset = capturedOffset, layerRotationZ = capturedRotationZ
+                )
+                layerStore.addStroke(layerId, command)
+                history.pushDraw(layerId, command)
+                updateHistoryCounts()
+                _uiState.update { s ->
+                    // Only retire the live overlay if no new stroke has started in the meantime; the
+                    // committed bitmap is always applied.
+                    val noNewStroke = strokeLayerId == null
+                    s.copy(
+                        layers = s.layers.map { if (it.id == layerId) it.copy(bitmap = finalBitmap) else it },
+                        liveStrokeLayerId = if (noNewStroke) null else s.liveStrokeLayerId,
+                        liveStrokeBitmap = if (noNewStroke) null else s.liveStrokeBitmap,
+                        liveStrokePoints = if (noNewStroke) emptyList() else s.liveStrokePoints
+                    )
+                }
+                scheduleDiskSave(layerId, finalBitmap, uri)
+                opEmitter.emit(
+                    Op.StrokeComplete(
+                        layerId,
+                        BrushStroke(
+                            points = pointsFlat,
+                            colorArgb = argb.toLong() and 0xFFFFFFFFL,
+                            brushSize = brushSize,
+                            brushFeathering = feathering,
+                            blendModeOrdinal = tool.ordinal
+                        )
+                    )
+                )
+            }
+        }
     }
 
     /**
@@ -1502,10 +1419,6 @@ class EditorViewModel @Inject constructor(
      * onStrokePoint/onStrokeEnd can't commit to a stale layer or bitmap.
      */
     private fun clearTransientStrokeState() {
-        strokeWorkingBitmap = null
-        strokeWorkingCanvas = null
-        strokePaint = null
-        strokePrevBitmapPoint = null
         strokeCollectedPoints = mutableListOf()
         strokeLayerId = null
 
@@ -1513,44 +1426,6 @@ class EditorViewModel @Inject constructor(
         liquifyJob = null
         liquifyOriginalBitmap = null
     }
-
-    private fun buildStrokePaint(tool: Tool, argbColor: Int, brushSize: Float, feathering: Float): Paint =
-        Paint().apply {
-            strokeWidth = brushSize
-            style = Paint.Style.STROKE
-            strokeCap = Paint.Cap.ROUND
-            strokeJoin = Paint.Join.ROUND
-            isAntiAlias = true
-            when (tool) {
-                Tool.BRUSH -> {
-                    color = argbColor
-                    if (feathering > 0f) maskFilter = BlurMaskFilter(brushSize * feathering * 0.5f, BlurMaskFilter.Blur.NORMAL)
-                }
-                Tool.ERASER -> {
-                    xfermode = PorterDuffXfermode(PorterDuff.Mode.CLEAR)
-                    if (feathering > 0f) maskFilter = BlurMaskFilter(brushSize * feathering * 0.5f, BlurMaskFilter.Blur.NORMAL)
-                }
-                Tool.BLUR -> {
-                    maskFilter = BlurMaskFilter(brushSize * 0.5f, BlurMaskFilter.Blur.NORMAL)
-                    alpha = 150
-                }
-                Tool.BURN -> {
-                    color = android.graphics.Color.BLACK
-                    alpha = (255 * 0.3f).toInt().coerceIn(0, 255)
-                    xfermode = PorterDuffXfermode(PorterDuff.Mode.DARKEN)
-                }
-                Tool.DODGE -> {
-                    color = android.graphics.Color.WHITE
-                    alpha = (255 * 0.3f).toInt().coerceIn(0, 255)
-                    xfermode = PorterDuffXfermode(PorterDuff.Mode.LIGHTEN)
-                }
-                Tool.HEAL -> {
-                    color = argbColor
-                    alpha = 128
-                }
-                else -> {}
-            }
-        }
 
     override fun onColorClicked() {
         dispatch(EditorIntent.ShowColorPicker)

--- a/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/util/ImageProcessor.kt
+++ b/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/util/ImageProcessor.kt
@@ -112,6 +112,55 @@ object ImageProcessor {
                     }
         }
 
+        /**
+         * Single source of truth for a tool's stroke [Paint]. Used both for the live vector preview
+         * and the final rasterization so the in-progress stroke looks identical to the committed
+         * result. [brushSize] is in the destination's pixel units (bitmap px when committing, local
+         * canvas px when previewing). Liquify isn't paint-based, so it returns a plain brush paint.
+         */
+        fun buildToolPaint(
+            tool: Tool,
+            brushColor: Int,
+            brushSize: Float,
+            intensity: Float = 0.5f,
+            feathering: Float = 0f,
+        ): Paint = Paint().apply {
+            strokeWidth = brushSize
+            style = Paint.Style.STROKE
+            strokeCap = Paint.Cap.ROUND
+            strokeJoin = Paint.Join.ROUND
+            isAntiAlias = true
+            when (tool) {
+                Tool.BRUSH -> {
+                    color = brushColor
+                    if (feathering > 0f) maskFilter = BlurMaskFilter(brushSize * feathering * 0.5f, BlurMaskFilter.Blur.NORMAL)
+                }
+                Tool.ERASER -> {
+                    xfermode = PorterDuffXfermode(PorterDuff.Mode.CLEAR)
+                    if (feathering > 0f) maskFilter = BlurMaskFilter(brushSize * feathering * 0.5f, BlurMaskFilter.Blur.NORMAL)
+                }
+                Tool.BLUR -> {
+                    maskFilter = BlurMaskFilter(brushSize * intensity.coerceAtLeast(0.1f), BlurMaskFilter.Blur.NORMAL)
+                    alpha = 150
+                }
+                Tool.HEAL -> {
+                    color = brushColor
+                    alpha = 128
+                }
+                Tool.BURN -> {
+                    color = Color.BLACK
+                    alpha = (255 * intensity * 0.3f).toInt().coerceIn(0, 255)
+                    xfermode = PorterDuffXfermode(PorterDuff.Mode.DARKEN)
+                }
+                Tool.DODGE -> {
+                    color = Color.WHITE
+                    alpha = (255 * intensity * 0.3f).toInt().coerceIn(0, 255)
+                    xfermode = PorterDuffXfermode(PorterDuff.Mode.LIGHTEN)
+                }
+                else -> { color = brushColor }
+            }
+        }
+
             suspend fun applyToolToBitmap(
                         originalBitmap: Bitmap,
                         stroke: List<Offset>,
@@ -129,93 +178,11 @@ object ImageProcessor {
                                 val canvas = Canvas(resultBitmap)
 
                                         when (tool) {
-                                                        Tool.BRUSH -> {
-                                                                            val paint = Paint().apply {
-                                                                                                    color = brushColor
-                                                                                                    strokeWidth = brushSize
-                                                                                                    style = Paint.Style.STROKE
-                                                                                                    strokeCap = Paint.Cap.ROUND
-                                                                                                    strokeJoin = Paint.Join.ROUND
-                                                                                                    isAntiAlias = true
-                                                                                                    if (feathering > 0f) {
-                                                                                                        maskFilter = BlurMaskFilter(brushSize * feathering * 0.5f, BlurMaskFilter.Blur.NORMAL)
-                                                                                                    }
-                                                                            }
-                                                                                            drawStroke(canvas, stroke, paint)
-                                                        }
-
-                                                                    Tool.ERASER -> {
-                                                                                        val paint = Paint().apply {
-                                                                                                                strokeWidth = brushSize
-                                                                                                                style = Paint.Style.STROKE
-                                                                                                                strokeCap = Paint.Cap.ROUND
-                                                                                                                strokeJoin = Paint.Join.ROUND
-                                                                                                                isAntiAlias = true
-                                                                                                                xfermode = PorterDuffXfermode(PorterDuff.Mode.CLEAR)
-                                                                                                                if (feathering > 0f) {
-                                                                                                                    maskFilter = BlurMaskFilter(brushSize * feathering * 0.5f, BlurMaskFilter.Blur.NORMAL)
-                                                                                                                }
-                                                                                        }
-                                                                                                        drawStroke(canvas, stroke, paint)
-                                                                    }
-
-                                                                                Tool.BLUR -> {
-                                                                                                    val paint = Paint().apply {
-                                                                                                                            strokeWidth = brushSize
-                                                                                                                            style = Paint.Style.STROKE
-                                                                                                                            strokeCap = Paint.Cap.ROUND
-                                                                                                                            strokeJoin = Paint.Join.ROUND
-                                                                                                                            isAntiAlias = true
-                                                                                                                            maskFilter = BlurMaskFilter(brushSize * intensity.coerceAtLeast(0.1f), BlurMaskFilter.Blur.NORMAL)
-                                                                                                                                                alpha = 150
-                                                                                                    }
-                                                                                                                    drawStroke(canvas, stroke, paint)
-                                                                                }
-
-                                                                                            Tool.LIQUIFY -> {
-                                                                                                                applyLiquifyNative(resultBitmap, stroke, brushSize, intensity)
-                                                                                            }
-
-                                                                                                        Tool.HEAL -> {
-                                                                                                                            val paint = Paint().apply {
-                                                                                                                                                    color = brushColor
-                                                                                                                                                    strokeWidth = brushSize
-                                                                                                                                                    style = Paint.Style.STROKE
-                                                                                                                                                    strokeCap = Paint.Cap.ROUND
-                                                                                                                                                    strokeJoin = Paint.Join.ROUND
-                                                                                                                                                    isAntiAlias = true
-                                                                                                                                                    alpha = 128
-                                                                                                                            }
-                                                                                                                                            drawStroke(canvas, stroke, paint)
-                                                                                                        }
-                                                                                                        
-                                                                                                                    Tool.BURN -> {
-                                                                                                                                        val paint = Paint().apply {
-                                                                                                                                                                color = Color.BLACK
-                                                                                                                                                                strokeWidth = brushSize
-                                                                                                                                                                style = Paint.Style.STROKE
-                                                                                                                                                                strokeCap = Paint.Cap.ROUND
-                                                                                                                                                                strokeJoin = Paint.Join.ROUND
-                                                                                                                                                                alpha = (255 * intensity * 0.3f).toInt().coerceIn(0, 255)
-                                                                                                                                                                                    xfermode = PorterDuffXfermode(PorterDuff.Mode.DARKEN)
-                                                                                                                                        }
-                                                                                                                                                        drawStroke(canvas, stroke, paint)
-                                                                                                                    }
-                                                                                                                    
-                                                                                                                                Tool.DODGE -> {
-                                                                                                                                                    val paint = Paint().apply {
-                                                                                                                                                                            color = Color.WHITE
-                                                                                                                                                                            strokeWidth = brushSize
-                                                                                                                                                                            style = Paint.Style.STROKE
-                                                                                                                                                                            strokeCap = Paint.Cap.ROUND
-                                                                                                                                                                            strokeJoin = Paint.Join.ROUND
-                                                                                                                                                                            alpha = (255 * intensity * 0.3f).toInt().coerceIn(0, 255)
-                                                                                                                                                                                                xfermode = PorterDuffXfermode(PorterDuff.Mode.LIGHTEN)
-                                                                                                                                                                                                                }
-                                                                                                                                                                    drawStroke(canvas, stroke, paint)
-                                                                                                                                }
-                                                                                                                                
-                                                                                                                                            else -> {}
+                                            Tool.LIQUIFY -> applyLiquifyNative(resultBitmap, stroke, brushSize, intensity)
+                                            else -> drawStroke(
+                                                canvas, stroke,
+                                                buildToolPaint(tool, brushColor, brushSize, intensity, feathering)
+                                            )
                                         }
 
                                                 resultBitmap


### PR DESCRIPTION
Drawing lagged because every drag point rasterized into the layer bitmap and re-uploaded the whole texture to the GPU, and the first dab waited on a background full-bitmap copy.

Now the in-progress stroke is shown as a live vector overlay (no per-point bitmap work, no texture re-upload) and is rasterized into the layer once, on finger-up:

- EditorViewModel: onStrokeStart/onStrokePoint just publish the stroke's screen-space points (liveStrokePoints); onStrokeEnd rasterizes the whole stroke into the layer bitmap a single time. Liquify keeps its baked-bitmap path since it warps pixels and can't be drawn as a path.
- MainScreen: for the active stroke, the committed layer and the live stroke are drawn into one offscreen-composited group, so destructive tools (eraser CLEAR, burn DARKEN, dodge LIGHTEN) composite against the layer and reveal what's beneath - matching the final raster.
- ImageProcessor.buildToolPaint: one source of truth for each tool's stroke paint, shared by the live preview and the final rasterization so they look identical. applyToolToBitmap now uses it too.
- EditorUiState.liveStrokePoints added; dead incremental-rasterization state and the duplicate paint builder removed.

## Summary by Sourcery

Show in-progress paint strokes as a live vector overlay and rasterize them into layers only on stroke completion to eliminate per-point bitmap work and improve responsiveness.

New Features:
- Add live vector stroke preview for all non-Liquify paint tools using screen-space points in editor UI state.

Enhancements:
- Centralize brush/eraser and other paint tool configuration in a shared ImageProcessor.buildToolPaint helper used by both preview and final rasterization.
- Refine layer rendering to offscreen-composite the active layer with the live stroke so destructive blend modes preview identically to the final raster.
- Simplify EditorViewModel stroke state by removing incremental bitmap drawing in favor of a single apply-on-end path and keeping Liquify as the only bitmap-streaming tool.