### PR TITLE
Auto-increment AAB versionName patch in CI release build

### DIFF
--- a/.github/workflows/release-aab.yml
+++ b/.github/workflows/release-aab.yml
@@ -113,7 +113,18 @@ jobs:
           # upload is always accepted, while still increasing by 1 per commit.
           VERSION_CODE=$(( $(git rev-list --count HEAD) + 10000 ))
           echo "version_code=$VERSION_CODE" >> "$GITHUB_OUTPUT"
-          echo "Package: $PKG  versionCode: $VERSION_CODE"
+
+          # versionName patch = commits since the last minor bump, so the human-readable version
+          # advances per commit and resets to 0 each time versionMinor is bumped in version.properties.
+          # Mirrors release-apk.yml; falls back to the file's versionPatch if blame can't resolve it.
+          MINOR_COMMIT=$(git blame -L '/versionMinor=/',+1 version.properties | awk '{print $1}' | tr -d '^')
+          if [ -n "$MINOR_COMMIT" ]; then
+            VERSION_PATCH=$(git rev-list --count "$MINOR_COMMIT"..HEAD)
+          else
+            VERSION_PATCH=$(grep 'versionPatch=' version.properties | cut -d'=' -f2 | tr -d '\r ')
+          fi
+          echo "version_patch=$VERSION_PATCH" >> "$GITHUB_OUTPUT"
+          echo "Package: $PKG  versionCode: $VERSION_CODE  versionPatch: $VERSION_PATCH"
 
       - name: Build Release AAB (signed)
         env:
@@ -125,7 +136,7 @@ jobs:
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
         run: |
-          ./gradlew bundleRelease -PversionBuild=${{ steps.meta.outputs.version_code }}
+          ./gradlew bundleRelease -PversionBuild=${{ steps.meta.outputs.version_code }} -PversionPatch=${{ steps.meta.outputs.version_patch }}
 
       - name: Upload AAB artifact
         uses: actions/upload-artifact@v7

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,6 +38,10 @@ val localProperties = Properties().apply {
 // git commit count — see release-aab.yml); when present we do NOT auto-increment or rewrite the file,
 // so the ephemeral CI checkout stays clean and Play receives exactly <n>.
 val versionBuildOverride = project.findProperty("versionBuild")?.toString()?.toIntOrNull()
+// Likewise `-PversionPatch=<n>` sets the versionName patch segment (CI passes the commit count since
+// the last minor bump — see release-aab.yml) so the human-readable version advances per commit
+// without rewriting the file. When EITHER override is present the file is left untouched.
+val versionPatchOverride = project.findProperty("versionPatch")?.toString()?.toIntOrNull()
 
 // True when the requested tasks actually compile/assemble the app — not a sync, `tasks`, `clean`,
 // a `--dry-run`, or a diagnostic like `buildEnvironment`/`buildHealth`. Build verbs are matched as a
@@ -58,9 +62,9 @@ val lastMinor = versionProps.getProperty("versionMinorLast", verMinor)
 val isMinorBumped = verMinor != lastMinor
 
 var currentVersionCode = versionBuildOverride ?: versionProps.getProperty("versionBuild", "1").toInt()
-var currentPatch = if (isMinorBumped) 0 else versionProps.getProperty("versionPatch", "0").toInt()
+var currentPatch = versionPatchOverride ?: if (isMinorBumped) 0 else versionProps.getProperty("versionPatch", "0").toInt()
 
-if (versionBuildOverride == null && isBuilding) {
+if (versionBuildOverride == null && versionPatchOverride == null && isBuilding) {
     currentVersionCode++ // build never resets
     // A minor bump makes this build the new minor's .0; otherwise advance the patch.
     if (!isMinorBumped) currentPatch++


### PR DESCRIPTION
## Problem

Running the **Build & Publish AAB (Play)** workflow (`release-aab.yml`) didn't bump the app version:

- It invoked `./gradlew bundleRelease -PversionBuild=<commit count + 10000>`. The `-PversionBuild` override makes `app/build.gradle.kts` **skip the patch increment and file rewrite**, so the AAB's `versionName` was frozen at `<major>.<minor>.0` until `version.properties` was hand-edited.
- `build.gradle.kts` had **no way to override the patch**, and the AAB workflow never computed one — unlike `release-apk.yml`, which already derives the patch from `git rev-list --count <last-minor-bump>..HEAD`.

(`versionCode` itself does increment, but only per commit — re-running the workflow on the same commit yields the same code.)

## Fix

- **`app/build.gradle.kts`**: add a `-PversionPatch=<n>` override (parallel to `-PversionBuild`). When **either** override is present the file is left untouched, keeping the ephemeral CI checkout clean.
- **`release-aab.yml`**: compute the patch as commits since the last `versionMinor` bump (mirroring `release-apk.yml`, with a fallback to the file's `versionPatch`) and pass `-PversionPatch`.

Result: an AAB build's `versionName` now advances per commit and resets to `0` on each minor bump, and `versionCode` keeps incrementing per commit — all with no manual edits beyond bumping `versionMinor`.

## Notes
- Requires full git history; the AAB workflow already checks out with `fetch-depth: 0`.
- No `version.properties` changes (and local `bundleRelease` still auto-increments via the file as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017yfb8vFDvprj6wgkQTmmTm)_