### PR TITLE
Fix: survive ARCore camera-pipe teardown crash (Failed to load metadata for CameraId)

### DIFF
--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/crash/CrashReporter.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/crash/CrashReporter.kt
@@ -33,7 +33,8 @@ class CrashReporter(private val context: Context) : Thread.UncaughtExceptionHand
         // delegating to the default handler simply restores plain-JVM "only that thread dies" semantics.
         if (thread !== Looper.getMainLooper().thread && isRecoverableArCameraCrash(throwable)) {
             try {
-                saveReport(buildReport(throwable))
+                // fatal = false so CrashUploadWorker files it as a recovered event, not a force-close.
+                saveReport(buildReport(throwable, fatal = false))
             } catch (e: Exception) {
                 Log.e("CrashReporter", "Failed to save crash report", e)
             }
@@ -41,7 +42,7 @@ class CrashReporter(private val context: Context) : Thread.UncaughtExceptionHand
             return
         }
         try {
-            val report = buildReport(throwable)
+            val report = buildReport(throwable, fatal = true)
             saveReport(report)
         } catch (e: Exception) {
             Log.e("CrashReporter", "Failed to save crash report", e)
@@ -50,12 +51,16 @@ class CrashReporter(private val context: Context) : Thread.UncaughtExceptionHand
         }
     }
 
