### PR TITLE
Auto-pause SLAM mapping once the AR anchor is locked (battery)

### DIFF
--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -644,6 +644,9 @@ class ArViewModel @Inject constructor(
             return
         }
         isInArMode = enabled
+        // A new/destroyed session resets native mapping to running, so drop our cached command and
+        // let the next tracking frame re-assert the correct auto-mapping state.
+        lastMappingPausedCmd = null
         Timber.i("ARDIAG setArMode(enabled=$enabled) layers=${projectRepository.currentProject.value?.layers?.size ?: 0} scanMode=${_uiState.value.arScanMode} sessionExists=${session != null}")
         if (enabled) {
             val now = System.currentTimeMillis()
@@ -669,6 +672,7 @@ class ArViewModel @Inject constructor(
     fun exitArMode() {
         isInArMode = false
         isDestroying = true
+        lastMappingPausedCmd = null
         // Cancel any in-flight session update (including a running stereo probe) so it stops pumping
         // the camera and releases the session mutex before cleanup tries to acquire it.
         sessionUpdateJob?.cancel()
@@ -1333,6 +1337,33 @@ class ArViewModel @Inject constructor(
             (nowMs - lastTrackingTimestampMs) > STEREO_STUCK_GRACE_MS
         ) {
             recoverFromBrokenStereo()
+        }
+
+        // Battery: SLAM mapping (gaussian-splat optimization) is the dominant AR power cost. Once the
+        // projection anchor is locked and tracking is solid the wall is mapped, so settle mapping;
+        // tracking + relocalization keep running. It resumes automatically on tracking loss so the
+        // map can re-acquire/extend.
+        updateAutoMapping(isTracking)
+    }
+
+    // Last steady-state mapping-paused command we issued, so we only call into native on a change.
+    // Reset to null while capture/export owns the flag, so we re-assert once that flow releases it.
+    private var lastMappingPausedCmd: Boolean? = null
+
+    /**
+     * Auto-settle SLAM mapping to save battery: pause the heavy gaussian-splat mapping once the
+     * projection anchor is established and tracking is solid, and resume it on tracking loss so the
+     * map can re-acquire. Capture/export drive [SlamManager.setMappingPaused] directly via the
+     * isCaptureRequested flow, so while a capture is requested we step aside (and forget our last
+     * command, re-asserting the correct state once the capture releases the flag).
+     */
+    private fun updateAutoMapping(isTracking: Boolean) {
+        val state = _uiState.value
+        if (state.isCaptureRequested) { lastMappingPausedCmd = null; return }
+        val shouldPause = isInArMode && state.isAnchorEstablished && isTracking
+        if (shouldPause != lastMappingPausedCmd) {
+            slamManager.setMappingPaused(shouldPause)
+            lastMappingPausedCmd = shouldPause
         }
     }
 


### PR DESCRIPTION
## Problem
Battery drains ~5%/min in **active AR use**. After auditing the usual hard-drain culprits, there's no leak or runaway loop — the code is already power-aware (GL pauses on background, GPS isn't running, camera is off outside AR, perception overlays already throttle under thermal/power-save). The drain is the inherent live AR stack: **ARCore camera + continuously-rendering GL + nonstop native gaussian-splat SLAM mapping**.

The dominant, most *reducible* piece is the SLAM **mapping** — it runs flat-out the entire AR session and only pauses briefly during capture. For the core use case (you've mapped the wall and are now painting against a locked anchor), continuously re-optimizing the splat map is largely wasted GPU/CPU.

## Fix (auto-pause, per your call)
`updateAutoMapping(isTracking)` — called each tracking frame from `setTrackingState` — settles mapping via the existing `SlamManager.setMappingPaused` once **(in AR && anchor established && tracking solid)**, and **resumes on tracking loss** so the map can re-acquire/extend. Rendering, tracking, and relocalization are untouched.

- Only calls native on a state change.
- **Defers to capture/export** (`isCaptureRequested`), which own the flag directly, and re-asserts once they release it.
- Cache reset on AR enter/exit so a fresh session (native mapping defaults to running) re-asserts correctly.

## Tradeoff / verification — needs device
Pausing mapping means the map stops *extending* until tracking drops and it resumes — the intended behavior for "wall already mapped, now painting." **Please verify on-device that tracking robustness and painting-progress detection are unaffected**, and confirm the battery improvement. If auto-pause ever feels too aggressive, the same hook can be gated behind a manual "Lock Map" toggle instead. Not compiled locally (no Android SDK in the authoring env); CI is the first build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018V1ysU9z4tTviN5RYcLo8V)_

## Summary by Sourcery

Auto-pause SLAM mapping during AR sessions once the projection anchor is established and tracking is stable to reduce battery usage, while resuming mapping on tracking loss and when capture/export flows require it.

Enhancements:
- Reset cached mapping-pause state when entering or exiting AR mode so each session re-establishes the correct mapping behavior.
- Introduce an auto-mapping state manager that avoids redundant native calls by tracking the last issued mapping pause command.