### PR TITLE
Add least-privilege permissions to all workflows (CodeQL #7)

### DIFF
--- a/.github/workflows/clear_cache.yml
+++ b/.github/workflows/clear_cache.yml
@@ -3,6 +3,10 @@ name: Clear Gradle Cache
 on:
   workflow_dispatch: # Runs manually only
 
+# Least-privilege default token; jobs needing more declare their own permissions block.
+permissions:
+  contents: read
+
 jobs:
   clear-cache:
     runs-on: ubuntu-latest

--- a/.github/workflows/gemini-dispatch.yml
+++ b/.github/workflows/gemini-dispatch.yml
@@ -22,6 +22,10 @@ defaults:
   run:
     shell: 'bash'
 
+# Least-privilege default token; jobs needing more declare their own permissions block.
+permissions:
+  contents: read
+
 jobs:
   debugger:
     if: |-

--- a/.github/workflows/gemini-invoke.yml
+++ b/.github/workflows/gemini-invoke.yml
@@ -16,6 +16,10 @@ defaults:
   run:
     shell: 'bash'
 
+# Least-privilege default token; jobs needing more declare their own permissions block.
+permissions:
+  contents: read
+
 jobs:
   invoke:
     runs-on: 'ubuntu-latest'

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -16,6 +16,10 @@ defaults:
   run:
     shell: 'bash'
 
+# Least-privilege default token; jobs needing more declare their own permissions block.
+permissions:
+  contents: read
+
 jobs:
   review:
     runs-on: 'ubuntu-latest'

--- a/.github/workflows/gemini-scheduled-triage.yml
+++ b/.github/workflows/gemini-scheduled-triage.yml
@@ -25,6 +25,10 @@ defaults:
   run:
     shell: 'bash'
 
+# Least-privilege default token; jobs needing more declare their own permissions block.
+permissions:
+  contents: read
+
 jobs:
   triage:
     runs-on: 'ubuntu-latest'

--- a/.github/workflows/gemini-triage.yml
+++ b/.github/workflows/gemini-triage.yml
@@ -16,6 +16,10 @@ defaults:
   run:
     shell: 'bash'
 
+# Least-privilege default token; jobs needing more declare their own permissions block.
+permissions:
+  contents: read
+
 jobs:
   triage:
     runs-on: 'ubuntu-latest'

--- a/.github/workflows/jules-agent.yml
+++ b/.github/workflows/jules-agent.yml
@@ -4,6 +4,10 @@ on:
   issues:
     types: [opened]
 
+# Least-privilege default token; jobs needing more declare their own permissions block.
+permissions:
+  contents: read
+
 jobs:
   jules-triage:
     runs-on: ubuntu-latest

--- a/.github/workflows/jules-auto-merge.yml
+++ b/.github/workflows/jules-auto-merge.yml
@@ -3,6 +3,10 @@ name: Jules Auto-Merge Branch
 on:
   create:
 
+# Least-privilege default token; jobs needing more declare their own permissions block.
+permissions:
+  contents: read
+
 jobs:
   jules-branch-manager:
     if: github.event.ref_type == 'branch'

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -8,6 +8,10 @@
 name: Labeler
 on: [pull_request]
 
+# Least-privilege default token; jobs needing more declare their own permissions block.
+permissions:
+  contents: read
+
 jobs:
   label:
 

--- a/.github/workflows/merged-build.yml
+++ b/.github/workflows/merged-build.yml
@@ -12,6 +12,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Least-privilege default token for all jobs. The build-and-release job overrides this
+# with the elevated scopes it needs (tags/releases/issues) in its own permissions block.
+permissions:
+  contents: read
+
 jobs:
   unit-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-aab.yml
+++ b/.github/workflows/release-aab.yml
@@ -30,6 +30,10 @@ on:
         type: boolean
         default: false
 
+# Least-privilege default token; jobs needing more declare their own permissions block.
+permissions:
+  contents: read
+
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-apk.yml
+++ b/.github/workflows/release-apk.yml
@@ -3,6 +3,10 @@ name: Compile and Release APK
 on:
   workflow_dispatch:
 
+# Least-privilege default token; jobs needing more declare their own permissions block.
+permissions:
+  contents: read
+
 jobs:
   build-and-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -4,6 +4,10 @@ on:
   issues:
     types: [opened]
 
+# Least-privilege default token; jobs needing more declare their own permissions block.
+permissions:
+  contents: read
+
 jobs:
   summary:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-libs.yml
+++ b/.github/workflows/update-libs.yml
@@ -3,6 +3,10 @@ name: Update Dependencies
 on:
   workflow_dispatch:
 
+# Least-privilege default token; jobs needing more declare their own permissions block.
+permissions:
+  contents: read
+
 jobs:
   update-libs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What
Adds explicit **least-privilege top-level `permissions:`** to every GitHub Actions workflow, resolving the CodeQL "workflow does not contain permissions" class (originally **issue #7** on `merged-build.yml:17`).

- **`merged-build.yml`** — the actually-flagged one: its `unit-tests` job ran with the default broad token. Added top-level `contents: read`; `build-and-release` keeps its own elevated block.
- **13 more workflows** (`clear_cache`, `gemini-*`, `jules-*`, `label`, `release-aab`, `release-apk`, `summary`, `update-libs`) — these already scope permissions per-job, but now also carry a top-level `contents: read` default as defense-in-depth (per GitHub's hardening guidance). Job-level blocks override it, so the bots/releases keep the write scopes they need.

## Safety
Job-level `permissions:` always override the top-level default, so this **only tightens** the implicit token for any unscoped job and makes the posture explicit — no behavior change for jobs that already declare their scopes. All 18 workflow files parse as valid YAML.

## Excluded — needs separate attention
**`dependabot.yml` is malformed**: it's a Dependabot *config* (`updates:`/`package-ecosystem:`) wrongly placed as a workflow, with invalid `on:`/`jobs:`. It's the failing `dependabot.yml` check that's been red on recent runs. A permissions block can't fix it — it should be either moved to `.github/dependabot.yml` with correct config, or deleted. I left it untouched; happy to fix it in a separate PR if you tell me which you want.

## Verification
YAML-only; no app code. Validated all workflows parse. CI is the first real run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add least-privilege default GitHub token permissions to all affected workflows to harden CI security and make permissions explicit.

CI:
- Set a top-level permissions: contents: read default in merged-build.yml so unscoped jobs run with a read-only token while preserving existing elevated job-level permissions.
- Add a top-level permissions: contents: read default to other GitHub Actions workflows as a defense-in-depth baseline that can be overridden by job-specific permissions.