### PR TITLE
Claude/tutorial design flow nygfo6

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -524,6 +524,16 @@ class MainActivity : ComponentActivity() {
                 // current walkthrough step is asking the user to interact with.
                 val railItemBounds = remember { androidx.compose.runtime.mutableStateMapOf<String, androidx.compose.ui.geometry.Rect>() }
 
+                // Coach state is hoisted here (above azAdvanced) so the rail's onInteraction callback
+                // can advance the walkthrough when the user taps the very item it points at. The rail
+                // consumes its own taps, so they never reach the coach overlay's screen-tap observer —
+                // onInteraction is the supported "the user used the rail" signal, and it fires for the
+                // Design host and the Open/Sketch/Text sub-items alike.
+                val coachStep = rememberCoachStep(editorUiState, arUiState)
+                var coachLineIdx by androidx.compose.runtime.saveable.rememberSaveable(coachStep?.key) {
+                    mutableStateOf(0)
+                }
+
                 AzHostActivityLayout(navController = navController, currentDestination = currentRoute, initiallyExpanded = false) {
                     azTheme(
                         activeColor = Cyan,
@@ -544,7 +554,14 @@ class MainActivity : ComponentActivity() {
                         // interaction (tap, toggle, cycler, nested-rail open, reloc drag) here, so
                         // the do-it-to-advance walkthrough advances when the user performs the
                         // targeted action. Replaces the scattered per-item onRailTap calls.
-                        onInteraction = { id, _ -> mainViewModel.onRailInteraction(id) },
+                        onInteraction = { id, _ ->
+                            mainViewModel.onRailInteraction(id)
+                            // Advance the adaptive coach when the user taps the item it's pointing at
+                            // (Design → Open → Sketch → Text). Rail taps don't reach the overlay's
+                            // own tap observer, so this is what moves the coach forward on the rail.
+                            val cs = coachStep
+                            if (cs != null && id == cs.targetForLine(coachLineIdx)) coachLineIdx++
+                        },
                         // Window-space bounds per item, so the walkthrough can point at its target.
                         onItemGloballyPositioned = { id, rect -> railItemBounds[id] = rect }
                     )
@@ -634,7 +651,8 @@ class MainActivity : ComponentActivity() {
                         // step's lines one at a time (screen tap or idle timer), and remembers each
                         // step as shown so it never nags. Tapping Help (tutorialModeActive) replays
                         // coaching for the session, ignoring the persisted "already seen" set.
-                        val coachStep = rememberCoachStep(editorUiState, arUiState)
+                        // coachStep / coachLineIdx are hoisted above azAdvanced so rail taps can drive
+                        // them; the overlay below is the canvas-tap driver for the same line index.
                         val replayCoaching = mainUiState.tutorialModeActive
                         val coachSeenThisSession =
                             remember(replayCoaching) { androidx.compose.runtime.mutableStateListOf<String>() }
@@ -646,7 +664,9 @@ class MainActivity : ComponentActivity() {
                                 OnboardingCoachOverlay(
                                     step = coachStep,
                                     gestureInProgress = editorUiState.gestureInProgress,
+                                    lineIdx = coachLineIdx,
                                     boundsFor = { railItemBounds[it] },
+                                    onAdvance = { coachLineIdx++ },
                                     onSeen = {
                                         coachSeenThisSession.add(key)
                                         if (!replayCoaching) mainViewModel.markTutorialCompletePersistent(key)

--- a/app/src/main/java/com/hereliesaz/graffitixr/OnboardingCoach.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/OnboardingCoach.kt
@@ -121,7 +121,9 @@ fun rememberCoachStep(editor: EditorUiState, ar: ArUiState): CoachStep? {
 fun OnboardingCoachOverlay(
     step: CoachStep,
     gestureInProgress: Boolean,
+    lineIdx: Int,
     boundsFor: (String) -> Rect?,
+    onAdvance: () -> Unit,
     onSeen: () -> Unit,
 ) {
     var settled by remember(step.key) { mutableStateOf(false) }
@@ -134,16 +136,16 @@ fun OnboardingCoachOverlay(
     }
     if (gestureInProgress || !settled) return
 
-    var lineIdx by rememberSaveable(step.key) { mutableStateOf(0) }
-    // Resolve the pointer target for the line currently showing — for a multi-target step this moves
-    // the arrow from item to item as the user pages through (e.g. Open → Sketch → Text). Reading the
-    // bounds here keeps the arrow live as the rail reports positions (the Design menu opening, etc.).
+    // The current line is controlled by the caller, so two sources can drive it: the overlay's own
+    // screen tap (canvas), and a matching rail interaction (rail taps are consumed by the rail and
+    // never reach this overlay, so they advance through the hoisted state instead). The pointer
+    // target is resolved per line — for a multi-target step the arrow moves item to item.
     val targetBounds = step.targetForLine(lineIdx)?.let(boundsFor)
     ModeOnboardingOverlay(
         positionKey = step.key,
         step = lineIdx,
         lines = step.lines,
-        onAdvance = { lineIdx++ },
+        onAdvance = onAdvance,
         onDismiss = onSeen,
         targetBounds = targetBounds,
     )

--- a/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/EditorViewModel.kt
+++ b/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/EditorViewModel.kt
@@ -1226,7 +1226,8 @@ class EditorViewModel @Inject constructor(
      */
     fun onStrokeStart(startPoint: Offset, canvasSize: IntSize) {
         val state = _uiState.value
-        if (state.activeTool == Tool.NONE) return
+        // NONE and COLOR aren't paint tools — they never produce a stroke.
+        if (state.activeTool == Tool.NONE || state.activeTool == Tool.COLOR) return
         val layerId = state.activeLayerId ?: return
         val layer = state.layers.find { it.id == layerId } ?: return
         val originalBitmap = layer.bitmap ?: return

--- a/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/util/ImageProcessor.kt
+++ b/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/util/ImageProcessor.kt
@@ -179,6 +179,7 @@ object ImageProcessor {
 
                                         when (tool) {
                                             Tool.LIQUIFY -> applyLiquifyNative(resultBitmap, stroke, brushSize, intensity)
+                                            Tool.NONE, Tool.COLOR -> Unit // not paint tools — nothing to rasterize
                                             else -> drawStroke(
                                                 canvas, stroke,
                                                 buildToolPaint(tool, brushColor, brushSize, intensity, feathering)

--- a/feature/editor/src/test/java/com/hereliesaz/graffitixr/feature/editor/EditorViewModelTest.kt
+++ b/feature/editor/src/test/java/com/hereliesaz/graffitixr/feature/editor/EditorViewModelTest.kt
@@ -374,7 +374,7 @@ class EditorViewModelTest {
     }
 
     @Test
-    fun `onStrokeStart replays all buffered points after bitmap copy`() = runTest {
+    fun `onStrokePoint accumulates the live vector stroke for non-Liquify tools`() = runTest {
         val uri = Uri.parse("content://test/image.png")
         viewModel.onAddLayer(uri)
         testDispatcher.scheduler.advanceUntilIdle()
@@ -393,8 +393,13 @@ class EditorViewModelTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         val state = viewModel.uiState.value
-        assertNotNull(state.liveStrokeBitmap)
-        assertTrue("Expected liveStrokeVersion >= 1, got ${state.liveStrokeVersion}", state.liveStrokeVersion >= 1)
+        // Non-Liquify tools render as an instant vector overlay — no per-point bitmap upload.
+        assertEquals(layerId, state.liveStrokeLayerId)
+        assertNull(state.liveStrokeBitmap)
+        assertEquals(
+            listOf(Offset(10f, 10f), Offset(20f, 20f), Offset(30f, 30f), Offset(40f, 40f)),
+            state.liveStrokePoints
+        )
     }
 
     @Test


### PR DESCRIPTION
## Summary by Sourcery

Hoist onboarding coach state so rail interactions can advance tutorial steps and adjust stroke handling so non-paint tools do not produce rasterized strokes.

Bug Fixes:
- Ensure tutorial coach advances when users interact with the targeted rail items, including nested design sub-items.
- Prevent NONE and COLOR tools from starting or rasterizing strokes in the image processor, aligning behavior with non-paint tools.

Tests:
- Update editor view model stroke handling test to assert accumulation of live vector stroke points for non-Liquify tools instead of bitmap-based rendering.