### PR TITLE
Claude/tutorial design flow nygfo6

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -533,6 +533,9 @@ class MainActivity : ComponentActivity() {
                 var coachLineIdx by androidx.compose.runtime.saveable.rememberSaveable(coachStep?.key) {
                     mutableStateOf(0)
                 }
+                // True only while the coach overlay is actually on screen — gates rail-tap advancement
+                // so a startup/selection sync can't skip the first ("tap Design") line.
+                var coachVisible by remember { mutableStateOf(false) }
 
                 AzHostActivityLayout(navController = navController, currentDestination = currentRoute, initiallyExpanded = false) {
                     azTheme(
@@ -559,8 +562,9 @@ class MainActivity : ComponentActivity() {
                             // Advance the adaptive coach when the user taps the item it's pointing at
                             // (Design → Open → Sketch → Text). Rail taps don't reach the overlay's
                             // own tap observer, so this is what moves the coach forward on the rail.
+                            // Gated on coachVisible so a startup sync can't skip the first line.
                             val cs = coachStep
-                            if (cs != null && id == cs.targetForLine(coachLineIdx)) coachLineIdx++
+                            if (cs != null && coachVisible && id == cs.targetForLine(coachLineIdx)) coachLineIdx++
                         },
                         // Window-space bounds per item, so the walkthrough can point at its target.
                         onItemGloballyPositioned = { id, rect -> railItemBounds[id] = rect }
@@ -671,6 +675,7 @@ class MainActivity : ComponentActivity() {
                                         coachSeenThisSession.add(key)
                                         if (!replayCoaching) mainViewModel.markTutorialCompletePersistent(key)
                                     },
+                                    onVisibilityChanged = { coachVisible = it },
                                 )
                             }
                         }

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainViewModel.kt
@@ -38,9 +38,11 @@ data class MainUiState(
     // True when the current capture was initiated via the tap-to-target path (Phase 4).
     val captureOriginatedFromTap: Boolean = false,
     val tutorialCompleted: Map<String, Boolean> = emptyMap(),
-    // When true, the do-it-to-advance walkthrough is running: the card shows the next action and
-    // performing that exact rail interaction advances the tour. An explicit, user-toggled mode.
-    val tutorialModeActive: Boolean = false,
+    // Drives the adaptive onboarding coach in "replay" mode: when true the coach surfaces every
+    // session, ignoring the persisted "already seen" set. Enabled by default so the tutorial is on
+    // automatically at launch; the Help button toggles it off (and the do-it-to-advance walkthrough,
+    // which also reads this flag, follows the same switch).
+    val tutorialModeActive: Boolean = true,
     // The ordered walkthrough for the current mode/layers. Each step targets one rail item id and
     // carries its instruction lines. Fed by the composable via [setTutorialSequence]; empty when no
     // tour is active. Reaching the end clears this but leaves [tutorialModeActive] on.

--- a/app/src/main/java/com/hereliesaz/graffitixr/OnboardingCoach.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/OnboardingCoach.kt
@@ -1,11 +1,11 @@
 package com.hereliesaz.graffitixr
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.platform.LocalContext
@@ -125,6 +125,7 @@ fun OnboardingCoachOverlay(
     boundsFor: (String) -> Rect?,
     onAdvance: () -> Unit,
     onSeen: () -> Unit,
+    onVisibilityChanged: (Boolean) -> Unit = {},
 ) {
     var settled by remember(step.key) { mutableStateOf(false) }
     LaunchedEffect(step.key, gestureInProgress) {
@@ -134,6 +135,13 @@ fun OnboardingCoachOverlay(
             settled = true
         }
     }
+    // Report whether the coach is actually surfaced. A rail interaction must only advance a *visible*
+    // step — otherwise a startup/selection sync that fires onInteraction before the coach appears
+    // would silently skip its first line (the "tap Design" intro the user needs to see).
+    val visible = settled && !gestureInProgress
+    LaunchedEffect(visible) { onVisibilityChanged(visible) }
+    DisposableEffect(Unit) { onDispose { onVisibilityChanged(false) } }
+
     if (gestureInProgress || !settled) return
 
     // The current line is controlled by the caller, so two sources can drive it: the overlay's own


### PR DESCRIPTION
## Summary by Sourcery

Enable the adaptive onboarding coach by default and ensure tutorial steps only advance when the coach overlay is actually visible.

New Features:
- Report onboarding coach overlay visibility back to callers via a new callback so UI logic can react to whether the coach is surfaced.

Enhancements:
- Track coach overlay visibility in MainActivity to gate rail-tap advancement and prevent startup syncs from skipping the first tutorial line.
- Set tutorial mode to be active by default so the onboarding coach and walkthrough run automatically on first launch.