### PR TITLE
Add signed AAB build + automated Google Play publishing

### DIFF
--- a/.github/workflows/release-aab.yml
+++ b/.github/workflows/release-aab.yml
@@ -1,0 +1,158 @@
+name: Build & Publish AAB (Play)
+
+# Manually-triggered workflow that builds a SIGNED Android App Bundle and,
+# optionally, publishes it to Google Play via the Play Developer API.
+#
+# Safe by default: it builds + uploads the .aab as a workflow artifact only.
+# Publishing to Play happens ONLY when `publish` is set to true, and defaults
+# to the internal track with draft status.
+on:
+  workflow_dispatch:
+    inputs:
+      track:
+        description: "Play track to publish to"
+        type: choice
+        default: internal
+        options:
+          - internal
+          - alpha
+          - beta
+          - production
+      status:
+        description: "Release status on the chosen track"
+        type: choice
+        default: draft
+        options:
+          - draft
+          - completed
+      publish:
+        description: "Publish to Play? (off = build + upload .aab artifact only)"
+        type: boolean
+        default: false
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # Full history so the commit count (versionCode) is correct.
+          fetch-depth: 0
+
+      - name: Setup Dependencies
+        run: chmod +x setup_libs.sh && ./setup_libs.sh
+
+      - name: Inject Google Services
+        env:
+          GOOGLE_SERVICES_API_KEY: ${{ secrets.GOOGLE_SERVICES_API_KEY }}
+          PROJECT_ID: ${{ secrets.PROJECT_ID }}
+          CLIENT_ID: ${{ secrets.CLIENT_ID }}
+          ARCORE_API_KEY: ${{ secrets.ARCORE_API_KEY }}
+        run: |
+          if [ -f "app/google-services.json.template" ]; then
+            echo "Template found. Injecting secrets..."
+            sed -e 's/{{\([^}]*\)}}/${\1}/g' app/google-services.json.template | envsubst > app/google-services.json
+          else
+            echo "Warning: google-services.json.template not found. Skipping injection."
+          fi
+
+          # Inject ARCore API Key into local.properties for build.gradle.kts to pick up
+          echo "ARCORE_API_KEY=$ARCORE_API_KEY" >> local.properties
+
+      - name: Generate Keystore from Secrets
+        env:
+          KEYSTORE_PRIVATE: ${{ secrets.KEYSTORE_PRIVATE }}
+          KEYSTORE_CHAIN: ${{ secrets.KEYSTORE_CHAIN }}
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+        run: |
+          echo "Generating keystore from certificate chain and private key..."
+
+          # Write the private key and certificate chain to temporary files
+          echo "$KEYSTORE_PRIVATE" > private_key.pem
+          echo "$KEYSTORE_CHAIN" > certificate_chain.crt
+
+          # Create a PKCS12 file from the key and certificate chain
+          openssl pkcs12 -export -in certificate_chain.crt -inkey private_key.pem \
+            -name "$KEY_ALIAS" -out keystore.p12 \
+            -password pass:"$KEYSTORE_PASSWORD"
+
+          # Convert the PKCS12 file to a JKS keystore
+          keytool -importkeystore -srckeystore keystore.p12 -srcstoretype PKCS12 \
+            -destkeystore app/keystore.jks -deststoretype JKS \
+            -srcstorepass "$KEYSTORE_PASSWORD" \
+            -deststorepass "$KEYSTORE_PASSWORD" \
+            -alias "$KEY_ALIAS" -noprompt
+
+          echo "Keystore generated successfully at app/keystore.jks"
+
+          # Clean up temporary files
+          rm private_key.pem certificate_chain.crt keystore.p12
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+        with:
+          cache-read-only: false
+          dependency-graph: disabled
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Resolve package name and versionCode
+        id: meta
+        run: |
+          # Read the applicationId straight from the build config (don't hardcode).
+          PKG=$(grep -E 'applicationId\s*=' app/build.gradle.kts | head -n1 | sed -E 's/.*"([^"]+)".*/\1/')
+          echo "package_name=$PKG" >> "$GITHUB_OUTPUT"
+
+          # Monotonic versionCode derived from the git commit count, plus a fixed
+          # baseline offset. The offset keeps the Play versionCode strictly above
+          # the legacy file-based codes (version.properties has reached ~151 from
+          # local/GitHub-release builds) so the first and every subsequent Play
+          # upload is always accepted, while still increasing by 1 per commit.
+          VERSION_CODE=$(( $(git rev-list --count HEAD) + 10000 ))
+          echo "version_code=$VERSION_CODE" >> "$GITHUB_OUTPUT"
+          echo "Package: $PKG  versionCode: $VERSION_CODE"
+
+      - name: Build Release AAB (signed)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+        run: |
+          ./gradlew bundleRelease -PversionBuild=${{ steps.meta.outputs.version_code }} \
+            -Pandroid.injected.signing.store.file=$(pwd)/app/keystore.jks \
+            -Pandroid.injected.signing.store.password=$KEYSTORE_PASSWORD \
+            -Pandroid.injected.signing.key.alias=$KEY_ALIAS \
+            -Pandroid.injected.signing.key.password=$KEY_PASSWORD
+
+      - name: Upload AAB artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: graffitixr-release-aab
+          path: app/build/outputs/bundle/release/*.aab
+          if-no-files-found: error
+
+      - name: Publish to Google Play
+        if: ${{ inputs.publish }}
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: ${{ steps.meta.outputs.package_name }}
+          releaseFiles: app/build/outputs/bundle/release/*.aab
+          track: ${{ inputs.track }}
+          status: ${{ inputs.status }}

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Strictly decoupled multi-module Clean Architecture:
 - [Testing Strategy](docs/testing.md)
 - [Data Formats](docs/data_formats.md)
 - [Contributing](docs/contributing.md)
+- [Release & Google Play Delivery](docs/RELEASE.md)
 
 ---
 *Documentation updated on 2026-04-26 during multi-glass integration and co-op robustness phase.*

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,7 +35,7 @@ val localProperties = Properties().apply {
 //      so the ephemeral CI checkout stays clean and Play receives exactly <n>.
 //   2. Otherwise fall back to the value stored in version.properties, preserving
 //      the existing local behaviour of auto-incrementing on release builds.
-val versionBuildOverride = (project.findProperty("versionBuild") as String?)?.toIntOrNull()
+val versionBuildOverride = project.findProperty("versionBuild")?.toString()?.toIntOrNull()
 var currentVersionCode = versionBuildOverride ?: versionProps.getProperty("versionBuild", "1").toInt()
 
 // Automatically increment versionCode for local release builds (no override supplied).

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -28,11 +28,19 @@ val localProperties = Properties().apply {
     }
 }
 
-var currentVersionCode = versionProps.getProperty("versionBuild", "1").toInt()
+// versionCode resolution:
+//   1. An explicit override via `-PversionBuild=<n>` always wins (CI passes a
+//      monotonic value derived from the git commit count — see release-aab.yml).
+//      When the override is present we do NOT auto-increment or rewrite the file,
+//      so the ephemeral CI checkout stays clean and Play receives exactly <n>.
+//   2. Otherwise fall back to the value stored in version.properties, preserving
+//      the existing local behaviour of auto-incrementing on release builds.
+val versionBuildOverride = (project.findProperty("versionBuild") as String?)?.toIntOrNull()
+var currentVersionCode = versionBuildOverride ?: versionProps.getProperty("versionBuild", "1").toInt()
 
-// Automatically increment versionCode for release builds
+// Automatically increment versionCode for local release builds (no override supplied).
 val isReleaseBuild = gradle.startParameter.taskNames.any { it.contains("Release", ignoreCase = true) }
-if (isReleaseBuild) {
+if (isReleaseBuild && versionBuildOverride == null) {
     currentVersionCode++
     versionProps.setProperty("versionBuild", currentVersionCode.toString())
     versionPropsFile.outputStream().use {
@@ -104,6 +112,18 @@ android {
         jniLibs {
             pickFirsts += "**/libc++_shared.so"
         }
