### PR TITLE
AR: move whole design along plane via Layer item; center overlay on marks

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
@@ -180,6 +180,19 @@ fun MainScreen(
 
                     val visibleLayers = uiState.layers.filter { it.isVisible && it.bitmap != null }
 
+                    // Push the AR whole-design adjustment (set via the rail's "Layer" item) to the
+                    // renderer, which applies it as an in-plane move/scale/rotate of the overlay along
+                    // the wall plane. Offsets are stored in world meters (converted at the gesture site).
+                    val arOverlayAdj = uiState.modeAdjustments[EditorMode.AR]
+                    LaunchedEffect(arOverlayAdj, rendererRef.value) {
+                        rendererRef.value?.let { r ->
+                            r.overlayPanX = arOverlayAdj?.offsetX ?: 0f
+                            r.overlayPanY = arOverlayAdj?.offsetY ?: 0f
+                            r.overlayScale = arOverlayAdj?.scale ?: 1f
+                            r.overlayRotationDeg = arOverlayAdj?.rotation ?: 0f
+                        }
+                    }
+
                     LaunchedEffect(visibleLayers, arUiState.isAnchorEstablished) {
                         if (!arUiState.isAnchorEstablished || visibleLayers.isEmpty()) {
                             rendererRef.value?.updateOverlayBitmap(null)
@@ -442,7 +455,9 @@ fun MainScreen(
                         // While editing the whole design as a unit for this mode, transform gestures
                         // drive the mode adjustment instead of the active layer.
                         val editingMode = uiState.editingModeLayer && uiState.editorMode != EditorMode.DESIGN
-                        if (!isTouchLocked && !isImageLocked && (activeLayer != null || editingMode) && !isWaitingForTap) {
+                        // editingMode edits the whole design, so it isn't gated by the active layer's
+                        // image lock (the mode has its own Lock via isTransformLocked, in the reducer).
+                        if (!isTouchLocked && !isWaitingForTap && (editingMode || (!isImageLocked && activeLayer != null))) {
                             if (uiState.activeTool == Tool.NONE) {
                                 detectSmartOverlayGestures(
                                     getValidBounds = { androidx.compose.ui.geometry.Rect(0f, 0f, size.width.toFloat(), size.height.toFloat()) },
@@ -450,7 +465,14 @@ fun MainScreen(
                                     onGestureEnd = { editorViewModel.onGestureEnd() },
                                     onGesture = { _, pan, zoom, rotation ->
                                         if (editingMode) {
-                                            editorViewModel.onModeTransformGesture(uiState.editorMode, pan, zoom, rotation)
+                                            // In AR the overlay lives on the wall in meters, so convert
+                                            // the screen-pixel drag to in-plane meters (screen Y is down,
+                                            // plane local Y is up → flip Y). Other modes stay in pixels.
+                                            val adjustedPan = if (uiState.editorMode == EditorMode.AR) {
+                                                val mpp = rendererRef.value?.currentMetersPerPixel ?: 0f
+                                                androidx.compose.ui.geometry.Offset(pan.x * mpp, -pan.y * mpp)
+                                            } else pan
+                                            editorViewModel.onModeTransformGesture(uiState.editorMode, adjustedPan, zoom, rotation)
                                         } else {
                                             editorViewModel.onTransformGesture(pan, zoom, rotation)
                                         }

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainViewModel.kt
@@ -369,7 +369,7 @@ class MainViewModel @Inject constructor(
         val planeNormal = floatArrayOf(wallPlane[3], wallPlane[4], wallPlane[5])
         val anchor = slamManager.getAnchorTransform()
         // Clear any prior marks-centering override; the builder re-publishes it on a successful build.
-        slamManager.overlayMarkCenterWorld = null
+        slamManager.overlayMarkCenterLocal = null
         viewModelScope.launch(Dispatchers.IO) {
             val currentProject = projectRepository.currentProject.value ?: return@launch
             val fp = MetricFingerprintBuilder.buildSingle(

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainViewModel.kt
@@ -368,6 +368,8 @@ class MainViewModel @Inject constructor(
         val planePoint = floatArrayOf(wallPlane[0], wallPlane[1], wallPlane[2])
         val planeNormal = floatArrayOf(wallPlane[3], wallPlane[4], wallPlane[5])
         val anchor = slamManager.getAnchorTransform()
+        // Clear any prior marks-centering override; the builder re-publishes it on a successful build.
+        slamManager.overlayMarkCenterWorld = null
         viewModelScope.launch(Dispatchers.IO) {
             val currentProject = projectRepository.currentProject.value ?: return@launch
             val fp = MetricFingerprintBuilder.buildSingle(

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/Fingerprint.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/Fingerprint.kt
@@ -20,6 +20,10 @@ data class Fingerprint(
     // Canonical 256x256 raw-gray patch of the marks (row-major) for the distortion head. Empty when
     // the head isn't in use. Defaulted so older saved projects deserialize unchanged.
     val patchData: ByteArray = ByteArray(0),
+    // Marks centroid [x,y,z] in the fingerprint anchor's local frame, so the AR overlay can re-center
+    // on the marks after a project reload (when the builder doesn't run). Empty when unavailable;
+    // defaulted so older saved projects deserialize unchanged.
+    val markCenterLocal: List<Float> = emptyList(),
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -35,6 +39,7 @@ data class Fingerprint(
         if (descriptorsCols != other.descriptorsCols) return false
         if (descriptorsType != other.descriptorsType) return false
         if (!patchData.contentEquals(other.patchData)) return false
+        if (markCenterLocal != other.markCenterLocal) return false
         return true
     }
 
@@ -46,6 +51,7 @@ data class Fingerprint(
         result = 31 * result + descriptorsCols
         result = 31 * result + descriptorsType
         result = 31 * result + patchData.contentHashCode()
+        result = 31 * result + markCenterLocal.hashCode()
         return result
     }
 }

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/util/ImageExt.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/util/ImageExt.kt
@@ -14,9 +14,11 @@ const val MARK_HIGHLIGHT_COLOR: Int = 0xFF00E5FF.toInt() // bright cyan
 
 // Connected mark components smaller than max(this floor, area / NOISE_AREA_DIVISOR) pixels are
 // treated as sensor/texture noise and dropped, so the user never sees meaningless "dots" — only
-// whole marks survive. Tunable; deliberately conservative so thin real strokes are kept.
-private const val MIN_MARK_PIXELS_FLOOR = 12
-private const val NOISE_AREA_DIVISOR = 40000
+// whole marks survive. Raised the floor and tightened the area ratio (~4x) so small specks are
+// never highlighted as potential markings in the first place; still keeps genuine thin strokes.
+// On a ~2 MP capture the area term dominates: n/10000 ≈ 200 px.
+private const val MIN_MARK_PIXELS_FLOOR = 48
+private const val NOISE_AREA_DIVISOR = 10000
 
 // How forgiving the erase touch is. A tap that misses every mark pixel snaps to the nearest mark
 // within this fraction of the larger image dimension (floored at the px constant so it stays a

--- a/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
+++ b/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
@@ -65,13 +65,15 @@ class SlamManager @Inject constructor(
     fun updateAnchorTransform(transform: FloatArray) = nativeUpdateAnchorTransform(transform)
 
     /**
-     * World-space (ARCore/GL frame) centroid of the matched fingerprint marks for the current
-     * target, or null to fall back to the tracked anchor's own position. Set by the AR fingerprint
-     * builder when a target is built; read by the AR renderer to center the artwork overlay on the
-     * marks instead of the screen-center anchor. Plain Kotlin state (not native) shared across the
-     * view models and the GL thread, hence @Volatile.
+     * Centroid of the matched fingerprint marks, expressed in the FINGERPRINT ANCHOR's local frame
+     * (the anchor PoseFusion converges the live render anchor toward), or null to fall back to the
+     * anchor's own position. Anchor-local (not world) so it survives a project reload into a new
+     * ARCore session: the renderer reconstructs the world point from the live anchor each frame. Set
+     * by the AR fingerprint builder on capture and re-published on project load; read by the AR
+     * renderer to center the artwork overlay on the marks instead of the screen-center anchor. Plain
+     * Kotlin state (not native) shared across the view models and the GL thread, hence @Volatile.
      */
-    @Volatile var overlayMarkCenterWorld: FloatArray? = null
+    @Volatile var overlayMarkCenterLocal: FloatArray? = null
 
     fun updateDeviceMotion(angularVel: FloatArray, linearVel: FloatArray) {
         nativeUpdateDeviceMotion(angularVel, linearVel)

--- a/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
+++ b/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
@@ -64,6 +64,15 @@ class SlamManager @Inject constructor(
 
     fun updateAnchorTransform(transform: FloatArray) = nativeUpdateAnchorTransform(transform)
 
+    /**
+     * World-space (ARCore/GL frame) centroid of the matched fingerprint marks for the current
+     * target, or null to fall back to the tracked anchor's own position. Set by the AR fingerprint
+     * builder when a target is built; read by the AR renderer to center the artwork overlay on the
+     * marks instead of the screen-center anchor. Plain Kotlin state (not native) shared across the
+     * view models and the GL thread, hence @Volatile.
+     */
+    @Volatile var overlayMarkCenterWorld: FloatArray? = null
+
     fun updateDeviceMotion(angularVel: FloatArray, linearVel: FloatArray) {
         nativeUpdateDeviceMotion(angularVel, linearVel)
     }

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -674,8 +674,8 @@ class ArViewModel @Inject constructor(
         isDestroying = true
         lastMappingPausedCmd = null
         // Drop the marks-centering override so a later AR re-entry (or a different project) doesn't
-        // center the overlay on a stale target's marks before a new one is built.
-        slamManager.overlayMarkCenterWorld = null
+        // center the overlay on a stale target's marks before a new one is built/restored.
+        slamManager.overlayMarkCenterLocal = null
         // Cancel any in-flight session update (including a running stereo probe) so it stops pumping
         // the camera and releases the session mutex before cleanup tries to acquire it.
         sessionUpdateJob?.cancel()
@@ -1189,6 +1189,10 @@ class ArViewModel @Inject constructor(
                     val s = kotlin.math.sqrt(fp.patchData.size.toDouble()).toInt()
                     if (s * s == fp.patchData.size) slamManager.setWallPatchBytes(fp.patchData, s)
                 }
+                // Re-publish the marks centroid (anchor-local) so the overlay re-centers on the marks
+                // after reload, even though the builder doesn't run on a restored fingerprint.
+                slamManager.overlayMarkCenterLocal =
+                    if (fp.markCenterLocal.size >= 3) fp.markCenterLocal.toFloatArray() else null
             }
             // Restore the persistent wall feature map (Phase 2a: stored in native; matched in Phase 2b).
             // Independent of the marks fingerprint above and co-registered to the same anchor. Null on

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -673,6 +673,9 @@ class ArViewModel @Inject constructor(
         isInArMode = false
         isDestroying = true
         lastMappingPausedCmd = null
+        // Drop the marks-centering override so a later AR re-entry (or a different project) doesn't
+        // center the overlay on a stale target's marks before a new one is built.
+        slamManager.overlayMarkCenterWorld = null
         // Cancel any in-flight session update (including a running stereo probe) so it stops pumping
         // the camera and releases the session mutex before cleanup tries to acquire it.
         sessionUpdateJob?.cancel()

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/MetricFingerprintBuilder.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/MetricFingerprintBuilder.kt
@@ -67,8 +67,9 @@ object MetricFingerprintBuilder {
             val tri = MetricMarks.triangulate(matched.corrs, cv0, cv1, intr0[0], intr0[1], intr0[2], intr0[3])
             if (tri.count < minPoints) return null
 
-            // Center the AR overlay on the marks (their world centroid), not the screen-center anchor.
-            slam.overlayMarkCenterWorld = marksCentroidWorld(tri.pointsCam0, cv0)
+            // Center the AR overlay on the marks (their centroid), not the screen-center anchor.
+            val markCenterLocal = marksCentroidLocal(tri.pointsCam0, cv0, anchorModel)
+            slam.overlayMarkCenterLocal = markCenterLocal
 
             // Keep the rows of frame-0's descriptors (and the frame-0 keypoints) whose match survived.
             val keptDesc = Mat(tri.count, matched.descriptors.cols(), matched.descriptors.type())
@@ -96,7 +97,10 @@ object MetricFingerprintBuilder {
             slam.restoreWallFingerprintMetric(
                 bytes, rows, cols, type, tri.pointsCam0, anchorModel, intr0,
             )
-            return Fingerprint(keypoints, tri.pointsCam0.toList(), bytes, rows, cols, type)
+            return Fingerprint(
+                keypoints, tri.pointsCam0.toList(), bytes, rows, cols, type,
+                markCenterLocal = markCenterLocal?.toList() ?: emptyList(),
+            )
         } finally {
             matched.descriptors.release()
         }
@@ -202,8 +206,9 @@ object MetricFingerprintBuilder {
         )
         if (res.count < minPoints) return null
 
-        // Center the AR overlay on the marks (their world centroid), not the screen-center anchor.
-        slam.overlayMarkCenterWorld = marksCentroidWorld(res.pointsCam, cvView)
+        // Center the AR overlay on the marks (their centroid), not the screen-center anchor.
+        val markCenterLocal = marksCentroidLocal(res.pointsCam, cvView, anchorModel)
+        slam.overlayMarkCenterLocal = markCenterLocal
 
         val keptDesc = Mat(res.count, descAll.cols(), descAll.type())
         val keypoints = ArrayList<KeyPoint>(res.count)
@@ -228,7 +233,10 @@ object MetricFingerprintBuilder {
         keptDesc.release()
 
         slam.restoreWallFingerprintMetric(bytes, rows, cols, type, res.pointsCam, anchorModel, intr)
-        return Fingerprint(keypoints, res.pointsCam.toList(), bytes, rows, cols, type)
+        return Fingerprint(
+            keypoints, res.pointsCam.toList(), bytes, rows, cols, type,
+            markCenterLocal = markCenterLocal?.toList() ?: emptyList(),
+        )
     }
 
     /** SuperPoint detect (native, CLAHE'd) on both views + L2 ratio match → Matched (CV_32F descs). */
@@ -273,22 +281,28 @@ object MetricFingerprintBuilder {
     }
 
     /**
-     * World-space (ARCore/GL frame) centroid of the kept 3D marks, used to center the AR overlay on
-     * the marks rather than the screen-center anchor. [pointsCam] are in the capture's CV camera
-     * frame (flat [x,y,z,...]); inverting the CV world→camera view brings their mean into world
-     * space. Returns null if there are no points or the view isn't invertible.
+     * Centroid [x,y,z] of the kept 3D marks expressed in the FINGERPRINT ANCHOR's local frame, used
+     * to center the AR overlay on the marks rather than the screen-center anchor. [pointsCam] are in
+     * the capture's CV camera frame (flat [x,y,z,...]): invert the CV world→camera view to get their
+     * mean in world space, then invert [anchorModel] (the anchor's world pose) to express it in the
+     * anchor's frame — which survives a reload into a new ARCore session. Returns null if there are
+     * no points or either matrix isn't invertible.
      */
-    private fun marksCentroidWorld(pointsCam: FloatArray, cvView: FloatArray): FloatArray? {
+    private fun marksCentroidLocal(pointsCam: FloatArray, cvView: FloatArray, anchorModel: FloatArray): FloatArray? {
         val n = pointsCam.size / 3
         if (n == 0) return null
         var sx = 0f; var sy = 0f; var sz = 0f
         for (i in 0 until n) { sx += pointsCam[i * 3]; sy += pointsCam[i * 3 + 1]; sz += pointsCam[i * 3 + 2] }
         val cam = floatArrayOf(sx / n, sy / n, sz / n, 1f)
-        val inv = FloatArray(16)
-        if (!Matrix.invertM(inv, 0, cvView, 0)) return null
+        val invView = FloatArray(16)
+        if (!Matrix.invertM(invView, 0, cvView, 0)) return null
         val world = FloatArray(4)
-        Matrix.multiplyMV(world, 0, inv, 0, cam, 0)
-        return floatArrayOf(world[0], world[1], world[2])
+        Matrix.multiplyMV(world, 0, invView, 0, cam, 0)
+        val invAnchor = FloatArray(16)
+        if (!Matrix.invertM(invAnchor, 0, anchorModel, 0)) return null
+        val local = FloatArray(4)
+        Matrix.multiplyMV(local, 0, invAnchor, 0, world, 0)
+        return floatArrayOf(local[0], local[1], local[2])
     }
 
     private fun toGray(bitmap: Bitmap): Mat {

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/MetricFingerprintBuilder.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/MetricFingerprintBuilder.kt
@@ -1,6 +1,7 @@
 package com.hereliesaz.graffitixr.feature.ar.anchor
 
 import android.graphics.Bitmap
+import android.opengl.Matrix
 import com.hereliesaz.graffitixr.common.model.Fingerprint
 import com.hereliesaz.graffitixr.nativebridge.SlamManager
 import org.opencv.android.Utils
@@ -65,6 +66,9 @@ object MetricFingerprintBuilder {
             val cv1 = MetricMarks.glViewToCv(glView1)
             val tri = MetricMarks.triangulate(matched.corrs, cv0, cv1, intr0[0], intr0[1], intr0[2], intr0[3])
             if (tri.count < minPoints) return null
+
+            // Center the AR overlay on the marks (their world centroid), not the screen-center anchor.
+            slam.overlayMarkCenterWorld = marksCentroidWorld(tri.pointsCam0, cv0)
 
             // Keep the rows of frame-0's descriptors (and the frame-0 keypoints) whose match survived.
             val keptDesc = Mat(tri.count, matched.descriptors.cols(), matched.descriptors.type())
@@ -198,6 +202,9 @@ object MetricFingerprintBuilder {
         )
         if (res.count < minPoints) return null
 
+        // Center the AR overlay on the marks (their world centroid), not the screen-center anchor.
+        slam.overlayMarkCenterWorld = marksCentroidWorld(res.pointsCam, cvView)
+
         val keptDesc = Mat(res.count, descAll.cols(), descAll.type())
         val keypoints = ArrayList<KeyPoint>(res.count)
         for ((dst, src) in res.kept.withIndex()) {
@@ -263,6 +270,25 @@ object MetricFingerprintBuilder {
         val descs = Mat(n, d, org.opencv.core.CvType.CV_32F)
         descs.put(0, 0, raw.copyOfRange(2 + 2 * n, 2 + 2 * n + n * d))
         return Pair(pos, descs)
+    }
+
+    /**
+     * World-space (ARCore/GL frame) centroid of the kept 3D marks, used to center the AR overlay on
+     * the marks rather than the screen-center anchor. [pointsCam] are in the capture's CV camera
+     * frame (flat [x,y,z,...]); inverting the CV world→camera view brings their mean into world
+     * space. Returns null if there are no points or the view isn't invertible.
+     */
+    private fun marksCentroidWorld(pointsCam: FloatArray, cvView: FloatArray): FloatArray? {
+        val n = pointsCam.size / 3
+        if (n == 0) return null
+        var sx = 0f; var sy = 0f; var sz = 0f
+        for (i in 0 until n) { sx += pointsCam[i * 3]; sy += pointsCam[i * 3 + 1]; sz += pointsCam[i * 3 + 2] }
+        val cam = floatArrayOf(sx / n, sy / n, sz / n, 1f)
+        val inv = FloatArray(16)
+        if (!Matrix.invertM(inv, 0, cvView, 0)) return null
+        val world = FloatArray(4)
+        Matrix.multiplyMV(world, 0, inv, 0, cam, 0)
+        return floatArrayOf(world[0], world[1], world[2])
     }
 
     private fun toGray(bitmap: Bitmap): Mat {

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -1390,9 +1390,12 @@ class ArRenderer(
             // Compute the in-plane (overlay-local) offset from the anchor to the marks ONCE per target
             // and then ride the (drift-tracked) anchor with that fixed offset applied.
             val markCenter = slamManager.overlayMarkCenterWorld
-            if (markCenter == null || markCenter.size < 3) {
+            // Also reset when the anchor is lost: a re-establish (e.g. plane realignment) lands at a
+            // new pose, so the offset must be recomputed against it. Without clearing appliedMarkCenter
+            // here, the unchanged markCenter would skip recomputation and leave the overlay misaligned.
+            if (markCenter == null || markCenter.size < 3 || !anchorEstablished) {
                 appliedMarkCenter = null; markOffsetX = 0f; markOffsetY = 0f
-            } else if (markCenter !== appliedMarkCenter && anchorEstablished) {
+            } else if (markCenter !== appliedMarkCenter) {
                 val dx = markCenter[0] - overlayBaseScratch[12]
                 val dy = markCenter[1] - overlayBaseScratch[13]
                 val dz = markCenter[2] - overlayBaseScratch[14]

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -322,10 +322,10 @@ class ArRenderer(
     // Meters-per-pixel at the overlay's depth this frame, so the UI can convert a screen-pixel drag
     // into an in-plane translation in meters. 0 until the overlay has been positioned.
     @Volatile var currentMetersPerPixel: Float = 0f
-    // Frozen in-plane offset (overlay-local meters) that shifts the overlay center from the tracked
-    // anchor onto the matched-marks centroid (SlamManager.overlayMarkCenterWorld). Computed once per
-    // target so the overlay still rides the drift-tracked anchor instead of pinning to a fixed point.
-    private var appliedMarkCenter: FloatArray? = null
+    // In-plane offset (overlay-local meters) that shifts the overlay center from the tracked anchor
+    // onto the matched-marks centroid. Recomputed each frame from SlamManager.overlayMarkCenterLocal
+    // (the marks centroid in the fingerprint anchor's frame) against the live anchor, so it tracks
+    // drift and survives anchor re-establishment and project reload.
     private var markOffsetX: Float = 0f
     private var markOffsetY: Float = 0f
     // Scratch for composing the overlay matrix (anchor frame * in-plane transform).
@@ -1387,22 +1387,23 @@ class ArRenderer(
             }
 
             // Center the overlay on the matched-marks centroid instead of the screen-center anchor.
-            // Compute the in-plane (overlay-local) offset from the anchor to the marks ONCE per target
-            // and then ride the (drift-tracked) anchor with that fixed offset applied.
-            val markCenter = slamManager.overlayMarkCenterWorld
-            // Also reset when the anchor is lost: a re-establish (e.g. plane realignment) lands at a
-            // new pose, so the offset must be recomputed against it. Without clearing appliedMarkCenter
-            // here, the unchanged markCenter would skip recomputation and leave the overlay misaligned.
-            if (markCenter == null || markCenter.size < 3 || !anchorEstablished) {
-                appliedMarkCenter = null; markOffsetX = 0f; markOffsetY = 0f
-            } else if (markCenter !== appliedMarkCenter) {
-                val dx = markCenter[0] - overlayBaseScratch[12]
-                val dy = markCenter[1] - overlayBaseScratch[13]
-                val dz = markCenter[2] - overlayBaseScratch[14]
+            // overlayMarkCenterLocal is the centroid in the fingerprint anchor's frame; reconstruct
+            // its world position from the live (drift-tracked, reloc-fused) anchor, then project the
+            // delta from the anchor onto the overlay-local in-plane axes. Recomputed every frame, so
+            // it follows drift and recovers automatically after anchor re-establishment / reload.
+            val markLocal = slamManager.overlayMarkCenterLocal
+            if (markLocal == null || markLocal.size < 3 || !anchorEstablished) {
+                markOffsetX = 0f; markOffsetY = 0f
+            } else {
+                val cwX = anchorMatrix[0] * markLocal[0] + anchorMatrix[4] * markLocal[1] + anchorMatrix[8] * markLocal[2] + anchorMatrix[12]
+                val cwY = anchorMatrix[1] * markLocal[0] + anchorMatrix[5] * markLocal[1] + anchorMatrix[9] * markLocal[2] + anchorMatrix[13]
+                val cwZ = anchorMatrix[2] * markLocal[0] + anchorMatrix[6] * markLocal[1] + anchorMatrix[10] * markLocal[2] + anchorMatrix[14]
+                val dx = cwX - overlayBaseScratch[12]
+                val dy = cwY - overlayBaseScratch[13]
+                val dz = cwZ - overlayBaseScratch[14]
                 // Project the world delta onto the overlay-local in-plane axes (columns 0 and 1).
                 markOffsetX = overlayBaseScratch[0] * dx + overlayBaseScratch[1] * dy + overlayBaseScratch[2] * dz
                 markOffsetY = overlayBaseScratch[4] * dx + overlayBaseScratch[5] * dy + overlayBaseScratch[6] * dz
-                appliedMarkCenter = markCenter
             }
 
             // Meters-per-pixel at the overlay depth, so the UI can convert a screen drag (px) into an

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -209,8 +209,6 @@ class ArRenderer(
     @Volatile var driftCostProbe: com.hereliesaz.graffitixr.feature.ar.eval.DriftCostProbe? = null
     // Scratch holder for the mark-PnP "truth" pose read from the native anchor transform.
     private val truthPoseScratch = FloatArray(16)
-    // Scratch for the lay-flat overlay anchor (anchorMatrix rotated so the quad lies on the wall).
-    private val flatAnchorScratch = FloatArray(16)
     // Visible-confidence threshold above which mark-PnP is treated as truth for eval.
     private val markVisibleConf = 0.5f
 
@@ -312,6 +310,28 @@ class ArRenderer(
     // Pre-allocated buffers for Surface Mesh updates (32x32 grid)
     private val meshVerticesBuffer = FloatArray(32 * 32 * 3)
     private val meshWeightsBuffer = FloatArray(32 * 32)
+
+    // --- Whole-design AR overlay transform (the "Layer" item in AR) ---
+    // In-plane translation (meters along the overlay's local X/Y), uniform scale, and rotation about
+    // the wall normal, applied to the artwork overlay ON TOP of the tracked anchor. Driven by the
+    // persisted per-mode adjustment (modeAdjustments[AR]); pushed from MainScreen.
+    @Volatile var overlayPanX: Float = 0f
+    @Volatile var overlayPanY: Float = 0f
+    @Volatile var overlayScale: Float = 1f
+    @Volatile var overlayRotationDeg: Float = 0f
+    // Meters-per-pixel at the overlay's depth this frame, so the UI can convert a screen-pixel drag
+    // into an in-plane translation in meters. 0 until the overlay has been positioned.
+    @Volatile var currentMetersPerPixel: Float = 0f
+    // Frozen in-plane offset (overlay-local meters) that shifts the overlay center from the tracked
+    // anchor onto the matched-marks centroid (SlamManager.overlayMarkCenterWorld). Computed once per
+    // target so the overlay still rides the drift-tracked anchor instead of pinning to a fixed point.
+    private var appliedMarkCenter: FloatArray? = null
+    private var markOffsetX: Float = 0f
+    private var markOffsetY: Float = 0f
+    // Scratch for composing the overlay matrix (anchor frame * in-plane transform).
+    private val overlayBaseScratch = FloatArray(16)
+    private val overlayLocalScratch = FloatArray(16)
+    private val overlayComposedScratch = FloatArray(16)
 
     fun attachSession(session: Session?) {
         sessionLock.withLock {
@@ -1358,15 +1378,51 @@ class ArRenderer(
             val hasMeshData = false
 
             lastStep = "overlayDraw"
-            // Lay the artwork FLAT on the wall: the quad's surface normal is its local +Z, but a
-            // plane anchor's +Y is the wall normal, so rotate the anchor frame -90° about X before
-            // drawing. Only when the anchor sits on a real plane; a free/fallback anchor draws as-is.
-            val overlayAnchorMatrix = if (anchorOnWallPlane) {
-                System.arraycopy(anchorMatrix, 0, flatAnchorScratch, 0, 16)
-                android.opengl.Matrix.rotateM(flatAnchorScratch, 0, -90f, 1f, 0f, 0f)
-                flatAnchorScratch
-            } else anchorMatrix
-            overlayRenderer.draw(viewMatrix, projMatrix, overlayAnchorMatrix,
+            // Base overlay frame = the tracked anchor. Lay the artwork FLAT on the wall: the quad's
+            // surface normal is its local +Z, but a plane anchor's +Y is the wall normal, so rotate
+            // the anchor frame -90° about X. Only on a real plane; a free/fallback anchor draws as-is.
+            System.arraycopy(anchorMatrix, 0, overlayBaseScratch, 0, 16)
+            if (anchorOnWallPlane) {
+                android.opengl.Matrix.rotateM(overlayBaseScratch, 0, -90f, 1f, 0f, 0f)
+            }
+
+            // Center the overlay on the matched-marks centroid instead of the screen-center anchor.
+            // Compute the in-plane (overlay-local) offset from the anchor to the marks ONCE per target
+            // and then ride the (drift-tracked) anchor with that fixed offset applied.
+            val markCenter = slamManager.overlayMarkCenterWorld
+            if (markCenter == null || markCenter.size < 3) {
+                appliedMarkCenter = null; markOffsetX = 0f; markOffsetY = 0f
+            } else if (markCenter !== appliedMarkCenter && anchorEstablished) {
+                val dx = markCenter[0] - overlayBaseScratch[12]
+                val dy = markCenter[1] - overlayBaseScratch[13]
+                val dz = markCenter[2] - overlayBaseScratch[14]
+                // Project the world delta onto the overlay-local in-plane axes (columns 0 and 1).
+                markOffsetX = overlayBaseScratch[0] * dx + overlayBaseScratch[1] * dy + overlayBaseScratch[2] * dz
+                markOffsetY = overlayBaseScratch[4] * dx + overlayBaseScratch[5] * dy + overlayBaseScratch[6] * dz
+                appliedMarkCenter = markCenter
+            }
+
+            // Meters-per-pixel at the overlay depth, so the UI can convert a screen drag (px) into an
+            // in-plane translation (m). projMatrix[5] = cot(fovY/2), so tan(fovY/2) = 1/projMatrix[5].
+            val ovz = viewMatrix[2] * overlayBaseScratch[12] + viewMatrix[6] * overlayBaseScratch[13] +
+                viewMatrix[10] * overlayBaseScratch[14] + viewMatrix[14]
+            val tanHalfFovY = if (projMatrix[5] != 0f) 1f / projMatrix[5] else 0f
+            currentMetersPerPixel =
+                if (surfaceHeight > 0) kotlin.math.abs(ovz) * 2f * tanHalfFovY / surfaceHeight else 0f
+
+            // User whole-design transform (AR "Layer" item) + marks-centering offset, in the overlay's
+            // local (in-plane) frame: translate along the plane, rotate about the normal, scale.
+            android.opengl.Matrix.setIdentityM(overlayLocalScratch, 0)
+            android.opengl.Matrix.translateM(
+                overlayLocalScratch, 0, markOffsetX + overlayPanX, markOffsetY + overlayPanY, 0f
+            )
+            android.opengl.Matrix.rotateM(overlayLocalScratch, 0, overlayRotationDeg, 0f, 0f, 1f)
+            android.opengl.Matrix.scaleM(overlayLocalScratch, 0, overlayScale, overlayScale, 1f)
+            android.opengl.Matrix.multiplyMM(
+                overlayComposedScratch, 0, overlayBaseScratch, 0, overlayLocalScratch, 0
+            )
+
+            overlayRenderer.draw(viewMatrix, projMatrix, overlayComposedScratch,
                 if (hasMeshData) meshVerticesBuffer else null,
                 if (hasMeshData) meshWeightsBuffer else null
             )

--- a/version.properties
+++ b/version.properties
@@ -2,5 +2,5 @@
 #Wed Jun 17 02:23:18 CDT 2026
 versionBuild=151
 versionMajor=1
-versionMinor=33
+versionMinor=34
 versionPatch=0


### PR DESCRIPTION
## What & why

Two related AR-placement issues:

1. **Move the whole design as one in AR.** Selecting the **Layer** item in AR should let the user make minor edits to all design layers together — in particular slide them along the wall plane (plus scale and rotate), and have the placement persist with the project.
2. **Wrong center.** The overlay was centered on a hit-test at **screen center (0.5, 0.5)** — the user's "center of the photo of the target" — instead of the **centroid of the matched green marks**.

## Feature 1 — AR "Layer" item moves/scales/rotates the whole design along the plane

The rail item (`mode.ar.layer` → `onModeLayerSelected(AR)` → `editingModeLayer`), the gesture routing to `onModeTransformGesture(AR, …)`, the per-mode adjustment accumulation, and persistence (`GraffitiProject.modeAdjustments`) **already existed** — but the AR overlay never consumed `modeAdjustments[AR]` (they're only applied for non-AR modes).

- `ArRenderer` now applies `modeAdjustments[AR]` as an **in-plane transform** of the overlay on top of the tracked anchor: translate along the plane tangent (anchor local X/Y), rotate about the wall normal, uniform scale.
- Screen-pixel drags are converted to **in-plane meters** at the gesture site using a per-frame `currentMetersPerPixel` exposed by the renderer, so the stored offset is in world meters and persists coherently.
- `MainScreen` pushes `modeAdjustments[AR]` → renderer and relaxes the gesture gate so whole-design editing isn't blocked by the *active layer's* image lock (the mode keeps its own Lock via `isTransformLocked`).

## Feature 2 — center the overlay on the matched-marks centroid

- `MetricFingerprintBuilder` computes the **world-space centroid** of the kept 3D marks (mean of `pointsCam` brought to world via the inverse capture view) and publishes it through `SlamManager.overlayMarkCenterWorld` (a shared, thread-safe channel).
- `ArRenderer` shifts the overlay onto that centroid via an **in-plane offset computed once per target**, so it still rides the drift-tracked anchor instead of pinning to a fixed world point.
- Native relocalization geometry (`points3d` / `anchorModel` passed to `restoreWallFingerprintMetric`) is **untouched** — only the rendered overlay center moves.

## Files
- `core/nativebridge/.../SlamManager.kt` — shared `overlayMarkCenterWorld` channel
- `feature/ar/.../anchor/MetricFingerprintBuilder.kt` — compute & publish marks centroid (both single-capture and triangulation paths)
- `feature/ar/.../rendering/ArRenderer.kt` — in-plane overlay transform + marks-centering + meters-per-pixel
- `feature/ar/.../ArViewModel.kt`, `app/.../MainViewModel.kt` — clear the center on AR exit / new capture
- `app/.../MainScreen.kt` — push `modeAdjustments[AR]` to the renderer; convert AR pan px→m; relax the lock gate

## Verification
- This environment has no Android SDK, so CI compiles the build. The geometry touches GL/AR integration that isn't unit-testable here; pure-math anchor files (`PlaneMarks`/`MetricMarks`) were intentionally left Android-free.
- **Manual (device):** create a target on a textured wall → design centers on the green marks (not screen center); **Modes ▸ AR ▸ Layer** → drag slides the design along the wall, pinch scales, twist rotates; mode **Lock** freezes it, **Reset** snaps back to the marks center; save/reopen restores the placement. Confirm non-Layer AR still transforms the active layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017yfb8vFDvprj6wgkQTmmTm)_

## Summary by Sourcery

Enable whole-design AR layer transforms and center AR overlays on fingerprint marks instead of screen center.

New Features:
- Allow the AR "Layer" item to move, scale, and rotate the entire design overlay along the detected wall plane, with adjustments persisted per mode in world units.
- Center the AR artwork overlay on the centroid of matched 3D fingerprint marks rather than the screen-center anchor.

Bug Fixes:
- Reset AR mark-centering state on AR exit and before new target builds to avoid reusing stale centroids.

Enhancements:
- Expose meters-per-pixel from the AR renderer so UI gestures in AR can be converted from screen pixels to in-plane meters.
- Relax transform gesture locking so whole-design AR editing is not blocked by the active layer's image lock.
- Compute and share the marks centroid in world space via SlamManager for reuse across AR components.