### PR TITLE
Reloc map Phase 3b: persist built map to .gxr + confidence pruning

### DIFF
--- a/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
+++ b/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
@@ -846,6 +846,11 @@ Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeSetMapRelocEnabled
     if (gSlamEngine) gSlamEngine->setMapRelocEnabled(enabled == JNI_TRUE);
 }
 
+JNIEXPORT void JNICALL
+Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeSetMapBuildEnabled(JNIEnv*, jobject, jboolean enabled) {
+    if (gSlamEngine) gSlamEngine->setMapBuildEnabled(enabled == JNI_TRUE);
+}
+
 jobject buildFingerprintObject(JNIEnv* env, const MobileGS::FingerprintData& fd) {
     if (fd.descriptors.empty()) return nullptr;
 

--- a/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
+++ b/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
@@ -778,6 +778,60 @@ Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeRestoreWallFingerp
     env->ReleaseFloatArrayElements(intrArray, intr, JNI_ABORT);
 }
 
+// Persistent wall feature map (Phase 2a: store only). Mirrors the metric-fingerprint restore but
+// adds parallel per-point confidence (jfloatArray) + obs (jintArray); anchor/intrinsics are
+// passed through only when correctly sized (16 / 4), else left at their native defaults.
+JNIEXPORT void JNICALL
+Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeRestoreWallFeatureMap(
+        JNIEnv* env, jobject thiz, jbyteArray descArray, jint rows, jint cols, jint type,
+        jfloatArray ptsArray, jfloatArray confArray, jintArray obsArray,
+        jfloatArray anchorArray, jfloatArray intrArray) {
+    if (!gSlamEngine) return;
+    jbyte* descData = env->GetByteArrayElements(descArray, nullptr);
+    cv::Mat descriptors(rows, cols, type, descData);
+    jsize ptsLen = env->GetArrayLength(ptsArray);
+    jfloat* ptsData = env->GetFloatArrayElements(ptsArray, nullptr);
+    std::vector<cv::Point3f> points3d;
+    points3d.reserve(ptsLen / 3);
+    for (int i = 0; i + 2 < ptsLen; i += 3)
+        points3d.push_back(cv::Point3f(ptsData[i], ptsData[i+1], ptsData[i+2]));
+
+    std::vector<float> conf;
+    jsize confLen = env->GetArrayLength(confArray);
+    if (confLen > 0) {
+        jfloat* c = env->GetFloatArrayElements(confArray, nullptr);
+        conf.assign(c, c + confLen);
+        env->ReleaseFloatArrayElements(confArray, c, JNI_ABORT);
+    }
+    std::vector<int> obs;
+    jsize obsLen = env->GetArrayLength(obsArray);
+    if (obsLen > 0) {
+        jint* o = env->GetIntArrayElements(obsArray, nullptr);
+        obs.assign(o, o + obsLen);
+        env->ReleaseIntArrayElements(obsArray, o, JNI_ABORT);
+    }
+
+    jfloat* anchor = (env->GetArrayLength(anchorArray) == 16) ? env->GetFloatArrayElements(anchorArray, nullptr) : nullptr;
+    jfloat* intr   = (env->GetArrayLength(intrArray) == 4)    ? env->GetFloatArrayElements(intrArray, nullptr)   : nullptr;
+
+    gSlamEngine->restoreWallFeatureMap(descriptors, points3d, conf, obs, anchor, intr);
+
+    env->ReleaseByteArrayElements(descArray, descData, JNI_ABORT);
+    env->ReleaseFloatArrayElements(ptsArray, ptsData, JNI_ABORT);
+    if (anchor) env->ReleaseFloatArrayElements(anchorArray, anchor, JNI_ABORT);
+    if (intr)   env->ReleaseFloatArrayElements(intrArray, intr, JNI_ABORT);
+}
+
+JNIEXPORT void JNICALL
+Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeClearWallFeatureMap(JNIEnv*, jobject) {
+    if (gSlamEngine) gSlamEngine->clearWallFeatureMap();
+}
+
+JNIEXPORT jint JNICALL
+Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeGetMapPointCount(JNIEnv*, jobject) {
+    return gSlamEngine ? gSlamEngine->getMapPointCount() : 0;
+}
+
 jobject buildFingerprintObject(JNIEnv* env, const MobileGS::FingerprintData& fd) {
     if (fd.descriptors.empty()) return nullptr;
 

--- a/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
+++ b/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
@@ -786,33 +786,42 @@ Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeRestoreWallFeature
         JNIEnv* env, jobject thiz, jbyteArray descArray, jint rows, jint cols, jint type,
         jfloatArray ptsArray, jfloatArray confArray, jintArray obsArray,
         jfloatArray anchorArray, jfloatArray intrArray) {
-    if (!gSlamEngine) return;
+    // Defensive validation (a malformed/old .gxr must never crash native): null refs, a descriptor
+    // blob big enough for rows*cols*elemSize, and parallel arrays of matching length.
+    if (!gSlamEngine || !descArray || !ptsArray) return;
+    if (rows < 0 || cols < 0) return;
+    jsize descLen = env->GetArrayLength(descArray);
+    if (descLen < (jsize)(rows * cols * CV_ELEM_SIZE(type))) return;
+    jsize ptsLen = env->GetArrayLength(ptsArray);
+    if (ptsLen != rows * 3) return;
+    jsize confLen = confArray ? env->GetArrayLength(confArray) : 0;
+    if (confLen > 0 && confLen != rows) return;
+    jsize obsLen = obsArray ? env->GetArrayLength(obsArray) : 0;
+    if (obsLen > 0 && obsLen != rows) return;
+
     jbyte* descData = env->GetByteArrayElements(descArray, nullptr);
     cv::Mat descriptors(rows, cols, type, descData);
-    jsize ptsLen = env->GetArrayLength(ptsArray);
     jfloat* ptsData = env->GetFloatArrayElements(ptsArray, nullptr);
     std::vector<cv::Point3f> points3d;
-    points3d.reserve(ptsLen / 3);
+    points3d.reserve(rows);
     for (int i = 0; i + 2 < ptsLen; i += 3)
         points3d.push_back(cv::Point3f(ptsData[i], ptsData[i+1], ptsData[i+2]));
 
     std::vector<float> conf;
-    jsize confLen = env->GetArrayLength(confArray);
     if (confLen > 0) {
         jfloat* c = env->GetFloatArrayElements(confArray, nullptr);
         conf.assign(c, c + confLen);
         env->ReleaseFloatArrayElements(confArray, c, JNI_ABORT);
     }
     std::vector<int> obs;
-    jsize obsLen = env->GetArrayLength(obsArray);
     if (obsLen > 0) {
         jint* o = env->GetIntArrayElements(obsArray, nullptr);
         obs.assign(o, o + obsLen);
         env->ReleaseIntArrayElements(obsArray, o, JNI_ABORT);
     }
 
-    jfloat* anchor = (env->GetArrayLength(anchorArray) == 16) ? env->GetFloatArrayElements(anchorArray, nullptr) : nullptr;
-    jfloat* intr   = (env->GetArrayLength(intrArray) == 4)    ? env->GetFloatArrayElements(intrArray, nullptr)   : nullptr;
+    jfloat* anchor = (anchorArray && env->GetArrayLength(anchorArray) == 16) ? env->GetFloatArrayElements(anchorArray, nullptr) : nullptr;
+    jfloat* intr   = (intrArray && env->GetArrayLength(intrArray) == 4)    ? env->GetFloatArrayElements(intrArray, nullptr)   : nullptr;
 
     gSlamEngine->restoreWallFeatureMap(descriptors, points3d, conf, obs, anchor, intr);
 

--- a/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
+++ b/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
@@ -841,6 +841,11 @@ Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeGetMapPointCount(J
     return gSlamEngine ? gSlamEngine->getMapPointCount() : 0;
 }
 
+JNIEXPORT void JNICALL
+Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeSetMapRelocEnabled(JNIEnv*, jobject, jboolean enabled) {
+    if (gSlamEngine) gSlamEngine->setMapRelocEnabled(enabled == JNI_TRUE);
+}
+
 jobject buildFingerprintObject(JNIEnv* env, const MobileGS::FingerprintData& fd) {
     if (fd.descriptors.empty()) return nullptr;
 

--- a/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
+++ b/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
@@ -851,6 +851,17 @@ Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeSetMapBuildEnabled
     if (gSlamEngine) gSlamEngine->setMapBuildEnabled(enabled == JNI_TRUE);
 }
 
+JNIEXPORT jbyteArray JNICALL
+Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeExportWallFeatureMap(JNIEnv* env, jobject) {
+    if (!gSlamEngine) return nullptr;
+    std::vector<uint8_t> blob = gSlamEngine->exportWallFeatureMap();
+    if (blob.empty()) return nullptr;
+    jbyteArray arr = env->NewByteArray((jsize)blob.size());
+    if (!arr) return nullptr;
+    env->SetByteArrayRegion(arr, 0, (jsize)blob.size(), reinterpret_cast<const jbyte*>(blob.data()));
+    return arr;
+}
+
 jobject buildFingerprintObject(JNIEnv* env, const MobileGS::FingerprintData& fd) {
     if (fd.descriptors.empty()) return nullptr;
 

--- a/core/nativebridge/src/main/cpp/MobileGS.cpp
+++ b/core/nativebridge/src/main/cpp/MobileGS.cpp
@@ -625,6 +625,26 @@ void MobileGS::restoreWallFingerprintMetric(const cv::Mat& d, const std::vector<
     if (intrinsics4)    memcpy(mFingerprintIntrinsics, intrinsics4, 4 * sizeof(float));
 }
 
+void MobileGS::restoreWallFeatureMap(const cv::Mat& d, const std::vector<cv::Point3f>& p,
+                                     const std::vector<float>& conf, const std::vector<int>& obs,
+                                     const float* anchorMatrix16, const float* intrinsics4) {
+    std::lock_guard<std::mutex> lock(mMutex);
+    mMapDescriptors = d.clone();
+    mMapPoints3D = p;
+    mMapConfidence = conf;
+    mMapObs = obs;
+    if (anchorMatrix16) memcpy(mMapAnchorMatrix, anchorMatrix16, 16 * sizeof(float));
+    if (intrinsics4)    memcpy(mMapIntrinsics, intrinsics4, 4 * sizeof(float));
+}
+
+void MobileGS::clearWallFeatureMap() {
+    std::lock_guard<std::mutex> lock(mMutex);
+    mMapDescriptors.release();
+    mMapPoints3D.clear();
+    mMapConfidence.clear();
+    mMapObs.clear();
+}
+
 std::vector<uint8_t> MobileGS::exportFingerprint() {
     std::lock_guard<std::mutex> lock(mMutex);
     if (mWallDescriptors.empty() || mWallKeypoints3D.empty()) return {};

--- a/core/nativebridge/src/main/cpp/MobileGS.cpp
+++ b/core/nativebridge/src/main/cpp/MobileGS.cpp
@@ -560,7 +560,8 @@ bool MobileGS::computeRectifyHomography(const float* viewCur16, cv::Mat& Hcur_fp
 
 std::vector<uint8_t> MobileGS::exportWallFeatureMap() const {
     std::lock_guard<std::mutex> lock(mMutex);
-    if (mMapPoints3D.empty() || mMapDescriptors.empty()) return {};
+    if (mMapPoints3D.empty() || mMapDescriptors.empty() ||
+        mMapPoints3D.size() != (size_t)mMapDescriptors.rows) return {};  // never export an inconsistent map
     cv::Mat dm = mMapDescriptors.isContinuous() ? mMapDescriptors : mMapDescriptors.clone();
     const int32_t n = (int32_t)mMapPoints3D.size();
     const int32_t descRows = dm.rows, descCols = dm.cols, descType = dm.type();
@@ -590,6 +591,7 @@ void MobileGS::growMapFromReloc(const glm::mat4& camFromFp, const std::vector<cv
     std::lock_guard<std::mutex> lock(mMutex);
     if (mWallKeypoints3D.size() < 8) return;                                   // need the fingerprint plane
     if (!mMapDescriptors.empty() && mMapDescriptors.type() != descs.type()) return;
+    if (mMapPoints3D.size() != (size_t)mMapDescriptors.rows) return;  // corrupted map: bail rather than crash
 
     // Keep the parallel arrays aligned with the points: a restored map may have carried points +
     // descriptors but empty confidence/obs (both optional in WallFeatureMap). Without this, the add
@@ -601,12 +603,20 @@ void MobileGS::growMapFromReloc(const glm::mat4& camFromFp, const std::vector<cv
     // never earned a re-observation). Compacts all four parallel arrays + the descriptor matrix.
     const size_t kMapCap = 5000;
     if (mMapPoints3D.size() >= kMapCap) {
-        std::vector<cv::Point3f> np; std::vector<float> nc; std::vector<int> no; cv::Mat nd;
-        np.reserve(mMapPoints3D.size());
-        for (size_t i = 0; i < mMapPoints3D.size(); ++i) {
-            if (mMapConfidence[i] >= 0.2f) {
+        std::vector<size_t> kept;
+        kept.reserve(mMapPoints3D.size());
+        for (size_t i = 0; i < mMapPoints3D.size(); ++i)
+            if (mMapConfidence[i] >= 0.2f) kept.push_back(i);
+        std::vector<cv::Point3f> np; np.reserve(kept.size());
+        std::vector<float> nc; nc.reserve(kept.size());
+        std::vector<int> no; no.reserve(kept.size());
+        cv::Mat nd;
+        if (!kept.empty()) {
+            nd.create((int)kept.size(), mMapDescriptors.cols, mMapDescriptors.type());
+            for (size_t idx = 0; idx < kept.size(); ++idx) {
+                size_t i = kept[idx];
                 np.push_back(mMapPoints3D[i]); nc.push_back(mMapConfidence[i]); no.push_back(mMapObs[i]);
-                nd.push_back(mMapDescriptors.row((int)i));
+                mMapDescriptors.row((int)i).copyTo(nd.row((int)idx));
             }
         }
         mMapPoints3D.swap(np); mMapConfidence.swap(nc); mMapObs.swap(no); mMapDescriptors = nd;

--- a/core/nativebridge/src/main/cpp/MobileGS.cpp
+++ b/core/nativebridge/src/main/cpp/MobileGS.cpp
@@ -220,6 +220,13 @@ void MobileGS::relocThreadFunc() {
         cv::Mat wallPatch;
         float fpIntrinsics[4];
         bool hasFpView = false;
+        // Phase 2b snapshot: the persistent feature map + the last reloc pose, used (when the flag is on)
+        // as the frustum-gate prior. The map is co-registered to the fingerprint anchor, so its points
+        // share wallKps3d's frame and the prior pose (camera_from_fpWorld) projects them directly.
+        cv::Mat mapDescs;
+        std::vector<cv::Point3f> mapKps3d;
+        float mapPriorPose[16];
+        long mapPriorSeq = 0;
         {
             std::lock_guard<std::mutex> lock(mMutex);
             wallDescs = mWallDescriptors.clone();
@@ -227,6 +234,10 @@ void MobileGS::relocThreadFunc() {
             wallPatch = mWallPatch.clone();
             memcpy(fpIntrinsics, mFingerprintIntrinsics, 4 * sizeof(float));
             hasFpView = mHasFingerprintView;
+            mapDescs = mMapDescriptors.clone();
+            mapKps3d = mMapPoints3D;
+            memcpy(mapPriorPose, mPnpCamFromFpWorld, 16 * sizeof(float));
+            mapPriorSeq = mPnpResultSeq.load(std::memory_order_relaxed);
         }
 
         if (frame.empty() || wallDescs.empty() || wallKps3d.empty() || !mRelocEnabled) continue;
@@ -308,6 +319,56 @@ void MobileGS::relocThreadFunc() {
                 if (imgPts.size() > before)
                     LOGI("Reloc: rectified (obliquity %.0f deg) added %zu corr (total %zu)",
                          obliqDeg, imgPts.size() - before, imgPts.size());
+            }
+        }
+
+        // --- Persistent feature-map matching (Phase 2b; default OFF via mMapRelocEnabled) ---
+        // When the overlay is larger than the marks, the marks leave frame; the map carries features
+        // across the whole wall so reloc still locks. Hard constraint: NEVER brute-force the whole map —
+        // frustum-gate to the subset the last reloc pose says is in view, then match only those and
+        // APPEND the correspondences (same fingerprint frame + intrinsics) so PnP solves over both.
+        // Requires a prior pose (mapPriorSeq>0, i.e. the fingerprint has locked at least once) and a
+        // matching descriptor type. Default-off, so this is inert until device-validated.
+        if (mMapRelocEnabled.load(std::memory_order_relaxed) && !mapDescs.empty() && mapPriorSeq > 0
+                && mapDescs.type() == wallDescs.type() && mapKps3d.size() == (size_t)mapDescs.rows) {
+            glm::mat4 camFromFp = glm::make_mat4(mapPriorPose);
+            double gfx = (fpIntrinsics[0] > 0.f) ? (double)fpIntrinsics[0] : 1000.0;
+            double gfy = (fpIntrinsics[1] > 0.f) ? (double)fpIntrinsics[1] : 1000.0;
+            double gcx = (fpIntrinsics[0] > 0.f) ? (double)fpIntrinsics[2] : gray.cols * 0.5;
+            double gcy = (fpIntrinsics[1] > 0.f) ? (double)fpIntrinsics[3] : gray.rows * 0.5;
+            std::vector<int> visible;
+            visible.reserve(mapKps3d.size());
+            for (int i = 0; i < (int)mapKps3d.size(); ++i) {
+                glm::vec4 pc = camFromFp * glm::vec4(mapKps3d[i].x, mapKps3d[i].y, mapKps3d[i].z, 1.0f);
+                if (pc.z <= 0.05f) continue; // behind / too close to the camera
+                float u = (float)(gfx * pc.x / pc.z + gcx);
+                float v = (float)(gfy * pc.y / pc.z + gcy);
+                if (u >= 0.f && u < gray.cols && v >= 0.f && v < gray.rows) visible.push_back(i);
+            }
+            if (visible.size() >= 8) {
+                cv::Mat gatedDescs;
+                gatedDescs.reserve(visible.size());
+                for (int i : visible) gatedDescs.push_back(mapDescs.row(i));
+                std::vector<cv::KeyPoint> kps; cv::Mat descs;
+                bool sp = spOk;
+                if (sp && !mSuperPoint.detect(gray, kps, descs)) sp = false;
+                if (!sp) mFeatureDetector->detectAndCompute(gray, cv::noArray(), kps, descs);
+                if (!descs.empty() && descs.type() == gatedDescs.type()) {
+                    cv::Ptr<cv::DescriptorMatcher>& matcher = (descs.type() == CV_32F) ? mL2Matcher : mMatcher;
+                    std::vector<std::vector<cv::DMatch>> matches;
+                    matcher->knnMatch(descs, gatedDescs, matches, 2);
+                    size_t before = imgPts.size();
+                    for (auto& m : matches) {
+                        if (m.size() < 2) continue;
+                        if (m[0].distance < 0.75f * m[1].distance) {
+                            imgPts.push_back(kps[m[0].queryIdx].pt);
+                            objPts.push_back(mapKps3d[visible[m[0].trainIdx]]);
+                        }
+                    }
+                    if (imgPts.size() > before)
+                        LOGI("Reloc map: gated %zu/%zu pts, added %zu corr (total %zu)",
+                             visible.size(), mapKps3d.size(), imgPts.size() - before, imgPts.size());
+                }
             }
         }
 

--- a/core/nativebridge/src/main/cpp/MobileGS.cpp
+++ b/core/nativebridge/src/main/cpp/MobileGS.cpp
@@ -565,6 +565,12 @@ void MobileGS::growMapFromReloc(const glm::mat4& camFromFp, const std::vector<cv
     if (mWallKeypoints3D.size() < 8) return;                                   // need the fingerprint plane
     if (!mMapDescriptors.empty() && mMapDescriptors.type() != descs.type()) return;
 
+    // Keep the parallel arrays aligned with the points: a restored map may have carried points +
+    // descriptors but empty confidence/obs (both optional in WallFeatureMap). Without this, the add
+    // path below would desync them from mMapPoints3D and corrupt per-point confidence.
+    if (mMapConfidence.size() != mMapPoints3D.size()) mMapConfidence.resize(mMapPoints3D.size(), 1.0f);
+    if (mMapObs.size() != mMapPoints3D.size()) mMapObs.resize(mMapPoints3D.size(), 1);
+
     // Fit the wall plane (centroid + normal) from the fingerprint's 3D points (in the fingerprint frame).
     cv::Point3f c(0.f, 0.f, 0.f);
     for (const auto& p : mWallKeypoints3D) c += p;
@@ -582,7 +588,7 @@ void MobileGS::growMapFromReloc(const glm::mat4& camFromFp, const std::vector<cv
 
     // Associate detected features to the existing map by descriptor; bump confidence on re-observation.
     std::vector<char> matched(kps.size(), 0);
-    if (!mMapDescriptors.empty()) {
+    if (mMapDescriptors.rows >= 2) {   // knnMatch(k=2) needs >=2 candidates for the Lowe ratio
         cv::Ptr<cv::DescriptorMatcher>& matcher = (descs.type() == CV_32F) ? mL2Matcher : mMatcher;
         std::vector<std::vector<cv::DMatch>> matches;
         matcher->knnMatch(descs, mMapDescriptors, matches, 2);

--- a/core/nativebridge/src/main/cpp/MobileGS.cpp
+++ b/core/nativebridge/src/main/cpp/MobileGS.cpp
@@ -484,6 +484,9 @@ void MobileGS::relocThreadFunc() {
                     mPnpMatchCount.store((int)imgPts.size(), std::memory_order_relaxed);
                     mPnpResultSeq.fetch_add(1, std::memory_order_relaxed);
                     LOGI("Relocalization: PnP match published (%zu/%zu inliers)", inliers.size(), imgPts.size());
+                    // Phase 3 passive build: grow the feature map from this locked frame (default OFF).
+                    if (mMapBuildEnabled.load(std::memory_order_relaxed))
+                        growMapFromReloc(pnpMat, baseKps, baseDescs, fx, fy, cx, cy);
                 }
             }
         }
@@ -553,6 +556,76 @@ bool MobileGS::computeRectifyHomography(const float* viewCur16, cv::Mat& Hcur_fp
     Hcur_fp = cv::Mat(Hc);
     Hfp_cur = Hcur_fp.inv();
     return true;
+}
+
+void MobileGS::growMapFromReloc(const glm::mat4& camFromFp, const std::vector<cv::KeyPoint>& kps,
+                                const cv::Mat& descs, double fx, double fy, double cx, double cy) {
+    if (descs.empty() || kps.empty() || (int)kps.size() != descs.rows) return;
+    std::lock_guard<std::mutex> lock(mMutex);
+    if (mWallKeypoints3D.size() < 8) return;                                   // need the fingerprint plane
+    if (!mMapDescriptors.empty() && mMapDescriptors.type() != descs.type()) return;
+
+    // Fit the wall plane (centroid + normal) from the fingerprint's 3D points (in the fingerprint frame).
+    cv::Point3f c(0.f, 0.f, 0.f);
+    for (const auto& p : mWallKeypoints3D) c += p;
+    c *= 1.0f / (float)mWallKeypoints3D.size();
+    double cov[6] = {0,0,0,0,0,0}; // xx,xy,xz,yy,yz,zz
+    for (const auto& p : mWallKeypoints3D) {
+        double dx = p.x - c.x, dy = p.y - c.y, dz = p.z - c.z;
+        cov[0]+=dx*dx; cov[1]+=dx*dy; cov[2]+=dx*dz; cov[3]+=dy*dy; cov[4]+=dy*dz; cov[5]+=dz*dz;
+    }
+    cv::Matx33d C(cov[0],cov[1],cov[2], cov[1],cov[3],cov[4], cov[2],cov[4],cov[5]);
+    cv::Vec3d eval; cv::Matx33d evec;
+    if (!cv::eigen(C, eval, evec)) return;
+    glm::vec3 n((float)evec(2,0), (float)evec(2,1), (float)evec(2,2));   // smallest-eigenvalue eigenvector
+    glm::vec3 cc(c.x, c.y, c.z);
+
+    // Associate detected features to the existing map by descriptor; bump confidence on re-observation.
+    std::vector<char> matched(kps.size(), 0);
+    if (!mMapDescriptors.empty()) {
+        cv::Ptr<cv::DescriptorMatcher>& matcher = (descs.type() == CV_32F) ? mL2Matcher : mMatcher;
+        std::vector<std::vector<cv::DMatch>> matches;
+        matcher->knnMatch(descs, mMapDescriptors, matches, 2);
+        for (auto& m : matches) {
+            if (m.size() < 2) continue;
+            if (m[0].distance < 0.75f * m[1].distance) {
+                int ti = m[0].trainIdx, qi = m[0].queryIdx;
+                if (ti >= 0 && ti < (int)mMapConfidence.size() && qi >= 0 && qi < (int)matched.size()) {
+                    mMapConfidence[ti] = std::min(1.0f, mMapConfidence[ti] + 0.1f);
+                    mMapObs[ti] += 1;
+                    matched[qi] = 1;
+                }
+            }
+        }
+    }
+
+    // Back-project unmatched features onto the wall plane and add them, up to the cap.
+    glm::mat4 fpFromCam = glm::inverse(camFromFp);
+    glm::vec3 camCenter(fpFromCam[3][0], fpFromCam[3][1], fpFromCam[3][2]);
+    glm::mat3 R = glm::mat3(fpFromCam);
+    const size_t kMapCap = 5000;
+    int added = 0;
+    for (size_t i = 0; i < kps.size(); ++i) {
+        if (matched[i]) continue;
+        if (mMapPoints3D.size() >= kMapCap) break;
+        glm::vec3 dir = R * glm::vec3((float)((kps[i].pt.x - cx) / fx),
+                                      (float)((kps[i].pt.y - cy) / fy), 1.0f);
+        float denom = glm::dot(n, dir);
+        if (std::fabs(denom) < 1e-6f) continue;
+        float t = glm::dot(n, cc - camCenter) / denom;
+        if (t <= 0.f) continue;            // plane intersection behind the camera
+        glm::vec3 P = camCenter + t * dir;
+        mMapPoints3D.push_back(cv::Point3f(P.x, P.y, P.z));
+        mMapConfidence.push_back(0.1f);
+        mMapObs.push_back(1);
+        mMapDescriptors.push_back(descs.row((int)i));
+        ++added;
+    }
+
+    // Co-register the map to the fingerprint anchor + intrinsics (same frame as the points above).
+    memcpy(mMapAnchorMatrix, mFingerprintAnchorMatrix, 16 * sizeof(float));
+    mMapIntrinsics[0]=(float)fx; mMapIntrinsics[1]=(float)fy; mMapIntrinsics[2]=(float)cx; mMapIntrinsics[3]=(float)cy;
+    if (added > 0) LOGI("Map build: +%d pts (map now %zu)", added, mMapPoints3D.size());
 }
 
 void MobileGS::tryUpdateFingerprint(const cv::Mat& grayClean) {

--- a/core/nativebridge/src/main/cpp/MobileGS.cpp
+++ b/core/nativebridge/src/main/cpp/MobileGS.cpp
@@ -260,12 +260,27 @@ void MobileGS::relocThreadFunc() {
         // the matched keypoints are mapped through it (rectified frame -> current image) before being
         // stored, so the returned 2D points are ALWAYS in the current camera image — exactly what the
         // PnP below expects.
-        auto buildCorr = [&](const cv::Mat& g, const cv::Mat& Hback,
-                             std::vector<cv::Point2f>& outImg, std::vector<cv::Point3f>& outObj) {
-            std::vector<cv::KeyPoint> kps; cv::Mat descs;
+        // Detect base-frame features ONCE and reuse them: SuperPoint is an ONNX model, so detecting the
+        // same gray twice (plain pass + map matching) would roughly double per-reloc cost. The scaled and
+        // rectified passes run on different images, so buildCorr still detects internally for those.
+        std::vector<cv::KeyPoint> baseKps; cv::Mat baseDescs;
+        {
             bool sp = spOk;
-            if (sp && !mSuperPoint.detect(g, kps, descs)) sp = false;
-            if (!sp) mFeatureDetector->detectAndCompute(g, cv::noArray(), kps, descs);
+            if (sp && !mSuperPoint.detect(gray, baseKps, baseDescs)) sp = false;
+            if (!sp) mFeatureDetector->detectAndCompute(gray, cv::noArray(), baseKps, baseDescs);
+        }
+
+        auto buildCorr = [&](const cv::Mat& g, const cv::Mat& Hback,
+                             std::vector<cv::Point2f>& outImg, std::vector<cv::Point3f>& outObj,
+                             const std::vector<cv::KeyPoint>* preKps = nullptr, const cv::Mat* preDescs = nullptr) {
+            std::vector<cv::KeyPoint> localKps; cv::Mat localDescs;
+            if (!(preKps && preDescs)) {
+                bool sp = spOk;
+                if (sp && !mSuperPoint.detect(g, localKps, localDescs)) sp = false;
+                if (!sp) mFeatureDetector->detectAndCompute(g, cv::noArray(), localKps, localDescs);
+            }
+            const std::vector<cv::KeyPoint>& kps = (preKps && preDescs) ? *preKps : localKps;
+            const cv::Mat& descs = (preKps && preDescs) ? *preDescs : localDescs;
             if (descs.empty() || wallDescs.empty()) return;
             if (descs.type() != wallDescs.type()) return;
 
@@ -289,7 +304,7 @@ void MobileGS::relocThreadFunc() {
 
         std::vector<cv::Point2f> imgPts;
         std::vector<cv::Point3f> objPts;
-        buildCorr(gray, cv::Mat(), imgPts, objPts);
+        buildCorr(gray, cv::Mat(), imgPts, objPts, &baseKps, &baseDescs);
 
         // Multi-scale matching (distance robustness). SuperPoint isn't scale-invariant, and the marks
         // shrink in the frame from far away and grow up close, so also match the frame DOWN- and
@@ -346,22 +361,20 @@ void MobileGS::relocThreadFunc() {
                 if (u >= 0.f && u < gray.cols && v >= 0.f && v < gray.rows) visible.push_back(i);
             }
             if (visible.size() >= 8) {
-                cv::Mat gatedDescs;
-                gatedDescs.reserve(visible.size());
-                for (int i : visible) gatedDescs.push_back(mapDescs.row(i));
-                std::vector<cv::KeyPoint> kps; cv::Mat descs;
-                bool sp = spOk;
-                if (sp && !mSuperPoint.detect(gray, kps, descs)) sp = false;
-                if (!sp) mFeatureDetector->detectAndCompute(gray, cv::noArray(), kps, descs);
-                if (!descs.empty() && descs.type() == gatedDescs.type()) {
-                    cv::Ptr<cv::DescriptorMatcher>& matcher = (descs.type() == CV_32F) ? mL2Matcher : mMatcher;
+                // Preallocate the gated descriptor block with the right size+type and copy rows
+                // (cv::Mat has no usable reserve() on an empty/typeless matrix). Reuse the base detection.
+                cv::Mat gatedDescs((int)visible.size(), mapDescs.cols, mapDescs.type());
+                for (size_t i = 0; i < visible.size(); ++i)
+                    mapDescs.row(visible[i]).copyTo(gatedDescs.row((int)i));
+                if (!baseDescs.empty() && baseDescs.type() == gatedDescs.type()) {
+                    cv::Ptr<cv::DescriptorMatcher>& matcher = (baseDescs.type() == CV_32F) ? mL2Matcher : mMatcher;
                     std::vector<std::vector<cv::DMatch>> matches;
-                    matcher->knnMatch(descs, gatedDescs, matches, 2);
+                    matcher->knnMatch(baseDescs, gatedDescs, matches, 2);
                     size_t before = imgPts.size();
                     for (auto& m : matches) {
                         if (m.size() < 2) continue;
                         if (m[0].distance < 0.75f * m[1].distance) {
-                            imgPts.push_back(kps[m[0].queryIdx].pt);
+                            imgPts.push_back(baseKps[m[0].queryIdx].pt);
                             objPts.push_back(mapKps3d[visible[m[0].trainIdx]]);
                         }
                     }

--- a/core/nativebridge/src/main/cpp/MobileGS.cpp
+++ b/core/nativebridge/src/main/cpp/MobileGS.cpp
@@ -633,8 +633,12 @@ void MobileGS::restoreWallFeatureMap(const cv::Mat& d, const std::vector<cv::Poi
     mMapPoints3D = p;
     mMapConfidence = conf;
     mMapObs = obs;
-    if (anchorMatrix16) memcpy(mMapAnchorMatrix, anchorMatrix16, 16 * sizeof(float));
-    if (intrinsics4)    memcpy(mMapIntrinsics, intrinsics4, 4 * sizeof(float));
+    // Reset (not leave stale) when a map omits co-registration, so it can't inherit a previous
+    // project's anchor/intrinsics.
+    static const float kIdentity16[16] = {1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1};
+    memcpy(mMapAnchorMatrix, anchorMatrix16 ? anchorMatrix16 : kIdentity16, 16 * sizeof(float));
+    if (intrinsics4) memcpy(mMapIntrinsics, intrinsics4, 4 * sizeof(float));
+    else             memset(mMapIntrinsics, 0, 4 * sizeof(float));
 }
 
 void MobileGS::clearWallFeatureMap() {
@@ -643,6 +647,10 @@ void MobileGS::clearWallFeatureMap() {
     mMapPoints3D.clear();
     mMapConfidence.clear();
     mMapObs.clear();
+    // Also drop stale co-registration so a later project can't inherit it.
+    static const float kIdentity16[16] = {1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1};
+    memcpy(mMapAnchorMatrix, kIdentity16, 16 * sizeof(float));
+    memset(mMapIntrinsics, 0, 4 * sizeof(float));
 }
 
 std::vector<uint8_t> MobileGS::exportFingerprint() {

--- a/core/nativebridge/src/main/cpp/MobileGS.cpp
+++ b/core/nativebridge/src/main/cpp/MobileGS.cpp
@@ -558,6 +558,32 @@ bool MobileGS::computeRectifyHomography(const float* viewCur16, cv::Mat& Hcur_fp
     return true;
 }
 
+std::vector<uint8_t> MobileGS::exportWallFeatureMap() const {
+    std::lock_guard<std::mutex> lock(mMutex);
+    if (mMapPoints3D.empty() || mMapDescriptors.empty()) return {};
+    cv::Mat dm = mMapDescriptors.isContinuous() ? mMapDescriptors : mMapDescriptors.clone();
+    const int32_t n = (int32_t)mMapPoints3D.size();
+    const int32_t descRows = dm.rows, descCols = dm.cols, descType = dm.type();
+    std::vector<float> conf = mMapConfidence; conf.resize(n, 1.0f);                 // defensive align
+    std::vector<int32_t> obs(mMapObs.begin(), mMapObs.end()); obs.resize(n, 1);
+    const size_t descBytes = dm.total() * dm.elemSize();
+    const size_t total = 4 * sizeof(int32_t) + (size_t)n * 3 * sizeof(float)
+                       + (size_t)n * sizeof(float) + (size_t)n * sizeof(int32_t)
+                       + 16 * sizeof(float) + 4 * sizeof(float) + descBytes;
+    std::vector<uint8_t> out(total);
+    uint8_t* p = out.data();
+    auto put = [&](const void* src, size_t len){ memcpy(p, src, len); p += len; };
+    put(&n, sizeof(int32_t)); put(&descRows, sizeof(int32_t));
+    put(&descCols, sizeof(int32_t)); put(&descType, sizeof(int32_t));
+    put(mMapPoints3D.data(), (size_t)n * 3 * sizeof(float)); // cv::Point3f = 3 contiguous floats
+    put(conf.data(), (size_t)n * sizeof(float));
+    put(obs.data(), (size_t)n * sizeof(int32_t));
+    put(mMapAnchorMatrix, 16 * sizeof(float));
+    put(mMapIntrinsics, 4 * sizeof(float));
+    if (descBytes) put(dm.data, descBytes);
+    return out;
+}
+
 void MobileGS::growMapFromReloc(const glm::mat4& camFromFp, const std::vector<cv::KeyPoint>& kps,
                                 const cv::Mat& descs, double fx, double fy, double cx, double cy) {
     if (descs.empty() || kps.empty() || (int)kps.size() != descs.rows) return;
@@ -570,6 +596,21 @@ void MobileGS::growMapFromReloc(const glm::mat4& camFromFp, const std::vector<cv
     // path below would desync them from mMapPoints3D and corrupt per-point confidence.
     if (mMapConfidence.size() != mMapPoints3D.size()) mMapConfidence.resize(mMapPoints3D.size(), 1.0f);
     if (mMapObs.size() != mMapPoints3D.size()) mMapObs.resize(mMapPoints3D.size(), 1);
+
+    // Confidence-prune when at capacity so the map keeps refreshing within the cap (drop points that
+    // never earned a re-observation). Compacts all four parallel arrays + the descriptor matrix.
+    const size_t kMapCap = 5000;
+    if (mMapPoints3D.size() >= kMapCap) {
+        std::vector<cv::Point3f> np; std::vector<float> nc; std::vector<int> no; cv::Mat nd;
+        np.reserve(mMapPoints3D.size());
+        for (size_t i = 0; i < mMapPoints3D.size(); ++i) {
+            if (mMapConfidence[i] >= 0.2f) {
+                np.push_back(mMapPoints3D[i]); nc.push_back(mMapConfidence[i]); no.push_back(mMapObs[i]);
+                nd.push_back(mMapDescriptors.row((int)i));
+            }
+        }
+        mMapPoints3D.swap(np); mMapConfidence.swap(nc); mMapObs.swap(no); mMapDescriptors = nd;
+    }
 
     // Fit the wall plane (centroid + normal) from the fingerprint's 3D points (in the fingerprint frame).
     cv::Point3f c(0.f, 0.f, 0.f);
@@ -609,7 +650,6 @@ void MobileGS::growMapFromReloc(const glm::mat4& camFromFp, const std::vector<cv
     glm::mat4 fpFromCam = glm::inverse(camFromFp);
     glm::vec3 camCenter(fpFromCam[3][0], fpFromCam[3][1], fpFromCam[3][2]);
     glm::mat3 R = glm::mat3(fpFromCam);
-    const size_t kMapCap = 5000;
     int added = 0;
     for (size_t i = 0; i < kps.size(); ++i) {
         if (matched[i]) continue;

--- a/core/nativebridge/src/main/cpp/include/MobileGS.h
+++ b/core/nativebridge/src/main/cpp/include/MobileGS.h
@@ -56,6 +56,9 @@ public:
     int getMapPointCount() const { std::lock_guard<std::mutex> lock(mMutex); return (int)mMapPoints3D.size(); }
     // Phase 2b: gate live map-matching in relocThreadFunc. Default OFF — ships inert until validated.
     void setMapRelocEnabled(bool e) { mMapRelocEnabled.store(e, std::memory_order_relaxed); }
+    // Phase 3: passively grow the feature map from reloc-locked frames. Default OFF, and independent of
+    // the match flag (accumulate without matching, or match a persisted map without growing).
+    void setMapBuildEnabled(bool e) { mMapBuildEnabled.store(e, std::memory_order_relaxed); }
     void scheduleRelocCheck(const cv::Mat& colorFrame);
     void getAnchorTransform(float* outMat16) const;
     void getRelocResult(float* out19) const;       // [0..15]=pnpMat,16=inliers,17=matches,18=seq
@@ -154,6 +157,11 @@ private:
     // and the VIO baseline between the current and fingerprint-capture views, plus the viewing
     // obliquity in degrees. False if no fingerprint view is stored or the geometry is degenerate.
     bool computeRectifyHomography(const float* viewCur16, cv::Mat& Hcur_fp, cv::Mat& Hfp_cur, double& obliquityDeg);
+    // Phase 3 passive builder: on a reloc lock, back-project the frame's features onto the wall plane
+    // (fit from the fingerprint points) to get 3D points in the fingerprint frame, associate to the map
+    // by descriptor (bump confidence) or add new (capped). Co-registers the map to the fingerprint anchor.
+    void growMapFromReloc(const glm::mat4& camFromFp, const std::vector<cv::KeyPoint>& kps,
+                          const cv::Mat& descs, double fx, double fy, double cx, double cy);
 
     mutable std::mutex mMutex;
     std::atomic<bool> mIsArCoreTracking{false};
@@ -184,6 +192,7 @@ private:
     // Phase 2b flag: when true, relocThreadFunc also matches the frustum-gated map and merges those
     // correspondences into PnP. Default OFF so the map has zero effect on reloc until device-validated.
     std::atomic<bool> mMapRelocEnabled{false};
+    std::atomic<bool> mMapBuildEnabled{false};
 
     float mAnchorMatrix[16];
 

--- a/core/nativebridge/src/main/cpp/include/MobileGS.h
+++ b/core/nativebridge/src/main/cpp/include/MobileGS.h
@@ -54,6 +54,8 @@ public:
                                const float* anchorMatrix16, const float* intrinsics4);
     void clearWallFeatureMap();
     int getMapPointCount() const { std::lock_guard<std::mutex> lock(mMutex); return (int)mMapPoints3D.size(); }
+    // Phase 2b: gate live map-matching in relocThreadFunc. Default OFF — ships inert until validated.
+    void setMapRelocEnabled(bool e) { mMapRelocEnabled.store(e, std::memory_order_relaxed); }
     void scheduleRelocCheck(const cv::Mat& colorFrame);
     void getAnchorTransform(float* outMat16) const;
     void getRelocResult(float* out19) const;       // [0..15]=pnpMat,16=inliers,17=matches,18=seq
@@ -179,6 +181,9 @@ private:
     std::vector<int> mMapObs;
     float mMapAnchorMatrix[16] = {1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1};
     float mMapIntrinsics[4] = {0,0,0,0};
+    // Phase 2b flag: when true, relocThreadFunc also matches the frustum-gated map and merges those
+    // correspondences into PnP. Default OFF so the map has zero effect on reloc until device-validated.
+    std::atomic<bool> mMapRelocEnabled{false};
 
     float mAnchorMatrix[16];
 

--- a/core/nativebridge/src/main/cpp/include/MobileGS.h
+++ b/core/nativebridge/src/main/cpp/include/MobileGS.h
@@ -46,6 +46,14 @@ public:
     // fingerprint anchor pose and the intrinsics the reloc PnP should use.
     void restoreWallFingerprintMetric(const cv::Mat& descriptors, const std::vector<cv::Point3f>& points3d,
                                       const float* anchorMatrix16, const float* intrinsics4);
+    // Persistent wall *feature* map (lean reloc backbone; docs/RELOC_MAP_DESIGN.md), co-registered to
+    // the fingerprint anchor. Restore replaces the stored map (confidence/obs optional). Phase 2a stores
+    // it only; reloc matching against it (Phase 2b) is gated separately.
+    void restoreWallFeatureMap(const cv::Mat& descriptors, const std::vector<cv::Point3f>& points3d,
+                               const std::vector<float>& confidence, const std::vector<int>& obs,
+                               const float* anchorMatrix16, const float* intrinsics4);
+    void clearWallFeatureMap();
+    int getMapPointCount() const { std::lock_guard<std::mutex> lock(mMutex); return (int)mMapPoints3D.size(); }
     void scheduleRelocCheck(const cv::Mat& colorFrame);
     void getAnchorTransform(float* outMat16) const;
     void getRelocResult(float* out19) const;       // [0..15]=pnpMat,16=inliers,17=matches,18=seq
@@ -161,6 +169,16 @@ private:
     cv::Mat mArtworkDescriptors;
     std::vector<cv::Point3f> mArtworkKeypoints3D;
     std::atomic<float> mPaintingProgress{0.0f};
+
+    // --- Persistent wall feature map (lean reloc backbone; docs/RELOC_MAP_DESIGN.md) ---
+    // Co-registered to the fingerprint anchor. Phase 2a stores it; reloc matching (Phase 2b) is gated
+    // separately, so today this is inert state with no effect on relocalization.
+    cv::Mat mMapDescriptors;
+    std::vector<cv::Point3f> mMapPoints3D;
+    std::vector<float> mMapConfidence;
+    std::vector<int> mMapObs;
+    float mMapAnchorMatrix[16] = {1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1};
+    float mMapIntrinsics[4] = {0,0,0,0};
 
     float mAnchorMatrix[16];
 

--- a/core/nativebridge/src/main/cpp/include/MobileGS.h
+++ b/core/nativebridge/src/main/cpp/include/MobileGS.h
@@ -54,6 +54,9 @@ public:
                                const float* anchorMatrix16, const float* intrinsics4);
     void clearWallFeatureMap();
     int getMapPointCount() const { std::lock_guard<std::mutex> lock(mMutex); return (int)mMapPoints3D.size(); }
+    // Phase 3b: pack the live feature map (points/descriptors/confidence/obs + co-registration) into a
+    // self-describing little-endian blob for .gxr persistence; empty if there's no map. Race-free (one lock).
+    std::vector<uint8_t> exportWallFeatureMap() const;
     // Phase 2b: gate live map-matching in relocThreadFunc. Default OFF — ships inert until validated.
     void setMapRelocEnabled(bool e) { mMapRelocEnabled.store(e, std::memory_order_relaxed); }
     // Phase 3: passively grow the feature map from reloc-locked frames. Default OFF, and independent of

--- a/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
+++ b/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
@@ -5,6 +5,7 @@ import android.content.res.AssetManager
 import android.graphics.Bitmap
 import android.util.Log
 import com.hereliesaz.graffitixr.common.model.Fingerprint
+import com.hereliesaz.graffitixr.common.model.WallFeatureMap
 import com.hereliesaz.graffitixr.common.sensor.CameraFrame
 import com.hereliesaz.graffitixr.common.sensor.ImuSample
 import com.hereliesaz.graffitixr.common.sensor.PixelFormat
@@ -97,6 +98,18 @@ class SlamManager @Inject constructor(
     ) {
         nativeRestoreWallFingerprintMetric(descriptorsData, rows, cols, type, points3d, anchorMatrix, intrinsics)
     }
+
+    /** Restore the persistent wall feature map into native (Phase 2a: stored; matched in Phase 2b). */
+    fun restoreWallFeatureMap(map: WallFeatureMap) {
+        nativeRestoreWallFeatureMap(
+            map.descriptorsData, map.descriptorsRows, map.descriptorsCols, map.descriptorsType,
+            map.points3d, map.confidence, map.obsCount, map.anchor, map.intrinsics,
+        )
+    }
+    /** Drop the in-native wall feature map. */
+    fun clearWallFeatureMap() = nativeClearWallFeatureMap()
+    /** Live wall-feature-map point count — diagnostic. */
+    fun getMapPointCount(): Int = nativeGetMapPointCount()
 
     fun setArtworkFingerprint(
         bitmap: Bitmap,
@@ -489,6 +502,13 @@ class SlamManager @Inject constructor(
         descriptorsData: ByteArray, rows: Int, cols: Int, type: Int,
         points3d: FloatArray, anchorMatrix: FloatArray, intrinsics: FloatArray
     )
+    private external fun nativeRestoreWallFeatureMap(
+        descriptorsData: ByteArray, rows: Int, cols: Int, type: Int,
+        points3d: FloatArray, confidence: FloatArray, obsCount: IntArray,
+        anchor: FloatArray, intrinsics: FloatArray
+    )
+    private external fun nativeClearWallFeatureMap()
+    private external fun nativeGetMapPointCount(): Int
     private external fun nativeSetArtworkFingerprint(
         bitmap: Bitmap, depthBuffer: ByteBuffer?,
         depthW: Int, depthH: Int, depthStride: Int,

--- a/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
+++ b/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
@@ -12,6 +12,7 @@ import com.hereliesaz.graffitixr.common.sensor.PixelFormat
 import com.hereliesaz.graffitixr.common.util.NativeLibLoader
 import com.hereliesaz.graffitixr.common.wearable.WearableManager
 import java.nio.ByteBuffer
+import java.nio.ByteOrder
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineScope
@@ -114,6 +115,30 @@ class SlamManager @Inject constructor(
     fun setMapRelocEnabled(enabled: Boolean) = nativeSetMapRelocEnabled(enabled)
     /** Phase 3: passively grow the feature map from reloc-locked frames. Default OFF; independent of matching. */
     fun setMapBuildEnabled(enabled: Boolean) = nativeSetMapBuildEnabled(enabled)
+
+    /**
+     * Phase 3b: read the in-native feature map back as a [WallFeatureMap] for .gxr persistence, or null
+     * when empty. Unpacks the native little-endian blob: [n, rows, cols, type][points][conf][obs][anchor16]
+     * [intrinsics4][descriptors]. Returns null (skip this save) if a concurrent grow left it inconsistent.
+     */
+    fun getWallFeatureMap(): WallFeatureMap? {
+        val blob = nativeExportWallFeatureMap() ?: return null
+        if (blob.size < 16) return null
+        val bb = ByteBuffer.wrap(blob).order(ByteOrder.LITTLE_ENDIAN)
+        val n = bb.int; val rows = bb.int; val cols = bb.int; val type = bb.int
+        if (n < 0 || rows < 0 || cols < 0) return null
+        return try {
+            val points = FloatArray(n * 3) { bb.float }
+            val conf = FloatArray(n) { bb.float }
+            val obs = IntArray(n) { bb.int }
+            val anchor = FloatArray(16) { bb.float }
+            val intrinsics = FloatArray(4) { bb.float }
+            val desc = ByteArray(blob.size - bb.position()).also { bb.get(it) }
+            WallFeatureMap(points, desc, rows, cols, type, conf, obs, anchor, intrinsics)
+        } catch (e: Exception) {
+            null
+        }
+    }
 
     fun setArtworkFingerprint(
         bitmap: Bitmap,
@@ -515,6 +540,7 @@ class SlamManager @Inject constructor(
     private external fun nativeGetMapPointCount(): Int
     private external fun nativeSetMapRelocEnabled(enabled: Boolean)
     private external fun nativeSetMapBuildEnabled(enabled: Boolean)
+    private external fun nativeExportWallFeatureMap(): ByteArray?
     private external fun nativeSetArtworkFingerprint(
         bitmap: Bitmap, depthBuffer: ByteBuffer?,
         depthW: Int, depthH: Int, depthStride: Int,

--- a/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
+++ b/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
@@ -127,6 +127,9 @@ class SlamManager @Inject constructor(
         val bb = ByteBuffer.wrap(blob).order(ByteOrder.LITTLE_ENDIAN)
         val n = bb.int; val rows = bb.int; val cols = bb.int; val type = bb.int
         if (n < 0 || rows < 0 || cols < 0) return null
+        // Bail before reading if the blob can't even hold the fixed-size fields (header + points/conf/obs
+        // + anchor + intrinsics = 96 + n*20 bytes), rather than catching a BufferUnderflowException.
+        if (blob.size < 96 + n * 20) return null
         return try {
             val points = FloatArray(n * 3) { bb.float }
             val conf = FloatArray(n) { bb.float }

--- a/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
+++ b/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
@@ -110,6 +110,8 @@ class SlamManager @Inject constructor(
     fun clearWallFeatureMap() = nativeClearWallFeatureMap()
     /** Live wall-feature-map point count — diagnostic. */
     fun getMapPointCount(): Int = nativeGetMapPointCount()
+    /** Phase 2b: enable live map-matching in reloc. Default OFF — experimental until device-validated. */
+    fun setMapRelocEnabled(enabled: Boolean) = nativeSetMapRelocEnabled(enabled)
 
     fun setArtworkFingerprint(
         bitmap: Bitmap,
@@ -509,6 +511,7 @@ class SlamManager @Inject constructor(
     )
     private external fun nativeClearWallFeatureMap()
     private external fun nativeGetMapPointCount(): Int
+    private external fun nativeSetMapRelocEnabled(enabled: Boolean)
     private external fun nativeSetArtworkFingerprint(
         bitmap: Bitmap, depthBuffer: ByteBuffer?,
         depthW: Int, depthH: Int, depthStride: Int,

--- a/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
+++ b/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
@@ -112,6 +112,8 @@ class SlamManager @Inject constructor(
     fun getMapPointCount(): Int = nativeGetMapPointCount()
     /** Phase 2b: enable live map-matching in reloc. Default OFF — experimental until device-validated. */
     fun setMapRelocEnabled(enabled: Boolean) = nativeSetMapRelocEnabled(enabled)
+    /** Phase 3: passively grow the feature map from reloc-locked frames. Default OFF; independent of matching. */
+    fun setMapBuildEnabled(enabled: Boolean) = nativeSetMapBuildEnabled(enabled)
 
     fun setArtworkFingerprint(
         bitmap: Bitmap,
@@ -512,6 +514,7 @@ class SlamManager @Inject constructor(
     private external fun nativeClearWallFeatureMap()
     private external fun nativeGetMapPointCount(): Int
     private external fun nativeSetMapRelocEnabled(enabled: Boolean)
+    private external fun nativeSetMapBuildEnabled(enabled: Boolean)
     private external fun nativeSetArtworkFingerprint(
         bitmap: Bitmap, depthBuffer: ByteBuffer?,
         depthW: Int, depthH: Int, depthStride: Int,

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -1172,8 +1172,12 @@ class ArViewModel @Inject constructor(
             // Restore the persistent wall feature map (Phase 2a: stored in native; matched in Phase 2b).
             // Independent of the marks fingerprint above and co-registered to the same anchor. Null on
             // every current project until the passive builder (Phase 3) starts producing one.
-            project.wallFeatureMap?.let { map ->
-                if (map.pointCount > 0) slamManager.restoreWallFeatureMap(map)
+            val map = project.wallFeatureMap
+            if (map != null && map.pointCount > 0) {
+                slamManager.restoreWallFeatureMap(map)
+            } else {
+                // No map on this project: clear any map left in native from a previously loaded project.
+                slamManager.clearWallFeatureMap()
             }
         }
     }

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -1169,6 +1169,12 @@ class ArViewModel @Inject constructor(
                     if (s * s == fp.patchData.size) slamManager.setWallPatchBytes(fp.patchData, s)
                 }
             }
+            // Restore the persistent wall feature map (Phase 2a: stored in native; matched in Phase 2b).
+            // Independent of the marks fingerprint above and co-registered to the same anchor. Null on
+            // every current project until the passive builder (Phase 3) starts producing one.
+            project.wallFeatureMap?.let { map ->
+                if (map.pointCount > 0) slamManager.restoreWallFeatureMap(map)
+            }
         }
     }
 

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -1111,7 +1111,8 @@ class ArViewModel @Inject constructor(
         // Save both native engine state (Voxel + Mesh) and ARCore Point Cloud
         slamManager.saveModel(mapPath)
         renderer?.saveCloudPoints(cloudPath)
-        
+        saveWallFeatureMap() // Phase 3b: persist the passive feature map into the project record
+
         lastSavedSplatCount.set(slamManager.getSplatCount())
         Timber.d("Atomic persistence complete: Saved all mapping components for $projectId")
     }
@@ -1129,6 +1130,23 @@ class ArViewModel @Inject constructor(
                 Timber.e(e, "Background map save failed")
             } finally {
                 isSaving.set(false)
+            }
+        }
+    }
+
+    /**
+     * Phase 3b: persist the in-session passive feature map into the project record (.gxr), preserving the
+     * rest of the current project. No-op when building is off / the map is empty. Async + best-effort.
+     */
+    private fun saveWallFeatureMap() {
+        val project = projectRepository.currentProject.value ?: return
+        viewModelScope.launch(Dispatchers.IO) {
+            try {
+                val map = slamManager.getWallFeatureMap() ?: return@launch
+                if (map.pointCount <= 0) return@launch
+                projectManager.saveProject(appContext, project.copy(wallFeatureMap = map))
+            } catch (e: Exception) {
+                Timber.e(e, "Wall feature map save failed")
             }
         }
     }


### PR DESCRIPTION
## Reloc map — Phase 3b: persist the built map to `.gxr` + confidence pruning (stacked on #1686)

Closes the persistence loop — the **read-back counterpart of Phase 2a's restore** — so a passively-built map survives a restart.

### Changes
- **`MobileGS::exportWallFeatureMap()`** — packs the live map (points / descriptors / confidence / obs + co-registration) into **one self-describing little-endian blob under a single lock** (race-free). Verified the native pack order == the Kotlin unpack order.
- **Pruning** — `growMapFromReloc` now **confidence-prunes** at the 5k cap (drops points that never earned a re-observation), so the map keeps refreshing within the bound.
- **`GraffitiJNI`** `nativeExportWallFeatureMap` → `jbyteArray`; **`SlamManager.getWallFeatureMap()`** unpacks it (returns null on a concurrent-grow inconsistency → skip this save, retry next).
- **`ArViewModel.saveWallFeatureMap()`** writes it into the project record via `saveProject(targetImages=null)` (cheap — no image rewrite), wired into `saveMapBlocking`.

### Inert by default + one validation note
Map-building is OFF by default, so this is inert. ⚠️ **For device validation:** the legacy `saveMapNow()` early-returns on `splatCount<=0` (now always 0), so confirm `saveMapBlocking` actually fires on the autosave/exit path when building is enabled — the save *trigger* may need a small adjustment there. The export/unpack/persist machinery itself is complete.

### The feature-map engine is now complete
#1682 model → #1683 store → #1684 match → #1686 build → **#1687 persist**. What remains is **enabling the flags on-device** to validate + tune the SLAM math.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018V1ysU9z4tTviN5RYcLo8V)_