### PR TITLE
docs: accuracy pass on core engine/architecture docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,12 @@ Strictly decoupled multi-module Clean Architecture:
 *   `:app` — Navigation, camera orchestration, and Hilt dependency injection.
 *   `:feature:ar` — ARCore session management, `ArRenderer`, and SLAM data processing.
 *   `:feature:editor` — Multi-layer image manipulation and GPU-accelerated Liquify.
+*   `:feature:dashboard` — Project library, onboarding, and settings.
 *   `:core:nativebridge` — Native C++ engine (`MobileGS`), JNI bridge, and relocalization threads.
 *   `:android_collaboration_module` — Peer-to-peer networking and project sync.
 *   `:opencv` — Static OpenCV SDK for computer vision tasks.
 *   `:core:data` / `:core:domain` / `:core:common` — Unified data layer and wearable abstraction.
+*   `:core:design` — Shared Compose design system (reusable controls and overlays).
 
 ## Documentation
 - [Architecture Overview](docs/ARCHITECTURE.md)
@@ -54,4 +56,4 @@ Strictly decoupled multi-module Clean Architecture:
 - [Release & Google Play Delivery](docs/RELEASE.md)
 
 ---
-*Documentation updated on 2026-04-26 during multi-glass integration and co-op robustness phase.*
+*Documentation updated on 2026-06-22 during the SLAM right-size and documentation-accuracy pass.*

--- a/docs/ANALYSIS.md
+++ b/docs/ANALYSIS.md
@@ -1,7 +1,7 @@
 # GRAFFITIXR: AUTOPSY & ANALYSIS
 
 ## STATUS: PRODUCTION READY (STABLE)
-**Date:** 2026-04-24
+**Date:** 2026-06-22
 **Condition:** The patient is in peak physical condition. The engine has been streamlined for real-world street art conditions, prioritizing spatial memory over visual vanity.
 
 ---
@@ -28,6 +28,11 @@
 * **Fix:** **Mandatory HW Stereo**. Session initialization now forces `REQUIRE_AND_USE`.
 * **Reward:** HW Stereo data is assigned **0.9 confidence** (nearly immutable), while mono gets 0.5.
 
+### [FIXED] The Dead Scaffolding (Right-Size)
+* **Issue:** Vestigial no-op machinery survived earlier pivots: an idle background thread polling frames only to call an empty `VoxelHash::optimize()`, a never-started sort thread, and empty stubs (`runPnPMatch`, `interpolateAnchorStep`).
+* **Fix:** Excised the dead threads, members, and stubs. Relocalization stays in `relocThreadFunc`; pose smoothing stays in the Kotlin `PoseFusion` layer.
+* **Win:** One fewer always-on thread, lower idle battery/CPU, smaller maintenance surface — with zero behavior change.
+
 ---
 
 ## 2. ARCHITECTURAL OVERVIEW (Current)
@@ -44,4 +49,4 @@
 3.  **Community:** Prepare for Beta launch.
 
 ---
-*Documentation updated on 2026-04-24 during Persistent Voxel Memory and Pocket-Ready recovery implementation.*
+*Documentation updated on 2026-06-22 during the SLAM right-size and documentation-accuracy pass.*

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -61,4 +61,4 @@ camera.getViewMatrix/ProjectionMatrix ───────► updateCamera()
 The engine uses a dedicated background thread (`relocThreadFunc`) to continuously match the current camera frame against stored wall fingerprints. On a high-confidence PnP match, the engine automatically corrects global drift, enabling the mural to "snap back" instantly when the user resumes from a screen-off event.
 
 ---
-*Documentation updated on 2026-04-24 during Persistent Voxel Memory and Pocket-Ready recovery implementation.*
+*Documentation updated on 2026-06-22 during the SLAM right-size and documentation-accuracy pass.*

--- a/docs/BLUEPRINT.md
+++ b/docs/BLUEPRINT.md
@@ -34,4 +34,4 @@ We are building a tool that respects the "flow" of painting. It must be:
 * **No Gamification:** No points, no leaderboards, no avatars.
 
 ---
-*Documentation updated on 2026-04-24 during Persistent Voxel Memory and Pocket-Ready recovery implementation.*
+*Documentation updated on 2026-06-22 during the SLAM right-size and documentation-accuracy pass.*

--- a/docs/NATIVE_ENGINE.md
+++ b/docs/NATIVE_ENGINE.md
@@ -54,4 +54,4 @@ A single OpenGL ES 3.0 render path runs inside `ArRenderer`:
 | `draw()` | OpenGL ES render — called by `ArRenderer` each frame. |
 
 ---
-*Documentation updated on 2026-04-24 during Persistent Voxel Memory and Pocket-Ready recovery implementation.*
+*Documentation updated on 2026-06-22 during the SLAM right-size and documentation-accuracy pass.*

--- a/docs/SLAM_SETUP.md
+++ b/docs/SLAM_SETUP.md
@@ -57,4 +57,4 @@ Cause: Incorrect rotation code in JNI.
 Fix: Ensure `ArRenderer` is passing the correct `cvRotateCode` to both color and depth feeds.
 
 ---
