### PR TITLE
Fix invalid gemini-dispatch.yml (missing plan-execute workflow)

### DIFF
--- a/.github/workflows/gemini-dispatch.yml
+++ b/.github/workflows/gemini-dispatch.yml
@@ -171,27 +171,12 @@ jobs:
       additional_context: '${{ needs.dispatch.outputs.additional_context }}'
     secrets: 'inherit'
 
-  plan-execute:
-    needs: 'dispatch'
-    if: |-
-      ${{ needs.dispatch.outputs.command == 'approve' }}
-    uses: './.github/workflows/gemini-plan-execute.yml'
-    permissions:
-      contents: 'write'
-      id-token: 'write'
-      issues: 'write'
-      pull-requests: 'write'
-    with:
-      additional_context: '${{ needs.dispatch.outputs.additional_context }}'
-    secrets: 'inherit'
-
   fallthrough:
     needs:
       - 'dispatch'
       - 'review'
       - 'triage'
       - 'invoke'
-      - 'plan-execute'
     if: |-
       ${{ always() && !cancelled() && (failure() || needs.dispatch.outputs.command == 'fallthrough') }}
     runs-on: 'ubuntu-latest'


### PR DESCRIPTION
## Problem
`gemini-dispatch.yml` is invalid:
```
error parsing called workflow ".github/workflows/gemini-dispatch.yml"
 -> "./.github/workflows/gemini-plan-execute.yml": failed to fetch workflow: workflow was not found.
```
The `plan-execute` job calls `./.github/workflows/gemini-plan-execute.yml`, but that file doesn't exist in the repo (only `dispatch`, `invoke`, `review`, `scheduled-triage`, `triage` are present). A missing reusable-workflow reference invalidates the **whole** `gemini-dispatch.yml`, so all its commands (review / triage / invoke) break — not just the `/approve` plan-execute path, which was never functional here.

## Fix
Remove the `plan-execute` job and its entry in `fallthrough.needs`. The workflow validates again and the working commands are restored. The `/approve` command now no-ops (it routed only to the missing workflow).

YAML re-validated; no remaining `plan-execute` references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018V1ysU9z4tTviN5RYcLo8V)_