### PR TITLE
Remove dead Bluetooth permissions (Meta SDK follow-up)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,20 +31,12 @@
     <!-- OTA Updater Permissions -->
     <uses-permission android:name="android.permission.INTERNET" />
 
-    <!-- Meta Wearables Permissions -->
-    <uses-permission android:name="android.permission.BLUETOOTH" />
-    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
-    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
-    <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
-
     <!--
-        Permissions above (BLUETOOTH*, ACCESS_*_LOCATION, ACCESS_WIFI_STATE, etc.)
-        would otherwise imply required hardware features and filter the Play Store
-        listing. Mark them optional explicitly: the wearables / location flows are
-        not core to the app, and core camera is the only required hardware.
+        Permissions above (ACCESS_*_LOCATION, ACCESS_WIFI_STATE, etc.) would otherwise
+        imply required hardware features and filter the Play Store listing. Mark them
+        optional explicitly: the location/wifi flows are not core to the app, and core
+        camera is the only required hardware.
     -->
-    <uses-feature android:name="android.hardware.bluetooth" android:required="false" />
-    <uses-feature android:name="android.hardware.bluetooth_le" android:required="false" />
     <uses-feature android:name="android.hardware.wifi" android:required="false" />
     <uses-feature android:name="android.hardware.location" android:required="false" />
     <uses-feature android:name="android.hardware.location.gps" android:required="false" />

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -174,7 +174,6 @@ class MainActivity : ComponentActivity() {
     var showPosterDialog by mutableStateOf(false)
     var posterSourceLayerId by mutableStateOf<String?>(null)
     var hasCameraPermission by mutableStateOf(false)
-    var hasBluetoothPermission by mutableStateOf(false)
     var showWallSourceDialog by mutableStateOf(false)
     var isExporting by mutableStateOf(false)
     // Crash report captured on the previous run (native SIGSEGV and/or JVM), shown on launch.
@@ -182,19 +181,6 @@ class MainActivity : ComponentActivity() {
 
     private val permissionLauncher = registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { p ->
         hasCameraPermission = p[Manifest.permission.CAMERA] ?: false
-        hasBluetoothPermission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            p[Manifest.permission.BLUETOOTH_CONNECT] ?: false
-        } else {
-            true
-        }
-        if (hasBluetoothPermission) {
-            checkAndInitializeWearables()
-        }
-    }
-
-    private fun checkAndInitializeWearables() {
-        // Meta Wearables DAT SDK removed (the mwdat dependency was dropped). The smart-glasses
-        // provider abstraction (WearableManager/SmartGlassProvider) remains for Xreal; no Meta init.
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -203,14 +189,6 @@ class MainActivity : ComponentActivity() {
         hasCameraPermission = ContextCompat.checkSelfPermission(
             this, Manifest.permission.CAMERA
         ) == PackageManager.PERMISSION_GRANTED
-
-        hasBluetoothPermission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            ContextCompat.checkSelfPermission(
-                this, Manifest.permission.BLUETOOTH_CONNECT
-            ) == PackageManager.PERMISSION_GRANTED
-        } else {
-            true
-        }
 
         // Surface any crash captured on the previous run: native backtrace (signal handler) and/or
         // the JVM CrashReporter dump. Read + delete so it shows exactly once.
@@ -236,7 +214,6 @@ class MainActivity : ComponentActivity() {
 
         securityProviderManager.installAsync(this)
         slamManager.ensureInitialized()
-        checkAndInitializeWearables()
 
         lifecycleScope.launch {
             securityProviderManager.securityProviderState.collect { state ->
@@ -1380,10 +1357,6 @@ class MainActivity : ComponentActivity() {
         val navStrings = strings.nav
         val requestPermissions = {
             val perms = mutableListOf(Manifest.permission.CAMERA, Manifest.permission.ACCESS_FINE_LOCATION)
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                perms.add(Manifest.permission.BLUETOOTH_CONNECT)
-                perms.add(Manifest.permission.BLUETOOTH_SCAN)
-            }
             permissionLauncher.launch(perms.toTypedArray())
         }
 


### PR DESCRIPTION
## Remove dead Bluetooth permissions + wearables-init plumbing

Follow-up to dropping the Meta Wearables SDK (#1679). Bluetooth was used **only** to initialize the Meta glasses — Xreal is USB, co-op is network/QR, and a codebase audit found no `BluetoothAdapter`/`BluetoothManager` usage anywhere else. With Meta gone, this plumbing is dead and was still making the app **request Bluetooth permissions users don't need** — a privacy/UX wart for an offline-first app.

### Changes
- **MainActivity:** drop `hasBluetoothPermission` state, the `BLUETOOTH_CONNECT`/`BLUETOOTH_SCAN` entries in the runtime permission request, the launcher/`onCreate` bluetooth reads, and the no-op `checkAndInitializeWearables()` + its two call sites.
- **AndroidManifest:** remove `BLUETOOTH` / `BLUETOOTH_CONNECT` / `BLUETOOTH_SCAN` / `BLUETOOTH_ADVERTISE` permissions and the `bluetooth`/`bluetooth_le` `uses-feature` entries (kept wifi/location).

`grep`-verified: no remaining `bluetooth` / `checkAndInitializeWearables` references. The `SmartGlassProvider`/`WearableManager`/Xreal abstraction is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018V1ysU9z4tTviN5RYcLo8V)_