### PR TITLE
Single-capture: gate on a green wall plane before the review step

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -297,7 +297,18 @@ class MainActivity : ComponentActivity() {
 
                 LaunchedEffect(currentTempCapture, currentCaptureStep, isWaitingForTap) {
                     if (currentTempCapture != null) {
-                        if (currentCaptureStep == CaptureStep.NONE && isWaitingForTap) {
+                        val tapPath = currentCaptureStep == CaptureStep.NONE && isWaitingForTap
+                        // Depth-off (single-capture) target creation back-projects onto the green
+                        // ARCore wall plane, so it needs one. Gate BEFORE the review step: if the tap
+                        // wasn't on a green wall, discard the frame and let the artist re-aim/re-tap,
+                        // rather than letting them erase marks on a capture we'd reject at confirm.
+                        val depthOff = arUiState.targetDepthBuffer == null
+                        val plane = arUiState.targetWallPlane
+                        val onGreenWall = plane != null && plane.size >= 6
+                        if (tapPath && depthOff && !onGreenWall) {
+                            arViewModel.clearCaptureForRetry()
+                            mainViewModel.notifyTargetNotOnWall()
+                        } else if (tapPath) {
                             mainViewModel.setCaptureStep(CaptureStep.REVIEW)
                         } else if (currentCaptureStep == CaptureStep.CAPTURE) {
                             mainViewModel.setCaptureStep(CaptureStep.REVIEW)

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainViewModel.kt
@@ -343,9 +343,7 @@ class MainViewModel @Inject constructor(
     private fun handleSingleCapture(bitmap: Bitmap, intr: FloatArray, view: FloatArray, wallPlane: FloatArray?) {
         if (wallPlane == null || wallPlane.size < 6) {
             resetCaptureUi()
-            Toast.makeText(context,
-                "Aim at a wall shown in green (face it straight-on, within ~3 m), then tap your marks.",
-                Toast.LENGTH_LONG).show()
+            Toast.makeText(context, notOnGreenWallMessage, Toast.LENGTH_LONG).show()
             return
         }
         resetCaptureUi()
@@ -388,15 +386,19 @@ class MainViewModel @Inject constructor(
         }
     }
 
+    // Shared guidance shown when single-capture target creation isn't aimed at a green wall plane
+    // (used by both the pre-review gate and the handleSingleCapture backstop). Toast-in-VM matches the
+    // existing capture toasts here; a full AppStrings/event-channel i18n pass is a separate cleanup.
+    private val notOnGreenWallMessage =
+        "Aim at a wall shown in green (face it straight-on, within ~3 m), then tap your marks."
+
     /**
      * The single-capture tap wasn't on a green (parallel, in-range) wall plane. Guide the artist;
      * the capture frame is discarded separately (ArViewModel.clearCaptureForRetry) so they stay in
      * tap mode and can simply re-aim and tap again.
      */
     fun notifyTargetNotOnWall() {
-        Toast.makeText(context,
-            "Aim at a wall shown in green (face it straight-on, within ~3 m), then tap your marks.",
-            Toast.LENGTH_LONG).show()
+        Toast.makeText(context, notOnGreenWallMessage, Toast.LENGTH_LONG).show()
     }
 
     fun onCancelCaptureClicked() {

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainViewModel.kt
@@ -388,6 +388,17 @@ class MainViewModel @Inject constructor(
         }
     }
 
+    /**
+     * The single-capture tap wasn't on a green (parallel, in-range) wall plane. Guide the artist;
+     * the capture frame is discarded separately (ArViewModel.clearCaptureForRetry) so they stay in
+     * tap mode and can simply re-aim and tap again.
+     */
+    fun notifyTargetNotOnWall() {
+        Toast.makeText(context,
+            "Aim at a wall shown in green (face it straight-on, within ~3 m), then tap your marks.",
+            Toast.LENGTH_LONG).show()
+    }
+
     fun onCancelCaptureClicked() {
         _uiState.update {
             it.copy(

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -1672,7 +1672,25 @@ class ArViewModel @Inject constructor(
         }
     }
 
-    fun computePhysicalExtent(
+    /**
+     * Discard a just-captured frame so the artist can re-aim and re-tap without restarting capture —
+     * used when single-capture target creation is refused because the tap wasn't on a green wall
+     * plane. Nulls the captured bitmap (so the capture→review effect won't re-fire on stale data) and
+     * the captured wall plane, and clears the on-image markers.
+     */
+    fun clearCaptureForRetry() {
+        pendingTapPosition = null
+        _uiState.update {
+            it.copy(
+                tempCaptureBitmap = null,
+                annotatedCaptureBitmap = null,
+                targetWallPlane = null,
+                tapMarks = emptyList(),
+                unwarpPoints = emptyList(),
+                targetKeypoints = emptyList()
+            )
+        }
+    }
         depthBuffer: ByteBuffer?,
         depthW: Int, depthH: Int,
         colorW: Int, colorH: Int,

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -1691,6 +1691,8 @@ class ArViewModel @Inject constructor(
             )
         }
     }
+
+    fun computePhysicalExtent(
         depthBuffer: ByteBuffer?,
         depthW: Int, depthH: Int,
         colorW: Int, colorH: Int,


### PR DESCRIPTION
## What
Enforce the **green wall plane** requirement *before* the mask-review step, not at confirm time.

Previously (PR #1692) the single-capture path only checked for a green plane in `handleSingleCapture`, i.e. **after** the artist had already gone through the review/erase step — so tapping a non-green wall meant throwaway work and a late rejection.

## Change
Gate at the capture→review transition (`MainActivity` `LaunchedEffect`):
- For a depth-off (single-capture) **tap** with **no green `targetWallPlane`**, discard the frame and show guidance instead of entering `REVIEW`.
- `ArViewModel.clearCaptureForRetry()` nulls the captured bitmap + wall plane + on-image markers, so the effect won't re-fire on stale data and the artist stays in tap mode to simply re-aim and tap again.
- `MainViewModel.notifyTargetNotOnWall()` shows the guidance toast.

The depth path (real depth available) is unaffected; the confirm-time check in `handleSingleCapture` stays as a defensive backstop.

## ⚠️ Verification
Authored blind — the environment's headless Android-SDK setup script couldn't run in-session (auth env vars absent + `dl.google.com` egress blocked at runtime; it's a container-startup script). So this is **CI-gated for compile**, device-gated for behavior: tapping a non-green wall should now refuse immediately with guidance and let you re-tap, while a green wall proceeds to review as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018V1ysU9z4tTviN5RYcLo8V)_