### PR TITLE
Add gated safe-camera-config retry for dead-camera devices (Galaxy A26)

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
@@ -204,9 +204,14 @@ fun MainScreen(
                             if (ts > 0L) break // camera is streaming — healthy, stop watching
                             val elapsed = android.os.SystemClock.elapsedRealtime() - startMs
                             if (com.hereliesaz.graffitixr.feature.ar.ArCameraHealth.isCameraDead(elapsed, ts)) {
+                                // Tell AR the HAL never streamed: the next AR entry this process drops
+                                // to ARCore's safest default camera config (skips the fps-variant swap),
+                                // a best-effort recovery for budget HALs (e.g. Galaxy A26) that open a
+                                // config but never feed it.
+                                arViewModel.onCameraStreamStalled()
                                 Toast.makeText(
                                     context,
-                                    "Camera isn't delivering frames — leaving AR. Reopen AR to try again.",
+                                    "Camera isn't delivering frames — leaving AR. Reopen AR to retry with a safer camera mode.",
                                     Toast.LENGTH_LONG
                                 ).show()
                                 editorViewModel.setEditorMode(EditorMode.DESIGN)

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
@@ -211,7 +211,7 @@ fun MainScreen(
                                 arViewModel.onCameraStreamStalled()
                                 Toast.makeText(
                                     context,
-                                    "Camera isn't delivering frames — leaving AR. Reopen AR to retry with a safer camera mode.",
+                                    context.getString(DesignR.string.camera_stalled_error),
                                     Toast.LENGTH_LONG
                                 ).show()
                                 editorViewModel.setEditorMode(EditorMode.DESIGN)

--- a/core/design/src/main/res/values/strings.xml
+++ b/core/design/src/main/res/values/strings.xml
@@ -338,6 +338,8 @@
 
     <!-- Message shown when camera permission is denied. -->
     <string name="camera_permission_required">Camera permission is required for AR mode.</string>
+    <!-- Shown when the camera never delivers frames to AR (dead-camera watchdog); reopening AR retries with a safer camera config. -->
+    <string name="camera_stalled_error">Camera isn\'t delivering frames — leaving AR. Reopen AR to retry with a safer camera mode.</string>
     <!-- Action to open system settings. -->
     <string name="open_settings">Open Settings</string>
 

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -874,7 +874,14 @@ class ArViewModel @Inject constructor(
             // a black camera. So we only select stereo when the one-time worker-thread probe has proven
             // this device's dual lenses actually triangulate depth (stereoCapable == true) and it hasn't
             // since been marked unstable. Everything else stays on the safe mono 30 FPS back config.
-            val useStereo = stereoCapable == true && !forcedStereoUnstable && !forceSafeCameraConfig
+            // Snapshot the @Volatile decision inputs once: this runs on Dispatchers.Default while the
+            // settings collectors and the dead-camera watchdog flip these flags on the main thread, so
+            // reading each member at multiple points could see them change mid-init. One snapshot keeps
+            // the whole session-build decision self-consistent (it's a per-session decision anyway).
+            val safeConfigForced = forceSafeCameraConfig
+            val stereoUnstable = forcedStereoUnstable
+            val isStereoCapable = stereoCapable
+            val useStereo = isStereoCapable == true && !stereoUnstable && !safeConfigForced
             var stereoActive = false
             if (useStereo) {
                 val stereoConfigs = try {
@@ -903,7 +910,7 @@ class ArViewModel @Inject constructor(
                 // If no same-cameraId fps variant exists, we leave the default untouched. After a
                 // dead-camera stall we skip the swap entirely (safe mode) — even that minimal swap is
                 // suspect on HALs that open a config but never feed it.
-                if (forceSafeCameraConfig) {
+                if (safeConfigForced) {
                     // A previous AR entry this process never streamed a frame (dead-camera watchdog).
                     // Don't touch ARCore's default config at all — not even the same-cameraId fps swap,
                     // which is the prime suspect for a config the HAL opens but never feeds. The pure
@@ -935,7 +942,7 @@ class ArViewModel @Inject constructor(
                     } else {
                         appendDiag("camera fps: no ${_uiState.value.cameraTargetFps} match for default cfg — using default")
                     }
-                    Timber.i("ARDIAG dual-lens: mono config cam=${s.cameraConfig.cameraId} fps=${_uiState.value.cameraTargetFps} (stereoCapable=$stereoCapable)")
+                    Timber.i("ARDIAG dual-lens: mono config cam=${s.cameraConfig.cameraId} fps=${_uiState.value.cameraTargetFps} (stereoCapable=$isStereoCapable)")
                 }
             }
 
@@ -955,7 +962,7 @@ class ArViewModel @Inject constructor(
             // Surface the camera-config decision ON SCREEN (not just logcat) so a black-camera report
             // tells us whether the live session is on stereo or mono — the difference between a
             // forced-stereo fault and a deeper camera-feeding fault.
-            appendDiag("AR session: ${if (stereoActive) "STEREO" else "mono"} cam=${s.cameraConfig.cameraId} cap=$stereoCapable unstable=$forcedStereoUnstable")
+            appendDiag("AR session: ${if (stereoActive) "STEREO" else "mono"} cam=${s.cameraConfig.cameraId} cap=$isStereoCapable unstable=$stereoUnstable")
             Timber.i("ARDIAG initArSessionLocked: session created OK (stereoActive=$stereoActive rendererAttached=${renderer != null})")
 
             // Critical: if the renderer is already attached, update it with the new session

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -553,6 +553,14 @@ class ArViewModel @Inject constructor(
     // disparity fails / VIO never tracks). Persisted; once set, sessions skip the stereo config.
     @Volatile private var forcedStereoUnstable: Boolean = false
 
+    // Set when the dead-camera watchdog reports the HAL never streamed a frame (e.g. Galaxy A26
+    // budget HAL). Makes the NEXT AR entry (same process) skip the fps-variant swap and run ARCore's
+    // pure default camera config — the most broadly compatible. Process-scoped (NOT persisted): if
+    // the safe config also fails the cause is below the config layer, and a fresh launch should retry
+    // the normal path once (the watchdog re-catches it) rather than be permanently pinned to a config
+    // that may not work either.
+    @Volatile private var forceSafeCameraConfig: Boolean = false
+
     // One-time dual-lens depth-triangulation probe result: null = not yet probed, true = the lenses
     // produce a real depth map (adopt the stereo config), false = no usable depth / thrashes / never
     // tracks (stay mono). Persisted via SettingsRepository.stereoCapability so it runs once per install.
@@ -632,6 +640,16 @@ class ArViewModel @Inject constructor(
     fun onActivityPaused() {
         isActivityResumed = false
         updateSessionStateLocked()
+    }
+
+    /**
+     * Called by the dead-camera watchdog when the camera HAL never delivered a frame to ARCore.
+     * Pins the safest ARCore default camera config for the next AR entry this process (no fps-variant
+     * swap, no hardware stereo). Idempotent; process-scoped so a fresh launch retries normally.
+     */
+    fun onCameraStreamStalled() {
+        forceSafeCameraConfig = true
+        Timber.w("ARDIAG onCameraStreamStalled: next AR entry will use ARCore default camera config (safe mode)")
     }
 
     fun setArMode(enabled: Boolean, context: Context) {
@@ -856,7 +874,7 @@ class ArViewModel @Inject constructor(
             // a black camera. So we only select stereo when the one-time worker-thread probe has proven
             // this device's dual lenses actually triangulate depth (stereoCapable == true) and it hasn't
             // since been marked unstable. Everything else stays on the safe mono 30 FPS back config.
-            val useStereo = stereoCapable == true && !forcedStereoUnstable
+            val useStereo = stereoCapable == true && !forcedStereoUnstable && !forceSafeCameraConfig
             var stereoActive = false
             if (useStereo) {
                 val stereoConfigs = try {
@@ -882,33 +900,43 @@ class ArViewModel @Inject constructor(
                 // compatible one — and only swap to a same-cameraId variant that differs in fps.
                 // (Matching cameraId keeps us on the camera/stream ARCore already validated; we don't
                 // also match resolution because CameraConfig doesn't expose it in this ARCore version.)
-                // If no same-cameraId fps variant exists, we leave the default untouched.
-                // Under battery pressure (tier ≥ medium) cap the camera to 30fps even if 60 was
-                // chosen. Done here at session build only — a mid-session CameraConfig swap resets
-                // tracking, which would be perceptible; the seamless mid-session levers are the
-                // render/SLAM rate ceilings instead.
-                val effectiveCameraFps =
-                    if (_uiState.value.adaptiveRateEnabled && _uiState.value.batteryTier >= 1) 30
-                    else _uiState.value.cameraTargetFps
-                val targetFps = if (effectiveCameraFps == 60)
-                    CameraConfig.TargetFps.TARGET_FPS_60 else CameraConfig.TargetFps.TARGET_FPS_30
-                val defaultCfg = s.cameraConfig
-                val fpsConfig = try {
-                    s.getSupportedCameraConfigs(CameraConfigFilter(s).apply {
-                        facingDirection = CameraConfig.FacingDirection.BACK
-                        this.targetFps = EnumSet.of(targetFps)
-                    }).firstOrNull { it.cameraId == defaultCfg.cameraId }
-                } catch (e: Exception) {
-                    Timber.w(e, "camera fps config query failed")
-                    null
-                }
-                if (fpsConfig != null) {
-                    s.cameraConfig = fpsConfig
-                    appendDiag("camera fps: pinned ${_uiState.value.cameraTargetFps} (matched default cfg)")
+                // If no same-cameraId fps variant exists, we leave the default untouched. After a
+                // dead-camera stall we skip the swap entirely (safe mode) — even that minimal swap is
+                // suspect on HALs that open a config but never feed it.
+                if (forceSafeCameraConfig) {
+                    // A previous AR entry this process never streamed a frame (dead-camera watchdog).
+                    // Don't touch ARCore's default config at all — not even the same-cameraId fps swap,
+                    // which is the prime suspect for a config the HAL opens but never feeds. The pure
+                    // default is the broadest-compatible config ARCore offers.
+                    appendDiag("camera: SAFE MODE — ARCore default config (stream stalled previously, no fps swap)")
+                    Timber.w("ARDIAG mono config: SAFE MODE default cam=${s.cameraConfig.cameraId} (forceSafeCameraConfig)")
                 } else {
-                    appendDiag("camera fps: no ${_uiState.value.cameraTargetFps} match for default cfg — using default")
+                    // Pin the camera frame rate (default 30, user-selectable 30/60). Under battery
+                    // pressure (tier ≥ medium) cap to 30fps even if 60 was chosen. Done here at session
+                    // build only — a mid-session CameraConfig swap resets tracking.
+                    val effectiveCameraFps =
+                        if (_uiState.value.adaptiveRateEnabled && _uiState.value.batteryTier >= 1) 30
+                        else _uiState.value.cameraTargetFps
+                    val targetFps = if (effectiveCameraFps == 60)
+                        CameraConfig.TargetFps.TARGET_FPS_60 else CameraConfig.TargetFps.TARGET_FPS_30
+                    val defaultCfg = s.cameraConfig
+                    val fpsConfig = try {
+                        s.getSupportedCameraConfigs(CameraConfigFilter(s).apply {
+                            facingDirection = CameraConfig.FacingDirection.BACK
+                            this.targetFps = EnumSet.of(targetFps)
+                        }).firstOrNull { it.cameraId == defaultCfg.cameraId }
+                    } catch (e: Exception) {
+                        Timber.w(e, "camera fps config query failed")
+                        null
+                    }
+                    if (fpsConfig != null) {
+                        s.cameraConfig = fpsConfig
+                        appendDiag("camera fps: pinned ${_uiState.value.cameraTargetFps} (matched default cfg)")
+                    } else {
+                        appendDiag("camera fps: no ${_uiState.value.cameraTargetFps} match for default cfg — using default")
+                    }
+                    Timber.i("ARDIAG dual-lens: mono config cam=${s.cameraConfig.cameraId} fps=${_uiState.value.cameraTargetFps} (stereoCapable=$stereoCapable)")
                 }
-                Timber.i("ARDIAG dual-lens: mono config cam=${s.cameraConfig.cameraId} fps=${_uiState.value.cameraTargetFps} (stereoCapable=$stereoCapable)")
             }
 
             // isDualLensActive / isHardwareStereoActive just reflect the camera config for the diag


### PR DESCRIPTION
## Problem

On the **Galaxy A26** (and other budget Samsung HALs, e.g. SM-A236U) AR mode opens an ARCore session but **the camera HAL never feeds ARCore a frame** — `frame.timestamp` stays `0`, so ARCore reports it can't capture features and the screen stays black.

A 10s **dead-camera watchdog** in `MainScreen.kt` already detects this and drops the user back to DESIGN cleanly (no crash) — but there was **no retry with a different camera configuration**. AR was simply unusable on these devices.

## Change

When the watchdog detects a stalled stream it now calls a new `ArViewModel.onCameraStreamStalled()`, which sets a process-scoped `forceSafeCameraConfig` flag. The **next AR entry this process** then runs ARCore's **untouched default camera config**:

- skips the same-cameraId **fps-variant swap** (the prime suspect — a config the HAL opens but never streams from), and
- skips hardware stereo.

The user-facing toast now reads *"…Reopen AR to retry with a safer camera mode."*

### Why process-scoped, not persisted
Unlike the persisted `forcedStereoUnstable` flag, this one resets on app restart. The true cause is unverified — if the safe config *also* fails (cause below the config layer), a persisted flag would permanently pin a possibly-broken config with no user gesture to clear it. A process flag retries the normal path once on a fresh launch and lets the watchdog re-catch it.

### Why it can't regress healthy devices
`forceSafeCameraConfig` starts `false` and is only ever set from inside the `isCameraDead(...)` branch, which never fires on a device that streams frames within the 10s window. Healthy devices keep the exact current config-selection path.

## Files
- `feature/ar/.../ArViewModel.kt` — `forceSafeCameraConfig` flag, `onCameraStreamStalled()`, gating in `initArSessionLocked`'s mono branch + stereo selection.
- `app/.../MainScreen.kt` — dead-camera watchdog calls `onCameraStreamStalled()` and updates the toast copy.

## Verification
- **Compile gate:** CI runs `:feature:ar` + `:app` Kotlin compilation.
- **On-device (A26 — required, this is the real test):** enter AR → expect black screen → after ~10s the toast appears and AR exits (watchdog as today). Tap AR again and confirm via `adb logcat -s ARDIAG` the diag line reads `SAFE MODE — ARCore default config`, then observe whether the camera now streams. If it streams, the workaround holds; if still black, the cause is below the config layer and the next step is a camera-surface/strategy change.
- **Regression check (any working AR device):** AR still enters normally; the diag shows the usual `camera fps: pinned …` (never `SAFE MODE`).

> ⚠️ This is a **blind best-effort** — there is no Android SDK in the build environment and the A26 can't be reproduced here, so on-device logcat verification is needed before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3bkLPqDMuhhdvyDZ45mKC)_