### PR TITLE
Reloc map Phase 2b: frustum-gated map matching in reloc (default-OFF flag)

### DIFF
--- a/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
+++ b/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
@@ -778,6 +778,60 @@ Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeRestoreWallFingerp
     env->ReleaseFloatArrayElements(intrArray, intr, JNI_ABORT);
 }
 
+// Persistent wall feature map (Phase 2a: store only). Mirrors the metric-fingerprint restore but
+// adds parallel per-point confidence (jfloatArray) + obs (jintArray); anchor/intrinsics are
+// passed through only when correctly sized (16 / 4), else left at their native defaults.
+JNIEXPORT void JNICALL
+Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeRestoreWallFeatureMap(
+        JNIEnv* env, jobject thiz, jbyteArray descArray, jint rows, jint cols, jint type,
+        jfloatArray ptsArray, jfloatArray confArray, jintArray obsArray,
+        jfloatArray anchorArray, jfloatArray intrArray) {
+    if (!gSlamEngine) return;
+    jbyte* descData = env->GetByteArrayElements(descArray, nullptr);
+    cv::Mat descriptors(rows, cols, type, descData);
+    jsize ptsLen = env->GetArrayLength(ptsArray);
+    jfloat* ptsData = env->GetFloatArrayElements(ptsArray, nullptr);
+    std::vector<cv::Point3f> points3d;
+    points3d.reserve(ptsLen / 3);
+    for (int i = 0; i + 2 < ptsLen; i += 3)
+        points3d.push_back(cv::Point3f(ptsData[i], ptsData[i+1], ptsData[i+2]));
+
+    std::vector<float> conf;
+    jsize confLen = env->GetArrayLength(confArray);
+    if (confLen > 0) {
+        jfloat* c = env->GetFloatArrayElements(confArray, nullptr);
+        conf.assign(c, c + confLen);
+        env->ReleaseFloatArrayElements(confArray, c, JNI_ABORT);
+    }
+    std::vector<int> obs;
+    jsize obsLen = env->GetArrayLength(obsArray);
+    if (obsLen > 0) {
+        jint* o = env->GetIntArrayElements(obsArray, nullptr);
+        obs.assign(o, o + obsLen);
+        env->ReleaseIntArrayElements(obsArray, o, JNI_ABORT);
+    }
+
+    jfloat* anchor = (env->GetArrayLength(anchorArray) == 16) ? env->GetFloatArrayElements(anchorArray, nullptr) : nullptr;
+    jfloat* intr   = (env->GetArrayLength(intrArray) == 4)    ? env->GetFloatArrayElements(intrArray, nullptr)   : nullptr;
+
+    gSlamEngine->restoreWallFeatureMap(descriptors, points3d, conf, obs, anchor, intr);
+
+    env->ReleaseByteArrayElements(descArray, descData, JNI_ABORT);
+    env->ReleaseFloatArrayElements(ptsArray, ptsData, JNI_ABORT);
+    if (anchor) env->ReleaseFloatArrayElements(anchorArray, anchor, JNI_ABORT);
+    if (intr)   env->ReleaseFloatArrayElements(intrArray, intr, JNI_ABORT);
+}
+
+JNIEXPORT void JNICALL
+Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeClearWallFeatureMap(JNIEnv*, jobject) {
+    if (gSlamEngine) gSlamEngine->clearWallFeatureMap();
+}
+
+JNIEXPORT jint JNICALL
+Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeGetMapPointCount(JNIEnv*, jobject) {
+    return gSlamEngine ? gSlamEngine->getMapPointCount() : 0;
+}
+
 jobject buildFingerprintObject(JNIEnv* env, const MobileGS::FingerprintData& fd) {
     if (fd.descriptors.empty()) return nullptr;
 

--- a/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
+++ b/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
@@ -786,33 +786,42 @@ Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeRestoreWallFeature
         JNIEnv* env, jobject thiz, jbyteArray descArray, jint rows, jint cols, jint type,
         jfloatArray ptsArray, jfloatArray confArray, jintArray obsArray,
         jfloatArray anchorArray, jfloatArray intrArray) {
-    if (!gSlamEngine) return;
+    // Defensive validation (a malformed/old .gxr must never crash native): null refs, a descriptor
+    // blob big enough for rows*cols*elemSize, and parallel arrays of matching length.
+    if (!gSlamEngine || !descArray || !ptsArray) return;
+    if (rows < 0 || cols < 0) return;
+    jsize descLen = env->GetArrayLength(descArray);
+    if (descLen < (jsize)(rows * cols * CV_ELEM_SIZE(type))) return;
+    jsize ptsLen = env->GetArrayLength(ptsArray);
+    if (ptsLen != rows * 3) return;
+    jsize confLen = confArray ? env->GetArrayLength(confArray) : 0;
+    if (confLen > 0 && confLen != rows) return;
+    jsize obsLen = obsArray ? env->GetArrayLength(obsArray) : 0;
+    if (obsLen > 0 && obsLen != rows) return;
+
     jbyte* descData = env->GetByteArrayElements(descArray, nullptr);
     cv::Mat descriptors(rows, cols, type, descData);
-    jsize ptsLen = env->GetArrayLength(ptsArray);
     jfloat* ptsData = env->GetFloatArrayElements(ptsArray, nullptr);
     std::vector<cv::Point3f> points3d;
-    points3d.reserve(ptsLen / 3);
+    points3d.reserve(rows);
     for (int i = 0; i + 2 < ptsLen; i += 3)
         points3d.push_back(cv::Point3f(ptsData[i], ptsData[i+1], ptsData[i+2]));
 
     std::vector<float> conf;
-    jsize confLen = env->GetArrayLength(confArray);
     if (confLen > 0) {
         jfloat* c = env->GetFloatArrayElements(confArray, nullptr);
         conf.assign(c, c + confLen);
         env->ReleaseFloatArrayElements(confArray, c, JNI_ABORT);
     }
     std::vector<int> obs;
-    jsize obsLen = env->GetArrayLength(obsArray);
     if (obsLen > 0) {
         jint* o = env->GetIntArrayElements(obsArray, nullptr);
         obs.assign(o, o + obsLen);
         env->ReleaseIntArrayElements(obsArray, o, JNI_ABORT);
     }
 
-    jfloat* anchor = (env->GetArrayLength(anchorArray) == 16) ? env->GetFloatArrayElements(anchorArray, nullptr) : nullptr;
-    jfloat* intr   = (env->GetArrayLength(intrArray) == 4)    ? env->GetFloatArrayElements(intrArray, nullptr)   : nullptr;
+    jfloat* anchor = (anchorArray && env->GetArrayLength(anchorArray) == 16) ? env->GetFloatArrayElements(anchorArray, nullptr) : nullptr;
+    jfloat* intr   = (intrArray && env->GetArrayLength(intrArray) == 4)    ? env->GetFloatArrayElements(intrArray, nullptr)   : nullptr;
 
     gSlamEngine->restoreWallFeatureMap(descriptors, points3d, conf, obs, anchor, intr);
 

--- a/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
+++ b/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
@@ -841,6 +841,11 @@ Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeGetMapPointCount(J
     return gSlamEngine ? gSlamEngine->getMapPointCount() : 0;
 }
 
+JNIEXPORT void JNICALL
+Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeSetMapRelocEnabled(JNIEnv*, jobject, jboolean enabled) {
+    if (gSlamEngine) gSlamEngine->setMapRelocEnabled(enabled == JNI_TRUE);
+}
+
 jobject buildFingerprintObject(JNIEnv* env, const MobileGS::FingerprintData& fd) {
     if (fd.descriptors.empty()) return nullptr;
 

--- a/core/nativebridge/src/main/cpp/MobileGS.cpp
+++ b/core/nativebridge/src/main/cpp/MobileGS.cpp
@@ -625,6 +625,26 @@ void MobileGS::restoreWallFingerprintMetric(const cv::Mat& d, const std::vector<
     if (intrinsics4)    memcpy(mFingerprintIntrinsics, intrinsics4, 4 * sizeof(float));
 }
 
+void MobileGS::restoreWallFeatureMap(const cv::Mat& d, const std::vector<cv::Point3f>& p,
+                                     const std::vector<float>& conf, const std::vector<int>& obs,
+                                     const float* anchorMatrix16, const float* intrinsics4) {
+    std::lock_guard<std::mutex> lock(mMutex);
+    mMapDescriptors = d.clone();
+    mMapPoints3D = p;
+    mMapConfidence = conf;
+    mMapObs = obs;
+    if (anchorMatrix16) memcpy(mMapAnchorMatrix, anchorMatrix16, 16 * sizeof(float));
+    if (intrinsics4)    memcpy(mMapIntrinsics, intrinsics4, 4 * sizeof(float));
+}
+
+void MobileGS::clearWallFeatureMap() {
+    std::lock_guard<std::mutex> lock(mMutex);
+    mMapDescriptors.release();
+    mMapPoints3D.clear();
+    mMapConfidence.clear();
+    mMapObs.clear();
+}
+
 std::vector<uint8_t> MobileGS::exportFingerprint() {
     std::lock_guard<std::mutex> lock(mMutex);
     if (mWallDescriptors.empty() || mWallKeypoints3D.empty()) return {};

--- a/core/nativebridge/src/main/cpp/MobileGS.cpp
+++ b/core/nativebridge/src/main/cpp/MobileGS.cpp
@@ -220,6 +220,13 @@ void MobileGS::relocThreadFunc() {
         cv::Mat wallPatch;
         float fpIntrinsics[4];
         bool hasFpView = false;
+        // Phase 2b snapshot: the persistent feature map + the last reloc pose, used (when the flag is on)
+        // as the frustum-gate prior. The map is co-registered to the fingerprint anchor, so its points
+        // share wallKps3d's frame and the prior pose (camera_from_fpWorld) projects them directly.
+        cv::Mat mapDescs;
+        std::vector<cv::Point3f> mapKps3d;
+        float mapPriorPose[16];
+        long mapPriorSeq = 0;
         {
             std::lock_guard<std::mutex> lock(mMutex);
             wallDescs = mWallDescriptors.clone();
@@ -227,6 +234,10 @@ void MobileGS::relocThreadFunc() {
             wallPatch = mWallPatch.clone();
             memcpy(fpIntrinsics, mFingerprintIntrinsics, 4 * sizeof(float));
             hasFpView = mHasFingerprintView;
+            mapDescs = mMapDescriptors.clone();
+            mapKps3d = mMapPoints3D;
+            memcpy(mapPriorPose, mPnpCamFromFpWorld, 16 * sizeof(float));
+            mapPriorSeq = mPnpResultSeq.load(std::memory_order_relaxed);
         }
 
         if (frame.empty() || wallDescs.empty() || wallKps3d.empty() || !mRelocEnabled) continue;
@@ -308,6 +319,56 @@ void MobileGS::relocThreadFunc() {
                 if (imgPts.size() > before)
                     LOGI("Reloc: rectified (obliquity %.0f deg) added %zu corr (total %zu)",
                          obliqDeg, imgPts.size() - before, imgPts.size());
+            }
+        }
+
+        // --- Persistent feature-map matching (Phase 2b; default OFF via mMapRelocEnabled) ---
+        // When the overlay is larger than the marks, the marks leave frame; the map carries features
+        // across the whole wall so reloc still locks. Hard constraint: NEVER brute-force the whole map —
+        // frustum-gate to the subset the last reloc pose says is in view, then match only those and
+        // APPEND the correspondences (same fingerprint frame + intrinsics) so PnP solves over both.
+        // Requires a prior pose (mapPriorSeq>0, i.e. the fingerprint has locked at least once) and a
+        // matching descriptor type. Default-off, so this is inert until device-validated.
+        if (mMapRelocEnabled.load(std::memory_order_relaxed) && !mapDescs.empty() && mapPriorSeq > 0
+                && mapDescs.type() == wallDescs.type() && mapKps3d.size() == (size_t)mapDescs.rows) {
+            glm::mat4 camFromFp = glm::make_mat4(mapPriorPose);
+            double gfx = (fpIntrinsics[0] > 0.f) ? (double)fpIntrinsics[0] : 1000.0;
+            double gfy = (fpIntrinsics[1] > 0.f) ? (double)fpIntrinsics[1] : 1000.0;
+            double gcx = (fpIntrinsics[0] > 0.f) ? (double)fpIntrinsics[2] : gray.cols * 0.5;
+            double gcy = (fpIntrinsics[1] > 0.f) ? (double)fpIntrinsics[3] : gray.rows * 0.5;
+            std::vector<int> visible;
+            visible.reserve(mapKps3d.size());
+            for (int i = 0; i < (int)mapKps3d.size(); ++i) {
+                glm::vec4 pc = camFromFp * glm::vec4(mapKps3d[i].x, mapKps3d[i].y, mapKps3d[i].z, 1.0f);
+                if (pc.z <= 0.05f) continue; // behind / too close to the camera
+                float u = (float)(gfx * pc.x / pc.z + gcx);
+                float v = (float)(gfy * pc.y / pc.z + gcy);
+                if (u >= 0.f && u < gray.cols && v >= 0.f && v < gray.rows) visible.push_back(i);
+            }
+            if (visible.size() >= 8) {
+                cv::Mat gatedDescs;
+                gatedDescs.reserve(visible.size());
+                for (int i : visible) gatedDescs.push_back(mapDescs.row(i));
+                std::vector<cv::KeyPoint> kps; cv::Mat descs;
+                bool sp = spOk;
+                if (sp && !mSuperPoint.detect(gray, kps, descs)) sp = false;
+                if (!sp) mFeatureDetector->detectAndCompute(gray, cv::noArray(), kps, descs);
+                if (!descs.empty() && descs.type() == gatedDescs.type()) {
+                    cv::Ptr<cv::DescriptorMatcher>& matcher = (descs.type() == CV_32F) ? mL2Matcher : mMatcher;
+                    std::vector<std::vector<cv::DMatch>> matches;
+                    matcher->knnMatch(descs, gatedDescs, matches, 2);
+                    size_t before = imgPts.size();
+                    for (auto& m : matches) {
+                        if (m.size() < 2) continue;
+                        if (m[0].distance < 0.75f * m[1].distance) {
+                            imgPts.push_back(kps[m[0].queryIdx].pt);
+                            objPts.push_back(mapKps3d[visible[m[0].trainIdx]]);
+                        }
+                    }
+                    if (imgPts.size() > before)
+                        LOGI("Reloc map: gated %zu/%zu pts, added %zu corr (total %zu)",
+                             visible.size(), mapKps3d.size(), imgPts.size() - before, imgPts.size());
+                }
             }
         }
 

--- a/core/nativebridge/src/main/cpp/MobileGS.cpp
+++ b/core/nativebridge/src/main/cpp/MobileGS.cpp
@@ -260,12 +260,27 @@ void MobileGS::relocThreadFunc() {
         // the matched keypoints are mapped through it (rectified frame -> current image) before being
         // stored, so the returned 2D points are ALWAYS in the current camera image — exactly what the
         // PnP below expects.
-        auto buildCorr = [&](const cv::Mat& g, const cv::Mat& Hback,
-                             std::vector<cv::Point2f>& outImg, std::vector<cv::Point3f>& outObj) {
-            std::vector<cv::KeyPoint> kps; cv::Mat descs;
+        // Detect base-frame features ONCE and reuse them: SuperPoint is an ONNX model, so detecting the
+        // same gray twice (plain pass + map matching) would roughly double per-reloc cost. The scaled and
+        // rectified passes run on different images, so buildCorr still detects internally for those.
+        std::vector<cv::KeyPoint> baseKps; cv::Mat baseDescs;
+        {
             bool sp = spOk;
-            if (sp && !mSuperPoint.detect(g, kps, descs)) sp = false;
-            if (!sp) mFeatureDetector->detectAndCompute(g, cv::noArray(), kps, descs);
+            if (sp && !mSuperPoint.detect(gray, baseKps, baseDescs)) sp = false;
+            if (!sp) mFeatureDetector->detectAndCompute(gray, cv::noArray(), baseKps, baseDescs);
+        }
+
+        auto buildCorr = [&](const cv::Mat& g, const cv::Mat& Hback,
+                             std::vector<cv::Point2f>& outImg, std::vector<cv::Point3f>& outObj,
+                             const std::vector<cv::KeyPoint>* preKps = nullptr, const cv::Mat* preDescs = nullptr) {
+            std::vector<cv::KeyPoint> localKps; cv::Mat localDescs;
+            if (!(preKps && preDescs)) {
+                bool sp = spOk;
+                if (sp && !mSuperPoint.detect(g, localKps, localDescs)) sp = false;
+                if (!sp) mFeatureDetector->detectAndCompute(g, cv::noArray(), localKps, localDescs);
+            }
+            const std::vector<cv::KeyPoint>& kps = (preKps && preDescs) ? *preKps : localKps;
+            const cv::Mat& descs = (preKps && preDescs) ? *preDescs : localDescs;
             if (descs.empty() || wallDescs.empty()) return;
             if (descs.type() != wallDescs.type()) return;
 
@@ -289,7 +304,7 @@ void MobileGS::relocThreadFunc() {
 
         std::vector<cv::Point2f> imgPts;
         std::vector<cv::Point3f> objPts;
-        buildCorr(gray, cv::Mat(), imgPts, objPts);
+        buildCorr(gray, cv::Mat(), imgPts, objPts, &baseKps, &baseDescs);
 
         // Multi-scale matching (distance robustness). SuperPoint isn't scale-invariant, and the marks
         // shrink in the frame from far away and grow up close, so also match the frame DOWN- and
@@ -346,22 +361,20 @@ void MobileGS::relocThreadFunc() {
                 if (u >= 0.f && u < gray.cols && v >= 0.f && v < gray.rows) visible.push_back(i);
             }
             if (visible.size() >= 8) {
-                cv::Mat gatedDescs;
-                gatedDescs.reserve(visible.size());
-                for (int i : visible) gatedDescs.push_back(mapDescs.row(i));
-                std::vector<cv::KeyPoint> kps; cv::Mat descs;
-                bool sp = spOk;
-                if (sp && !mSuperPoint.detect(gray, kps, descs)) sp = false;
-                if (!sp) mFeatureDetector->detectAndCompute(gray, cv::noArray(), kps, descs);
-                if (!descs.empty() && descs.type() == gatedDescs.type()) {
-                    cv::Ptr<cv::DescriptorMatcher>& matcher = (descs.type() == CV_32F) ? mL2Matcher : mMatcher;
+                // Preallocate the gated descriptor block with the right size+type and copy rows
+                // (cv::Mat has no usable reserve() on an empty/typeless matrix). Reuse the base detection.
+                cv::Mat gatedDescs((int)visible.size(), mapDescs.cols, mapDescs.type());
+                for (size_t i = 0; i < visible.size(); ++i)
+                    mapDescs.row(visible[i]).copyTo(gatedDescs.row((int)i));
+                if (!baseDescs.empty() && baseDescs.type() == gatedDescs.type()) {
+                    cv::Ptr<cv::DescriptorMatcher>& matcher = (baseDescs.type() == CV_32F) ? mL2Matcher : mMatcher;
                     std::vector<std::vector<cv::DMatch>> matches;
-                    matcher->knnMatch(descs, gatedDescs, matches, 2);
+                    matcher->knnMatch(baseDescs, gatedDescs, matches, 2);
                     size_t before = imgPts.size();
                     for (auto& m : matches) {
                         if (m.size() < 2) continue;
                         if (m[0].distance < 0.75f * m[1].distance) {
-                            imgPts.push_back(kps[m[0].queryIdx].pt);
+                            imgPts.push_back(baseKps[m[0].queryIdx].pt);
                             objPts.push_back(mapKps3d[visible[m[0].trainIdx]]);
                         }
                     }

--- a/core/nativebridge/src/main/cpp/MobileGS.cpp
+++ b/core/nativebridge/src/main/cpp/MobileGS.cpp
@@ -633,8 +633,12 @@ void MobileGS::restoreWallFeatureMap(const cv::Mat& d, const std::vector<cv::Poi
     mMapPoints3D = p;
     mMapConfidence = conf;
     mMapObs = obs;
-    if (anchorMatrix16) memcpy(mMapAnchorMatrix, anchorMatrix16, 16 * sizeof(float));
-    if (intrinsics4)    memcpy(mMapIntrinsics, intrinsics4, 4 * sizeof(float));
+    // Reset (not leave stale) when a map omits co-registration, so it can't inherit a previous
+    // project's anchor/intrinsics.
+    static const float kIdentity16[16] = {1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1};
+    memcpy(mMapAnchorMatrix, anchorMatrix16 ? anchorMatrix16 : kIdentity16, 16 * sizeof(float));
+    if (intrinsics4) memcpy(mMapIntrinsics, intrinsics4, 4 * sizeof(float));
+    else             memset(mMapIntrinsics, 0, 4 * sizeof(float));
 }
 
 void MobileGS::clearWallFeatureMap() {
@@ -643,6 +647,10 @@ void MobileGS::clearWallFeatureMap() {
     mMapPoints3D.clear();
     mMapConfidence.clear();
     mMapObs.clear();
+    // Also drop stale co-registration so a later project can't inherit it.
+    static const float kIdentity16[16] = {1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1};
+    memcpy(mMapAnchorMatrix, kIdentity16, 16 * sizeof(float));
+    memset(mMapIntrinsics, 0, 4 * sizeof(float));
 }
 
 std::vector<uint8_t> MobileGS::exportFingerprint() {

--- a/core/nativebridge/src/main/cpp/include/MobileGS.h
+++ b/core/nativebridge/src/main/cpp/include/MobileGS.h
@@ -54,6 +54,8 @@ public:
                                const float* anchorMatrix16, const float* intrinsics4);
     void clearWallFeatureMap();
     int getMapPointCount() const { std::lock_guard<std::mutex> lock(mMutex); return (int)mMapPoints3D.size(); }
+    // Phase 2b: gate live map-matching in relocThreadFunc. Default OFF — ships inert until validated.
+    void setMapRelocEnabled(bool e) { mMapRelocEnabled.store(e, std::memory_order_relaxed); }
     void scheduleRelocCheck(const cv::Mat& colorFrame);
     void getAnchorTransform(float* outMat16) const;
     void getRelocResult(float* out19) const;       // [0..15]=pnpMat,16=inliers,17=matches,18=seq
@@ -179,6 +181,9 @@ private:
     std::vector<int> mMapObs;
     float mMapAnchorMatrix[16] = {1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1};
     float mMapIntrinsics[4] = {0,0,0,0};
+    // Phase 2b flag: when true, relocThreadFunc also matches the frustum-gated map and merges those
+    // correspondences into PnP. Default OFF so the map has zero effect on reloc until device-validated.
+    std::atomic<bool> mMapRelocEnabled{false};
 
     float mAnchorMatrix[16];
 

--- a/core/nativebridge/src/main/cpp/include/MobileGS.h
+++ b/core/nativebridge/src/main/cpp/include/MobileGS.h
@@ -46,6 +46,14 @@ public:
     // fingerprint anchor pose and the intrinsics the reloc PnP should use.
     void restoreWallFingerprintMetric(const cv::Mat& descriptors, const std::vector<cv::Point3f>& points3d,
                                       const float* anchorMatrix16, const float* intrinsics4);
+    // Persistent wall *feature* map (lean reloc backbone; docs/RELOC_MAP_DESIGN.md), co-registered to
+    // the fingerprint anchor. Restore replaces the stored map (confidence/obs optional). Phase 2a stores
+    // it only; reloc matching against it (Phase 2b) is gated separately.
+    void restoreWallFeatureMap(const cv::Mat& descriptors, const std::vector<cv::Point3f>& points3d,
+                               const std::vector<float>& confidence, const std::vector<int>& obs,
+                               const float* anchorMatrix16, const float* intrinsics4);
+    void clearWallFeatureMap();
+    int getMapPointCount() const { std::lock_guard<std::mutex> lock(mMutex); return (int)mMapPoints3D.size(); }
     void scheduleRelocCheck(const cv::Mat& colorFrame);
     void getAnchorTransform(float* outMat16) const;
     void getRelocResult(float* out19) const;       // [0..15]=pnpMat,16=inliers,17=matches,18=seq
@@ -161,6 +169,16 @@ private:
     cv::Mat mArtworkDescriptors;
     std::vector<cv::Point3f> mArtworkKeypoints3D;
     std::atomic<float> mPaintingProgress{0.0f};
+
+    // --- Persistent wall feature map (lean reloc backbone; docs/RELOC_MAP_DESIGN.md) ---
+    // Co-registered to the fingerprint anchor. Phase 2a stores it; reloc matching (Phase 2b) is gated
+    // separately, so today this is inert state with no effect on relocalization.
+    cv::Mat mMapDescriptors;
+    std::vector<cv::Point3f> mMapPoints3D;
+    std::vector<float> mMapConfidence;
+    std::vector<int> mMapObs;
+    float mMapAnchorMatrix[16] = {1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1};
+    float mMapIntrinsics[4] = {0,0,0,0};
 
     float mAnchorMatrix[16];
 

--- a/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
+++ b/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
@@ -5,6 +5,7 @@ import android.content.res.AssetManager
 import android.graphics.Bitmap
 import android.util.Log
 import com.hereliesaz.graffitixr.common.model.Fingerprint
+import com.hereliesaz.graffitixr.common.model.WallFeatureMap
 import com.hereliesaz.graffitixr.common.sensor.CameraFrame
 import com.hereliesaz.graffitixr.common.sensor.ImuSample
 import com.hereliesaz.graffitixr.common.sensor.PixelFormat
@@ -97,6 +98,18 @@ class SlamManager @Inject constructor(
     ) {
         nativeRestoreWallFingerprintMetric(descriptorsData, rows, cols, type, points3d, anchorMatrix, intrinsics)
     }
+
+    /** Restore the persistent wall feature map into native (Phase 2a: stored; matched in Phase 2b). */
+    fun restoreWallFeatureMap(map: WallFeatureMap) {
+        nativeRestoreWallFeatureMap(
+            map.descriptorsData, map.descriptorsRows, map.descriptorsCols, map.descriptorsType,
+            map.points3d, map.confidence, map.obsCount, map.anchor, map.intrinsics,
+        )
+    }
+    /** Drop the in-native wall feature map. */
+    fun clearWallFeatureMap() = nativeClearWallFeatureMap()
+    /** Live wall-feature-map point count — diagnostic. */
+    fun getMapPointCount(): Int = nativeGetMapPointCount()
 
     fun setArtworkFingerprint(
         bitmap: Bitmap,
@@ -489,6 +502,13 @@ class SlamManager @Inject constructor(
         descriptorsData: ByteArray, rows: Int, cols: Int, type: Int,
         points3d: FloatArray, anchorMatrix: FloatArray, intrinsics: FloatArray
     )
+    private external fun nativeRestoreWallFeatureMap(
+        descriptorsData: ByteArray, rows: Int, cols: Int, type: Int,
+        points3d: FloatArray, confidence: FloatArray, obsCount: IntArray,
+        anchor: FloatArray, intrinsics: FloatArray
+    )
+    private external fun nativeClearWallFeatureMap()
+    private external fun nativeGetMapPointCount(): Int
     private external fun nativeSetArtworkFingerprint(
         bitmap: Bitmap, depthBuffer: ByteBuffer?,
         depthW: Int, depthH: Int, depthStride: Int,

--- a/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
+++ b/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
@@ -110,6 +110,8 @@ class SlamManager @Inject constructor(
     fun clearWallFeatureMap() = nativeClearWallFeatureMap()
     /** Live wall-feature-map point count — diagnostic. */
     fun getMapPointCount(): Int = nativeGetMapPointCount()
+    /** Phase 2b: enable live map-matching in reloc. Default OFF — experimental until device-validated. */
+    fun setMapRelocEnabled(enabled: Boolean) = nativeSetMapRelocEnabled(enabled)
 
     fun setArtworkFingerprint(
         bitmap: Bitmap,
@@ -509,6 +511,7 @@ class SlamManager @Inject constructor(
     )
     private external fun nativeClearWallFeatureMap()
     private external fun nativeGetMapPointCount(): Int
+    private external fun nativeSetMapRelocEnabled(enabled: Boolean)
     private external fun nativeSetArtworkFingerprint(
         bitmap: Bitmap, depthBuffer: ByteBuffer?,
         depthW: Int, depthH: Int, depthStride: Int,

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -1172,8 +1172,12 @@ class ArViewModel @Inject constructor(
             // Restore the persistent wall feature map (Phase 2a: stored in native; matched in Phase 2b).
             // Independent of the marks fingerprint above and co-registered to the same anchor. Null on
             // every current project until the passive builder (Phase 3) starts producing one.
-            project.wallFeatureMap?.let { map ->
-                if (map.pointCount > 0) slamManager.restoreWallFeatureMap(map)
+            val map = project.wallFeatureMap
+            if (map != null && map.pointCount > 0) {
+                slamManager.restoreWallFeatureMap(map)
+            } else {
+                // No map on this project: clear any map left in native from a previously loaded project.
+                slamManager.clearWallFeatureMap()
             }
         }
     }

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -1169,6 +1169,12 @@ class ArViewModel @Inject constructor(
                     if (s * s == fp.patchData.size) slamManager.setWallPatchBytes(fp.patchData, s)
                 }
             }
+            // Restore the persistent wall feature map (Phase 2a: stored in native; matched in Phase 2b).
+            // Independent of the marks fingerprint above and co-registered to the same anchor. Null on
+            // every current project until the passive builder (Phase 3) starts producing one.
+            project.wallFeatureMap?.let { map ->
+                if (map.pointCount > 0) slamManager.restoreWallFeatureMap(map)
+            }
         }
     }
 


### PR DESCRIPTION
## Reloc map — Phase 2b: frustum-gated map matching in reloc, **default-OFF flag** (stacked on #1683)

`relocThreadFunc` now — **only when `mMapRelocEnabled` is on** — also matches the persistent feature map and merges those correspondences into the same PnP solve, so reloc locks across the whole wall even when the marks are out of frame (the "overlay larger than the fingerprint" case).

**Default OFF → ships completely inert. Zero effect on relocalization until explicitly enabled and device-validated.** This is the safe way to land the crown-jewel change blind.

### Key design
- The map is **co-registered to the fingerprint anchor**, and the last published reloc pose (`mPnpCamFromFpWorld`) is *already* in that frame — so we **frustum-gate by projecting map points with that pose directly** (no VIO frame conversion) and match **only the visible subset**, honoring the hard *"never brute-force the whole map"* constraint.
- Map points share the fingerprint's frame + intrinsics, so their correspondences **append cleanly** to the PnP set (coarse-to-fine fusion: marks = precision, map = coverage).
- **Guards:** flag on · a prior lock exists (fingerprint locked ≥1, so we have a pose prior) · descriptor types match · ≥8 visible points.

### Changes
- `MobileGS`: `mMapRelocEnabled` flag + `setMapRelocEnabled`; snapshot map + prior pose in `relocThreadFunc`; the gated match/append block before PnP.
- `GraffitiJNI` + `SlamManager`: `nativeSetMapRelocEnabled` / `setMapRelocEnabled(Boolean)`.

### Validation
Symbol consistency verified (JNI ↔ extern ↔ native); `glm` helpers already used in-file. Behaviorally inert by default — the real test is enabling the flag on-device once Phase 3 produces a map.

### Next
**Phase 3** — passive map builder (accumulate features from normal-use keyframes), which finally populates the map this phase consumes.

> Stacked on #1683 (Phase 2a). Base retargets as the stack lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018V1ysU9z4tTviN5RYcLo8V)_