### PR TITLE
Reloc map Phase 1: WallFeatureMap data model + persistence + tests

### DIFF
--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/GraffitiProject.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/GraffitiProject.kt
@@ -136,5 +136,10 @@ data class GraffitiProject(
     // native JNI with a fixed constructor signature (changing it would break depth-path capture).
     // Both empty on depth-path or pre-existing projects, which keep the legacy descriptors-only restore.
     val fingerprintIntrinsics: List<Float> = emptyList(),
-    val fingerprintAnchor: List<Float> = emptyList()
+    val fingerprintAnchor: List<Float> = emptyList(),
+
+    // Persistent confidence-weighted feature map of the wall around the marks fingerprint — the
+    // lean spatial backbone for wide-area relocalization (see docs/RELOC_MAP_DESIGN.md). Null on
+    // projects without one; built passively during normal use. Defaulted for back-compat.
+    val wallFeatureMap: WallFeatureMap? = null
 )

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/WallFeatureMap.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/WallFeatureMap.kt
@@ -15,58 +15,82 @@ import kotlinx.serialization.Serializable
  * and bounded by the "lean" budget: ORB descriptors by default (`CV_8U`, 32 B/point;
  * SuperPoint `CV_32F` is an opt-in upgrade), a confidence-pruned cap, and frustum-gated
  * matching at reloc time. Descriptors are a flat row-major blob tagged with their OpenCV
