### PR TITLE
AR: raise FPS/cadence caps now that the app is trimmed down

### DIFF
--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/UiState.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/UiState.kt
@@ -110,7 +110,7 @@ data class ArUiState(
     val cameraTargetFps: Int = 60,
     /**
      * Perception-throttle triggers. When enabled and active, each drops the world-locked perception
-     * redraw rate from 30 to 15 fps to save power; camera + overlay + gestures stay full-rate.
+     * redraw rate from 60 to 30 fps to save power; camera + overlay + gestures stay full-rate.
      */
     val throttleOnThermal: Boolean = true,
     val throttleOnPowerSave: Boolean = true,
@@ -125,7 +125,7 @@ data class ArUiState(
      */
     val adaptiveRateEnabled: Boolean = true,
     /** Heavy-work cadence (fps) while idle. Tightened under battery/thermal pressure. */
-    val idleRateCeilingFps: Int = 12,
+    val idleRateCeilingFps: Int = 30,
     /** Heavy-work cadence cap (fps) while active; 0 = uncapped. Set >0 only under battery pressure. */
     val activeRateCeilingFps: Int = 0,
     /** Battery pressure tier: 0 = normal, 1 = medium (≤30%), 2 = low (≤15%). Drives degradation. */

--- a/core/domain/src/main/java/com/hereliesaz/graffitixr/domain/repository/SettingsRepository.kt
+++ b/core/domain/src/main/java/com/hereliesaz/graffitixr/domain/repository/SettingsRepository.kt
@@ -83,7 +83,7 @@ interface SettingsRepository {
     val cameraTargetFps: Flow<Int>
     suspend fun setCameraTargetFps(fps: Int)
 
-    /** Perception-throttle triggers: each, when on, drops perception to 15fps while active. Default on. */
+    /** Perception-throttle triggers: each, when on, drops perception to 30fps while active. Default on. */
     val throttleOnThermal: Flow<Boolean>
     suspend fun setThrottleOnThermal(on: Boolean)
     val throttleOnPowerSave: Flow<Boolean>

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -1879,7 +1879,7 @@ class ArViewModel @Inject constructor(
 
     // --- Adaptive perception throttle: device-stress signals -----------------------------------
     // Thermal pressure, power-save mode, and low battery each float perceptionSystemThrottle, which
-    // MainScreen pushes to the renderer to floor perception redraws at 15 fps. The renderer also
+    // MainScreen pushes to the renderer to floor perception redraws at 30 fps. The renderer also
     // self-throttles on measured frame lag; this covers the system-level signals it can't see.
     private val powerManager by lazy {
         appContext.getSystemService(Context.POWER_SERVICE) as? android.os.PowerManager
@@ -1898,10 +1898,10 @@ class ArViewModel @Inject constructor(
     private val BATTERY_TIER_LOW = 15
 
     /**
-     * Folds device-stress signals into the AR rate policy. The existing perception floor (15fps via
+     * Folds device-stress signals into the AR rate policy. The existing perception floor (30fps via
      * perceptionSystemThrottle) is the "super battery saver" and is left exactly as-is — thermal,
      * OS power-save mode, and the coarse low-battery warning. The battery *level* tiers added here do
-     * NOT touch that floor: a merely low level keeps perception at the full 30fps and only tightens
+     * NOT touch that floor: a merely low level keeps perception at the full 60fps and only tightens
      * the adaptive idle/active rate ceilings (and caps the camera to 30fps on the next AR entry).
      */
     private fun recomputeSystemThrottle() {
@@ -1915,13 +1915,16 @@ class ArViewModel @Inject constructor(
                 batteryPct <= BATTERY_TIER_MED -> 1
                 else -> 0
             }
-            // Unchanged super-saver floor (15fps). The battery-level tier is intentionally NOT a
+            // Super-saver perception floor (30fps). The battery-level tier is intentionally NOT a
             // trigger here — it only drives the rate ceilings below.
             val throttle = (s.throttleOnThermal && thermalHot) ||
                 (s.throttleOnPowerSave && saver) ||
                 (s.throttleOnLowBattery && batteryLow)
-            val idleCeiling = when (tier) { 2 -> 8; 1 -> 10; else -> 12 }
-            val activeCeiling = when (tier) { 2 -> 24; 1 -> 30; else -> 0 }
+            // Heavy-work cadence ceilings. Raised now that the app is trimmed down: normal use (tier 0)
+            // runs the idle gate at 30fps and active uncapped; the battery tiers still throttle, just
+            // less aggressively than before (idle was 12/10/8, active 0/30/24).
+            val idleCeiling = when (tier) { 2 -> 15; 1 -> 20; else -> 30 }
+            val activeCeiling = when (tier) { 2 -> 30; 1 -> 45; else -> 0 }
             s.copy(
                 perceptionSystemThrottle = throttle,
                 batteryTier = tier,

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -1447,7 +1447,7 @@ class ArRenderer(
             lastStep = "debugView"
             // Throttled perception: refresh the world-locked layers (coverage, scan grids, feature
             // points, plane grids, point cloud, voxel splats, mesh) into the FBO only when the pose
-            // moved or the map grew, capped at the selected rate (floored to 15 fps under thermal /
+            // moved or the map grew, capped at the selected rate (floored to 30 fps under thermal /
             // battery / lag), then composite every frame. Camera + overlay + gestures stay full-rate.
             // FBO-unavailable fallback: draw straight to the screen every frame so perception is never
             // blank. Relocating coverage + scan grids here moves them from under the artwork overlay to
@@ -1646,8 +1646,8 @@ class ArRenderer(
     }
 
     private companion object {
-        const val PERCEPTION_FULL_FPS = 30
-        const val PERCEPTION_FLOOR_FPS = 15
+        const val PERCEPTION_FULL_FPS = 60
+        const val PERCEPTION_FLOOR_FPS = 30
         // Rolling-average perception-refresh cost (ms) above which the lag trigger floors the rate.
         const val PERCEPTION_LAG_MS = 16f
         // Per-element view-matrix delta below which the pose is treated as unchanged (skip redraw).

--- a/feature/dashboard/src/main/java/com/hereliesaz/graffitixr/feature/dashboard/SettingsScreen.kt
+++ b/feature/dashboard/src/main/java/com/hereliesaz/graffitixr/feature/dashboard/SettingsScreen.kt
@@ -286,7 +286,7 @@ fun SettingsScreen(
                                     onCameraTargetFpsChanged(if (cameraTargetFps == 30) 60 else 30)
                                 }
                             )
-                            // Perception throttle triggers: each drops perception 30→15 fps to save
+                            // Perception throttle triggers: each drops perception 60→30 fps to save
                             // power while active. Default on. Lower = laggier perception but less drain.
                             SettingsItem(
                                 label = "Throttle: heat",

--- a/version.properties
+++ b/version.properties
@@ -2,5 +2,5 @@
 #Wed Jun 17 02:23:18 CDT 2026
 versionBuild=151
 versionMajor=1
-versionMinor=34
+versionMinor=35
 versionPatch=0


### PR DESCRIPTION
## Why

We capped FPS/cadence a while back to save battery. The app has since been trimmed down, so the everyday caps are no longer needed at their old aggressive values. Per the chosen approach, the adaptive-rate system and the battery/thermal safety throttles are **kept**, and the numbers are **raised** (idle gating kept, at a higher ceiling).

## Changes

**Raised everyday caps:**
- **Idle SLAM/heavy-work ceiling** (normal tier): `12 → 30` fps — `ArViewModel.recomputeSystemThrottle()` and the `UiState.idleRateCeilingFps` default.
- **Perception redraw**: full `30 → 60` fps, throttle floor `15 → 30` fps — `ArRenderer` `PERCEPTION_FULL_FPS` / `PERCEPTION_FLOOR_FPS`.

**Battery-tier ceilings raised but still protective** (`recomputeSystemThrottle`):
- idle: tier1 `10 → 20`, tier2 `8 → 15`
- active: tier1 `30 → 45`, tier2 `24 → 30` (tier 0 stays uncapped)

**Deliberately unchanged (safety nets, per "keep safety"):**
- Thermal / power-save / low-battery still throttle (now to the raised floors).
- Battery-tier thresholds (30% / 15%) and the camera force-to-30fps under battery pressure.
- Camera target fps default (60; user 30/60 toggle) and the internal SLAM frame-feed cadence.

Doc comments across `UiState`, `SettingsRepository`, `SettingsScreen`, `ArViewModel`, and `ArRenderer` updated to the new numbers. Minor version bumped to `1.35`.

## Verification
- `./gradlew :feature:ar:testDebugUnitTest :core:data:testDebugUnitTest` (no tests assert these constants, per exploration).
- **Manual (device):** in AR, confirm perception layers (feature points / plane grids / point cloud) redraw smoothly at up to 60fps; hold the phone still with a locked projection and confirm it still eases down (now ~30fps idle, not 12) and snaps back instantly on motion; under thermal/low-battery, confirm it still throttles to the raised floors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017yfb8vFDvprj6wgkQTmmTm)_