### PR TITLE
Hotfix: remove duplicate Mutex import breaking main build

### DIFF
--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -53,8 +53,6 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock


### PR DESCRIPTION
## 🔴 Build break on `main`

`:feature:ar:compileDebugKotlin` is failing on `main`:
```
e: ArViewModel.kt:56:32 Conflicting import: imported name 'Mutex' is ambiguous.
e: ArViewModel.kt:59:32 Conflicting import: imported name 'Mutex' is ambiguous.
```

`ArViewModel` already imported `kotlinx.coroutines.sync.Mutex` / `withLock` (used by the existing `sessionMutex` and `eraseOpMutex`). When `markRemovalMutex` was added (PR #1635), a **second, duplicate** `import Mutex` / `import withLock` pair was introduced, making the name ambiguous and breaking compilation.

## Fix
Remove the duplicate import pair, keeping the originals. One-file, import-only change.

## Note
The same dedup is also included in PR #1636 (so that branch builds), but this dedicated hotfix unblocks `main` immediately on its own. The two are identical deletions, so they won't conflict.

**Verification:** not built here — needs the CI Gradle run, but it's a pure duplicate-import removal that directly addresses the compiler error above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018V1ysU9z4tTviN5RYcLo8V)_