### PR TITLE
Fix: voxel cloud occluding artwork after target creation

### DIFF
--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -215,6 +215,9 @@ class ArRenderer(
             if (!value) {
                 anchorOrchestrator.clear()
                 quadInitialFitApplied = false
+                // Anchor cleared → the artist is back to scanning, so the voxel/perception map
+                // must become visible again. (It was hidden when the anchor was established.)
+                hideVisualization = false
             }
         }
     /** When true the SLAM/cloud visualization is suppressed — processing continues but nothing is drawn. */
@@ -506,7 +509,10 @@ class ArRenderer(
         // Show the perception mask (feature points / voxels) on the LIVE camera during scanning —
         // including while aiming a target. The captured frame is the raw camera image (GL overlays
         // aren't baked in), so the mask belongs here, not painted onto the frozen target preview.
-        if (anyLayerOn && isTracking) {
+        // Honor hideVisualization: once the anchor is established (and during freeze/export) the
+        // confidence-tinted voxel cloud must NOT be drawn over the artwork — it would occlude the
+        // very thing the artist is here to see. Processing keeps running; only the draw is gated.
+        if (anyLayerOn && isTracking && !hideVisualization) {
             if (showFeaturePoints) {
                 try {
                     frame.acquirePointCloud().use { arDebugRenderer.update(it) }

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -509,10 +509,15 @@ class ArRenderer(
         // Show the perception mask (feature points / voxels) on the LIVE camera during scanning —
         // including while aiming a target. The captured frame is the raw camera image (GL overlays
         // aren't baked in), so the mask belongs here, not painted onto the frozen target preview.
-        // Honor hideVisualization: once the anchor is established (and during freeze/export) the
-        // confidence-tinted voxel cloud must NOT be drawn over the artwork — it would occlude the
-        // very thing the artist is here to see. Processing keeps running; only the draw is gated.
-        if (anyLayerOn && isTracking && !hideVisualization) {
+        // The confidence-tinted voxel cloud must NOT be drawn over the artwork — it would occlude
+        // the very thing the artist is here to see. anchorEstablished is the authoritative gate:
+        // once a target exists the map is hidden (the artist is painting), EXCEPT while actively
+        // re-aligning to a plane, when seeing the map helps. We deliberately key off anchorEstablished
+        // rather than the shared hideVisualization flag, which freeze/export/user-settings also toggle
+        // and would otherwise flip the cloud back on mid-session. hideVisualization still suppresses it
+        // on demand (freeze preview, export capture, manual setting). Processing keeps running
+        // regardless; only the draw is gated.
+        if (anyLayerOn && isTracking && (!anchorEstablished || isInPlaneRealignment) && !hideVisualization) {
             if (showFeaturePoints) {
                 try {
                     frame.acquirePointCloud().use { arDebugRenderer.update(it) }


### PR DESCRIPTION
## The bug
After creating a target, the confidence-tinted (cyan→**pink**→green) voxel/perception cloud kept rendering over the camera and *over the artwork overlay* — exactly what an artist is here to see. This defeats the app's core purpose.

## Root cause
`ArRenderer` already sets `hideVisualization = true` the moment the anchor is established (`ArRenderer.kt:756`), and that flag's documented contract is *"the SLAM/cloud visualization is suppressed — processing continues but nothing is drawn."* But `drawPerceptionLayers()` never actually consulted it: the perception block (`if (anyLayerOn && isTracking)`) drew feature points, voxels, the point cloud, and the mesh regardless. So the cloud stayed on top of the artwork.

This same gap also meant the cloud bled into **freeze previews** and **exported screenshots**, which set `hideVisualization = true` too.

## Fix (2 small changes, `feature/ar/.../rendering/ArRenderer.kt`)
1. Gate the perception-draw block on `!hideVisualization`, so once the anchor is established (or during freeze/export) the cloud is not drawn over the artwork. Native SLAM processing is untouched — only the *draw* is gated.
2. Reset `hideVisualization = false` when the anchor is cleared, so the map reappears while the artist re-scans.

## Verification status
- **Not built/run here** — needs a CI build + on-device check. The change is minimal and follows the flag's existing intended semantics (the flag was already being set; it just wasn't honored in this draw path).
- Suggested manual check: create a target → confirm the pink voxels disappear and the overlay is clean; reset the target → confirm the map returns during re-scan; export a frame → confirm no voxels in the saved image.

## Context
First fix in a broader "squash broken features" pass. A full audit of the codebase (docs, stubs/dead code, feature wiring/DI, native/JNI) is complete; the remaining findings will be triaged with the maintainer and fixed in themed batches. This PR is just the voxel-occlusion fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018V1ysU9z4tTviN5RYcLo8V)_