-    private fun buildReport(throwable: Throwable): String {
+    private fun buildReport(throwable: Throwable, fatal: Boolean): String {
         val timestamp = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US).format(Date())
         val stackTrace = Log.getStackTraceString(throwable)
         val logcat = collectLogcat()
 
+        // FATAL must be the first line so consumers (CrashUploadWorker) can classify the report
+        // cheaply: true = the process was killed, false = the exception was caught and the app kept
+        // running.
         return """
+            FATAL: $fatal
             TIMESTAMP: $timestamp
             DEVICE: ${android.os.Build.MANUFACTURER} ${android.os.Build.MODEL} (Android ${android.os.Build.VERSION.RELEASE})
             VERSION: ${context.packageManager.getPackageInfo(context.packageName, 0).versionName}
@@ -90,11 +95,11 @@ class CrashReporter(private val context: Context) : Thread.UncaughtExceptionHand
 
     companion object {
         // Substrings that uniquely identify ARCore's camera-pipe "the camera device vanished while we
-        // were still using it" failure. Matched (case-insensitively) against every message in the
-        // throwable's cause + suppressed chain.
+        // were still using it" failure. Stored lowercase so matching only has to lowercase the
+        // message; checked against every message in the throwable's cause + suppressed chain.
         private val CAMERA_PIPE_MESSAGE_SIGNATURES = listOf(
-            "Failed to load metadata for CameraId",
-            "Unable to retrieve camera characteristics",
+            "failed to load metadata for cameraid",
+            "unable to retrieve camera characteristics",
         )
 
         /**
@@ -114,7 +119,7 @@ class CrashReporter(private val context: Context) : Thread.UncaughtExceptionHand
                 val message = t.message
                 if (message != null) {
                     val lower = message.lowercase(Locale.US)
-                    if (CAMERA_PIPE_MESSAGE_SIGNATURES.any { lower.contains(it.lowercase(Locale.US)) }) {
+                    if (CAMERA_PIPE_MESSAGE_SIGNATURES.any { lower.contains(it) }) {
                         matchedMessage = true
                     }
                 }

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/crash/CrashReporter.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/crash/CrashReporter.kt
@@ -1,6 +1,7 @@
 package com.hereliesaz.graffitixr.common.crash
 
 import android.content.Context
+import android.os.Looper
 import android.util.Log
 import java.io.File
 import java.io.FileOutputStream
@@ -20,6 +21,25 @@ class CrashReporter(private val context: Context) : Thread.UncaughtExceptionHand
     }
 
     override fun uncaughtException(thread: Thread, throwable: Throwable) {
+        // ARCore drives its camera through an internal CameraX "camera pipe" (logcat tag CXCP) on its
+        // own worker threads. On some devices (e.g. Samsung SM-A236U) a long run of ERROR_CAMERA_DEVICE
+        // makes the OEM camera HAL drop the device, and ARCore's pipe then throws
+        // "Failed to load metadata for CameraId-N" / "Unable to retrieve camera characteristics"
+        // out of getCameraCharacteristics while the session is already tearing down. This lands on an
+        // ARCore-managed background thread we cannot wrap in try/catch, so it reaches the default
+        // handler and kills the whole app — even though the user has just left AR and nothing in the
+        // foreground is broken. Record it for diagnostics, but let the process keep running instead of
+        // crashing to a full-screen report. The faulting worker thread is already unwinding; not
+        // delegating to the default handler simply restores plain-JVM "only that thread dies" semantics.
+        if (thread !== Looper.getMainLooper().thread && isRecoverableArCameraCrash(throwable)) {
+            try {
+                saveReport(buildReport(throwable))
+            } catch (e: Exception) {
+                Log.e("CrashReporter", "Failed to save crash report", e)
+            }
+            Log.w("CrashReporter", "Swallowed recoverable ARCore camera-pipe crash on ${thread.name}", throwable)
+            return
+        }
         try {
             val report = buildReport(throwable)
             saveReport(report)
@@ -39,10 +59,10 @@ class CrashReporter(private val context: Context) : Thread.UncaughtExceptionHand
             TIMESTAMP: $timestamp
             DEVICE: ${android.os.Build.MANUFACTURER} ${android.os.Build.MODEL} (Android ${android.os.Build.VERSION.RELEASE})
             VERSION: ${context.packageManager.getPackageInfo(context.packageName, 0).versionName}
-            
+
             STACK TRACE:
             $stackTrace
-            
+
             LOGCAT:
             $logcat
         """.trimIndent()
@@ -63,8 +83,55 @@ class CrashReporter(private val context: Context) : Thread.UncaughtExceptionHand
 
     private fun saveReport(report: String) {
         val file = File(context.cacheDir, "last_crash.txt")
-        FileOutputStream(file).use { 
+        FileOutputStream(file).use {
             it.write(report.toByteArray())
+        }
+    }
+
+    companion object {
+        // Substrings that uniquely identify ARCore's camera-pipe "the camera device vanished while we
+        // were still using it" failure. Matched (case-insensitively) against every message in the
+        // throwable's cause + suppressed chain.
+        private val CAMERA_PIPE_MESSAGE_SIGNATURES = listOf(
+            "Failed to load metadata for CameraId",
+            "Unable to retrieve camera characteristics",
+        )
+
+        /**
+         * True if [throwable] (or anything in its cause/suppressed chain) is the known ARCore
+         * camera-pipe teardown crash — a camera-metadata load failure raised from
+         * [android.hardware.camera2.CameraManager.getCameraCharacteristics]. Pure and Android-free so
+         * it can be unit-tested. The caller is responsible for restricting recovery to background
+         * threads.
+         */
+        fun isRecoverableArCameraCrash(throwable: Throwable): Boolean {
+            val seen = java.util.Collections.newSetFromMap(java.util.IdentityHashMap<Throwable, Boolean>())
+            var matchedMessage = false
+            var matchedFrame = false
+
+            fun visit(t: Throwable?) {
+                if (t == null || !seen.add(t)) return
+                val message = t.message
+                if (message != null) {
+                    val lower = message.lowercase(Locale.US)
+                    if (CAMERA_PIPE_MESSAGE_SIGNATURES.any { lower.contains(it.lowercase(Locale.US)) }) {
+                        matchedMessage = true
+                    }
+                }
+                if (t.stackTrace.any {
+                        it.className == "android.hardware.camera2.CameraManager" &&
+                            it.methodName == "getCameraCharacteristics"
+                    }) {
+                    matchedFrame = true
+                }
+                visit(t.cause)
+                t.suppressed?.forEach { visit(it) }
+            }
+
+            visit(throwable)
+            // Require BOTH the camera-metadata message AND the getCameraCharacteristics frame so an
+            // unrelated crash that merely mentions one of these strings is never silently swallowed.
+            return matchedMessage && matchedFrame
         }
     }
 }

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/crash/CrashUploadWorker.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/crash/CrashUploadWorker.kt
@@ -39,9 +39,17 @@ class CrashUploadWorker(private val context: Context) {
                 .build()
 
             val service = retrofit.create(GitHubCrashService::class.java)
+            // The report's first line is "FATAL: true|false" (see CrashReporter.buildReport). A
+            // recovered (non-fatal) report — e.g. a swallowed ARCore camera-pipe teardown crash — must
+            // not masquerade as a force-close in the issue tracker.
+            val recovered = report.lineSequence().firstOrNull()?.trim() == "FATAL: false"
             val issue = GitHubIssue(
-                title = "Auto-Report: App Crash",
-                body = "A force close occurred. Details below:\n\n```\n$report\n```"
+                title = if (recovered) "Auto-Report: Recovered Crash (non-fatal)" else "Auto-Report: App Crash",
+                body = if (recovered) {
+                    "A non-fatal exception was caught and the app kept running. Details below:\n\n```\n$report\n```"
+                } else {
+                    "A force close occurred. Details below:\n\n```\n$report\n```"
+                }
             )
 
             val response = service.createIssue(

--- a/core/common/src/test/java/com/hereliesaz/graffitixr/common/crash/CrashReporterTest.kt
+++ b/core/common/src/test/java/com/hereliesaz/graffitixr/common/crash/CrashReporterTest.kt
@@ -1,0 +1,76 @@
+package com.hereliesaz.graffitixr.common.crash
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CrashReporterTest {
+
+    /** Builds a throwable with a [android.hardware.camera2.CameraManager.getCameraCharacteristics] frame. */
+    private fun withGetCharacteristicsFrame(t: Throwable): Throwable = t.apply {
+        stackTrace = arrayOf(
+            StackTraceElement(
+                "android.hardware.camera2.CameraManager",
+                "getCameraCharacteristics",
+                "CameraManager.java",
+                776,
+            ),
+        )
+    }
+
+    @Test
+    fun `recognises the real ARCore camera-pipe teardown crash`() {
+        // Mirrors SM-A236U crash: ISE "Failed to load metadata" <- IAE getCameraCharacteristics.
+        val cause = withGetCharacteristicsFrame(
+            IllegalArgumentException(
+                "getCameraCharacteristics:1041: Unable to retrieve camera characteristics for " +
+                    "unknown device 0: No such file or directory (-2)",
+            ),
+        )
+        val crash = IllegalStateException("Failed to load metadata for CameraId-0!", cause)
+
+        assertTrue(CrashReporter.isRecoverableArCameraCrash(crash))
+    }
+
+    @Test
+    fun `recognises the signature when carried only by a suppressed throwable`() {
+        val suppressed = withGetCharacteristicsFrame(
+            IllegalStateException("Failed to load metadata for CameraId-1!"),
+        )
+        val crash = RuntimeException("camera pipe shutdown").apply { addSuppressed(suppressed) }
+
+        assertTrue(CrashReporter.isRecoverableArCameraCrash(crash))
+    }
+
+    @Test
+    fun `does not match when only the message signature is present`() {
+        // Same message, but no getCameraCharacteristics frame -> not the pipe teardown, don't swallow.
+        val crash = IllegalStateException("Failed to load metadata for CameraId-0!")
+
+        assertFalse(CrashReporter.isRecoverableArCameraCrash(crash))
+    }
+
+    @Test
+    fun `does not match when only the camera frame is present`() {
+        val crash = withGetCharacteristicsFrame(RuntimeException("some unrelated camera query"))
+
+        assertFalse(CrashReporter.isRecoverableArCameraCrash(crash))
+    }
+
+    @Test
+    fun `does not match an ordinary app crash`() {
+        val crash = NullPointerException("Attempt to invoke method on a null object reference")
+
+        assertFalse(CrashReporter.isRecoverableArCameraCrash(crash))
+    }
+
+    @Test
+    fun `terminates on a self-referential cause chain`() {
+        val a = RuntimeException("a")
+        val b = RuntimeException("b", a)
+        a.initCause(b) // cycle: a -> b -> a
+
+        // Must not loop forever; this chain has no camera signature.
+        assertFalse(CrashReporter.isRecoverableArCameraCrash(a))
+    }
+}


### PR DESCRIPTION
## The crash

```
java.lang.IllegalStateException: Failed to load metadata for CameraId-0!
  ...
Caused by: java.lang.IllegalArgumentException: getCameraCharacteristics:1041:
  Unable to retrieve camera characteristics for unknown device 0: No such file or directory (-2)
  at android.hardware.camera2.CameraManager.getCameraCharacteristics(CameraManager.java:776)
  Suppressed: ... [CoroutineName(CXCP-UseCase-0), ...]
```
Reported on **Samsung SM-A236U (Android 13), v1.35.1.**

## Root cause

The logcat shows the back camera (`CameraId-0`) repeatedly cycling
`OPEN → ACTIVE → RepeatCaptureReq Capture failed / Buffer lost → ERROR_CAMERA_DEVICE → CLOSE → reopen`
for ~30s, never delivering a usable frame (`Last visual features at: 0 ns`). On this
device's camera HAL that thrash eventually makes the service drop camera 0 entirely
(`STATUS_NOT_AVAILABLE`, then `getCameraCharacteristics … No such file or directory`).

ARCore drives its camera through an internal CameraX **camera pipe** (logcat tag `CXCP`)
on **its own worker threads**. When the device vanishes, that pipe throws
`Failed to load metadata for CameraId-0` out of `getCameraCharacteristics` — and it fires
right as the AR session is tearing down (the crash timestamp matches `Session::Pause` /
`Deleting ArSession`). Because it's raised on an **ARCore-managed background thread**, the
app's AR layer has no frame on the stack to wrap in `try/catch`; it reaches the default
uncaught-exception handler and kills the whole process with a full-screen crash report —
even though the user has *just left AR* and nothing in the foreground is broken.

## The fix

`CrashReporter` (the app's installed `UncaughtExceptionHandler`) now recognises this
specific background-thread camera-pipe teardown crash and lets the process keep running
instead of delegating to the killing default handler:

- Matches only when the throwable chain has **both** the camera-metadata message
  (`Failed to load metadata for CameraId` / `Unable to retrieve camera characteristics`)
  **and** an `android.hardware.camera2.CameraManager.getCameraCharacteristics` stack frame —
  so an unrelated crash that merely mentions one string is never silently swallowed.
- Gated to **non-main threads** only; main-thread and all other crashes still fail loudly.
- The crash is still written to `last_crash.txt` for diagnostics; only the process kill is
  suppressed. The faulting worker thread was already unwinding, so this just restores
  plain-JVM "only that thread dies" semantics.

This is the only place the exception is interceptable — it is thrown inside ARCore's
own threads, which the app cannot guard directly.

## Tests

`CrashReporterTest` (pure JVM, no Android deps) covers the real crash signature,
suppressed-only carriers, both partial-match cases (must **not** swallow), an ordinary
app crash, and a cyclic cause chain (termination).

> Note: pushed via the GitHub API because the session's egress proxy rejected the
> `git push` pack with HTTP 413. CI should still run normally on the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5KGbpyQQ7PbQJvvEf6tPu)_

## Summary by Sourcery

Handle specific ARCore camera-pipe teardown crashes without killing the app and classify crash reports as fatal or recovered for upload.

Bug Fixes:
- Prevent process termination on ARCore background-thread camera metadata failures during AR session teardown by treating them as recoverable crashes.

Enhancements:
- Include a fatality flag in crash reports and adjust crash upload logic to distinguish non-fatal recovered exceptions from true app force-closes.

Tests:
- Add unit tests for identifying recoverable ARCore camera-pipe crashes, including suppressed exceptions, partial matches, ordinary crashes, and cyclic cause chains.