### PR TITLE
Persist target fingerprint across saves; fix rotated-layer clipping

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
@@ -535,10 +535,18 @@ internal fun compositeLayersForAr(layers: List<Layer>): AndroidBitmap {
         val bmp = layer.bitmap ?: continue
         val halfW = bmp.width / 2f * layer.scale
         val halfH = bmp.height / 2f * layer.scale
-        val left = layer.offset.x - halfW
-        val top = layer.offset.y - halfH
-        val right = layer.offset.x + halfW
-        val bottom = layer.offset.y + halfH
+        // The layer is drawn rotated about its center, so the composite must be sized to the ROTATED
+        // bounding box. Using the unrotated half-extents here undersized the canvas and clipped the
+        // corners of any rotated layer.
+        val rad = Math.toRadians(layer.rotationZ.toDouble())
+        val cos = kotlin.math.abs(kotlin.math.cos(rad)).toFloat()
+        val sin = kotlin.math.abs(kotlin.math.sin(rad)).toFloat()
+        val rotHalfW = halfW * cos + halfH * sin
+        val rotHalfH = halfW * sin + halfH * cos
+        val left = layer.offset.x - rotHalfW
+        val top = layer.offset.y - rotHalfH
+        val right = layer.offset.x + rotHalfW
+        val bottom = layer.offset.y + rotHalfH
 
         if (left < minX) minX = left
         if (top < minY) minY = top

--- a/core/data/src/main/java/com/hereliesaz/graffitixr/data/ProjectManager.kt
+++ b/core/data/src/main/java/com/hereliesaz/graffitixr/data/ProjectManager.kt
@@ -85,6 +85,25 @@ class ProjectManager @Inject constructor(
         val root = File(context.filesDir, "projects/${projectData.id}")
         if (!root.exists()) root.mkdirs()
 
+        // The target fingerprint must survive EVERY routine save (layer edits, autosave, re-entering
+        // AR, etc.) and change only when the user creates a NEW target — which is the one path that
+        // passes a non-null fingerprint. So when the incoming project carries no fingerprint, carry
+        // over whatever is already persisted instead of nulling it. This makes it impossible for any
+        // other writer (or a stale-snapshot race) to wipe the saved target.
+        val incoming = if (projectData.fingerprint == null) {
+            val existing = runCatching {
+                val f = File(root, "project.json")
+                if (f.exists()) json.decodeFromString<GraffitiProject>(f.readText()) else null
+            }.getOrNull()
+            if (existing?.fingerprint != null) {
+                projectData.copy(
+                    fingerprint = existing.fingerprint,
+                    fingerprintIntrinsics = existing.fingerprintIntrinsics,
+                    fingerprintAnchor = existing.fingerprintAnchor,
+                )
+            } else projectData
+        } else projectData
+
         val thumbnailUri = if (thumbnail != null) {
             val file = File(root, "thumbnail.png")
             FileOutputStream(file).use { out ->
@@ -92,7 +111,7 @@ class ProjectManager @Inject constructor(
             }
             uriProvider.getUriForFile(file)
         } else {
-            projectData.thumbnailUri ?: run {
+            incoming.thumbnailUri ?: run {
                 val file = File(root, "thumbnail.png")
                 if (file.exists()) uriProvider.getUriForFile(file) else null
             }
@@ -100,7 +119,7 @@ class ProjectManager @Inject constructor(
 
         // Properly append new targets to the existing list
         val savedTargetUris = if (targetImages != null) {
-            val existingCount = projectData.targetImageUris.size
+            val existingCount = incoming.targetImageUris.size
             val newUris = targetImages.mapIndexed { index, bitmap ->
                 val file = File(root, "target_${existingCount + index}.png")
                 FileOutputStream(file).use { out ->
@@ -108,12 +127,12 @@ class ProjectManager @Inject constructor(
                 }
                 uriProvider.getUriForFile(file)
             }
-            projectData.targetImageUris + newUris
+            incoming.targetImageUris + newUris
         } else {
-            projectData.targetImageUris
+            incoming.targetImageUris
         }
 
-        val updatedGraffitiProject = projectData.copy(
+        val updatedGraffitiProject = incoming.copy(
             thumbnailUri = thumbnailUri,
             targetImageUris = savedTargetUris,
             lastModified = System.currentTimeMillis()

--- a/core/data/src/main/java/com/hereliesaz/graffitixr/data/ProjectManager.kt
+++ b/core/data/src/main/java/com/hereliesaz/graffitixr/data/ProjectManager.kt
@@ -91,15 +91,23 @@ class ProjectManager @Inject constructor(
         // over whatever is already persisted instead of nulling it. This makes it impossible for any
         // other writer (or a stale-snapshot race) to wipe the saved target.
         val incoming = if (projectData.fingerprint == null) {
-            val existing = runCatching {
+            val existing = try {
                 val f = File(root, "project.json")
                 if (f.exists()) json.decodeFromString<GraffitiProject>(f.readText()) else null
-            }.getOrNull()
-            if (existing?.fingerprint != null) {
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                throw e // never swallow cancellation
+            } catch (e: Exception) {
+                null
+            }
+            if (existing != null) {
                 projectData.copy(
                     fingerprint = existing.fingerprint,
                     fingerprintIntrinsics = existing.fingerprintIntrinsics,
                     fingerprintAnchor = existing.fingerprintAnchor,
+                    // Preserve the legacy target-fingerprint references too, so no save without them
+                    // can wipe an existing target.
+                    targetFingerprint = projectData.targetFingerprint ?: existing.targetFingerprint,
+                    targetFingerprintPath = projectData.targetFingerprintPath ?: existing.targetFingerprintPath,
                 )
             } else projectData
         } else projectData


### PR DESCRIPTION
## 1. Persist target fingerprint across all saves

The saved target wasn't surviving sessions: every routine save (layer edits, autosave, re-entering AR) round-trips the whole `GraffitiProject` through `saveProject`, so any writer with a stale/empty `currentProject` overwrote `project.json` with a null fingerprint.

`ProjectManager.saveProject` now **preserves the on-disk fingerprint** (and `fingerprintIntrinsics`, `fingerprintAnchor`, plus legacy `targetFingerprint`/`targetFingerprintPath`) whenever the incoming project carries none. Only target creation passes a non-null fingerprint, so the saved target changes **exactly when the user creates a new one** and is otherwise immutable.

Review fixes applied: preserve the legacy target refs too, and use try/catch that **rethrows `CancellationException`** (instead of `runCatching`, which would swallow it).

## 2. Fix rotated layers being clipped (AR composite)

Per the on-device report, rotated artwork was clipped. `compositeLayersForAr` sized the merged bitmap to each layer's **unrotated** extent, then drew the layer **rotated about its center** — so the rotated corners fell outside the canvas and were cut. The bounding box is now computed from the **rotated AABB** (`|w/2·cos|+|h/2·sin|`, `|w/2·sin|+|h/2·cos|`), keeping the whole image.

## Files
- `core/data/.../ProjectManager.kt`
- `app/.../MainScreen.kt`

## Testing
Persistence: data-layer change covered by existing unit tests. Clipping + persistence both want on-device confirmation (rotate a layer → no corner clipping; create a target → it's still there after restarting the app).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Preserve AR target fingerprint metadata across routine project saves and correct AR layer compositing bounds for rotated layers to prevent clipping.

Bug Fixes:
- Ensure existing target fingerprint metadata and legacy target references are retained when saving projects that provide no new fingerprint data.
- Fix AR layer compositing so rotated layers use a rotated bounding box, preventing their corners from being clipped.

Enhancements:
- Reuse existing project data when saving to maintain thumbnail and target image URI state while appending any new target images.