-*Documentation updated on 2026-04-24 during Persistent Voxel Memory and Pocket-Ready recovery implementation.*
+*Documentation updated on 2026-06-22 during the SLAM right-size and documentation-accuracy pass.*

--- a/docs/TELEOLOGICAL_SLAM.md
+++ b/docs/TELEOLOGICAL_SLAM.md
@@ -1,0 +1,47 @@
+# Teleological SLAM (Painting-Progress Correction)
+
+Conventional relocalization treats the wall as a fixed target: capture a
+fingerprint once, then match against it forever. That assumption breaks for a
+muralist, because **the wall changes as you paint it** — the very marks the
+fingerprint relies on get covered by the artwork, so matching gets *worse* the
+further along you are.
+
+GraffitiXR turns that around. Because the app already knows what the finished
+piece is supposed to look like (the overlay you loaded), it treats the goal
+state as additional information — hence *teleological* (goal-directed). The
+further along the painting is, the more real-world corroboration the engine
+has, and the more tightly the overlay locks to the wall.
+
+## Mechanism
+
+The work happens entirely in the native engine (`core/nativebridge`), layered
+on top of the OpenCV relocalizer:
+
+1. **Baseline fingerprint.** When the artist registers the wall, the engine
+   stores ORB/feature descriptors of the clean surface (the relocalization
+   fingerprint used by `relocThreadFunc` for snap-back).
+2. **Progress measurement (`MobileGS::tryUpdateFingerprint`).** On a clean
+   camera frame, the engine measures how much of the registered artwork base is
+   now corroborated by real wall content, writing the result to
+   `mPaintingProgress`. This stage is read-only with respect to the reloc
+   fingerprint.
+3. **Confidence weighting.** As `mPaintingProgress` rises, the corroborated
+   marks contribute more to the pose solution, so global drift correction
+   becomes more aggressive — the overlay "snaps" more tightly the more of the
+   mural exists on the wall.
+
+This is the inverse of the failure mode other tracing apps hit, where accuracy
+degrades as the original reference marks disappear under paint.
+
+## Relationship to the rest of the engine
+
+- **Relocalization** (snap-back after tracking loss / screen-off) is the
+  `relocThreadFunc` background thread — see [NATIVE_ENGINE.md](NATIVE_ENGINE.md)
+  and [SLAM_SETUP.md](SLAM_SETUP.md).
+- **Pose tracking** itself is provided by ARCore; the native engine layers
+  relocalization, the persistent voxel map, and this teleological correction on
+  top of ARCore's poses.
+- Pose smoothing/fusion lives in the Kotlin `PoseFusion` layer, not in C++.
+
+---
+*Documentation updated on 2026-06-22 during the SLAM right-size and documentation-accuracy pass.*

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -20,7 +20,7 @@ Unit tests live in `src/test/` inside each module. Run all at once or per-module
 | `EditorViewModelTest` | `:feature:editor` | Layer operations, bitmap dimensions, undo/redo |
 | `ProjectManagerTest` | `:core:data` | `getProjectList`, `deleteProject`, `getMapPath`, `importProjectFromUri` failure paths |
 
-*Note: Teleological PnP tracking was migrated completely to the C++ layer (`MobileGS::runPnPMatch`) to eliminate JVM overhead. As a result, it is tested visually on-device rather than via JVM unit tests.*
+*Note: Relocalization and teleological progress tracking run entirely in the C++ layer (`MobileGS::relocThreadFunc` for background PnP snap-back, `MobileGS::tryUpdateFingerprint` for painting-progress) to eliminate JVM overhead. As a result, they are verified visually on-device rather than via JVM unit tests.*
 
 ### Mock patterns
 


### PR DESCRIPTION
## Documentation accuracy pass (core)

Reconciles the core technical/product docs with what the code actually does. The docs were already substantially honest (they explicitly reject Gaussian splatting in favor of opaque surfels, and attribute snap-back to `relocThreadFunc`), so this is targeted correction rather than a rewrite:

- **`testing.md`** — fixed a false statement: it claimed PnP tracking was migrated to `MobileGS::runPnPMatch`, but that function was an empty stub (removed in #1660). Relocalization actually runs in `relocThreadFunc`, painting-progress in `tryUpdateFingerprint`.
- **`README.md`** — added the two modules that existed but were undocumented (`:feature:dashboard`, `:core:design`); refreshed the date stamp.
- **`TELEOLOGICAL_SLAM.md`** — was a 1-line stub yet linked from the README as real docs. Written out: the painting-progress mechanism (`tryUpdateFingerprint` → `mPaintingProgress`) and how it sits on top of ARCore poses + the relocalizer.
- **`ANALYSIS.md`** — logged the dead-scaffolding right-size; refreshed status date.
- Refreshed stale "2026-04-24" stamps across `ARCHITECTURE`/`BLUEPRINT`/`NATIVE_ENGINE`/`SLAM_SETUP`.

### Scope note
This is the **core English** slice. Translations (13 language folders) and historical design specs (`docs/superpowers/*`) are a larger follow-up tracked separately.

### Verification
- Markdown-only; no build impact. (Note: this branch shows CI red only because it branched off the Kotlin-broken main — see #1661; it will go green once rebased on the fixed main.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018V1ysU9z4tTviN5RYcLo8V)_