### PR TITLE
Rotate layers WITH the fingers (invert gesture rotation sign)

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
@@ -531,6 +531,13 @@ fun MainScreen(
                                     onGestureStart = { editorViewModel.onGestureStart() },
                                     onGestureEnd = { editorViewModel.onGestureEnd() },
                                     onGesture = { _, pan, zoom, rotation ->
+                                        // calculateRotation()'s sign is opposite our rotation
+                                        // convention, so the raw delta turns the design AGAINST the
+                                        // fingers on every axis (X/Y tilt and Z spin). Negate once here
+                                        // at the input boundary so it rotates WITH the fingers; the
+                                        // model keeps its own sign convention (positive delta → positive
+                                        // rotation), so reducers/tests are unaffected.
+                                        val turn = -rotation
                                         if (editingMode) {
                                             // In AR the overlay lives on the wall in meters, so convert
                                             // the screen-pixel drag to in-plane meters. Local +X on the
@@ -541,9 +548,9 @@ fun MainScreen(
                                                 val mpp = rendererRef.value?.currentMetersPerPixel ?: 0f
                                                 androidx.compose.ui.geometry.Offset(pan.x * mpp, -pan.y * mpp)
                                             } else pan
-                                            editorViewModel.onModeTransformGesture(uiState.editorMode, adjustedPan, zoom, rotation)
+                                            editorViewModel.onModeTransformGesture(uiState.editorMode, adjustedPan, zoom, turn)
                                         } else {
-                                            editorViewModel.onTransformGesture(pan, zoom, rotation)
+                                            editorViewModel.onTransformGesture(pan, zoom, turn)
                                         }
                                     }
                                 )


### PR DESCRIPTION
## Problem

Layer rotation ran **backwards on every axis** — a two-finger twist turned the design the opposite way for X/Y tilt and Z spin alike. The design should rotate **with** the fingers.

## Cause

The gesture pipeline feeds one rotation delta from Compose's `calculateRotation()` into both rotation paths:
- per-layer (DESIGN) → `onTransformGesture`
- per-mode (OVERLAY/MOCKUP/TRACE/AR) → `onModeTransformGesture` → `modeAdjustments` → AR content-rotation shader

That delta's sign is opposite the rotation convention used by `graphicsLayer` (and the AR shader), so the raw per-event delta drove rotation against the fingers. Because all three axes share the same delta (the double-tap axis cycle just routes it to X, Y, or Z), every axis was inverted together.

## Fix

Negate the delta **once at the gesture input boundary** in `MainScreen`, so the corrected sign flows into both paths and all renderers. The model/reducer sign convention is left untouched (positive delta still means positive rotation), so `EditorReducer`/`EditorViewModel` tests are unaffected — this is purely an input-mapping correction.

```kotlin
onGesture = { _, pan, zoom, rotation ->
    val turn = -rotation   // rotate WITH the fingers
    ...
    onModeTransformGesture(mode, adjustedPan, zoom, turn)   // or onTransformGesture(pan, zoom, turn)
}
```

## Files
- `app/.../MainScreen.kt` — invert the rotation delta in the `detectSmartOverlayGestures` callback.

## Verification
- **Compile gate:** CI runs `:app` Kotlin compilation.
- **On-device:** in DESIGN, two-finger twist a layer — it now follows the fingers. Double-tap to cycle to X then Y and confirm the tilt direction follows the twist. Repeat in Overlay/Mockup/Trace (whole-design) and in AR (overlay on the wall). Pan and zoom are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3bkLPqDMuhhdvyDZ45mKC)_

## Summary by Sourcery

Bug Fixes:
- Invert the rotation delta at the gesture input boundary so X/Y tilt and Z spin now rotate with the fingers in all editor modes.