### PR TITLE
ci: trust workspace in Gemini CLI workflows so they stop failing

### DIFF
--- a/.github/workflows/gemini-invoke.yml
+++ b/.github/workflows/gemini-invoke.yml
@@ -48,6 +48,9 @@ jobs:
         id: 'run_gemini'
         uses: 'google-github-actions/run-gemini-cli@v0' # ratchet:exclude
         env:
+          # Trust the CI checkout so the headless CLI doesn't refuse to run with
+          # "not running in a trusted directory" (it can't prompt in automation).
+          GEMINI_CLI_TRUST_WORKSPACE: 'true'
           TITLE: '${{ github.event.pull_request.title || github.event.issue.title }}'
           DESCRIPTION: '${{ github.event.pull_request.body || github.event.issue.body }}'
           EVENT_NAME: '${{ github.event_name }}'

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -49,6 +49,9 @@ jobs:
         uses: 'google-github-actions/run-gemini-cli@v0' # ratchet:exclude
         id: 'gemini_pr_review'
         env:
+          # Trust the CI checkout so the headless CLI doesn't refuse to run with
+          # "not running in a trusted directory" (it can't prompt in automation).
+          GEMINI_CLI_TRUST_WORKSPACE: 'true'
           GH_TOKEN: '${{ steps.mint_identity_token.outputs.token || secrets.GH_TOKEN || github.token }}'
           ISSUE_TITLE: '${{ github.event.pull_request.title || github.event.issue.title }}'
           ISSUE_BODY: '${{ github.event.pull_request.body || github.event.issue.body }}'

--- a/.github/workflows/gemini-scheduled-triage.yml
+++ b/.github/workflows/gemini-scheduled-triage.yml
@@ -95,6 +95,9 @@ jobs:
           ${{ steps.find_issues.outputs.issues_to_triage != '[]' }}
         uses: 'google-github-actions/run-gemini-cli@v0' # ratchet:exclude
         env:
+          # Trust the CI checkout so the headless CLI doesn't refuse to run with
+          # "not running in a trusted directory" (it can't prompt in automation).
+          GEMINI_CLI_TRUST_WORKSPACE: 'true'
           GH_TOKEN: '' # Do not pass any auth token here since this runs on untrusted inputs
           ISSUES_TO_TRIAGE: '${{ steps.find_issues.outputs.issues_to_triage }}'
           REPOSITORY: '${{ github.repository }}'

--- a/.github/workflows/gemini-triage.yml
+++ b/.github/workflows/gemini-triage.yml
@@ -65,6 +65,9 @@ jobs:
           ${{ steps.get_labels.outputs.available_labels != '' }}
         uses: 'google-github-actions/run-gemini-cli@v0' # ratchet:exclude
         env:
+          # Trust the CI checkout so the headless CLI doesn't refuse to run with
+          # "not running in a trusted directory" (it can't prompt in automation).
+          GEMINI_CLI_TRUST_WORKSPACE: 'true'
           GH_TOKEN: '' # Do NOT pass any auth tokens here since this runs on untrusted inputs
           ISSUE_TITLE: '${{ github.event.issue.title }}'
           ISSUE_BODY: '${{ github.event.issue.body }}'


### PR DESCRIPTION
## Problem

The Gemini Actions jobs (e.g. `review / review`) have been failing on every PR with:

```
Gemini CLI is not running in a trusted directory. To proceed, either use `--skip-trust`,
set the GEMINI_CLI_TRUST_WORKSPACE=true environment variable, or trust this directory...
```

The headless CLI can't prompt to trust the checkout in CI, so it exits 1 — surfacing as a red check and a "🤖 I'm sorry … unable to process your request" comment on each PR.

## Fix

Set `GEMINI_CLI_TRUST_WORKSPACE: 'true'` on the `run-gemini-cli` step in all four Gemini workflows so they run instead of red-flagging every PR:

- `gemini-review.yml`
- `gemini-invoke.yml`
- `gemini-triage.yml`
- `gemini-scheduled-triage.yml`

## Notes
- The untrusted-input triage steps still pass `GH_TOKEN: ''` (no auth tokens) — this change only opts the workspace into the CLI's trust check; it doesn't grant any new permissions.
- Workflow-only change; no app code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017yfb8vFDvprj6wgkQTmmTm)_