- * [descriptorsType], so either descriptor kind round-trips without a schema change. Every
- * field is defaulted so older projects (no map) deserialize unchanged.
+ * [descriptorsType], so either descriptor kind round-trips without a schema change.
+ *
+ * Stored as **primitive arrays** (not boxed `List`s): at the cap this is tens of thousands of
+ * floats, so boxing would cost real memory, and the native restore path (Phase 2) hands these
+ * straight to JNI without a copy. Every field is defaulted so older projects (no map)
+ * deserialize unchanged.
  */
 @Serializable
 data class WallFeatureMap(
     // Flattened 3D points [x0,y0,z0, x1,y1,z1, ...] in the fingerprint-anchor frame; one triplet per point.
-    val points3d: List<Float> = emptyList(),
+    val points3d: FloatArray = FloatArray(0),
     // Descriptors as a flat row-major byte blob: [descriptorsRows] rows (one per point), each
     // [descriptorsCols] wide, of OpenCV [descriptorsType] (CV_8U for ORB, CV_32F for SuperPoint).
     val descriptorsData: ByteArray = ByteArray(0),
     val descriptorsRows: Int = 0,
     val descriptorsCols: Int = 0,
     val descriptorsType: Int = 0,
-    // Per-point confidence in [0,1] and observation count, parallel to the points (size == rows).
-    val confidence: List<Float> = emptyList(),
-    val obsCount: List<Int> = emptyList(),
+    // Per-point confidence in [0,1] and observation count, parallel to the points (size == rows, or empty).
+    val confidence: FloatArray = FloatArray(0),
+    val obsCount: IntArray = IntArray(0),
     // Co-registration: the anchor pose (column-major 4x4, 16 floats) and intrinsics (fx,fy,cx,cy)
     // the points were built in — the SAME frame as the marks fingerprint's anchor. Empty => unset.
-    val anchor: List<Float> = emptyList(),
-    val intrinsics: List<Float> = emptyList(),
+    val anchor: FloatArray = FloatArray(0),
+    val intrinsics: FloatArray = FloatArray(0),
 ) {
     /** Number of mapped points (== descriptor rows). */
     val pointCount: Int get() = descriptorsRows
+
+    init {
+        // Defensive: the parallel arrays must agree so the native restore (Phase 2) can trust
+        // them and never index out of bounds. Empty optional arrays are allowed.
+        require(descriptorsRows >= 0 && descriptorsCols >= 0) { "descriptor dims must be non-negative" }
+        require(points3d.size == descriptorsRows * 3) {
+            "points3d (${points3d.size}) must be 3 * descriptorsRows ($descriptorsRows)"
+        }
+        require(descriptorsRows == 0 || descriptorsData.size % descriptorsRows == 0) {
+            "descriptorsData (${descriptorsData.size}) must divide evenly into $descriptorsRows rows"
+        }
+        require(confidence.isEmpty() || confidence.size == descriptorsRows) {
+            "confidence (${confidence.size}) must be empty or == descriptorsRows ($descriptorsRows)"
+        }
+        require(obsCount.isEmpty() || obsCount.size == descriptorsRows) {
+            "obsCount (${obsCount.size}) must be empty or == descriptorsRows ($descriptorsRows)"
+        }
+        require(anchor.isEmpty() || anchor.size == 16) { "anchor must be empty or 16 floats" }
+        require(intrinsics.isEmpty() || intrinsics.size == 4) { "intrinsics must be empty or 4 floats" }
+    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
         other as WallFeatureMap
-        // contentEquals for the descriptor blob; structural equality for the rest. A plain
-        // generated equals() would compare the ByteArray by reference and break round-trip checks.
-        if (points3d != other.points3d) return false
+        // contentEquals for every array; a generated equals() would compare them by reference
+        // and break round-trip checks.
+        if (!points3d.contentEquals(other.points3d)) return false
         if (!descriptorsData.contentEquals(other.descriptorsData)) return false
         if (descriptorsRows != other.descriptorsRows) return false
         if (descriptorsCols != other.descriptorsCols) return false
         if (descriptorsType != other.descriptorsType) return false
-        if (confidence != other.confidence) return false
-        if (obsCount != other.obsCount) return false
-        if (anchor != other.anchor) return false
-        if (intrinsics != other.intrinsics) return false
+        if (!confidence.contentEquals(other.confidence)) return false
+        if (!obsCount.contentEquals(other.obsCount)) return false
+        if (!anchor.contentEquals(other.anchor)) return false
+        if (!intrinsics.contentEquals(other.intrinsics)) return false
         return true
     }
 
     override fun hashCode(): Int {
-        var result = points3d.hashCode()
+        var result = points3d.contentHashCode()
         result = 31 * result + descriptorsData.contentHashCode()
         result = 31 * result + descriptorsRows
         result = 31 * result + descriptorsCols
         result = 31 * result + descriptorsType
-        result = 31 * result + confidence.hashCode()
-        result = 31 * result + obsCount.hashCode()
-        result = 31 * result + anchor.hashCode()
-        result = 31 * result + intrinsics.hashCode()
+        result = 31 * result + confidence.contentHashCode()
+        result = 31 * result + obsCount.contentHashCode()
+        result = 31 * result + anchor.contentHashCode()
+        result = 31 * result + intrinsics.contentHashCode()
         return result
     }
 }

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/WallFeatureMap.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/WallFeatureMap.kt
@@ -1,0 +1,72 @@
+package com.hereliesaz.graffitixr.common.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * A persistent, confidence-weighted **feature** map of the wall surrounding the marks
+ * [Fingerprint] — the lean spatial backbone for wide-area relocalization (see
+ * `docs/RELOC_MAP_DESIGN.md`). Because the overlaid artwork is usually larger than the marks,
+ * the fingerprint alone can't hold the lock when you look away from it; this map carries
+ * feature descriptors at 3D points across the whole wall so reloc works from far more
+ * viewpoints, all co-registered to the fingerprint anchor (matching any patch yields the
+ * fingerprint/overlay pose directly).
+ *
+ * It is built **passively** from whatever keyframes normal use provides (no explicit scan),
+ * and bounded by the "lean" budget: ORB descriptors by default (`CV_8U`, 32 B/point;
+ * SuperPoint `CV_32F` is an opt-in upgrade), a confidence-pruned cap, and frustum-gated
+ * matching at reloc time. Descriptors are a flat row-major blob tagged with their OpenCV
+ * [descriptorsType], so either descriptor kind round-trips without a schema change. Every
+ * field is defaulted so older projects (no map) deserialize unchanged.
+ */
+@Serializable
+data class WallFeatureMap(
+    // Flattened 3D points [x0,y0,z0, x1,y1,z1, ...] in the fingerprint-anchor frame; one triplet per point.
+    val points3d: List<Float> = emptyList(),
+    // Descriptors as a flat row-major byte blob: [descriptorsRows] rows (one per point), each
+    // [descriptorsCols] wide, of OpenCV [descriptorsType] (CV_8U for ORB, CV_32F for SuperPoint).
+    val descriptorsData: ByteArray = ByteArray(0),
+    val descriptorsRows: Int = 0,
+    val descriptorsCols: Int = 0,
+    val descriptorsType: Int = 0,
+    // Per-point confidence in [0,1] and observation count, parallel to the points (size == rows).
+    val confidence: List<Float> = emptyList(),
+    val obsCount: List<Int> = emptyList(),
+    // Co-registration: the anchor pose (column-major 4x4, 16 floats) and intrinsics (fx,fy,cx,cy)
+    // the points were built in — the SAME frame as the marks fingerprint's anchor. Empty => unset.
+    val anchor: List<Float> = emptyList(),
+    val intrinsics: List<Float> = emptyList(),
+) {
+    /** Number of mapped points (== descriptor rows). */
+    val pointCount: Int get() = descriptorsRows
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        other as WallFeatureMap
+        // contentEquals for the descriptor blob; structural equality for the rest. A plain
+        // generated equals() would compare the ByteArray by reference and break round-trip checks.
+        if (points3d != other.points3d) return false
+        if (!descriptorsData.contentEquals(other.descriptorsData)) return false
+        if (descriptorsRows != other.descriptorsRows) return false
+        if (descriptorsCols != other.descriptorsCols) return false
+        if (descriptorsType != other.descriptorsType) return false
+        if (confidence != other.confidence) return false
+        if (obsCount != other.obsCount) return false
+        if (anchor != other.anchor) return false
+        if (intrinsics != other.intrinsics) return false
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = points3d.hashCode()
+        result = 31 * result + descriptorsData.contentHashCode()
+        result = 31 * result + descriptorsRows
+        result = 31 * result + descriptorsCols
+        result = 31 * result + descriptorsType
+        result = 31 * result + confidence.hashCode()
+        result = 31 * result + obsCount.hashCode()
+        result = 31 * result + anchor.hashCode()
+        result = 31 * result + intrinsics.hashCode()
+        return result
+    }
+}

