### PR TITLE
Expose Co-op host/join from the AR rail

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -1939,6 +1939,33 @@ class MainActivity : ComponentActivity() {
                     azRailSubItem(id = "mode.ar.light", hostId = "mode.ar", text = navStrings.light, color = if (arUiState.isFlashlightOn) Cyan else navItemColor, shape = AzButtonShape.NONE) {
                         arViewModel.toggleFlashlight()
                     }
+                    // Co-op ▸ { Host, Join, Leave } — share this AR coordinate system with a nearby peer.
+                    azRailSubHostItem(id = "coop", hostId = "mode.ar", text = navStrings.coop, color = navItemColor, shape = AzButtonShape.NONE)
+                    val canHost = arUiState.isAnchorEstablished && arUiState.splatCount > 0
+                    val isHosting = arUiState.coopRole == CoopRole.HOST
+                    val isGuest = arUiState.coopRole == CoopRole.GUEST
+                    azRailSubItem(
+                        id = "coop.host", hostId = "coop", text = navStrings.hostCoop,
+                        color = if (isHosting) Cyan else if (canHost) navItemColor else Color.Gray,
+                        shape = AzButtonShape.NONE
+                    ) {
+                        // Hosting requires an established anchor with mapped splats to share.
+                        if (canHost && !isHosting) arViewModel.startHosting()
+                    }
+                    azRailSubItem(
+                        id = "coop.join", hostId = "coop", text = navStrings.joinCoop,
+                        color = if (isGuest) Cyan else navItemColor, shape = AzButtonShape.NONE
+                    ) {
+                        // Joining scans the host's QR, so the camera must be granted first.
+                        if (!isGuest) {
+                            if (hasCameraPermission) onShowJoinScanner() else requestPermissions()
+                        }
+                    }
+                    if (arUiState.coopRole != CoopRole.NONE) {
+                        azRailSubItem(id = "coop.leave", hostId = "coop", text = "Leave", color = HotPink, shape = AzButtonShape.NONE) {
+                            arViewModel.leaveSession()
+                        }
+                    }
                 }
                 modeLayerSubHost("mode.ar", EditorMode.AR, editorUiState, editorViewModel, navStrings, navItemColor, onOpenModeAdjust)
             }

--- a/app/src/main/java/com/hereliesaz/graffitixr/RailIdEnumerator.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/RailIdEnumerator.kt
@@ -11,7 +11,8 @@ import com.hereliesaz.graffitixr.common.model.Layer
  * Conditional registration in ConfigureRailItems is mirrored here:
  *   - target.host / target.create only registered in AR mode
  *   - design.wall only registered in MOCKUP mode
- *   - target.scanModeToggle / coop.main / coop.join only in AR mode
+ *   - coop / coop.host / coop.join only registered in AR mode (coop.leave is
+ *     additionally gated on an active session, so it is omitted here)
  *
  * CAVEAT: the per-layer block below emits the UNION of every layer-menu suffix, whereas
  * ConfigureRailItems registers a different suffix subset per layer type (text vs sketch vs
@@ -42,6 +43,7 @@ internal fun enumerateRailItemIdRegistrations(layers: List<Layer>, mode: EditorM
     if (mode == EditorMode.AR) {
         ids += "target.create"
         ids += "mode.ar.light"
+        ids += listOf("coop", "coop.host", "coop.join")
     }
     if (mode == EditorMode.OVERLAY) {
         ids += "mode.overlay.light"


### PR DESCRIPTION
## What
The co-op stack — `startHosting`/`joinFromQr`/`leaveSession`, the QR host/join overlays, and the spectator banner — was **fully built but unreachable**: no rail item ever invoked `startHosting()` or the join scanner, so the only path in was the edge-case "session not found" dialog. This adds a **Co-op menu under AR mode** (it shares the AR coordinate system):

- **Co-op ▸ Host** → `startHosting()`; enabled only with an established anchor and mapped splats (`canHost`), Cyan while hosting.
- **Co-op ▸ Join** → opens the QR scanner (`onShowJoinScanner`), requesting the camera first if needed; Cyan while a guest.
- **Co-op ▸ Leave** → shown only during an active session → `leaveSession()`.

Uses the existing `nav_coop`/`nav_host_coop`/`nav_join_coop` strings. Registers the new ids (`coop`/`coop.host`/`coop.join`) in `RailIdEnumerator` so the duplicate-ID guard test keeps mirroring `ConfigureRailItems`, and refreshes its stale `coop.main/coop.join` comment.

## Verification — needs device/CI
No Android SDK in the authoring environment, so this wasn't compiled locally — CI is the first build. Static check: every symbol (`startHosting`/`leaveSession`/`joinFromQr`, `CoopRole`, `Cyan`/`HotPink`, `hasCameraPermission`/`requestPermissions`, `navStrings.coop/hostCoop/joinCoop`) confirmed in-scope against the sibling `target.create`/flashlight rail items. On-device: in AR mode, open **Co-op** → **Host** (with an anchor placed) shows the host QR; **Join** opens the scanner; scanning connects; **Leave** appears and ends the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018V1ysU9z4tTviN5RYcLo8V)_

## Summary by Sourcery

Expose AR co-op hosting, joining, and leaving controls via the AR navigation rail and keep rail ID enumeration in sync.

New Features:
- Add Co-op host, join, and leave controls under the AR mode rail using existing co-op strings and colors.

Enhancements:
- Gate co-op hosting and joining based on AR anchor, splat mapping, co-op role, and camera permissions.
- Register new co-op rail item IDs in RailIdEnumerator and update its documentation comment to match AR rail configuration.