### PR TITLE
Auto-increment version.properties on every compile

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -33,18 +33,23 @@ val localProperties = Properties().apply {
 //      monotonic value derived from the git commit count — see release-aab.yml).
 //      When the override is present we do NOT auto-increment or rewrite the file,
 //      so the ephemeral CI checkout stays clean and Play receives exactly <n>.
-//   2. Otherwise fall back to the value stored in version.properties, preserving
-//      the existing local behaviour of auto-incrementing on release builds.
+//   2. Otherwise, auto-increment the stored build number on EVERY compile — any
+//      build type (debug or release), any machine. The increment is gated to an
+//      actual build/compile being requested so routine configuration (most
+//      importantly Android Studio's frequent project syncs) does NOT inflate it.
 val versionBuildOverride = project.findProperty("versionBuild")?.toString()?.toIntOrNull()
 var currentVersionCode = versionBuildOverride ?: versionProps.getProperty("versionBuild", "1").toInt()
 
-// Automatically increment versionCode for local release builds (no override supplied).
-val isReleaseBuild = gradle.startParameter.taskNames.any { it.contains("Release", ignoreCase = true) }
-if (isReleaseBuild && versionBuildOverride == null) {
+// True when the requested tasks actually compile/assemble the app (not a sync, `tasks`, `clean`, etc.).
+val isBuilding = gradle.startParameter.taskNames.any { taskName ->
+    val task = taskName.substringAfterLast(':').lowercase()
+    listOf("assemble", "build", "bundle", "install", "package", "compile").any { task.contains(it) }
+}
+if (versionBuildOverride == null && isBuilding) {
     currentVersionCode++
     versionProps.setProperty("versionBuild", currentVersionCode.toString())
     versionPropsFile.outputStream().use {
-        versionProps.store(it, "Auto-incremented by release build")
+        versionProps.store(it, "Auto-incremented on compile")
     }
 }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,10 +40,14 @@ val localProperties = Properties().apply {
 val versionBuildOverride = project.findProperty("versionBuild")?.toString()?.toIntOrNull()
 var currentVersionCode = versionBuildOverride ?: versionProps.getProperty("versionBuild", "1").toInt()
 
-// True when the requested tasks actually compile/assemble the app (not a sync, `tasks`, `clean`, etc.).
-val isBuilding = gradle.startParameter.taskNames.any { taskName ->
+// True when the requested tasks actually compile/assemble the app — not a sync, `tasks`, `clean`,
+// a `--dry-run`, or a diagnostic like `buildEnvironment`/`buildHealth`. Build verbs are matched as a
+// prefix and the `build` lifecycle task exactly, so diagnostics that merely contain "build" don't trip it.
+val startParameter = gradle.startParameter
+val buildVerbs = listOf("assemble", "bundle", "install", "package", "compile")
+val isBuilding = !startParameter.isDryRun && startParameter.taskNames.any { taskName ->
     val task = taskName.substringAfterLast(':').lowercase()
-    listOf("assemble", "build", "bundle", "install", "package", "compile").any { task.contains(it) }
+    task == "build" || buildVerbs.any { task.startsWith(it) }
 }
 if (versionBuildOverride == null && isBuilding) {
     currentVersionCode++


### PR DESCRIPTION
## Summary

Auto-increment `version.properties` on **every compile**, regardless of build type or machine.

Previously the build number incremented only on local **release** builds. Now it bumps on every build/compile:

- **APK** builds (`assemble*`) and **AAB** builds (`bundle*`) are treated identically — it doesn't matter which you produce.
- Also covers `build`, `install*`, `package*`, and `compile*` tasks, debug or release, on any machine.

### Guards (intentional no-bump cases)
- **CI / explicit override:** when `-PversionBuild=<n>` is supplied (all CI workflows pass a monotonic, git-commit-derived code), that value wins and is used verbatim **without** rewriting the file — so ephemeral CI checkouts stay clean and Google Play always receives a strictly increasing versionCode.
- **Non-building invocations:** the increment is gated to actual build/compile tasks, so routine Gradle configuration — most importantly Android Studio's frequent project syncs — and `clean`/`tasks`/`help` do **not** inflate the number.

Configuration cache is disabled in this project (`org.gradle.configuration-cache=false`), so the configuration-phase increment runs reliably on each build invocation.

## File
- `app/build.gradle.kts` — replace the release-only increment with an every-compile increment gated to build tasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017yfb8vFDvprj6wgkQTmmTm)_