### PR TITLE
Enable automatic crash reporting to GitHub issues (JVM + native)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -101,11 +101,21 @@ android {
             }
         }
 
-        // Do NOT bake a GitHub token into the shipped APK — a PAT embedded in a distributed app can
-        // be extracted from BuildConfig. CrashUploadWorker reads this and already no-ops when empty,
-        // so crash-log upload via an embedded token is intentionally disabled. (The GitHub Packages
-        // maven repo still authenticates at build time via the GH_TOKEN env var in settings.gradle.kts.)
-        buildConfigField("String", "GH_TOKEN", "\"\"")
+        // Crash auto-reporting: CrashUploadWorker files a GitHub issue containing the crash log, using
+        // this token. It is read at BUILD time from the GH_TOKEN env var (the same one
+        // settings.gradle.kts uses for the GitHub Packages maven repo), with a gradle-property
+        // fallback. When neither is present (typical local dev) it stays empty and CrashUploadWorker
+        // no-ops — so nothing breaks locally and no token is ever committed to Git.
+        //
+        // SECURITY: a non-empty token here is embedded in the shipped APK's BuildConfig and CAN be
+        // extracted by anyone who decompiles the app. Use a FINE-GRAINED token scoped to ONLY
+        // "Issues: write" on this single repo (HereLiesAz/GraffitiXR) — never a broad/classic PAT —
+        // so that a leaked token can, at worst, open issues on this one repo.
+        // GitHub tokens are [A-Za-z0-9_] only (ghp_* / github_pat_*), so no string escaping is needed.
+        val crashReportToken = System.getenv("GH_TOKEN")
+            ?: (project.findProperty("GH_TOKEN") as String?)
+            ?: ""
+        buildConfigField("String", "GH_TOKEN", "\"$crashReportToken\"")
     }
 
     // Release signing is a property of the project, not of each CI invocation. The keystore and

