### PR TITLE
Target creation: highlight whole marks, tap/drag to remove (no dots)

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -1074,7 +1074,7 @@ class MainActivity : ComponentActivity() {
                                         }
                                     },
                                     onUpdateUnwarpPoints = { arViewModel.setUnwarpPoints(it) },
-                                    onEraseAtPoint = { nx, ny -> arViewModel.applyEraseToMask(nx, ny, 0.05f) }
+                                    onEraseAtPoint = { nx, ny -> arViewModel.removeMarkAt(nx, ny) }
                                 )
 
                             }

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/util/ImageExt.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/util/ImageExt.kt
@@ -4,9 +4,26 @@ package com.hereliesaz.graffitixr.common.util
 import android.graphics.Bitmap
 
 /**
+ * Opaque colour every detected mark is painted with so the user can clearly SEE which marks
+ * will feed the wall fingerprint. The marks are dark by definition (that is how they are
+ * detected), so re-drawing them in their own colour would be near-invisible against a dark
+ * wall — they must be highlighted. Only the ALPHA channel matters to the native fingerprint
+ * masker (opaque = detect, transparent = skip), so the RGB highlight is purely visual.
+ */
+const val MARK_HIGHLIGHT_COLOR: Int = 0xFF00E5FF.toInt() // bright cyan
+
+// Connected mark components smaller than max(this floor, area / NOISE_AREA_DIVISOR) pixels are
+// treated as sensor/texture noise and dropped, so the user never sees meaningless "dots" — only
+// whole marks survive. Tunable; deliberately conservative so thin real strokes are kept.
+private const val MIN_MARK_PIXELS_FLOOR = 12
+private const val NOISE_AREA_DIVISOR = 40000
+
+/**
  * Deconstructs the visual reality of a poorly lit wall, stripping away the
  * chaotic noise of the background to isolate only the high-contrast markings.
- * Uses a Bradley-Roth adaptive threshold to outsmart uneven lighting.
+ * Uses a Bradley-Roth adaptive threshold to outsmart uneven lighting, then keeps only
+ * connected mark blobs large enough to be a real mark (despeckle) and paints each whole mark
+ * in [MARK_HIGHLIGHT_COLOR] so it is clearly visible — never a scatter of dots.
  *
  * If [tapPos] is provided, the threshold becomes significantly more discerning
  * the further a pixel is from the tap location, ensuring only highly relevant
@@ -15,17 +32,18 @@ import android.graphics.Bitmap
 fun Bitmap.isolateMarkings(tapPos: Pair<Float, Float>? = null): Bitmap {
     val w = this.width
     val h = this.height
+    val n = w * h
     val out = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
-    val pixels = IntArray(w * h)
+    val pixels = IntArray(n)
     this.getPixels(pixels, 0, w, 0, 0, w, h)
 
-    val luma = IntArray(w * h)
+    val luma = IntArray(n)
     for (i in pixels.indices) {
         val c = pixels[i]
         luma[i] = (((c shr 16) and 0xFF) * 0.299 + ((c shr 8) and 0xFF) * 0.587 + ((c) and 0xFF) * 0.114).toInt()
     }
 
-    val integral = IntArray(w * h)
+    val integral = IntArray(n)
     for (y in 0 until h) {
         var sum = 0
         for (x in 0 until w) {
@@ -41,6 +59,8 @@ fun Bitmap.isolateMarkings(tapPos: Pair<Float, Float>? = null): Bitmap {
     val tapY = tapPos?.second?.let { it * h }
     val maxDist = Math.sqrt((w * w + h * h).toDouble()).toFloat()
 
+    // 1) Adaptive threshold → binary mark map.
+    val isMark = BooleanArray(n)
     for (y in 0 until h) {
         for (x in 0 until w) {
             val x1 = maxOf(0, x - radius)
@@ -54,8 +74,7 @@ fun Bitmap.isolateMarkings(tapPos: Pair<Float, Float>? = null): Bitmap {
             val c = if (x1 > 0) integral[y2 * w + (x1 - 1)] else 0
             val d = integral[y2 * w + x2]
 
-            val sum = d - b - c + a
-            val avg = sum / count
+            val avg = (d - b - c + a) / count
 
             // Distance-based discernment boost
             val distFactor = if (tapX != null && tapY != null) {
@@ -68,20 +87,60 @@ fun Bitmap.isolateMarkings(tapPos: Pair<Float, Float>? = null): Bitmap {
             val effectiveOffset = (baseThresholdOffset * distFactor).toInt()
 
             val i = y * w + x
-            if (luma[i] < avg - effectiveOffset) {
-                pixels[i] = pixels[i] or -0x1000000 // Opaque mark
-            } else {
-                pixels[i] = 0x00000000 // Transparent void
-            }
+            isMark[i] = luma[i] < avg - effectiveOffset
         }
     }
-    out.setPixels(pixels, 0, w, 0, 0, w, h)
+
+    // 2) Despeckle + highlight: keep only 8-connected blobs big enough to be a real mark, and
+    //    paint each whole surviving mark with the highlight colour. 8-connectivity keeps diagonal
+    //    strokes whole (and matches eraseColorBlob, so a tap removes exactly one whole mark).
+    val minMarkPixels = maxOf(MIN_MARK_PIXELS_FLOOR, n / NOISE_AREA_DIVISOR)
+    val outPixels = IntArray(n) // zero == transparent void
+    val visited = BooleanArray(n)
+    val queue = integral // reuse: the integral image is no longer needed
+    for (start in 0 until n) {
+        if (!isMark[start] || visited[start]) continue
+        var head = 0
+        var tail = 0
+        queue[tail++] = start
+        visited[start] = true
+        while (head < tail) {
+            val p = queue[head++]
+            val px = p % w
+            val py = p / w
+            var dy = -1
+            while (dy <= 1) {
+                var dx = -1
+                while (dx <= 1) {
+                    if (!(dx == 0 && dy == 0)) {
+                        val nx = px + dx
+                        val ny = py + dy
+                        if (nx in 0 until w && ny in 0 until h) {
+                            val q = ny * w + nx
+                            if (isMark[q] && !visited[q]) {
+                                visited[q] = true
+                                queue[tail++] = q
+                            }
+                        }
+                    }
+                    dx++
+                }
+                dy++
+            }
+        }
+        if (tail >= minMarkPixels) {
+            for (k in 0 until tail) outPixels[queue[k]] = MARK_HIGHLIGHT_COLOR
+        }
+    }
+    out.setPixels(outPixels, 0, w, 0, 0, w, h)
     return out
 }
 
 /**
- * Executes a ruthless, non-recursive flood fill to eradicate a contiguous
- * blob of pixels from existence without inducing a StackOverflowError.
+ * Executes a ruthless, non-recursive flood fill to eradicate one contiguous mark from
+ * existence (clearing it to transparent) without inducing a StackOverflowError. 8-connected
+ * so a single tap removes the WHOLE mark — including diagonal strokes — matching the
+ * connectivity [isolateMarkings] uses to group marks. Tapping the void is a no-op.
  */
 fun Bitmap.eraseColorBlob(nx: Float, ny: Float): Bitmap {
     val w = this.width
@@ -112,29 +171,23 @@ fun Bitmap.eraseColorBlob(nx: Float, ny: Float): Bitmap {
         val cy = qy[head]
         head++
 
-        if (cx > 0 && pixels[cy * w + (cx - 1)] != 0) {
-            pixels[cy * w + (cx - 1)] = 0
-            qx[tail] = cx - 1
-            qy[tail] = cy
-            tail++
-        }
-        if (cx < w - 1 && pixels[cy * w + (cx + 1)] != 0) {
-            pixels[cy * w + (cx + 1)] = 0
-            qx[tail] = cx + 1
-            qy[tail] = cy
-            tail++
-        }
-        if (cy > 0 && pixels[(cy - 1) * w + cx] != 0) {
-            pixels[(cy - 1) * w + cx] = 0
-            qx[tail] = cx
-            qy[tail] = cy - 1
-            tail++
-        }
-        if (cy < h - 1 && pixels[(cy + 1) * w + cx] != 0) {
-            pixels[(cy + 1) * w + cx] = 0
-            qx[tail] = cx
-            qy[tail] = cy + 1
-            tail++
+        var dy = -1
+        while (dy <= 1) {
+            var dx = -1
+            while (dx <= 1) {
+                if (!(dx == 0 && dy == 0)) {
+                    val ax = cx + dx
+                    val ay = cy + dy
+                    if (ax in 0 until w && ay in 0 until h && pixels[ay * w + ax] != 0) {
+                        pixels[ay * w + ax] = 0
+                        qx[tail] = ax
+                        qy[tail] = ay
+                        tail++
+                    }
+                }
+                dx++
+            }
+            dy++
         }
     }
 

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/util/ImageExt.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/util/ImageExt.kt
@@ -97,39 +97,49 @@ fun Bitmap.isolateMarkings(tapPos: Pair<Float, Float>? = null): Bitmap {
     val minMarkPixels = maxOf(MIN_MARK_PIXELS_FLOOR, n / NOISE_AREA_DIVISOR)
     val outPixels = IntArray(n) // zero == transparent void
     val visited = BooleanArray(n)
-    val queue = integral // reuse: the integral image is no longer needed
-    for (start in 0 until n) {
-        if (!isMark[start] || visited[start]) continue
-        var head = 0
-        var tail = 0
-        queue[tail++] = start
-        visited[start] = true
-        while (head < tail) {
-            val p = queue[head++]
-            val px = p % w
-            val py = p / w
-            var dy = -1
-            while (dy <= 1) {
-                var dx = -1
-                while (dx <= 1) {
-                    if (!(dx == 0 && dy == 0)) {
-                        val nx = px + dx
-                        val ny = py + dy
-                        if (nx in 0 until w && ny in 0 until h) {
-                            val q = ny * w + nx
-                            if (isMark[q] && !visited[q]) {
-                                visited[q] = true
-                                queue[tail++] = q
+    // The queue stores packed (y shl 16 or x) coordinates so the inner loop avoids per-pixel
+    // div/mod to recover x,y (image dims are always < 65536). Reuses the integral buffer, which
+    // is no longer needed after thresholding.
+    val queue = integral
+    var start = -1
+    for (y in 0 until h) {
+        for (x in 0 until w) {
+            start++
+            if (!isMark[start] || visited[start]) continue
+            var head = 0
+            var tail = 0
+            queue[tail++] = (y shl 16) or x
+            visited[start] = true
+            while (head < tail) {
+                val p = queue[head++]
+                val px = p and 0xFFFF
+                val py = p ushr 16
+                var dy = -1
+                while (dy <= 1) {
+                    var dx = -1
+                    while (dx <= 1) {
+                        if (!(dx == 0 && dy == 0)) {
+                            val nx = px + dx
+                            val ny = py + dy
+                            if (nx in 0 until w && ny in 0 until h) {
+                                val q = ny * w + nx
+                                if (isMark[q] && !visited[q]) {
+                                    visited[q] = true
+                                    queue[tail++] = (ny shl 16) or nx
+                                }
                             }
                         }
+                        dx++
                     }
-                    dx++
+                    dy++
                 }
-                dy++
             }
-        }
-        if (tail >= minMarkPixels) {
-            for (k in 0 until tail) outPixels[queue[k]] = MARK_HIGHLIGHT_COLOR
+            if (tail >= minMarkPixels) {
+                for (k in 0 until tail) {
+                    val p = queue[k]
+                    outPixels[(p ushr 16) * w + (p and 0xFFFF)] = MARK_HIGHLIGHT_COLOR
+                }
+            }
         }
     }
     out.setPixels(outPixels, 0, w, 0, 0, w, h)

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -1523,6 +1523,21 @@ class ArViewModel @Inject constructor(
         }
     }
 
+    /**
+     * Remove the ENTIRE mark the user tapped or dragged onto from the fingerprint mask.
+     * Floods the whole connected highlighted blob to transparent (see eraseColorBlob) — no
+     * partial pixel erasing, no per-point dots. A drag calls this per touch sample; once a mark
+     * is cleared, re-touching its now-transparent area is a cheap no-op. The mask's alpha channel
+     * is what the native fingerprint masker reads, so the mark simply stops contributing.
+     */
+    fun removeMarkAt(nx: Float, ny: Float) {
+        val current = _uiState.value.annotatedCaptureBitmap ?: return
+        viewModelScope.launch(dispatchers.default) {
+            val updated = current.eraseColorBlob(nx, ny)
+            _uiState.update { it.copy(annotatedCaptureBitmap = updated) }
+        }
+    }
+
     fun applyEraseToMask(nx: Float, ny: Float, radius: Float) {
         val currentMask = _uiState.value.annotatedCaptureBitmap ?: return
         viewModelScope.launch(dispatchers.default) {

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -53,6 +53,8 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -1530,11 +1532,20 @@ class ArViewModel @Inject constructor(
      * is cleared, re-touching its now-transparent area is a cheap no-op. The mask's alpha channel
      * is what the native fingerprint masker reads, so the mark simply stops contributing.
      */
+    // Serializes drag-time mark removals so each flood-fill starts from the LATEST mask rather than
+    // a snapshot taken when the gesture sample fired. Without this, two rapid removeMarkAt calls both
+    // read the same bitmap and the later write clobbers the earlier removal, making erased marks
+    // reappear. A mutex (vs. doing the work inside _uiState.update {}) guarantees the expensive
+    // flood-fill runs exactly once per call instead of being re-evaluated on CAS contention.
+    private val markRemovalMutex = Mutex()
+
     fun removeMarkAt(nx: Float, ny: Float) {
-        val current = _uiState.value.annotatedCaptureBitmap ?: return
         viewModelScope.launch(dispatchers.default) {
-            val updated = current.eraseColorBlob(nx, ny)
-            _uiState.update { it.copy(annotatedCaptureBitmap = updated) }
+            markRemovalMutex.withLock {
+                val current = _uiState.value.annotatedCaptureBitmap ?: return@withLock
+                val updated = current.eraseColorBlob(nx, ny)
+                _uiState.update { it.copy(annotatedCaptureBitmap = updated) }
+            }
         }
     }
 

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/TargetCreationFlow.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/TargetCreationFlow.kt
@@ -20,7 +20,6 @@ import com.hereliesaz.aznavrail.model.AzButtonShape
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.scale
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
@@ -130,8 +129,8 @@ private fun TargetInstructionCard(
             "Now, drag the corners to align the cyan frame with the flat surface of your wall."
         )
         captureStep == CaptureStep.MASK || captureStep == CaptureStep.REVIEW -> Pair(
-            "ERASE FEATURES",
-            "Tap or drag across any features you don't want tracked."
+            "REMOVE MARKS",
+            "Tap a mark to remove it, or drag across marks to remove several."
         )
         else -> Pair("", "")
     }
@@ -186,12 +185,14 @@ private fun TargetInstructionCard(
 }
 
 /**
- * REVIEW step: shows the captured image with the detected-feature annotation overlay.
+ * REVIEW step: shows the user every mark on the wall, each whole mark highlighted over a
+ * dimmed photo of the capture (annotatedCaptureBitmap is the despeckled, highlighted mask
+ * from isolateMarkings — whole marks, never dots).
  *
- * The user taps or drags across features they don't want tracked — applyEraseToMask()
- * clears those pixels from annotatedCaptureBitmap (PorterDuff CLEAR). The native ORB
+ * Tap a mark to remove it, or drag across marks to remove each one the finger passes over;
+ * removeMarkAt() flood-fills the WHOLE touched mark out of annotatedCaptureBitmap. The native
  * engine reads the alpha channel of that bitmap as its detection mask (opaque = detect,
- * transparent = skip), so erased areas are excluded from the fingerprint automatically.
+ * transparent = skip), so a removed mark stops contributing to the fingerprint automatically.
  *
  * On confirm, annotatedCaptureBitmap is passed directly as the selection mask.
  */
@@ -204,7 +205,6 @@ private fun FeatureSelectionReview(
     onRetake: () -> Unit,
     onEraseAtPoint: (Float, Float) -> Unit
 ) {
-    var showFeatures by remember { mutableStateOf(true) }
     var boxSize by remember { mutableStateOf(IntSize.Zero) }
 
     Box(
@@ -212,7 +212,7 @@ private fun FeatureSelectionReview(
             .fillMaxSize()
             .onSizeChanged { boxSize = it }
     ) {
-        // -- Raw capture as base layer --
+        // -- Raw capture as faint context, dimmed so the highlighted marks dominate --
         rawBitmap?.let { bmp ->
             Image(
                 bitmap = bmp.asImageBitmap(),
@@ -221,17 +221,20 @@ private fun FeatureSelectionReview(
                 contentScale = ContentScale.Fit
             )
         }
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.Black.copy(alpha = 0.6f))
+        )
 
-        // -- Annotated feature overlay --
-        if (showFeatures) {
-            annotatedBitmap?.let { bmp ->
-                Image(
-                    bitmap = bmp.asImageBitmap(),
-                    contentDescription = "Feature Overlay",
-                    modifier = Modifier.fillMaxSize(),
-                    contentScale = ContentScale.Fit
-                )
-            }
+        // -- Highlighted marks (the whole-mark fingerprint mask), always shown --
+        annotatedBitmap?.let { bmp ->
+            Image(
+                bitmap = bmp.asImageBitmap(),
+                contentDescription = "Detected marks",
+                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.Fit
+            )
         }
 
         // -- Tap / drag gesture layer for erasing --
@@ -275,27 +278,18 @@ private fun FeatureSelectionReview(
             )
         }
 
-        // -- Show Features toggle --
-        Row(
+        // -- Hint: tap/drag removes a whole mark --
+        Text(
+            text = "Tap a mark to remove it, or drag across marks to remove several.",
+            color = Color.White,
+            style = MaterialTheme.typography.labelMedium,
+            textAlign = TextAlign.Center,
             modifier = Modifier
                 .align(Alignment.TopCenter)
-                .padding(top = 12.dp)
+                .padding(top = 12.dp, start = 24.dp, end = 24.dp)
                 .background(Color.Black.copy(alpha = 0.55f), RoundedCornerShape(24.dp))
-                .padding(horizontal = 12.dp, vertical = 4.dp),
-            horizontalArrangement = Arrangement.spacedBy(12.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Text(
-                strings.ar.targetShowFeatures,
-                color = Color.White,
-                style = MaterialTheme.typography.labelSmall
-            )
-            Switch(
-                checked = showFeatures,
-                onCheckedChange = { showFeatures = it },
-                modifier = Modifier.scale(0.7f)
-            )
-        }
+                .padding(horizontal = 16.dp, vertical = 6.dp)
+        )
 
         // -- Retake / Confirm FABs --
         Row(


### PR DESCRIPTION
## The ask
After capturing a target, the next step should show the artist **their actual marks on the wall** — each *whole* mark highlighted — and let them curate which marks feed the fingerprint by **tapping a mark to remove it** or **dragging across marks** to remove several. A mark is binary (highlighted or gone). **No dots, no drag-trail colours, no extra steps.**

## What was wrong
- The review overlay relied on the adaptive threshold's raw output, whose **speckle** read as meaningless dots, and `isolateMarkings` painted marks in their own dark colour (near-invisible on a dark wall).
- Erasing used `applyEraseToMask` — a **PorterDuff circle** that paints away pixels under the finger, not whole marks.
- There was a redundant "Show Features" toggle.
- (`eraseColorBlob`, a whole-mark flood-fill, already existed and was even imported in `ArViewModel` — just never wired up.)

## The fix
1. **`isolateMarkings()`** — after the adaptive threshold, **despeckle** via 8-connected components (drop blobs too small to be a real mark — the dots) and paint each surviving **whole mark** in a bright highlight (cyan). Only the **alpha** channel feeds the native fingerprint mask, so the colour is purely visual; mask semantics unchanged.
2. **`eraseColorBlob()`** — now **8-connected**, so one tap clears the *entire* mark (incl. diagonal strokes), matching the grouping used to highlight.
3. **`ArViewModel.removeMarkAt()`** — flood-removes the whole touched mark from the mask; the review gesture (tap + drag) is rewired to it.
4. **Review UI** — always show highlighted marks over a **dimmed** capture; remove the "Show Features" toggle; tap/drag removes whole marks. Flow still ends at **Confirm** (the unreachable RECTIFY step is untouched/never entered).

## Notes & verification
- **Not built/run here** — needs a CI build + on-device check. Please verify on device: capture a target → marks show as whole highlighted shapes (no speckle) → tap removes a whole mark → drag removes several → Confirm.
- `isolateMarkings` runs on the GL/capture thread exactly as before (parity; one-time capture).
- Two tunables (`MARK_HIGHLIGHT_COLOR`, the noise-size threshold `MIN_MARK_PIXELS_FLOOR` / `NOISE_AREA_DIVISOR`) are named constants in `ImageExt.kt` — easy to adjust if the despeckle is too aggressive/lenient on real walls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018V1ysU9z4tTviN5RYcLo8V)_