### PR TITLE
Lock AR overlay to world anchor (disable pose-fusion reloc by default)

### DIFF
--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -191,8 +191,13 @@ class ArRenderer(
 
     private val anchorOrchestrator = AnchorOrchestrator()
     private val poseFusion = com.hereliesaz.graffitixr.feature.ar.anchor.PoseFusion()
-    // A/B switch for the Sub-project A harness: when false, reproduce the old pre/post-anchor toggle.
-    @Volatile var fusionEnabled: Boolean = true
+    // A/B switch for the Sub-project A harness: when false, the overlay is driven purely by the
+    // world-locked ARCore anchor (the stable pre/post-anchor behavior). When true, the mark-PnP
+    // relocalization correction is fused on top — which, for a richly-detailed fingerprint (e.g. a
+    // painting) that relocalizes nearly every frame, can yank the overlay to a camera-relative pose
+    // and make it ride the screen. Default OFF so the artwork stays glued to the real-world anchor;
+    // re-enable once the reloc pose convention is verified world-consistent for image fingerprints.
+    @Volatile var fusionEnabled: Boolean = false
     // Whether the ARCore Depth API is actually enabled this session. Off by default — it starves VIO
     // on this hardware; metric depth comes from triangulation/stereo instead. Set from ArViewModel.
     @Volatile var depthApiEnabled: Boolean = false


### PR DESCRIPTION
## Symptom

The AR artwork rode the screen instead of staying on the target. From the on-device screenshots: the anchor establishes fine (**"ANCHOR LOCKED" ✓ at 2.1 m**), but as the camera moves the distance readout jumps **2.1 m → 6.0 m → 6.1 m** and the overlay drifts around / scales off the painting.

## Root cause

With the anchor established, the overlay pose is the **world-locked ARCore anchor** *corrected by* the **mark-PnP relocalization via pose-fusion** (`fusionEnabled = true`). The fingerprint here is a richly-detailed **painting**, so relocalization fires almost every frame; that correction resolved to a **camera-relative pose** and yanked the overlay to the screen each frame (hence the jumping distance and drift). The ARCore anchor itself is stable — only the fused correction was unstable.

## Fix

Default `fusionEnabled` to **false**, so the overlay is driven purely by the world-locked ARCore anchor (the stable pre/post-anchor behavior). This trades away PnP drift re-snap, but ARCore anchors are stable short-term and this makes the artwork stay glued to the real-world target. The flag remains toggleable via the eval harness; we can re-enable fusion once the reloc pose convention is verified world-consistent for image fingerprints.

## File
- `feature/ar/.../rendering/ArRenderer.kt`

## Testing
Needs on-device verification (no ARCore in CI): with this change the overlay should stay on the painting as you move, and the distance readout should track real movement instead of jumping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017yfb8vFDvprj6wgkQTmmTm)_