### PR TITLE
Localize the Co-op "Leave" rail label

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -1962,7 +1962,7 @@ class MainActivity : ComponentActivity() {
                         }
                     }
                     if (arUiState.coopRole != CoopRole.NONE) {
-                        azRailSubItem(id = "coop.leave", hostId = "coop", text = "Leave", color = HotPink, shape = AzButtonShape.NONE) {
+                        azRailSubItem(id = "coop.leave", hostId = "coop", text = navStrings.leaveCoop, color = HotPink, shape = AzButtonShape.NONE) {
                             arViewModel.leaveSession()
                         }
                     }

--- a/core/design/src/main/java/com/hereliesaz/graffitixr/design/theme/NavStrings.kt
+++ b/core/design/src/main/java/com/hereliesaz/graffitixr/design/theme/NavStrings.kt
@@ -123,6 +123,8 @@ fun rememberNavStrings(): NavStrings {
         hostCoopInfo = stringResource(R.string.nav_host_coop_info),
         joinCoop = stringResource(R.string.nav_join_coop),
         joinCoopInfo = stringResource(R.string.nav_join_coop_info),
+        leaveCoop = stringResource(R.string.nav_leave_coop),
+        leaveCoopInfo = stringResource(R.string.nav_leave_coop_info),
         wearable = stringResource(R.string.nav_wearable),
         wearableInfo = stringResource(R.string.nav_wearable_info)
     )
@@ -245,6 +247,8 @@ data class NavStrings(
     val hostCoopInfo: String,
     val joinCoop: String,
     val joinCoopInfo: String,
+    val leaveCoop: String,
+    val leaveCoopInfo: String,
     val wearable: String,
     val wearableInfo: String
 )

--- a/core/design/src/main/res/values/strings.xml
+++ b/core/design/src/main/res/values/strings.xml
@@ -62,6 +62,8 @@
     <string name="nav_host_coop_info">Host a co-op session to share your AR coordinate system with nearby peers.</string>
     <string name="nav_join_coop">Join</string>
     <string name="nav_join_coop_info">Join a nearby co-op session to align your AR view with the host.</string>
+    <string name="nav_leave_coop">Leave</string>
+    <string name="nav_leave_coop_info">Leave the current co-op session.</string>
 
     <string name="nav_wearable">Wearable</string>
     <string name="nav_wearable_info">Connect to smart glasses for a hands-free AR experience and perspective-aligned camera input.</string>


### PR DESCRIPTION
## What
Small follow-up to the Co-op rail menu (#1640), addressing Gemini's i18n note: the `coop.leave` item used a hardcoded `"Leave"` literal while its siblings `Host`/`Join` used `navStrings`.

- Adds `nav_leave_coop` / `nav_leave_coop_info` string resources.
- Threads `leaveCoop` / `leaveCoopInfo` through `NavStrings` (data class + `rememberNavStrings`).
- Uses `navStrings.leaveCoop` at the call site.

Scoped deliberately to just the Leave label — the other in-menu literals (`Freeze`/`Layer`/`Reset`/`Lock`) are left as-is for now.

## Verification
No Android SDK in the authoring environment, so not compiled locally — CI is the first build. Static check: `nav_leave_coop`/`nav_leave_coop_info` defined; `leaveCoop`/`leaveCoopInfo` added to both the `NavStrings` data class and its constructor call in `rememberNavStrings`; call site updated. No rail-ID changes, so the duplicate-ID guard is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018V1ysU9z4tTviN5RYcLo8V)_

## Summary by Sourcery

Localize the Co-op rail "Leave" menu item and align it with existing navigation string handling.

New Features:
- Add dedicated nav_leave_coop and nav_leave_coop_info string resources for the Co-op Leave action.

Enhancements:
- Thread new leaveCoop and leaveCoopInfo properties through NavStrings and use them for the Co-op Leave rail label instead of a hardcoded literal.