### PR TITLE
Increment version name (patch) on every compile; reset patch on minor bump

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -28,17 +28,16 @@ val localProperties = Properties().apply {
     }
 }
 
-// versionCode resolution:
-//   1. An explicit override via `-PversionBuild=<n>` always wins (CI passes a
-//      monotonic value derived from the git commit count — see release-aab.yml).
-//      When the override is present we do NOT auto-increment or rewrite the file,
-//      so the ephemeral CI checkout stays clean and Play receives exactly <n>.
-//   2. Otherwise, auto-increment the stored build number on EVERY compile — any
-//      build type (debug or release), any machine. The increment is gated to an
-//      actual build/compile being requested so routine configuration (most
-//      importantly Android Studio's frequent project syncs) does NOT inflate it.
+// Version resolution. On EVERY compile (any build type, any machine) both the build number and the
+// patch are incremented:
+//   - versionBuild  -> the Android versionCode. Monotonic; NEVER resets.
+//   - versionPatch  -> the patch segment of the versionName. Increments each compile, but resets to
+//                      0 when versionMinor was bumped since the last build (a new minor starts at .0).
+//                      versionMinorLast tracks the minor we last built so that reset is automatic.
+// An explicit `-PversionBuild=<n>` override always wins (CI passes a monotonic value derived from the
+// git commit count — see release-aab.yml); when present we do NOT auto-increment or rewrite the file,
+// so the ephemeral CI checkout stays clean and Play receives exactly <n>.
 val versionBuildOverride = project.findProperty("versionBuild")?.toString()?.toIntOrNull()
-var currentVersionCode = versionBuildOverride ?: versionProps.getProperty("versionBuild", "1").toInt()
 
 // True when the requested tasks actually compile/assemble the app — not a sync, `tasks`, `clean`,
 // a `--dry-run`, or a diagnostic like `buildEnvironment`/`buildHealth`. Build verbs are matched as a
@@ -49,18 +48,27 @@ val isBuilding = !startParameter.isDryRun && startParameter.taskNames.any { task
     val task = taskName.substringAfterLast(':').lowercase()
     task == "build" || buildVerbs.any { task.startsWith(it) }
 }
+
+val verMajor = versionProps.getProperty("versionMajor", "1")
+val verMinor = versionProps.getProperty("versionMinor", "0")
+var currentVersionCode = versionBuildOverride ?: versionProps.getProperty("versionBuild", "1").toInt()
+var currentPatch = versionProps.getProperty("versionPatch", "0").toInt()
+
 if (versionBuildOverride == null && isBuilding) {
-    currentVersionCode++
+    currentVersionCode++ // build never resets
+    // Reset patch to 0 when minor changed since the last build; otherwise increment it.
+    val lastMinor = versionProps.getProperty("versionMinorLast", verMinor)
+    currentPatch = if (verMinor != lastMinor) 0 else currentPatch + 1
+
     versionProps.setProperty("versionBuild", currentVersionCode.toString())
+    versionProps.setProperty("versionPatch", currentPatch.toString())
+    versionProps.setProperty("versionMinorLast", verMinor)
     versionPropsFile.outputStream().use {
         versionProps.store(it, "Auto-incremented on compile")
     }
 }
 
-val verMajor = versionProps.getProperty("versionMajor", "1")
-val verMinor = versionProps.getProperty("versionMinor", "0")
-val verPatch = versionProps.getProperty("versionPatch", "0")
-val currentVersionName = "$verMajor.$verMinor.$verPatch"
+val currentVersionName = "$verMajor.$verMinor.$currentPatch"
 
 android {
     namespace = "com.hereliesaz.graffitixr"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -51,14 +51,19 @@ val isBuilding = !startParameter.isDryRun && startParameter.taskNames.any { task
 
 val verMajor = versionProps.getProperty("versionMajor", "1")
 val verMinor = versionProps.getProperty("versionMinor", "0")
+// Detect a minor bump BEFORE the build-gated block so the reset also applies to CI/override builds
+// (and IDE syncs), where the block is skipped: a new minor always reads as patch 0 even if the file
+// still holds the previous minor's patch (it may not have been rewritten by a local build yet).
+val lastMinor = versionProps.getProperty("versionMinorLast", verMinor)
+val isMinorBumped = verMinor != lastMinor
+
 var currentVersionCode = versionBuildOverride ?: versionProps.getProperty("versionBuild", "1").toInt()
-var currentPatch = versionProps.getProperty("versionPatch", "0").toInt()
+var currentPatch = if (isMinorBumped) 0 else versionProps.getProperty("versionPatch", "0").toInt()
 
 if (versionBuildOverride == null && isBuilding) {
     currentVersionCode++ // build never resets
-    // Reset patch to 0 when minor changed since the last build; otherwise increment it.
-    val lastMinor = versionProps.getProperty("versionMinorLast", verMinor)
-    currentPatch = if (verMinor != lastMinor) 0 else currentPatch + 1
+    // A minor bump makes this build the new minor's .0; otherwise advance the patch.
+    if (!isMinorBumped) currentPatch++
 
     versionProps.setProperty("versionBuild", currentVersionCode.toString())
     versionProps.setProperty("versionPatch", currentPatch.toString())


### PR DESCRIPTION
## Summary

Fixes the displayed version never changing. Previously only `versionBuild` (the Android **versionCode**) auto-incremented, but the **versionName** is built from `major.minor.patch` — so it stayed `1.32.0` across every build. Now, on **every compile**:

- **`versionPatch` increments** → the versionName visibly changes (`1.32.0` → `1.32.1` → `1.32.2` …).
- **`versionBuild` increments** → monotonic versionCode; **never resets**.
- When **`versionMinor`** is bumped (by hand), **`versionPatch` resets to 0** on the next build, so a new minor starts at `.0` (e.g. set `versionMinor=33` → next build is `1.33.0`, then `1.33.1`…). This is tracked via a new `versionMinorLast` property so the reset is automatic.

### Unchanged guards (from the prior PRs)
- APK (`assemble*`) and AAB (`bundle*`) treated identically; also `build`/`install*`/`package*`/`compile*`.
- Skips `--dry-run`/`-m`, `build*` diagnostics (`buildEnvironment`, `buildHealth`), IDE syncs, `clean`/`tasks`.
- An explicit `-PversionBuild=<n>` override (all CI workflows) still wins and is used verbatim **without** rewriting the file, so Play keeps getting a monotonic, commit-derived versionCode.

## File
- `app/build.gradle.kts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017yfb8vFDvprj6wgkQTmmTm)_