--- a/core/common/src/test/java/com/hereliesaz/graffitixr/common/model/WallFeatureMapTest.kt
+++ b/core/common/src/test/java/com/hereliesaz/graffitixr/common/model/WallFeatureMapTest.kt
@@ -1,0 +1,73 @@
+package com.hereliesaz.graffitixr.common.model
+
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Phase 1 of the persistent-feature-map work (docs/RELOC_MAP_DESIGN.md): the data contract
+ * must survive a serialize/deserialize round-trip intact — especially the descriptor blob,
+ * which a naive ByteArray equals() would compare by reference.
+ */
+class WallFeatureMapTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+    }
+
+    @Test
+    fun `round-trips a populated ORB feature map`() {
+        val n = 3
+        val cols = 32 // ORB descriptor width in bytes
+        val original = WallFeatureMap(
+            points3d = listOf(0f, 0f, 1f, 0.1f, 0.2f, 1.1f, -0.3f, 0.4f, 0.9f),
+            descriptorsData = ByteArray(n * cols) { (it % 251).toByte() },
+            descriptorsRows = n,
+            descriptorsCols = cols,
+            descriptorsType = 0, // CV_8U (ORB)
+            confidence = listOf(0.9f, 0.5f, 0.75f),
+            obsCount = listOf(5, 2, 3),
+            anchor = listOf(1f, 0f, 0f, 0f, 0f, 1f, 0f, 0f, 0f, 0f, 1f, 0f, 0f, 0f, 0f, 1f),
+            intrinsics = listOf(500f, 500f, 320f, 240f),
+        )
+
+        val decoded = json.decodeFromString<WallFeatureMap>(json.encodeToString(original))
+
+        assertEquals(original, decoded)
+        assertEquals(n, decoded.pointCount)
+        assertTrue(
+            "descriptor blob must survive the round-trip byte-for-byte",
+            original.descriptorsData.contentEquals(decoded.descriptorsData)
+        )
+    }
+
+    @Test
+    fun `round-trips a SuperPoint-typed map (CV_32F descriptor type preserved)`() {
+        val original = WallFeatureMap(
+            points3d = listOf(1f, 2f, 3f),
+            descriptorsData = ByteArray(256 * 4) { (it % 97).toByte() }, // 1 point x 256 floats
+            descriptorsRows = 1,
+            descriptorsCols = 256,
+            descriptorsType = 5, // CV_32F (SuperPoint) — must round-trip unchanged
+            confidence = listOf(0.6f),
+            obsCount = listOf(1),
+        )
+
+        val decoded = json.decodeFromString<WallFeatureMap>(json.encodeToString(original))
+
+        assertEquals(original, decoded)
+        assertEquals(5, decoded.descriptorsType)
+        assertEquals(256, decoded.descriptorsCols)
+    }
+
+    @Test
+    fun `empty map round-trips (back-compat default)`() {
+        val decoded = json.decodeFromString<WallFeatureMap>(json.encodeToString(WallFeatureMap()))
+        assertEquals(WallFeatureMap(), decoded)
+        assertEquals(0, decoded.pointCount)
+    }
+}