--- a/app/src/main/java/com/hereliesaz/graffitixr/GraffitiApplication.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/GraffitiApplication.kt
@@ -52,14 +52,38 @@ class GraffitiApplication : Application() {
 
         // 1.2. Setup Crash Reporting
         CrashReporter(this).initialize()
-        // CoroutineExceptionHandler so a failure in the startup crash-upload can never escape this
-        // launch and force-close the app on launch (checkAndUpload is also self-guarded). Belt and
-        // suspenders: the crash-reporting path must never itself crash the app.
+        // Auto-report the previous run's crash(es) as a GitHub issue. CAPTURE the file contents NOW,
+        // synchronously, before MainActivity.onCreate reads + deletes them for its on-screen dialog
+        // (same startup transaction) — otherwise the async upload races that delete and finds nothing.
+        // Then upload off the main thread and delete each file on success. Covers both the JVM crash
+        // dump and the native (SIGSEGV/SIGABRT) backtrace. The benign isolated ":probe" native crash is
+        // intentionally NOT reported. Empty GH_TOKEN (local/dev builds) -> uploadCaptured no-ops.
+        // CoroutineExceptionHandler is belt-and-suspenders: the crash-reporting path must never itself
+        // crash the app on launch.
         val crashUploadErrorHandler = CoroutineExceptionHandler { _, e ->
             Log.e("GraffitiApplication", "Crash upload failed at startup; ignored", e)
         }
-        MainScope().launch(crashUploadErrorHandler) {
-            CrashUploadWorker(this@GraffitiApplication).checkAndUpload(BuildConfig.GH_TOKEN)
+        val crashToken = BuildConfig.GH_TOKEN
+        if (crashToken.isNotBlank()) {
+            val capturedCrashes = listOf(
+                "last_crash.txt" to "Auto-Report: App Crash",
+                "last_native_crash.txt" to "Auto-Report: Native Crash"
+            ).mapNotNull { (name, title) ->
+                runCatching {
+                    val f = java.io.File(cacheDir, name)
+                    if (f.exists()) Triple(f, title, f.readText()) else null
+                }.getOrNull()
+            }
+            if (capturedCrashes.isNotEmpty()) {
+                MainScope().launch(crashUploadErrorHandler) {
+                    val worker = CrashUploadWorker(this@GraffitiApplication)
+                    capturedCrashes.forEach { (file, title, report) ->
+                        if (worker.uploadCaptured(crashToken, title, report)) {
+                            runCatching { file.delete() }
+                        }
+                    }
+                }
+            }
         }
 
         // 2. Update Security Provider (Fix for SSLHandshakeException)

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/crash/CrashUploadWorker.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/crash/CrashUploadWorker.kt
@@ -17,6 +17,17 @@ import retrofit2.converter.gson.GsonConverterFactory
  */
 class CrashUploadWorker(private val context: Context) {
 
+    // Built once and reused: recreating Retrofit/OkHttp per upload accumulates thread + connection
+    // pools (wasteful, and worse when uploading several crash files in a row). `by lazy` defers
+    // creation to the first upload, which runs on Dispatchers.IO — so no work at construction time.
+    private val githubService: GitHubCrashService by lazy {
+        Retrofit.Builder()
+            .baseUrl("https://api.github.com/")
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+            .create(GitHubCrashService::class.java)
+    }
+
     /**
      * Upload one captured crash [report]. Returns true only on a successful upload. [baseTitle] is the
      * issue title for a fatal crash; a JVM report whose first line is "FATAL: false" (a swallowed /
@@ -38,12 +49,7 @@ class CrashUploadWorker(private val context: Context) {
 
     private suspend fun uploadToGitHub(report: String, token: String, baseTitle: String): Boolean {
         return try {
-            val retrofit = Retrofit.Builder()
-                .baseUrl("https://api.github.com/")
-                .addConverterFactory(GsonConverterFactory.create())
-                .build()
-
-            val service = retrofit.create(GitHubCrashService::class.java)
+            val service = githubService
             // JVM reports start with "FATAL: true|false" (see CrashReporter.buildReport). A recovered
             // (non-fatal) report must not masquerade as a force-close. Native reports have no such
             // line, so they keep their baseTitle ("Native Crash").

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/crash/CrashUploadWorker.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/crash/CrashUploadWorker.kt
@@ -6,56 +6,37 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
-import java.io.File
 
 /**
- * Checks for saved crash reports and uploads them to GitHub.
+ * Uploads captured crash reports to GitHub as issues.
+ *
+ * The report CONTENT is captured by the caller (GraffitiApplication) synchronously at startup, before
+ * MainActivity reads + deletes the crash files for its on-screen dialog — otherwise the upload would
+ * race that delete (same startup transaction) and usually find nothing. This class only performs the
+ * network upload, and never throws (a crash reporter must not crash the app).
  */
 class CrashUploadWorker(private val context: Context) {
 
-    suspend fun checkAndUpload(token: String) {
-        // No token (the common case for local/dev builds) -> nothing can be uploaded, so skip the
-        // IO-dispatcher switch and the disk read entirely. The report stays on disk for MainActivity
-        // to surface on next launch.
-        if (token.isBlank()) {
-            Log.i("CrashUploadWorker", "No GH_TOKEN; skipping crash upload.")
-            return
-        }
+    /**
+     * Upload one captured crash [report]. Returns true only on a successful upload. [baseTitle] is the
+     * issue title for a fatal crash; a JVM report whose first line is "FATAL: false" (a swallowed /
+     * recovered exception) is retitled so it isn't mistaken for a force-close.
+     */
+    suspend fun uploadCaptured(token: String, baseTitle: String, report: String): Boolean =
         withContext(Dispatchers.IO) {
-            // This runs at startup (Application.onCreate). It must NEVER throw: an uncaught exception
-            // here propagates out of the launching coroutine and force-closes the app ON LAUNCH — and
-            // it only runs when a previous crash left last_crash.txt, so the failure would be an
-            // occasional launch crash that compounds the very crash it was trying to report.
-            // Reading/deleting the file (file IO) and the upload are all wrapped so a crash reporter
-            // can never crash the app.
+            if (token.isBlank()) {
+                Log.i("CrashUploadWorker", "No GH_TOKEN; skipping crash upload.")
+                return@withContext false
+            }
             try {
-                val file = File(context.cacheDir, "last_crash.txt")
-                if (!file.exists()) return@withContext
-
-                val report = file.readText()
-                val success = uploadToGitHub(report, token)
-
-                if (success) {
-                    // If the delete fails the report is re-uploaded next launch (a duplicate issue);
-                    // log it so that's diagnosable rather than silent.
-                    if (file.delete()) {
-                        Log.i("CrashUploadWorker", "Crash report uploaded and deleted.")
-                    } else {
-                        Log.w("CrashUploadWorker", "Uploaded crash report but failed to delete it; may re-upload next launch.")
-                    }
-                }
+                uploadToGitHub(report, token, baseTitle)
             } catch (e: Throwable) {
-                Log.e("CrashUploadWorker", "checkAndUpload failed; ignoring so startup isn't interrupted", e)
+                Log.e("CrashUploadWorker", "Crash upload failed; ignored so startup isn't interrupted", e)
+                false
             }
         }
-    }
 
-    private suspend fun uploadToGitHub(report: String, token: String): Boolean {
-        if (token.isEmpty()) {
-            Log.e("CrashUploadWorker", "GH_TOKEN is empty, skipping upload.")
-            return false
-        }
-
+    private suspend fun uploadToGitHub(report: String, token: String, baseTitle: String): Boolean {
         return try {
             val retrofit = Retrofit.Builder()
                 .baseUrl("https://api.github.com/")
@@ -63,17 +44,19 @@ class CrashUploadWorker(private val context: Context) {
                 .build()
 
             val service = retrofit.create(GitHubCrashService::class.java)
-            // The report's first line is "FATAL: true|false" (see CrashReporter.buildReport). A
-            // recovered (non-fatal) report — e.g. a swallowed ARCore camera-pipe teardown crash — must
-            // not masquerade as a force-close in the issue tracker.
+            // JVM reports start with "FATAL: true|false" (see CrashReporter.buildReport). A recovered
+            // (non-fatal) report must not masquerade as a force-close. Native reports have no such
+            // line, so they keep their baseTitle ("Native Crash").
             val recovered = report.lineSequence().firstOrNull()?.trim() == "FATAL: false"
+            val title = if (recovered) "Auto-Report: Recovered Crash (non-fatal)" else baseTitle
+            val intro = if (recovered) {
+                "A non-fatal exception was caught and the app kept running. Details below:"
+            } else {
+                "A crash occurred. Details below:"
+            }
             val issue = GitHubIssue(
-                title = if (recovered) "Auto-Report: Recovered Crash (non-fatal)" else "Auto-Report: App Crash",
-                body = if (recovered) {
-                    "A non-fatal exception was caught and the app kept running. Details below:\n\n```\n$report\n```"
-                } else {
-                    "A force close occurred. Details below:\n\n```\n$report\n```"
-                }
+                title = title,
+                body = "$intro\n\n```\n$report\n```"
             )
 
             val response = service.createIssue(


### PR DESCRIPTION
## Why
Crashes weren't auto-reporting. `BuildConfig.GH_TOKEN` was hardcoded to `""`, so `CrashUploadWorker` always no-opped — that's why the auto-filed crash issues **stop at ~v1.30** (current is 1.35.1) and we've been blind to current crashes with no device to pull logs from.

## What this does
1. **`app/build.gradle.kts`** — `GH_TOKEN` is now read at **build time** from the `GH_TOKEN` env var (the same one `settings.gradle.kts` already uses for the GitHub Packages Maven repo), with a gradle-property fallback. Absent (local/dev) → empty → uploader no-ops, nothing committed to git.
2. **`GraffitiApplication`** — captures the previous run's crash file(s) **synchronously at startup, then uploads off-main and deletes on success.** The sync capture matters: `MainActivity.onCreate` reads+deletes those files for its on-screen dialog in the *same* startup transaction, so an async read would lose the race and find nothing. Now also uploads the **native** (`SIGSEGV`/`SIGABRT`) backtrace — `last_native_crash.txt` — not just the JVM dump; the benign isolated `:probe` native crash is excluded.
3. **`CrashUploadWorker`** — uploads captured content (no file-read race), titles **native vs app vs recovered-non-fatal** crashes distinctly, and never throws.

Result: both JVM and native crashes self-file as `Auto-Report:` issues on this repo, so the current launch crash and the AR camera issue become diagnosable **without the physical device** — which is exactly what's been blocking root-causing them.

## ⚠️ Security tradeoff (please read)
A non-empty token is embedded in the shipped APK's `BuildConfig` and **can be extracted** by anyone who decompiles the app. The in-file comment says it, repeating here:

- Use a **fine-grained PAT scoped to only `Issues: write` on `HereLiesAz/GraffitiXR`** — never a classic/broad PAT. Worst case if leaked: someone opens issues on this one repo.
- Set that token as the `GH_TOKEN` env var in the **release/AAB build workflows** (it's already present for Maven auth, but confirm it's the narrowly-scoped one before shipping a public build).
- If you'd rather not embed a token at all, the more robust long-term option is Firebase Crashlytics / Play Console crash reporting — say the word and I'll wire that instead.

No app-behavior change for users beyond the background upload; empty token keeps current behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5KGbpyQQ7PbQJvvEf6tPu)_