### PR TITLE
fix: AR drag direction, auto-open Layers, time tutorial steps to user flow

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -988,6 +988,39 @@ class MainActivity : ComponentActivity() {
                                 )
                             }
 
+                            // In-capture hint: shows the "just tap the screen" line *inside* the
+                            // capture modal, exactly when it applies. The adaptive coach is suppressed
+                            // here by anyModalActive, so this line would otherwise never reach the user
+                            // at the moment they need it. Dismissed when the anchor lands; remembered
+                            // via the same completedTutorials DataStore as the rest of the coach.
+                            val captureHintKey = "coach.ar.capture"
+                            val showCaptureHint = mainUiState.isCapturingTarget
+                                && mainUiState.isWaitingForTap
+                                && !arUiState.isAnchorEstablished
+                                && (mainUiState.tutorialModeActive || captureHintKey !in completedTutorials)
+                            if (showCaptureHint) {
+                                val captureHintText = remember {
+                                    context.resources.getStringArray(DesignR.array.onboarding_ar)
+                                        .getOrNull(2).orEmpty()
+                                }
+                                if (captureHintText.isNotEmpty()) {
+                                    Text(
+                                        text = captureHintText,
+                                        color = Color.White,
+                                        modifier = Modifier
+                                            .align(Alignment.TopCenter)
+                                            .padding(top = 24.dp, start = 24.dp, end = 24.dp)
+                                            .background(Color.Black.copy(alpha = 0.7f), RoundedCornerShape(8.dp))
+                                            .padding(horizontal = 16.dp, vertical = 12.dp)
+                                    )
+                                }
+                            }
+                            LaunchedEffect(arUiState.isAnchorEstablished) {
+                                if (arUiState.isAnchorEstablished && !mainUiState.tutorialModeActive) {
+                                    mainViewModel.markTutorialCompletePersistent(captureHintKey)
+                                }
+                            }
+
                             if (mainUiState.isCapturingTarget) {
                                 TargetCreationUi(
                                     uiState = arUiState,
@@ -1368,14 +1401,13 @@ class MainActivity : ComponentActivity() {
                 // Each layer is a relocItem (drag to reorder); tapping it opens its nested rail of
                 // editing tools (edit/size/font/color/blend/invert/paint/retouch/etc.). The hidden
                 // menu carries link/duplicate/copy/flatten/delete.
-                // Keep Layers expanded whenever there are layers and we're in Design mode (reactive,
-                // so adding the first layer or re-entering Design auto-expands it).
+                // Layers is data-driven: any layer at all means open. No persisted user-collapse —
+                // expandWhen is edge-triggered so a once-collapsed host would otherwise stick.
                 azRailSubHostItem(
                     id = "design.layers", hostId = "host.design", text = "Layers",
                     color = navItemColor, shape = AzButtonShape.RECTANGLE,
-                    initiallyExpanded = railExpansion["design.layers"] ?: editorUiState.layers.isNotEmpty(),
-                    expandWhen = { editorUiState.layers.isNotEmpty() && editorUiState.editorMode == EditorMode.DESIGN },
-                    onExpandedChange = { editorViewModel.onRailHostExpansionChanged("design.layers", it) }
+                    initiallyExpanded = editorUiState.layers.isNotEmpty(),
+                    expandWhen = { editorUiState.layers.isNotEmpty() && editorUiState.editorMode == EditorMode.DESIGN }
                 )
                 editorUiState.layers.reversed().forEach { layer ->
                     val activeTool = editorUiState.activeTool

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
@@ -528,13 +528,13 @@ fun MainScreen(
                                     onGesture = { _, pan, zoom, rotation ->
                                         if (editingMode) {
                                             // In AR the overlay lives on the wall in meters, so convert
-                                            // the screen-pixel drag to in-plane meters. The overlay's
-                                            // world frame runs opposite the screen on both axes here, so
-                                            // negate both so the artwork follows the finger. Other modes
-                                            // stay in pixels.
+                                            // the screen-pixel drag to in-plane meters. Local +X on the
+                                            // wall is camera-right (matches screen +X), local +Y is
+                                            // wall-up (opposite screen +Y), so x passes through and y
+                                            // is negated so the artwork follows the finger.
                                             val adjustedPan = if (uiState.editorMode == EditorMode.AR) {
                                                 val mpp = rendererRef.value?.currentMetersPerPixel ?: 0f
-                                                androidx.compose.ui.geometry.Offset(-pan.x * mpp, pan.y * mpp)
+                                                androidx.compose.ui.geometry.Offset(pan.x * mpp, -pan.y * mpp)
                                             } else pan
                                             editorViewModel.onModeTransformGesture(uiState.editorMode, adjustedPan, zoom, rotation)
                                         } else {

--- a/app/src/main/java/com/hereliesaz/graffitixr/OnboardingCoach.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/OnboardingCoach.kt
@@ -66,7 +66,6 @@ fun rememberCoachStep(editor: EditorUiState, ar: ArUiState): CoachStep? {
         }
 
         val design = arr(DesignR.array.onboarding_design)
-        val designLayers = arr(DesignR.array.onboarding_design_layers)
         val arLines = arr(DesignR.array.onboarding_ar)
         val overlay = arr(DesignR.array.onboarding_overlay)
         val mockup = arr(DesignR.array.onboarding_mockup)
@@ -74,21 +73,15 @@ fun rememberCoachStep(editor: EditorUiState, ar: ArUiState): CoachStep? {
 
         when (editor.editorMode) {
             EditorMode.DESIGN -> when {
-                // Intro on 'Design', then — once the user presses it open — walk the pointer across
-                // the layer sources (Open / Sketch / Text), explaining each in turn before they pick.
-                // Falls back to the plain 2-line step if the per-source copy is missing (e.g. an
-                // incomplete localization) so the card never shows a blank line.
+                // Point at 'Design' with a single "open Design and add a layer" line. Once Design is
+                // expanded, Open / Sketch / Text speak for themselves; dismissal happens automatically
+                // the moment the first layer appears and the next step (select) takes over.
                 !hasLayers -> {
-                    val intro = design.getOrNull(0)
-                    if (intro != null && designLayers.isNotEmpty()) {
-                        CoachStep(
-                            key = "coach.design.add",
-                            targetId = "host.design",
-                            lines = listOf(intro) + designLayers,
-                            lineTargets = listOf("host.design", "design.addImg", "design.addDraw", "design.addText"),
-                        )
+                    val addLine = design.getOrNull(1) ?: design.getOrNull(0)
+                    if (addLine != null) {
+                        CoachStep("coach.design.add", "host.design", listOf(addLine))
                     } else {
-                        CoachStep("coach.design.add", "host.design", lines(design, 0, 1))
+                        CoachStep("coach.design.add", "host.design", lines(design, 0))
                     }
                 }
                 activeLayer == null -> CoachStep("coach.design.select", firstLayerTarget, lines(design, 2))
@@ -124,9 +117,10 @@ fun rememberCoachStep(editor: EditorUiState, ar: ArUiState): CoachStep? {
                 else -> CoachStep("coach.trace.freeze", "mode.trace.freeze", lines(trace, 2))
             }
             EditorMode.AR -> when {
-                // Capture itself is modal-gated, so the coach is hidden during it; this points the
-                // user at starting the capture in the first place.
-                !hasTarget -> CoachStep("coach.ar.target", "target.create", lines(arLines, 0, 1, 2, 4))
+                // Pre-capture only: intro, "scan the wall" and the texture tip. The "just tap the
+                // screen" instruction belongs *inside* the capture modal — the coach is suppressed
+                // there, so that line is rendered as a separate hint by the capture UI itself.
+                !hasTarget -> CoachStep("coach.ar.target", "target.create", lines(arLines, 0, 1, 4))
                 !hasLayers -> CoachStep("coach.ar.add", "host.design", lines(arLines, 3))
                 else -> null
             }


### PR DESCRIPTION
## Summary

Three coupled UX fixes the user reported, scoped to the AR experience and the side-rail / tutorial flow.

### 1. AR-mode drag follows the finger on both axes

`MainScreen.kt` was negating only `pan.x` in AR mode while leaving `pan.y` positive — the comment claimed both were negated, but only X was. The overlay's local plane has +X right (matches screen) and +Y up (opposite screen), so the correct mapping is `Offset(pan.x * mpp, -pan.y * mpp)`. Non-AR modes pass `pan` through unchanged and are untouched — the user confirmed drag works fine in Overlay / Mockup / Trace.

### 2. Layers sub-host auto-opens whenever layers exist

`MainActivity.kt`'s `design.layers` `azRailSubHostItem` was seeded from persisted `railExpansion["design.layers"]` and used `expandWhen` as a fallback. Per the AzNavRail 10.16 docs, `expandWhen` is **edge-triggered** (false→true only) and is suppressed by manual user collapse until the next rising edge. Result: once collapsed, it could stick shut. The host is now data-driven — `initiallyExpanded = layers.isNotEmpty()`, no `onExpandedChange` persistence. AzNavRail is already pinned at 10.16 (latest), no version bump needed.

### 3. Tutorial steps fire exactly when the user needs them

Two concrete mismatches fixed in `OnboardingCoach.kt`:

- **`coach.design.add`** previously walked 4 lines (intro + Open + Sketch + Text) that advanced on either screen taps or rail taps, so users could screen-tap past everything without using the UI. Collapsed to a single "Open Design and add a layer" line — dismissal is automatic the moment `layers.isNotEmpty()` flips and `coach.design.select` takes over.
- **`coach.ar.target`** was showing `arLines[0,1,2,4]` while the user was still in pre-capture AR. Line 2 ("Just tap the screen…") describes the in-capture moment, but the coach is suppressed (`anyModalActive`) the instant the capture modal opens — so that line never reached the user when it applied. Now: pre-capture step uses lines `[0, 1, 4]`; a new in-capture hint inside the capture modal renders line `[2]` only when `isCapturingTarget && isWaitingForTap && !isAnchorEstablished`, and clears on anchor lock. Remembered via the same `completedTutorials` DataStore.

Mockup / Trace / Overlay progressions were already correctly gated and are left alone.

## Test plan

- [ ] AR drag: enter AR, place an anchor, drag overlay left/right/up/down — overlay follows the finger on both axes.
- [ ] Regression: Overlay, Mockup, Trace drag still work as before (unchanged path).
- [ ] Layers host: fresh project in Design with no layers → host hidden/collapsed. Add Image/Sketch/Text — Layers expands immediately. Switch to AR and back — still expands.
- [ ] Tutorial Design: fresh install → land in Design → see single "Open 'Design' and add a layer" line. Add any layer — dismisses; `coach.design.select` takes over.
- [ ] Tutorial AR: fresh install → switch to AR → scan + texture tip (no "tap the screen"). Tap Create Anchor — pre-capture coach disappears; in-capture line "Just tap the screen" appears inside the modal. Complete capture — line clears; `coach.ar.add` takes over if no layers, otherwise coach is silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NArfzV67dHVVxT1uPb8Abh

---
_Generated by [Claude Code](https://claude.ai/code/session_01NArfzV67dHVVxT1uPb8Abh)_

## Summary by Sourcery

Align AR interaction, layers panel behavior, and tutorial prompts with the intended user flow in AR and Design modes.

New Features:
- Show a contextual AR capture hint inside the capture modal, guiding users to tap the screen at the correct moment.

Bug Fixes:
- Correct AR overlay drag mapping so the artwork follows the finger consistently on both axes.
- Make the Layers panel auto-expand whenever layers exist instead of sticking closed due to persisted user collapse state.
- Retime AR and Design tutorial steps so guidance appears only when relevant and cannot be skipped without performing key actions.

Enhancements:
- Simplify the Design onboarding step to a single data-driven instruction tied to the first layer being added.
- Separate pre-capture AR coaching from in-capture hints so onboarding copy matches the user’s actual state.