### PR TITLE
Right-size SLAM (1/n): delete dead native scaffolding

### DIFF
--- a/core/nativebridge/src/main/cpp/MobileGS.cpp
+++ b/core/nativebridge/src/main/cpp/MobileGS.cpp
@@ -100,10 +100,6 @@ void MobileGS::initialize(int width, int height) {
         mMapRunning = true;
         mMapThread = std::thread(&MobileGS::mapThreadFunc, this);
     }
-    if (!mOptimizeRunning) {
-        mOptimizeRunning = true;
-        mOptimizeThread = std::thread(&MobileGS::optimizeThreadFunc, this);
-    }
 }
 
 void MobileGS::initGl() {
@@ -144,7 +140,6 @@ void MobileGS::resetGlContext() {
 
 void MobileGS::draw(bool debugTint) {
     std::lock_guard<std::mutex> lock(mMutex);
-    interpolateAnchorStep();
     if (!mCameraReady) return;
 
     glm::mat4 V = glm::make_mat4(mViewMatrix);
@@ -166,7 +161,6 @@ void MobileGS::draw(bool debugTint) {
 
 void MobileGS::drawDebugLayers(bool voxels, bool mesh) {
     std::lock_guard<std::mutex> lock(mMutex);
-    interpolateAnchorStep();
     if (!mCameraReady) return;
     glm::mat4 V = glm::make_mat4(mViewMatrix);
     glm::mat4 P = glm::make_mat4(mProjMatrix);
@@ -181,7 +175,6 @@ void MobileGS::drawDebugLayers(bool voxels, bool mesh) {
 
 void MobileGS::drawCoverage() {
     std::lock_guard<std::mutex> lock(mMutex);
-    interpolateAnchorStep();
     if (!mCameraReady) return;
     glm::mat4 V = glm::make_mat4(mViewMatrix);
     glm::mat4 P = glm::make_mat4(mProjMatrix);
@@ -552,8 +545,6 @@ void MobileGS::relocThreadFunc() {
         std::this_thread::sleep_for(std::chrono::milliseconds(200));
     }
 }
-void MobileGS::runPnPMatch(const cv::Mat& frame) {}
-
 bool MobileGS::computeRectifyHomography(const float* viewCur16, cv::Mat& Hcur_fp,
                                         cv::Mat& Hfp_cur, double& obliquityDeg) {
     glm::mat4 viewCur = glm::make_mat4(viewCur16);
@@ -724,43 +715,18 @@ void MobileGS::tryUpdateFingerprint(const cv::Mat& grayClean) {
     }
     LOGI("Teleological self-grow: promoted %zu marks (wall now %zu)", newPts.size(), mWallKeypoints3D.size());
 }
-void MobileGS::interpolateAnchorStep() {}
 void MobileGS::setArCoreTrackingState(bool t) { mIsArCoreTracking.store(t, std::memory_order_relaxed); }
-
-void MobileGS::optimizeThreadFunc() {
-    setpriority(PRIO_PROCESS, 0, 19);
-    JniThreadAttacher attacher;
-    while (mOptimizeRunning) {
-        FrameData latestFrame;
-        bool hasFrame = false;
-        {
-            std::lock_guard<std::mutex> lock(mQueueMutex);
-            if (!mFrameQueue.empty()) { latestFrame = mFrameQueue.back(); hasFrame = true; }
-        }
-        if (hasFrame) {
-            cv::Mat colorRGB;
-            if (latestFrame.isYuv) cv::cvtColor(latestFrame.color, colorRGB, cv::COLOR_YUV2RGB_NV21);
-            else colorRGB = latestFrame.color;
-            mVoxelHash.optimize(latestFrame.depth, colorRGB, latestFrame.viewMatrix, latestFrame.projMatrix);
-        }
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    }
-}
 
 void MobileGS::destroy() {
     mMapRunning = false;
-    mOptimizeRunning = false;
     mRelocRunning = false;
-    mSortRunning = false;
     mQueueCv.notify_all();
     {
         std::lock_guard<std::mutex> lock(mRelocMutex);
         mRelocCv.notify_all();
     }
     if (mMapThread.joinable()) mMapThread.join();
-    if (mOptimizeThread.joinable()) mOptimizeThread.join();
     if (mRelocThread.joinable()) mRelocThread.join();
-    if (mSortThread.joinable()) mSortThread.join();
 }
 
 void MobileGS::saveModel(const std::string& p) {
@@ -1153,8 +1119,6 @@ MobileGS::FingerprintData MobileGS::generateFingerprint(
 
     return fd;
 }
-void MobileGS::sortThreadFunc() {}
-
 void MobileGS::getStageTimingsAndReset(float* out) {
     for (int i = 0; i < kStageCount; ++i) {
         uint64_t n = mStageSamples[i].exchange(0, std::memory_order_relaxed);

--- a/core/nativebridge/src/main/cpp/VoxelHash.cpp
+++ b/core/nativebridge/src/main/cpp/VoxelHash.cpp
@@ -439,5 +439,3 @@ void VoxelHash::prune(float threshold) {
         mDataDirty = true;
     }
 }
-void VoxelHash::optimize(const cv::Mat& depth, const cv::Mat& color, const float* viewMat, const float* projMat) {}
-void VoxelHash::sort(const glm::vec3& camPos) {}

--- a/core/nativebridge/src/main/cpp/include/MobileGS.h
+++ b/core/nativebridge/src/main/cpp/include/MobileGS.h
@@ -120,8 +120,6 @@ public:
 
 private:
     void mapThreadFunc();
-    void optimizeThreadFunc();
-    void sortThreadFunc();
 
     struct FrameData {
         cv::Mat depth;
@@ -140,19 +138,11 @@ private:
     std::vector<FrameData> mFrameQueue;
     std::atomic<bool> mMapRunning{false};
 
-    std::thread mOptimizeThread;
-    std::atomic<bool> mOptimizeRunning{false};
-
-    std::thread mSortThread;
-    std::atomic<bool> mSortRunning{false};
-
     void relocThreadFunc();
-    void runPnPMatch(const cv::Mat& frame);
     // Teleological self-grow (gatekeeper stage): measure how much of the registered artwork base is now
     // corroborated by real wall content in the clean camera frame -> mPaintingProgress. Read-only on the
     // reloc fingerprint; the promotion step (adding validated new marks) is staged separately.
     void tryUpdateFingerprint(const cv::Mat& grayClean);
-    void interpolateAnchorStep();
     // Plane-guided rectification: homography (current-image <-> fingerprint-image) from the wall plane
     // and the VIO baseline between the current and fingerprint-capture views, plus the viewing
     // obliquity in degrees. False if no fingerprint view is stored or the geometry is degenerate.

--- a/core/nativebridge/src/main/cpp/include/VoxelHash.h
+++ b/core/nativebridge/src/main/cpp/include/VoxelHash.h
@@ -41,7 +41,6 @@ public:
     void addKeyframe(const VoxelFrame& kf);
     // colorMode: 0 = normal opaque albedo, 1 = debug confidence ramp, 2 = coverage (alpha=confidence)
     void draw(const glm::mat4& mvp, const glm::mat4& view, float focalY, int screenHeight, int colorMode = 0);
-    void sort(const glm::vec3& camPos);
     void clear();
     void prune(float threshold);
     /** Minimum angular baseline (degrees) before a re-observation counts as a parallax check. */
@@ -52,7 +51,6 @@ public:
     int getSplatCount() const;
     int getImmutableSplatCount() const;
     void getAnchorCandidates(std::vector<Splat>& out, float threshold, int maxCount) const;
-    void optimize(const cv::Mat& depth, const cv::Mat& color, const float* viewMat, const float* projMat);
     float getVisibleConfidenceAvg(const glm::mat4& mvp) const;
     float getGlobalConfidenceAvg() const;
 


### PR DESCRIPTION
## Stage 1 of the SLAM right-size: delete dead native scaffolding

First, safest stage of the approved right-size plan. Removes vestigial no-op code from the `MobileGS` engine — none of it sits on the working relocalization / fingerprint / painting-progress path:

- **`optimizeThreadFunc`** — a live idle-priority (nice 19) thread that polled the frame queue every 100 ms only to call `VoxelHash::optimize()`, which is an **empty no-op**. Pure battery/CPU and complexity cost. Removed the thread, its spawn/join, the `mOptimizeThread`/`mOptimizeRunning` members, and the empty `VoxelHash::optimize()`.
- **`sortThreadFunc` / `mSortThread` / `mSortRunning` / `VoxelHash::sort()`** — declared and joined but **never started**, the functions empty. Removed.
- **`runPnPMatch()`** — empty, no callers (real PnP runs in `relocThreadFunc`). Removed.
- **`interpolateAnchorStep()`** — empty no-op called 3× in `draw` / `drawDebugLayers` / `drawCoverage`; pose smoothing lives in Kotlin `PoseFusion`. Removed the function and its 3 call sites (behavior-preserving).

**Net:** 50 deletions across `MobileGS.cpp/.h` and `VoxelHash.cpp/.h`. No behavior change — every removed symbol was dead or a no-op. Verified no dangling references remain.

### Verification
- Compile/build validated by CI (no Android SDK/NDK locally).
- AR entry/exit to be smoke-tested on-device (behavior should be identical since all removed code was dead/no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018V1ysU9z4tTviN5RYcLo8V)_