### PR TITLE
Fix occasional launch force-close: crash uploader must never crash the app

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/GraffitiApplication.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/GraffitiApplication.kt
@@ -9,6 +9,7 @@ import com.hereliesaz.graffitixr.common.crash.CrashReporter
 import com.hereliesaz.graffitixr.common.crash.CrashUploadWorker
 import com.hereliesaz.graffitixr.common.util.NativeLibLoader
 import dagger.hilt.android.HiltAndroidApp
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -51,7 +52,13 @@ class GraffitiApplication : Application() {
 
         // 1.2. Setup Crash Reporting
         CrashReporter(this).initialize()
-        MainScope().launch {
+        // CoroutineExceptionHandler so a failure in the startup crash-upload can never escape this
+        // launch and force-close the app on launch (checkAndUpload is also self-guarded). Belt and
+        // suspenders: the crash-reporting path must never itself crash the app.
+        val crashUploadErrorHandler = CoroutineExceptionHandler { _, e ->
+            Log.e("GraffitiApplication", "Crash upload failed at startup; ignored", e)
+        }
+        MainScope().launch(crashUploadErrorHandler) {
             CrashUploadWorker(this@GraffitiApplication).checkAndUpload(BuildConfig.GH_TOKEN)
         }
 

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/crash/CrashUploadWorker.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/crash/CrashUploadWorker.kt
@@ -14,15 +14,24 @@ import java.io.File
 class CrashUploadWorker(private val context: Context) {
 
     suspend fun checkAndUpload(token: String) = withContext(Dispatchers.IO) {
-        val file = File(context.cacheDir, "last_crash.txt")
-        if (!file.exists()) return@withContext
+        // This runs at startup (Application.onCreate). It must NEVER throw: an uncaught exception here
+        // propagates out of the launching coroutine and force-closes the app ON LAUNCH — and it only
+        // runs when a previous crash left last_crash.txt, so the failure would be an occasional
+        // launch crash that compounds the very crash it was trying to report. Reading/deleting the
+        // file (file IO) and the upload are all wrapped so a crash reporter can never crash the app.
+        try {
+            val file = File(context.cacheDir, "last_crash.txt")
+            if (!file.exists()) return@withContext
 
-        val report = file.readText()
-        val success = uploadToGitHub(report, token)
-        
-        if (success) {
-            file.delete()
-            Log.i("CrashUploadWorker", "Crash report uploaded and deleted.")
+            val report = file.readText()
+            val success = uploadToGitHub(report, token)
+
+            if (success) {
+                file.delete()
+                Log.i("CrashUploadWorker", "Crash report uploaded and deleted.")
+            }
+        } catch (e: Throwable) {
+            Log.e("CrashUploadWorker", "checkAndUpload failed; ignoring so startup isn't interrupted", e)
         }
     }
 

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/crash/CrashUploadWorker.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/crash/CrashUploadWorker.kt
@@ -13,25 +13,40 @@ import java.io.File
  */
 class CrashUploadWorker(private val context: Context) {
 
-    suspend fun checkAndUpload(token: String) = withContext(Dispatchers.IO) {
-        // This runs at startup (Application.onCreate). It must NEVER throw: an uncaught exception here
-        // propagates out of the launching coroutine and force-closes the app ON LAUNCH — and it only
-        // runs when a previous crash left last_crash.txt, so the failure would be an occasional
-        // launch crash that compounds the very crash it was trying to report. Reading/deleting the
-        // file (file IO) and the upload are all wrapped so a crash reporter can never crash the app.
-        try {
-            val file = File(context.cacheDir, "last_crash.txt")
-            if (!file.exists()) return@withContext
+    suspend fun checkAndUpload(token: String) {
+        // No token (the common case for local/dev builds) -> nothing can be uploaded, so skip the
+        // IO-dispatcher switch and the disk read entirely. The report stays on disk for MainActivity
+        // to surface on next launch.
+        if (token.isBlank()) {
+            Log.i("CrashUploadWorker", "No GH_TOKEN; skipping crash upload.")
+            return
+        }
+        withContext(Dispatchers.IO) {
+            // This runs at startup (Application.onCreate). It must NEVER throw: an uncaught exception
+            // here propagates out of the launching coroutine and force-closes the app ON LAUNCH — and
+            // it only runs when a previous crash left last_crash.txt, so the failure would be an
+            // occasional launch crash that compounds the very crash it was trying to report.
+            // Reading/deleting the file (file IO) and the upload are all wrapped so a crash reporter
+            // can never crash the app.
+            try {
+                val file = File(context.cacheDir, "last_crash.txt")
+                if (!file.exists()) return@withContext
 
-            val report = file.readText()
-            val success = uploadToGitHub(report, token)
+                val report = file.readText()
+                val success = uploadToGitHub(report, token)
 
-            if (success) {
-                file.delete()
-                Log.i("CrashUploadWorker", "Crash report uploaded and deleted.")
+                if (success) {
+                    // If the delete fails the report is re-uploaded next launch (a duplicate issue);
+                    // log it so that's diagnosable rather than silent.
+                    if (file.delete()) {
+                        Log.i("CrashUploadWorker", "Crash report uploaded and deleted.")
+                    } else {
+                        Log.w("CrashUploadWorker", "Uploaded crash report but failed to delete it; may re-upload next launch.")
+                    }
+                }
+            } catch (e: Throwable) {
+                Log.e("CrashUploadWorker", "checkAndUpload failed; ignoring so startup isn't interrupted", e)
             }
-        } catch (e: Throwable) {
-            Log.e("CrashUploadWorker", "checkAndUpload failed; ignoring so startup isn't interrupted", e)
         }
     }
 


### PR DESCRIPTION
## Symptom
Occasional **force-close on launch** (reported on Galaxy A23/A26), independent of the AR camera issue.

## Root cause
`CrashUploadWorker.checkAndUpload` runs at startup from `GraffitiApplication.onCreate` via `MainScope().launch { … }`, and **only when a previous crash left `last_crash.txt`**. Inside it, `file.readText()` and `file.delete()` were **outside** the `try` (only the network upload was guarded). So any file-IO hiccup — or anything else thrown before/after the guarded block — escaped the coroutine and force-closed the app **on launch**.

This fits "occasional" exactly:
- It only triggers after a prior crash created `last_crash.txt` (these devices crash in AR a lot — see the camera-not-feeding issue), so it's intermittent.
- A failed launch leaves the file in place, so the **next** launch hits the same path again — it can self-perpetuate.
- It's the crash *reporter* taking down the app — the same invariant the earlier `CrashReporter` fix established: **the crash-reporting path must never itself crash the app.**

## Fix
- Wrap the entire `checkAndUpload` body in `try/catch(Throwable)` so reading, uploading, and deleting the report can never escape.
- Add a `CoroutineExceptionHandler` to the launching coroutine in `GraffitiApplication` as belt-and-suspenders.

Both are small, self-contained, and low-risk.

## Honest scope note
I diagnosed this by inspecting the launch path (an unguarded throw in startup code is a textbook intermittent-launch-crash), **not** from a captured stack trace — I still don't have the trace for your specific force-close. This removes the most plausible app-side cause I can see; if the occasional launch crash persists after this, it's something else (e.g. a native `SIGSEGV` at startup, or the `azNavRail` bump that landed just before) and I'll need the trace from `last_crash.txt` / `last_native_crash.txt` (shown on the next successful launch) or `adb logcat -d "*:E"` to go further.

Separately tracked and **not** addressed here: AR camera never feeds ARCore (`ts=0`) on these devices — that's a platform/device-level issue, not this launch crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5KGbpyQQ7PbQJvvEf6tPu)_