### PR TITLE
Fix native SIGSEGV in SuperPointDetector descriptor sampling

### DIFF
--- a/core/nativebridge/src/main/cpp/SuperPointDetector.cpp
+++ b/core/nativebridge/src/main/cpp/SuperPointDetector.cpp
@@ -176,9 +176,12 @@ void SuperPointDetector::sampleDescriptors(const cv::Mat& descTensor, const std:
     const float* dp = (const float*)descTensor.data;
     descs.create((int)kps.size(), D, CV_32F);
     for (int i = 0; i < (int)kps.size(); ++i) {
-        float u = kps[i].pt.x / 8.0f, v = kps[i].pt.y / 8.0f;
-        int u0 = std::min(Wd - 1, std::max(0, (int)u));
-        int v0 = std::min(Hd - 1, std::max(0, (int)v));
+        // Clamp the float coordinates to the descriptor grid before deriving
+        // indices/weights, so out-of-range keypoints sample the edge (clamp-to-edge)
+        // instead of reading out of bounds or extrapolating with fu/fv outside [0,1].
+        float u = std::max(0.0f, std::min(static_cast<float>(Wd - 1), kps[i].pt.x / 8.0f));
+        float v = std::max(0.0f, std::min(static_cast<float>(Hd - 1), kps[i].pt.y / 8.0f));
+        int u0 = (int)u, v0 = (int)v;
         int u1 = std::min(Wd - 1, u0 + 1), v1 = std::min(Hd - 1, v0 + 1);
         float fu = u - u0, fv = v - v0;
         float* row = descs.ptr<float>(i);

--- a/core/nativebridge/src/main/cpp/SuperPointDetector.cpp
+++ b/core/nativebridge/src/main/cpp/SuperPointDetector.cpp
@@ -119,13 +119,17 @@ bool SuperPointDetector::detect(const cv::Mat& gray,
             kps = std::move(filtered);
         }
 
+        if (kps.empty()) return false;
+
+        // Sample descriptors while keypoints are still in network-input space
+        // (the descriptor tensor is at input/8 resolution). Only after sampling
+        // do we rescale the keypoints back to original image space for the caller.
+        descs = cv::Mat();
+        sampleDescriptors(*descPtr, kps, descs);
+
         if (scaleX != 1.0f || scaleY != 1.0f) {
             for (auto& kp : kps) { kp.pt.x *= scaleX; kp.pt.y *= scaleY; }
         }
-
-        if (kps.empty()) return false;
-        descs = cv::Mat();
-        sampleDescriptors(*descPtr, kps, descs);
         return true;
     } catch (...) {
         return false;
@@ -173,7 +177,8 @@ void SuperPointDetector::sampleDescriptors(const cv::Mat& descTensor, const std:
     descs.create((int)kps.size(), D, CV_32F);
     for (int i = 0; i < (int)kps.size(); ++i) {
         float u = kps[i].pt.x / 8.0f, v = kps[i].pt.y / 8.0f;
-        int u0 = std::max(0, (int)u), v0 = std::max(0, (int)v);
+        int u0 = std::min(Wd - 1, std::max(0, (int)u));
+        int v0 = std::min(Hd - 1, std::max(0, (int)v));
         int u1 = std::min(Wd - 1, u0 + 1), v1 = std::min(Hd - 1, v0 + 1);
         float fu = u - u0, fv = v - v0;
         float* row = descs.ptr<float>(i);


### PR DESCRIPTION
## Problem

A native crash (SIGSEGV, sig=11) was reported from production:

```
#03 SuperPointDetector::sampleDescriptors
#04 SuperPointDetector::detect
#05 MobileGS::getFingerprintKeypoints
#06 Java_..._SlamManager_nativeGetFingerprintKeypoints
```

It is an out-of-bounds read of the SuperPoint descriptor tensor.

## Root cause

In `core/nativebridge/src/main/cpp/SuperPointDetector.cpp`:

1. `extractKeypoints` produces keypoints in **network-input space** — the frame is downscaled to ≤640×480 before inference.
2. `detect` rescaled those keypoints **back to original image space** (`kp.pt *= scaleX/scaleY`) **before** sampling descriptors.
3. `sampleDescriptors` indexes the descriptor tensor (sized `input/8`) by dividing keypoint coords by 8 — so the rescaled, larger coordinates overshot the tensor bounds `[0, Wd-1] × [0, Hd-1]`.
4. The bilinear sampler only clamped the **lower** bound of `u0`/`v0` (`max(0, …)`), with no upper clamp, so an overshoot indexed past the buffer → segfault.

## Fix

- **Reorder `detect`**: sample descriptors while keypoints are still in network-input space, then rescale to original space afterward for the caller. Mask filtering (which compares against the resized mask in input space) stays before the rescale, so its behavior is unchanged.
- **Harden `sampleDescriptors`**: clamp the upper bound of `u0`/`v0` to `Wd-1`/`Hd-1` so any future coordinate-space mismatch degrades gracefully instead of crashing.

Returned keypoints remain in original-image space and descriptors are now sampled at the correct locations, so callers (overlay alignment in `getFingerprintKeypoints`, fingerprint matching) are unaffected aside from the bug fix.

## Verification

⚠️ The native lib could not be built in this environment — the Android SDK/NDK is not provisioned (`SDK location not found`). The change is a small, self-contained C++ edit with no signature changes. Recommend building `:core:nativebridge` for `arm64-v8a` and exercising `nativeGetFingerprintKeypoints` with a >640×480 frame whose keypoints land near the right/bottom edge (the previous OOB trigger).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EG3JBD1vFXt32mischrk6w

---
_Generated by [Claude Code](https://claude.ai/code/session_01EG3JBD1vFXt32mischrk6w)_