### PR TITLE
Fix Help button toggling a dead guidance controller

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -78,7 +78,7 @@ import com.google.android.gms.common.GoogleApiAvailability
 import com.hereliesaz.aznavrail.*
 import com.hereliesaz.aznavrail.model.*
 import com.hereliesaz.aznavrail.HiddenMenuScope
-import com.hereliesaz.aznavrail.tutorial.rememberAzGuidanceController
+import com.hereliesaz.aznavrail.tutorial.LocalAzGuidanceController
 import com.hereliesaz.graffitixr.common.model.ArScanMode
 import com.hereliesaz.graffitixr.common.model.MuralMethod
 import com.hereliesaz.graffitixr.common.model.CaptureStep
@@ -497,10 +497,11 @@ class MainActivity : ComponentActivity() {
                     )
                 }
 
-                // The reactive guidance controller (AzNavRail 10.18) is created and provided by
-                // AzHostActivityLayout. It isn't in scope inside the host lambda where the rail's Help
-                // button is declared, so the onscreen block below stashes it here (via
-                // rememberAzGuidanceController) and Help reads it to enable / replay the guided tour.
+                // The reactive guidance controller (AzNavRail 10.18) is created by AzHostActivityLayout
+                // and provided to its subtree via LocalAzGuidanceController. It isn't in scope inside
+                // the (non-composable) host lambda where the rail's Help button is declared, so the
+                // onscreen block below reads it from that composition local and stashes it here for
+                // Help to enable / replay the guided tour.
                 val guidanceHolder = remember { mutableStateOf<com.hereliesaz.aznavrail.tutorial.AzGuidanceController?>(null) }
 
                 AzHostActivityLayout(navController = navController, currentDestination = currentRoute, initiallyExpanded = false) {
@@ -602,10 +603,12 @@ class MainActivity : ComponentActivity() {
                         val completedTutorials by mainViewModel.completedTutorials.collectAsState()
 
                         // The reactive guidance overlay is rendered automatically by
-                        // AzHostActivityLayout; we only grab the controller it provides so the rail's
-                        // Help button can enable / replay the guided tour. The guidance graph itself
-                        // (statuses, edges, goals) is declared in ConfigureGuidance above.
-                        val guidance = rememberAzGuidanceController()
+                        // AzHostActivityLayout; we only need the controller it created so the rail's
+                        // Help button can enable / replay the guided tour. Read it from the composition
+                        // local the host provides — NOT rememberAzGuidanceController(), which would
+                        // remember a *separate* controller that doesn't drive the rendered overlay. The
+                        // guidance graph itself (statuses, edges, goals) is declared in ConfigureGuidance.
+                        val guidance = LocalAzGuidanceController.current
                         SideEffect { guidanceHolder.value = guidance }
 
                         // First-launch explainer for devices where ARCore is


### PR DESCRIPTION
## Why

Follow-up to #1712. A code review flagged the controller acquisition in `MainActivity`, and investigating it surfaced a real (latent) bug.

In the `onscreen` block I obtained the guidance controller with `rememberAzGuidanceController()`. Decompiling the 10.18 AAR shows that function `rememberSaveable`s a **new** controller — it does **not** read `LocalAzGuidanceController`. `AzHostActivityLayout` creates its own controller, drives the auto-mounted instruction overlay with it, and **provides that instance via `LocalAzGuidanceController`**. So the Help button was enabling/disabling/activating a **separate, dead controller**, and its active-color reflected that dead instance.

Auto-start guidance still worked (it's all internal to the host's controller, which is why this compiled and #1712 merged cleanly) — **only the manual Help replay/toggle was broken**.

## Fix

Read the controller from `LocalAzGuidanceController.current` (the host-provided instance) instead of `rememberAzGuidanceController()`. One-line change plus the import and comments.

The `guidanceHolder` + `SideEffect` bridge is kept intentionally: rail items — including Help — are registered in `AzHostActivityLayout`'s **non-composable** content lambda (its type is `Function1<AzNavHostScope, Unit>`, no `Composer`), which can't read a composition local directly. The bridge now carries the **correct** controller. (This is also why the original review's literal suggestion — calling `rememberAzGuidanceController()` at the top of the content lambda — couldn't be applied: that lambda isn't a `@Composable` scope.)

## Verification

- No Android SDK in the authoring environment, so CI is the compile gate.
- Manual smoke test: tapping **Help** should now enable/replay the guided tour and the button should turn cyan while guidance is enabled; tapping again disables it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B3bkLPqDMuhhdvyDZ45mKC

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3bkLPqDMuhhdvyDZ45mKC)_