### PR TITLE
AR: proactively leave AR on a dead camera + harden Gemini review CI

### DIFF
--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -48,6 +48,12 @@ jobs:
       - name: 'Run Gemini pull request review'
         uses: 'google-github-actions/run-gemini-cli@v0' # ratchet:exclude
         id: 'gemini_pr_review'
+        # The Gemini review is advisory. When the backing service is unavailable
+        # (e.g. the Gemini API is disabled/quota-exhausted for the GCP project, which
+        # surfaces as a 403 PERMISSION_DENIED), the CLI exits non-zero. That must not
+        # red-X the PR and gate a human's merge on an external-integration outage, so
+        # the step is allowed to fail without failing the job.
+        continue-on-error: true
         env:
           # Trust the CI checkout so the headless CLI doesn't refuse to run with
           # "not running in a trusted directory" (it can't prompt in automation).

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
@@ -191,7 +191,9 @@ fun MainScreen(
                         val startMs = android.os.SystemClock.elapsedRealtime()
                         while (true) {
                             kotlinx.coroutines.delay(1000)
-                            val ts = r.latestFrame.get()?.timestamp ?: 0L
+                            // Read via a :feature:ar helper that returns a Long — :app can't access
+                            // ARCore's Frame type (it's an implementation dep of :feature:ar).
+                            val ts = com.hereliesaz.graffitixr.feature.ar.lastArFrameTimestampNs(r)
                             if (ts > 0L) break // camera is streaming — healthy, stop watching
                             val elapsed = android.os.SystemClock.elapsedRealtime() - startMs
                             if (com.hereliesaz.graffitixr.feature.ar.ArCameraHealth.isCameraDead(elapsed, ts)) {

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
@@ -178,6 +178,34 @@ fun MainScreen(
                         rendererRef.value?.updateFlashlight(arUiState.isFlashlightOn)
                     }
 
+                    // Dead-camera watchdog. On some devices (e.g. Samsung SM-A236U) the camera HAL
+                    // never feeds ARCore — the session opens but no frame ever lands (frame.timestamp
+                    // stays 0). Left alone, ARCore's internal camera pipe keeps thrashing the device
+                    // through ERROR_CAMERA_DEVICE/reopen cycles, which can end in an uncatchable
+                    // teardown crash. If no frame has arrived after the timeout, leave AR: switching
+                    // editorMode off AR disposes this branch, whose onDispose calls exitArMode() for a
+                    // clean teardown. Keyed on the renderer so it (re)starts with each AR session and
+                    // is cancelled the moment we leave AR.
+                    LaunchedEffect(rendererRef.value) {
+                        val r = rendererRef.value ?: return@LaunchedEffect
+                        val startMs = android.os.SystemClock.elapsedRealtime()
+                        while (true) {
+                            kotlinx.coroutines.delay(1000)
+                            val ts = r.latestFrame.get()?.timestamp ?: 0L
+                            if (ts > 0L) break // camera is streaming — healthy, stop watching
+                            val elapsed = android.os.SystemClock.elapsedRealtime() - startMs
+                            if (com.hereliesaz.graffitixr.feature.ar.ArCameraHealth.isCameraDead(elapsed, ts)) {
+                                Toast.makeText(
+                                    context,
+                                    "Camera isn't delivering frames — leaving AR. Reopen AR to try again.",
+                                    Toast.LENGTH_LONG
+                                ).show()
+                                editorViewModel.setEditorMode(EditorMode.DESIGN)
+                                break
+                            }
+                        }
+                    }
+
                     val visibleLayers = uiState.layers.filter { it.isVisible && it.bitmap != null }
 
                     // Push the AR whole-design adjustment (set via the rail's "Layer" item) to the

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArCameraHealth.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArCameraHealth.kt
@@ -1,0 +1,32 @@
+package com.hereliesaz.graffitixr.feature.ar
+
+/**
+ * Pure decision helpers for the AR camera-health watchdog. Kept Android-free so the timeout logic is
+ * unit-testable without a device.
+ */
+object ArCameraHealth {
+
+    /**
+     * How long the AR session may run without ARCore ever delivering a real camera frame before the
+     * camera is treated as dead. The renderer's own on-screen stall warning fires at ~8s of ts=0 on
+     * this hardware; this is set a little past that so the UI-side abandon only triggers once the
+     * in-engine watchdog has also given up.
+     */
+    const val DEAD_CAMERA_TIMEOUT_MS = 10_000L
+
+    /**
+     * True when an AR session that has been running for [elapsedMs] still hasn't received a single
+     * camera frame, i.e. [lastFrameTimestampNs] is still 0. ARCore returns a frame timestamp of 0
+     * until its first camera image lands, so a still-zero timestamp past [timeoutMs] means the camera
+     * never started feeding the session (e.g. a HAL that drops the device under repeated
+     * ERROR_CAMERA_DEVICE). Leaving such a session open lets ARCore's internal camera pipe keep
+     * thrashing the dead device, which on some devices ends in an uncatchable teardown crash — so the
+     * caller should abandon AR when this returns true. A non-zero timestamp means frames are flowing
+     * and the session is healthy, regardless of elapsed time.
+     */
+    fun isCameraDead(
+        elapsedMs: Long,
+        lastFrameTimestampNs: Long,
+        timeoutMs: Long = DEAD_CAMERA_TIMEOUT_MS,
+    ): Boolean = lastFrameTimestampNs == 0L && elapsedMs >= timeoutMs
+}

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/CameraFrameAccess.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/CameraFrameAccess.kt
@@ -1,0 +1,12 @@
+package com.hereliesaz.graffitixr.feature.ar
+
+import com.hereliesaz.graffitixr.feature.ar.rendering.ArRenderer
+
+/**
+ * Timestamp (ns) of the most recent ARCore frame the renderer has processed, or 0 if none has
+ * arrived yet. Lives in :feature:ar so the :app module can read camera-feeding health WITHOUT
+ * depending on the ARCore SDK directly: ArRenderer.latestFrame is an AtomicReference of
+ * com.google.ar.core.Frame, a type :app cannot access, so callers there only ever see this Long.
+ */
+fun lastArFrameTimestampNs(renderer: ArRenderer): Long =
+    renderer.latestFrame.get()?.timestamp ?: 0L

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/ArCameraHealthTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/ArCameraHealthTest.kt
@@ -1,0 +1,34 @@
+package com.hereliesaz.graffitixr.feature.ar
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ArCameraHealthTest {
+
+    private val timeout = ArCameraHealth.DEAD_CAMERA_TIMEOUT_MS
+
+    @Test
+    fun `dead when no frame ever arrived past the timeout`() {
+        assertTrue(ArCameraHealth.isCameraDead(elapsedMs = timeout, lastFrameTimestampNs = 0L))
+        assertTrue(ArCameraHealth.isCameraDead(elapsedMs = timeout + 5_000L, lastFrameTimestampNs = 0L))
+    }
+
+    @Test
+    fun `not dead before the timeout even with no frames`() {
+        assertFalse(ArCameraHealth.isCameraDead(elapsedMs = timeout - 1L, lastFrameTimestampNs = 0L))
+        assertFalse(ArCameraHealth.isCameraDead(elapsedMs = 0L, lastFrameTimestampNs = 0L))
+    }
+
+    @Test
+    fun `never dead once frames are flowing, regardless of elapsed time`() {
+        assertFalse(ArCameraHealth.isCameraDead(elapsedMs = timeout + 60_000L, lastFrameTimestampNs = 1L))
+        assertFalse(ArCameraHealth.isCameraDead(elapsedMs = 0L, lastFrameTimestampNs = 123_456_789L))
+    }
+
+    @Test
+    fun `respects a custom timeout`() {
+        assertFalse(ArCameraHealth.isCameraDead(elapsedMs = 1_000L, lastFrameTimestampNs = 0L, timeoutMs = 2_000L))
+        assertTrue(ArCameraHealth.isCameraDead(elapsedMs = 2_000L, lastFrameTimestampNs = 0L, timeoutMs = 2_000L))
+    }
+}


### PR DESCRIPTION
Follow-ups to #1705 (which *contained* the ARCore camera-pipe teardown crash). This addresses the **root cause** and the CI noise that surfaced on that PR.

## 1. Proactively leave AR when the camera never feeds frames

In the reported crash (Samsung SM-A236U) the camera HAL never delivered a frame to ARCore — `frame.timestamp` stayed `0` and `Last visual features at: 0 ns` for ~30s while ARCore's internal CameraX pipe (`CXCP`) thrashed the device through `ERROR_CAMERA_DEVICE`/reopen cycles, until the eventual teardown crashed. The app only toasted "exit and try again" and waited for the user.

Now the app abandons AR on its own:

- **`ArCameraHealth`** (new, pure, unit-tested): `isCameraDead(elapsedMs, lastFrameTimestampNs, timeout)` — ARCore returns timestamp `0` until its first image lands, so a still-zero timestamp past the timeout (10s, just past the renderer's own 8s `ts=0` stall warning) means the camera never started feeding.
- **`MainScreen`** runs a watchdog while in AR (keyed on the renderer, so it starts/stops with the session): it polls the renderer's already-public `latestFrame`, and if the camera is dead it toasts and switches `editorMode` off AR. That disposes the AR branch, whose existing `onDispose` calls `arViewModel.exitArMode()` — the same clean teardown path a manual exit uses. A healthy session (non-zero timestamp) stops the watch immediately and is unaffected.

This deliberately reuses public surface (`ArRenderer.latestFrame`, `exitArMode`, `setEditorMode`) and the existing dispose→teardown path rather than threading new state through the AR session lifecycle.

**Scope/limitation:** this targets the *never-fed* case from the crash report (timestamp stays 0). A camera that streams briefly then dies mid-session isn't covered here; the merged #1705 handler still keeps such a teardown from crashing the app.

## 2. Harden the Gemini review CI

The `review / review` check failed on #1705 with `403 PERMISSION_DENIED — Gemini API … is disabled` for the GCP project. The Gemini PR review is advisory, so its step is now `continue-on-error: true` — an external-service outage no longer red-Xes the PR and gates a human's merge. (Enabling the API in the GCP project remains the real fix for getting reviews back; that's a repo/cloud setting, not code.)

## Not changed: `submit-gradle`

That check is GitHub's **automatic dependency submission** (a repo Settings → Code security toggle, not a workflow file in this repo); its failure on #1705 was a transient `5xx` from GitHub's Dependency-Submission API *after* the Gradle build succeeded. It's non-blocking and not fixable from the codebase.

## Tests

`ArCameraHealthTest` covers: dead past timeout, not-dead before timeout, never-dead once frames flow, and a custom timeout.

> Pushed via the GitHub API (the sandbox's git proxy rejects `git push` with HTTP 413 and direct API access is disabled for the session). Verified each pushed file byte-for-byte against local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5KGbpyQQ7PbQJvvEf6tPu)_