+    }
+
+    // App Bundle configuration. These splits are ON by default for an AAB; we set
+    // them explicitly so the modular-delivery intent is documented in the build.
+    // Play generates optimized per-device APKs from `bundleRelease`, so the large
+    // per-ABI native payload (:core:nativebridge / OpenCV / LiteRT NPU runtimes)
+    // is only downloaded for the device's actual ABI — no separate artifacts to
+    // build. See docs/RELEASE.md.
+    bundle {
+        abi { enableSplit = true }
+        density { enableSplit = true }
+        language { enableSplit = true }
     }
 }
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,242 @@
+# Release & Google Play Delivery
+
+GraffitiXR ships to Google Play as a **signed Android App Bundle (AAB)**. This
+document covers building a signed bundle locally, how the `versionCode` is
+derived, modular delivery, the publishing workflow, and the one‑time setup the
+maintainer must perform.
+
+## TL;DR
+
+```bash
+# Local signed AAB (uses your own keystore via injected signing properties)
+./gradlew bundleRelease \
+  -Pandroid.injected.signing.store.file=$(pwd)/app/keystore.jks \
+  -Pandroid.injected.signing.store.password=$KEYSTORE_PASSWORD \
+  -Pandroid.injected.signing.key.alias=$KEY_ALIAS \
+  -Pandroid.injected.signing.key.password=$KEY_PASSWORD
+# → app/build/outputs/bundle/release/app-release.aab
+```
+
+Publishing is automated by the **Build & Publish AAB (Play)**
+(`.github/workflows/release-aab.yml`) workflow — run it from the Actions tab.
+
+---
+
+## 1. Building a signed AAB
+
+The release artifact is an `.aab`, not an APK. Google Play uses the bundle to
+generate optimized per‑device APKs (see [Modular delivery](#3-modular-delivery--size)).
+
+Signing matches the existing repo convention used by `release-apk.yml`:
+**CI‑injected signing** via `-Pandroid.injected.signing.*` properties. There is
+**no** `signingConfigs.release` block checked into `app/build.gradle.kts`, and
+**no keystore is committed** (`*.jks` / `*.keystore` are git‑ignored).
+
+To build a signed bundle locally you provide your own keystore on the command
+line, exactly as shown in the TL;DR above. Without the injected signing
+properties, `bundleRelease` produces an **unsigned** bundle (fine for
+inspection, not for upload).
+
+### versionCode override
+
+`app/build.gradle.kts` resolves `versionCode` in this order:
+
+1. **`-PversionBuild=<n>` override (CI):** if supplied it is used verbatim, and
+   the build does **not** auto‑increment or rewrite `version.properties`.
+2. **`version.properties` fallback (local):** the stored `versionBuild` value is
+   used and auto‑incremented on local release builds, preserving the previous
+   behaviour.
+
+CI passes a **monotonic** value so Play never rejects an upload for a duplicate
+or lower code:
+
+```
+versionCode = (git rev-list --count HEAD) + 10000
+```
+
+The `+10000` baseline keeps the Play `versionCode` strictly above the legacy
+file‑based codes (`version.properties` reached ~151 via local / GitHub‑release
+builds) while still increasing by exactly 1 per commit. `versionName` remains
+`major.minor.patch` from `version.properties`.
+
+---
+
+## 2. Publishing via the workflow
+
+Workflow: **`.github/workflows/release-aab.yml`** — `workflow_dispatch` only.
+
+Inputs:
+
+| Input     | Default    | Description |
+|-----------|------------|-------------|
+| `track`   | `internal` | `internal` / `alpha` / `beta` / `production` |
+| `status`  | `draft`    | `draft` or `completed` |
+| `publish` | `false`    | **Off ⇒ build + upload the `.aab` as a workflow artifact only.** On ⇒ also upload to Play. |
+
+What it does:
+
+1. Checks out with `fetch-depth: 0` (needed for the commit‑count versionCode).
+2. Runs `setup_libs.sh`, injects `google-services.json`, and materializes
+   `app/keystore.jks` from secrets (same steps as `release-apk.yml`).
+3. Sets up JDK 17 (Temurin) + Gradle.
+4. Reads `applicationId` from `app/build.gradle.kts` (not hardcoded) and computes
+   the versionCode.
+5. Runs `bundleRelease` with the versionCode and injected signing.
+6. Uploads the `.aab` as a build artifact (`graffitixr-release-aab`).
+7. **Only if `publish == true`:** uploads to Play with
+   [`r0adkll/upload-google-play@v1`](https://github.com/r0adkll/upload-google-play)
+   using `serviceAccountJsonPlainText`, the resolved `packageName`
+   (`com.hereliesaz.graffitixr`), the `.aab` glob, and the chosen `track` /
+   `status`.
+
+Default behaviour is safe: leaving `publish` off just produces a downloadable,
+signed bundle for manual inspection or manual console upload.
+
+---
+
+## 3. Modular delivery & size
+
+### Automatic bundle splits (already in effect)
+
+An AAB does **not** need separate per‑device artifacts. From a single
+`bundleRelease`, Play generates and serves optimized APKs split by:
+
+- **ABI** — this is the big win here. The native payload
+  (`:core:nativebridge`, OpenCV, and the LiteRT **NPU runtime** libraries for
+  Qualcomm/MediaTek/Google Tensor) is large; with per‑ABI splits a device only
+  downloads its own architecture's `.so` files.
+- **Screen density** — only the matching drawable densities.
+- **Language** — only the device's locale resources.
+
+These splits are enabled explicitly in `app/build.gradle.kts`
+(`bundle { abi/density/language { enableSplit = true } }`), which matches the
+AAB defaults — documented in code so the intent is obvious.
+
+### Dynamic feature modules — current status & rationale
+
+The project is already cleanly multi‑module (`:feature:ar`, `:feature:editor`,
+`:feature:dashboard`, `:android_collaboration_module`, `:core:*`), but these are
+`com.android.library` modules **statically linked** into `:app`. They are
+**compile‑time dependencies**: `app/.../MainScreen.kt` imports and uses their
+types directly (`ArViewModel`, `CameraPreview`, `FreezePreviewScreen`,
+`ArRenderer`, `EditorViewModel`, `DrawingCanvas`, …).
+
+Converting these to **on‑demand** `com.android.dynamic-feature` modules was
+evaluated and intentionally **not** done in this change, because:
+
+- **They aren't optional.** AR and the editor are the app's core surfaces, not
+  rarely‑used add‑ons. The README positions AR/precision tracing and the
+  multi‑layer editor as the primary product.
+- **Tight coupling.** On‑demand delivery requires the base module to *not*
+  reference feature types at compile time. That means decoupling through
+  interfaces + `SplitInstallManager` + reflective entry points, plus making
+  Hilt work across dynamic features — a large refactor that **cannot be
+  build‑verified in this environment**. Shipping an unverified conversion risks
+  breaking the app.
+- **The size win is already captured** by the automatic per‑ABI split above —
+  the dominant size driver is the native/NPU payload, not optional UI code.
+
+The `com.android.dynamic-feature` plugin alias is added to the version catalog
+(`libs.plugins.android.dynamic.feature`) so the infrastructure is ready.
+
+**Recommended future candidates** (each as a separately reviewed, build‑verified
+PR), in priority order:
+
+1. **LiteRT NPU runtimes** (`core/nativebridge/libs/litert_npu_runtime_libraries/*`)
+   as **conditional / install‑time** dynamic features targeted by device — these
+   are large, vendor‑specific, and only one vendor's runtime is ever used on a
+   given device.
+2. **Co‑op / collaboration** (`:android_collaboration_module`) as an **on‑demand**
+   feature — genuinely optional (peer‑to‑peer multiplayer painting), but first
+   needs decoupling from `:feature:ar`/`:app`.
+
+When implementing, wire the module into `settings.gradle.kts`, list it under
+`android { dynamicFeatures = setOf(":feature:xxx") }` in `:app`, add a
+`<dist:module dist:onDemand="true|false">` block to the feature manifest, and
+load on‑demand modules with the Play Feature Delivery `SplitInstall` APIs.
+
+### R8 / minify + resource shrinking
+
+Already enabled for `release` (`isMinifyEnabled = true`,
+`isShrinkResources = true`) with a well‑maintained `app/proguard-rules.pro`
+(explicit keeps for ARCore, OpenCV/native JNI, the SLAM bridge, serialization,
+and AzNavRail). No change needed; left on.
+
+### Play In‑App Updates (optional follow‑up)
+
+Consider the Play Core **In‑App Updates** API to prompt users to update from
+within the app (flexible for minor, immediate for critical). Optional and not
+included here.
+
+---
+
+## 4. Required repository secrets
+
+### Signing (already used by `release-apk.yml`)
+
+| Secret | Purpose |
+|--------|---------|
+| `KEYSTORE_PRIVATE` | PEM private key — assembled into `app/keystore.jks` in CI |
+| `KEYSTORE_CHAIN`   | PEM certificate chain |
+| `KEYSTORE_PASSWORD`| Keystore (store) password |
+| `KEY_ALIAS`        | Key alias |
+| `KEY_PASSWORD`     | Key password |
+
+### Google Play publishing (new)
+
+| Secret | Purpose |
+|--------|---------|
+| `PLAY_SERVICE_ACCOUNT_JSON` | Full JSON key of a Google Cloud service account with Play release access |
+
+### Build config (already used)
+
+`GOOGLE_SERVICES_API_KEY`, `PROJECT_ID`, `CLIENT_ID`, `ARCORE_API_KEY`,
+and `GH_TOKEN` (for the GitHub Packages Maven repo). See `release-apk.yml`.
+
+---
+
+## 5. One‑time maintainer setup (manual)
+
+The automated publish step cannot work until these are done **once**:
+
+1. **Create a Google Cloud service account** in the project linked to your Play
+   Console, and create a **JSON key** for it.
+2. In **Play Console → Users and permissions**, invite that service account and
+   grant it release permissions (at least *Release to testing tracks* /
+   *Release to production* as needed) for this app.
+3. Put the JSON key contents into the **`PLAY_SERVICE_ACCOUNT_JSON`** repo
+   secret, and add the signing secrets above if not already present.
+4. **Upload the very first release manually.** For a brand‑new app the Play
+   Developer API **cannot** create the first release — the first `.aab` must be
+   uploaded by hand in the Play Console (Internal testing is fine). Run the
+   workflow with `publish = false`, download the `graffitixr-release-aab`
+   artifact, and upload it in the console. After that first manual upload, the
+   workflow can publish subsequent builds with `publish = true`.
+
+> If you opt into **Play App Signing** (recommended), the keystore above becomes
+> your **upload** key; Google re‑signs with the managed app‑signing key.
+
+---
+
+## 6. Data safety & privacy
+
+Play requires an accurate **Data safety** form and a privacy policy. For
+GraffitiXR:
+
+- **No AdMob / ads.** The manifest declares no ads SDK and the app does **not**
+  request the `com.google.android.gms.permission.AD_ID` permission. Declare
+  "no advertising ID" accordingly.
+- **Core product is offline / local.** The README states zero cloud dependencies
+  and local‑only processing — reflect that (no/minimal data collection) in the
+  form.
+- **Third‑party SDKs that may collect data:** the **Meta Wearables (mwdat)**
+  integration and Google Play Services / ARCore are present. Review their data
+  practices and disclose anything they collect on your behalf.
+- **Permissions to justify:** `CAMERA` (core), plus optional `BLUETOOTH*`,
+  `ACCESS_*_LOCATION`, Wi‑Fi, and `INTERNET` — all already marked as optional
+  hardware features in the manifest so they don't filter the listing.
+- The network security config (`@xml/network_security_config`) sets
+  `cleartextTrafficPermitted="false"` globally (and for `api.github.com`), so no
+  cleartext HTTP is allowed — good for the security/data‑safety posture.
+
+Keep the Data safety declaration in sync whenever an SDK or permission changes.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -115,6 +115,7 @@ zxing-android-embedded = { group = "com.journeyapps", name = "zxing-android-embe
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
+android-dynamic-feature = { id = "com.android.dynamic-feature", version.ref = "agp" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 jetbrains-kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }


### PR DESCRIPTION
## What this does

Sets up modular Google Play delivery via **App Bundles (AAB)** with a fully automated, **signed** publish workflow. Inspected the existing build first and matched the repo's conventions (CI‑injected signing, JDK 17/Temurin, `gradle/actions/setup-gradle@v4`, `setup_libs.sh` + Google‑services injection, commit‑count versioning).

### Changes
- **`app/build.gradle.kts`**
  - `versionCode` now honors a **`-PversionBuild=<n>` override** (used verbatim, no auto‑increment/file rewrite) so CI can pass a monotonic value; local behavior (file‑based auto‑increment) is unchanged when no override is given.
  - Added an explicit `bundle { abi/density/language { enableSplit = true } }` block — documents the automatic per‑device splits (matches AAB defaults; behavior unchanged).
- **`.github/workflows/release-aab.yml`** (new, `workflow_dispatch`)
  - Inputs: `track` (internal/alpha/beta/**production**, default `internal`), `status` (draft/completed, default `draft`), `publish` (bool, default **false** = build + upload the `.aab` artifact only).
  - Builds **signed** `bundleRelease` (CI‑injected signing), uploads the `.aab` artifact, then **optionally** publishes via `r0adkll/upload-google-play@v1` (`serviceAccountJsonPlainText`, resolved `packageName`, releaseFiles glob, track, status).
  - Reads `applicationId` from the build config rather than hardcoding; `versionCode = git rev-list --count HEAD + 10000` (offset keeps it strictly above legacy file codes ~151 while increasing per commit).
- **`gradle/libs.versions.toml`**: added `com.android.dynamic-feature` plugin alias (ready infrastructure).
- **`docs/RELEASE.md`** (new) + README link: full release guide.

## Modular delivery decision (STEP 4)
- **AAB automatic ABI/density/language splits are the main size win here** and need no separate artifacts — the dominant payload is the per‑ABI native/NPU code (`:core:nativebridge`, OpenCV, LiteRT NPU runtimes), downloaded only for the device's ABI.
- **No on‑demand dynamic‑feature conversion in this PR, by design.** The existing `:feature:*` modules are statically linked **compile‑time** deps — `MainScreen.kt` references their types directly (`ArViewModel`, `CameraPreview`, `EditorViewModel`, …), and AR/editor are core (not optional). An on‑demand conversion needs interface decoupling + `SplitInstall` + Hilt‑across‑features, a large refactor that **can't be build‑verified here**. `docs/RELEASE.md` lays out the recommended follow‑ups (LiteRT NPU runtimes as conditional/install‑time; co‑op module as on‑demand) as separately reviewed PRs.
- **R8 minify + resource shrinking** are already enabled for `release` with a maintained `proguard-rules.pro` — left on.

## ⚠️ Manual setup the maintainer must do
1. Add repo secret **`PLAY_SERVICE_ACCOUNT_JSON`** (full JSON key of a Google Cloud service account). Signing secrets (`KEYSTORE_*`, `KEY_*`) already exist from `release-apk.yml`.
2. In Play Console → Users & permissions, grant that service account release access for `com.hereliesaz.graffitixr`.
3. **First release must be uploaded manually** in the Play Console — the API can't create the very first release. Run the workflow with `publish = false`, download the `graffitixr-release-aab` artifact, upload it by hand, then use `publish = true` thereafter.
4. Complete the Play **Data safety** form: no ads / no `AD_ID`, local‑first processing, and disclose any data collected by the Meta Wearables (mwdat) / Play Services / ARCore SDKs.

## Verification status
- **Not built/run in this environment.** Changes are static‑review level only; the new workflow and the signed `bundleRelease` need a **CI run to validate** (and the first Play publish needs the one‑time setup above). The `versionCode` override, bundle block, and signing approach mirror the working `release-apk.yml` patterns already in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018V1ysU9z4tTviN5RYcLo8V)_