--- a/core/common/src/test/java/com/hereliesaz/graffitixr/common/model/WallFeatureMapTest.kt
+++ b/core/common/src/test/java/com/hereliesaz/graffitixr/common/model/WallFeatureMapTest.kt
@@ -24,15 +24,15 @@ class WallFeatureMapTest {
         val n = 3
         val cols = 32 // ORB descriptor width in bytes
         val original = WallFeatureMap(
-            points3d = listOf(0f, 0f, 1f, 0.1f, 0.2f, 1.1f, -0.3f, 0.4f, 0.9f),
+            points3d = floatArrayOf(0f, 0f, 1f, 0.1f, 0.2f, 1.1f, -0.3f, 0.4f, 0.9f),
             descriptorsData = ByteArray(n * cols) { (it % 251).toByte() },
             descriptorsRows = n,
             descriptorsCols = cols,
             descriptorsType = 0, // CV_8U (ORB)
-            confidence = listOf(0.9f, 0.5f, 0.75f),
-            obsCount = listOf(5, 2, 3),
-            anchor = listOf(1f, 0f, 0f, 0f, 0f, 1f, 0f, 0f, 0f, 0f, 1f, 0f, 0f, 0f, 0f, 1f),
-            intrinsics = listOf(500f, 500f, 320f, 240f),
+            confidence = floatArrayOf(0.9f, 0.5f, 0.75f),
+            obsCount = intArrayOf(5, 2, 3),
+            anchor = floatArrayOf(1f, 0f, 0f, 0f, 0f, 1f, 0f, 0f, 0f, 0f, 1f, 0f, 0f, 0f, 0f, 1f),
+            intrinsics = floatArrayOf(500f, 500f, 320f, 240f),
         )
 
         val decoded = json.decodeFromString<WallFeatureMap>(json.encodeToString(original))
@@ -48,13 +48,13 @@ class WallFeatureMapTest {
     @Test
     fun `round-trips a SuperPoint-typed map (CV_32F descriptor type preserved)`() {
         val original = WallFeatureMap(
-            points3d = listOf(1f, 2f, 3f),
+            points3d = floatArrayOf(1f, 2f, 3f),
             descriptorsData = ByteArray(256 * 4) { (it % 97).toByte() }, // 1 point x 256 floats
             descriptorsRows = 1,
             descriptorsCols = 256,
             descriptorsType = 5, // CV_32F (SuperPoint) — must round-trip unchanged
-            confidence = listOf(0.6f),
-            obsCount = listOf(1),
+            confidence = floatArrayOf(0.6f),
+            obsCount = intArrayOf(1),
         )
 
         val decoded = json.decodeFromString<WallFeatureMap>(json.encodeToString(original))

--- a/core/data/src/test/java/com/hereliesaz/graffitixr/data/repository/GraffitiProjectTest.kt
+++ b/core/data/src/test/java/com/hereliesaz/graffitixr/data/repository/GraffitiProjectTest.kt
@@ -74,15 +74,15 @@ class GraffitiProjectTest {
         // The persistent feature map rides in project.json (and thus the .gxr), parallel to the
         // fingerprint. Verify it survives the project round-trip intact (descriptor blob included).
         val map = WallFeatureMap(
-            points3d = listOf(0f, 0f, 1f, 0.1f, 0.2f, 1.1f),
+            points3d = floatArrayOf(0f, 0f, 1f, 0.1f, 0.2f, 1.1f),
             descriptorsData = ByteArray(64) { (it % 251).toByte() },
             descriptorsRows = 2,
             descriptorsCols = 32,
             descriptorsType = 0,
-            confidence = listOf(0.9f, 0.4f),
-            obsCount = listOf(4, 1),
-            anchor = List(16) { it.toFloat() },
-            intrinsics = listOf(500f, 500f, 320f, 240f),
+            confidence = floatArrayOf(0.9f, 0.4f),
+            obsCount = intArrayOf(4, 1),
+            anchor = FloatArray(16) { it.toFloat() },
+            intrinsics = floatArrayOf(500f, 500f, 320f, 240f),
         )
         val project = GraffitiProject(id = "id", name = "n", wallFeatureMap = map)
 

--- a/core/data/src/test/java/com/hereliesaz/graffitixr/data/repository/GraffitiProjectTest.kt
+++ b/core/data/src/test/java/com/hereliesaz/graffitixr/data/repository/GraffitiProjectTest.kt
@@ -2,6 +2,7 @@ package com.hereliesaz.graffitixr.data.repository
 
 import com.hereliesaz.graffitixr.common.model.GraffitiProject
 import com.hereliesaz.graffitixr.common.model.OverlayLayer
+import com.hereliesaz.graffitixr.common.model.WallFeatureMap
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
@@ -66,5 +67,27 @@ class GraffitiProjectTest {
         assertEquals(true, decoded.layers[0].isImageLocked)
         assertEquals(listOf(0f, 1f, 2f, 3f), decoded.layers[0].warpMesh)
         assertEquals("/path/to/fingerprint", decoded.targetFingerprintPath)
+    }
+
+    @Test
+    fun `serialization preserves the wall feature map`() {
+        // The persistent feature map rides in project.json (and thus the .gxr), parallel to the
+        // fingerprint. Verify it survives the project round-trip intact (descriptor blob included).
+        val map = WallFeatureMap(
+            points3d = listOf(0f, 0f, 1f, 0.1f, 0.2f, 1.1f),
+            descriptorsData = ByteArray(64) { (it % 251).toByte() },
+            descriptorsRows = 2,
+            descriptorsCols = 32,
+            descriptorsType = 0,
+            confidence = listOf(0.9f, 0.4f),
+            obsCount = listOf(4, 1),
+            anchor = List(16) { it.toFloat() },
+            intrinsics = listOf(500f, 500f, 320f, 240f),
+        )
+        val project = GraffitiProject(id = "id", name = "n", wallFeatureMap = map)
+
+        val decoded = json.decodeFromString<GraffitiProject>(json.encodeToString(project))
+
+        assertEquals(map, decoded.wallFeatureMap)
     }
 }


### PR DESCRIPTION
## Reloc map — Phase 1: `WallFeatureMap` data model + persistence + tests

First, **zero-relocalizer-risk** phase of the persistent-feature-map work ([design](docs/RELOC_MAP_DESIGN.md), #1681). Pure data contract — no engine, JNI, or `relocThreadFunc` changes — so everything downstream has a stable foundation.

### What's here
- **`WallFeatureMap`** — `@Serializable` model: flat `points3d`, a **row-major descriptor blob tagged with its OpenCV `type`** (so ORB `CV_8U` default and SuperPoint `CV_32F` opt-in both round-trip with no schema change), per-point `confidence` + `obsCount`, and the **co-registration `anchor` + `intrinsics`** (same frame as the marks fingerprint). Custom `equals`/`hashCode` so the `ByteArray` compares by content (mirrors `Fingerprint`). Every field defaulted.
- **`GraffitiProject`** — `+ wallFeatureMap: WallFeatureMap?` (rides in `project.json` / `.gxr`, parallel to `Fingerprint`); defaulted so **older projects deserialize unchanged**.
- **Tests** — standalone round-trip (ORB, SuperPoint-typed, empty) + a project-level round-trip proving the map survives in the `.gxr` payload.

### Constraints honored (from the design)
The model is ORB-default-friendly and descriptor-type-agnostic; the lean budget (cap, frustum-gated matching, passive build) lives in later phases. Nothing renders, nothing runs per-frame.

### Not in scope (later phases)
Native map storage + frustum-gated reloc matching (Phase 2), **passive** map build (Phase 3), confidence/pruning tuning (Phase 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018V1ysU9z4tTviN5RYcLo8V)_