### PR TITLE
Add per-mode position lock (Trace/Mockup) + Trace doc fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ And then, there's a decent suite of pertinent design tools, with support for mul
 ## Modes
 *   **AR Mural:** The core precision instrument for anchoring digital concepts to physical surfaces using confidence-based voxel mapping.
 *   **Mockup Mode:** Fast tools for visualizing layers and blend modes on top of static wall photos.
-*   **Trace (Lightbox):** Full-brightness surface for copying onto paper with touch-lock and triple-tap exit.
+*   **Trace (Lightbox):** Full-brightness surface for copying onto paper with touch-lock and four-tap exit.
 *   **Stencil Tool:** Automated generation of multi-layer printable stencils (1-3 colors) with tiled PDF export.
 
 ## Architecture

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -1357,6 +1357,10 @@ class MainActivity : ComponentActivity() {
             editorViewModel.onModeLayerSelected(mode)
             onOpenModeAdjust(mode)
         }
+        val locked = editorUiState.modeAdjustments[mode]?.isTransformLocked == true
+        azRailSubItem(id = "$modeId.layer.lock", hostId = "$modeId.layer", text = if (locked) "Unlock" else "Lock", color = if (locked) Cyan else navItemColor, shape = AzButtonShape.NONE) {
+            editorViewModel.onToggleModeTransformLocked(mode)
+        }
         azRailSubItem(id = "$modeId.layer.reset", hostId = "$modeId.layer", text = "Reset", color = navItemColor, shape = AzButtonShape.NONE) {
             editorViewModel.onModeLayerReset(mode)
         }

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/EditorModels.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/EditorModels.kt
@@ -132,6 +132,10 @@ data class ModeAdjustment(
     val saturation: Float = 1f,
     val opacity: Float = 1f,
     val isInverted: Boolean = false,
+    // When true, pan/zoom/rotate gestures for this mode are ignored — the user has positioned the
+    // whole-design layer and locked it in place (e.g. a Trace reference that must not drift while
+    // tracing). Tone/opacity edits and the lightbox touch-lock are independent of this.
+    val isTransformLocked: Boolean = false,
 ) {
     val isIdentity: Boolean
         get() = offsetX == 0f && offsetY == 0f && scale == 1f && rotation == 0f &&

--- a/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/EditorIntent.kt
+++ b/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/EditorIntent.kt
@@ -64,6 +64,7 @@ internal sealed interface EditorIntent {
     data class SetModeAdjustment(val mode: EditorMode, val adjustment: ModeAdjustment) : EditorIntent
     data class SetAllModeAdjustments(val adjustments: Map<EditorMode, ModeAdjustment>) : EditorIntent
     data class ApplyModeTransformGesture(val mode: EditorMode, val pan: Offset, val zoom: Float, val rotation: Float) : EditorIntent
+    data class ToggleModeTransformLocked(val mode: EditorMode) : EditorIntent
     data class SetGestureInProgress(val inProgress: Boolean) : EditorIntent
 
     // ── Effect-result / transient flags (dispatched by the VM around async work) ───

--- a/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/EditorReducer.kt
+++ b/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/EditorReducer.kt
@@ -81,13 +81,21 @@ internal object EditorReducer {
         is EditorIntent.SetAllModeAdjustments -> state.copy(modeAdjustments = intent.adjustments)
         is EditorIntent.ApplyModeTransformGesture -> {
             val cur = state.modeAdjustments[intent.mode] ?: ModeAdjustment()
-            val updated = cur.copy(
-                offsetX = cur.offsetX + intent.pan.x,
-                offsetY = cur.offsetY + intent.pan.y,
-                scale = (cur.scale * intent.zoom).coerceIn(0.1f, 10f),
-                rotation = cur.rotation + intent.rotation,
-            )
-            state.copy(modeAdjustments = state.modeAdjustments + (intent.mode to updated))
+            // Locked: the user pinned this mode's whole-design position, so ignore transform gestures.
+            if (cur.isTransformLocked) state
+            else {
+                val updated = cur.copy(
+                    offsetX = cur.offsetX + intent.pan.x,
+                    offsetY = cur.offsetY + intent.pan.y,
+                    scale = (cur.scale * intent.zoom).coerceIn(0.1f, 10f),
+                    rotation = cur.rotation + intent.rotation,
+                )
+                state.copy(modeAdjustments = state.modeAdjustments + (intent.mode to updated))
+            }
+        }
+        is EditorIntent.ToggleModeTransformLocked -> {
+            val cur = state.modeAdjustments[intent.mode] ?: ModeAdjustment()
+            state.copy(modeAdjustments = state.modeAdjustments + (intent.mode to cur.copy(isTransformLocked = !cur.isTransformLocked)))
         }
 
         is EditorIntent.SetLoading -> state.copy(isLoading = intent.loading)

--- a/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/EditorViewModel.kt
+++ b/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/EditorViewModel.kt
@@ -1029,6 +1029,12 @@ class EditorViewModel @Inject constructor(
         saveProject()
     }
 
+    /** Toggle the per-mode transform lock — pins/unpins the whole-design position for [mode]. */
+    fun onToggleModeTransformLocked(mode: EditorMode) {
+        dispatch(EditorIntent.ToggleModeTransformLocked(mode))
+        saveProject()
+    }
+
     override fun onGestureEnd() {
         saveProject()
         dispatch(EditorIntent.SetGestureInProgress(false))


### PR DESCRIPTION
## What
First slice of the **Trace + Mockup build-out**: a per-mode **position-then-lock** control, which is exactly the "Position + lock controls" you asked for. Under each mode's **Layer** menu there's now a **Lock**/**Unlock** item — position/scale/rotate the whole-design layer, lock it, and pan/zoom/rotate gestures are ignored so it can't drift while you trace (or while composing on a Mockup wall photo).

This is distinct from:
- the **lightbox touch-lock** (Freeze) — which blocks *all* touches + maxes brightness, and
- **tone/opacity** edits — which still work while transform-locked.

## Changes
- `ModeAdjustment.isTransformLocked` — new field, `@Serializable` + defaulted, so existing saved projects deserialize unchanged.
- `EditorIntent.ToggleModeTransformLocked` + reducer — toggles the flag; `ApplyModeTransformGesture` is a no-op while locked.
- `EditorViewModel.onToggleModeTransformLocked` — dispatches + persists.
- Rail item in `modeLayerSubHost` (applies to AR/Overlay/Mockup/Trace), shows Cyan + "Unlock" when active. Labels are literals to match the sibling "Layer"/"Reset" items.
- README: Trace exit documented as **four-tap** (matches the implemented threshold; per your call to keep 4).

## On the rest of Trace/Mockup
Per my code analysis, the wall-photo pick/capture flow (`setBackgroundImage`/`takePictureLauncher`/`backgroundPicker`) **and** per-layer blend-mode/opacity already exist and are wired. I can't see what's "buggy in practice" without a device, so rather than guess and add the wrong thing, I shipped this concrete, well-specified piece first. **If you can tell me the specific Trace/Mockup misbehavior on-device** (what you do → expect → see), I'll target it precisely next.

## Verification — needs device
Not built/run here. Please check: enter a mode, select **Layer**, position the design, tap **Lock** → gestures no longer move it (Adjust/opacity still work), **Unlock** restores movement, and the lock state survives save/reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018V1ysU9z4tTviN5RYcLo8V)_