### PR TITLE
Harden Design coach step against missing onboarding copy

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/OnboardingCoach.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/OnboardingCoach.kt
@@ -76,12 +76,21 @@ fun rememberCoachStep(editor: EditorUiState, ar: ArUiState): CoachStep? {
             EditorMode.DESIGN -> when {
                 // Intro on 'Design', then — once the user presses it open — walk the pointer across
                 // the layer sources (Open / Sketch / Text), explaining each in turn before they pick.
-                !hasLayers -> CoachStep(
-                    key = "coach.design.add",
-                    targetId = "host.design",
-                    lines = listOf(design.getOrNull(0).orEmpty()) + designLayers,
-                    lineTargets = listOf("host.design", "design.addImg", "design.addDraw", "design.addText"),
-                )
+                // Falls back to the plain 2-line step if the per-source copy is missing (e.g. an
+                // incomplete localization) so the card never shows a blank line.
+                !hasLayers -> {
+                    val intro = design.getOrNull(0)
+                    if (intro != null && designLayers.isNotEmpty()) {
+                        CoachStep(
+                            key = "coach.design.add",
+                            targetId = "host.design",
+                            lines = listOf(intro) + designLayers,
+                            lineTargets = listOf("host.design", "design.addImg", "design.addDraw", "design.addText"),
+                        )
+                    } else {
+                        CoachStep("coach.design.add", "host.design", lines(design, 0, 1))
+                    }
+                }
                 activeLayer == null -> CoachStep("coach.design.select", firstLayerTarget, lines(design, 2))
                 else -> CoachStep("coach.design.use", "host.modes", lines(design, 3))
             }


### PR DESCRIPTION
Both review bots flagged that design.getOrNull(0).orEmpty() would render a blank first coaching line if onboarding_design[0] is missing (e.g. an incomplete localization). Only build the multi-target walkthrough when the intro line and the per-source lines are present; otherwise fall back to the plain 2-line Design step. Keeps lines and lineTargets aligned (a naive listOfNotNull would desync them).

## Summary by Sourcery

Bug Fixes:
- Prevent the Design coach step from showing an empty first line when the intro or per-source onboarding copy is missing.