### PR TITLE
Fix MainViewModel tests for tutorial-mode-on default

### DIFF
--- a/app/src/test/java/com/hereliesaz/graffitixr/MainViewModelTest.kt
+++ b/app/src/test/java/com/hereliesaz/graffitixr/MainViewModelTest.kt
@@ -36,6 +36,11 @@ class MainViewModelTest {
         Dispatchers.setMain(testDispatcher)
         every { settingsRepository.completedTutorials } returns flowOf(emptySet<String>())
         viewModel = MainViewModel(projectRepository, slamManager, projectManager, settingsRepository, context)
+        // The do-it-to-advance walkthrough tests below were written against a tutorial-mode-OFF
+        // start and toggle it on themselves. Production now defaults the mode ON (so the coach
+        // surfaces automatically at launch), so normalize back to off here. The production default
+        // is covered separately by `tutorial mode is on by default`.
+        if (viewModel.uiState.value.tutorialModeActive) viewModel.toggleTutorialMode()
     }
 
     @After
@@ -73,6 +78,14 @@ class MainViewModelTest {
     fun `setCaptureStep updates state`() = runTest {
         viewModel.setCaptureStep(CaptureStep.REVIEW)
         assertEquals(CaptureStep.REVIEW, viewModel.uiState.value.captureStep)
+    }
+
+    @Test
+    fun `tutorial mode is on by default`() = runTest {
+        // A fresh ViewModel (not the setup() one, which normalizes the mode off) must start with
+        // tutorial mode enabled so the onboarding coach surfaces automatically at launch.
+        val fresh = MainViewModel(projectRepository, slamManager, projectManager, settingsRepository, context)
+        assertEquals(true, fresh.uiState.value.tutorialModeActive)
     }
 
     // --- Do-it-to-advance walkthrough ---------------------------------------------------------


### PR DESCRIPTION
Defaulting tutorialModeActive to true broke the do-it-to-advance walkthrough tests, which assume an off start and toggle the mode on themselves. Normalize the mode to off in setup() so those tests are unchanged, and add a dedicated test asserting the production default is on.

## Summary by Sourcery

Normalize MainViewModel test setup to start with tutorial mode disabled while adding coverage for the new production default of tutorial mode being enabled on first launch.

Tests:
- Adjust MainViewModel test setup to explicitly turn tutorial mode off so existing walkthrough tests remain valid.
- Add a new MainViewModel test asserting tutorial mode is enabled by default in production.