### PR TITLE
Fix NPE constructing ArViewModel (throttle collector vs lazy powerManager)

### DIFF
--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -1925,12 +1925,17 @@ class ArViewModel @Inject constructor(
     // Thermal pressure, power-save mode, and low battery each float perceptionSystemThrottle, which
     // MainScreen pushes to the renderer to floor perception redraws at 30 fps. The renderer also
     // self-throttles on measured frame lag; this covers the system-level signals it can't see.
-    private val powerManager by lazy {
-        appContext.getSystemService(Context.POWER_SERVICE) as? android.os.PowerManager
-    }
-    private val batteryManager by lazy {
-        appContext.getSystemService(Context.BATTERY_SERVICE) as? android.os.BatteryManager
-    }
+    // Computed getters, NOT `by lazy`: the throttle-settings collectors launched in init call
+    // recomputeSystemThrottle() (which reads powerManager) on their first emission, and DataStore can
+    // replay a cached value synchronously *during construction* — before a `by lazy` delegate field
+    // declared this far down the class is initialized, which NPE'd in the synthetic getter. A getter
+    // has no backing field and reads appContext (a constructor param, always set), so it is safe to
+    // touch at any point in construction. getSystemService returns the same cached service singleton,
+    // so listener add/remove identity is preserved and the per-call cost is negligible.
+    private val powerManager: android.os.PowerManager?
+        get() = appContext.getSystemService(Context.POWER_SERVICE) as? android.os.PowerManager
+    private val batteryManager: android.os.BatteryManager?
+        get() = appContext.getSystemService(Context.BATTERY_SERVICE) as? android.os.BatteryManager
     private var thermalListener: android.os.PowerManager.OnThermalStatusChangedListener? = null
     private var powerReceiver: android.content.BroadcastReceiver? = null
     @Volatile private var thermalHot = false

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -1933,9 +1933,9 @@ class ArViewModel @Inject constructor(
     // touch at any point in construction. getSystemService returns the same cached service singleton,
     // so listener add/remove identity is preserved and the per-call cost is negligible.
     private val powerManager: android.os.PowerManager?
-        get() = appContext.getSystemService(Context.POWER_SERVICE) as? android.os.PowerManager
+        get() = appContext.getSystemService(android.os.PowerManager::class.java)
     private val batteryManager: android.os.BatteryManager?
-        get() = appContext.getSystemService(Context.BATTERY_SERVICE) as? android.os.BatteryManager
+        get() = appContext.getSystemService(android.os.BatteryManager::class.java)
     private var thermalListener: android.os.PowerManager.OnThermalStatusChangedListener? = null
     private var powerReceiver: android.content.BroadcastReceiver? = null
     @Volatile private var thermalHot = false


### PR DESCRIPTION
## Problem

App crashes on launch (intermittently) with a `NullPointerException` while Hilt constructs `ArViewModel`:

```
java.lang.NullPointerException
  at ArViewModel.getPowerManager (ArViewModel.kt:1928)
  at ArViewModel.recomputeSystemThrottle (ArViewModel.kt:1955)
  at ArViewModel$7$1.emit  (throttleFlow collector)
  at ArViewModel.<init>   (ArViewModel.kt:486)
  ... HiltViewModelFactory → MainActivity.getArViewModel
```

## Cause

The init block launches collectors on the throttle-settings flows, and each calls `recomputeSystemThrottle()` on its **first emission**:

```kotlin
viewModelScope.launch {
    settingsRepository.throttleOnThermal.collect { on ->
        _uiState.update { it.copy(throttleOnThermal = on) }
        recomputeSystemThrottle()   // reads powerManager
    }
}
```

`recomputeSystemThrottle()` reads `powerManager`, which was a `by lazy` property declared near the **bottom** of the class (line ~1928). Kotlin initializes property delegates top-to-bottom, so that `Lazy` backing field is set late in construction. DataStore can replay its cached value **synchronously on `Dispatchers.Main.immediate` during construction** — before that delegate field is assigned — so the synthetic `getPowerManager` dereferenced a `null` delegate and threw. The timing dependence is why it's intermittent.

## Fix

Convert `powerManager` and `batteryManager` from `by lazy` to **no-backing-field `get()` computed properties**:

```kotlin
private val powerManager: PowerManager?
    get() = appContext.getSystemService(Context.POWER_SERVICE) as? PowerManager
```

They read `appContext` — a constructor parameter, assigned before any init block runs — so they're safe to touch at any point during construction. `getSystemService` returns the same cached service singleton per `Context`, so thermal-listener add/remove identity is preserved and the per-call cost is negligible (these are read only on settings/thermal/battery events).

## Files
- `feature/ar/.../ArViewModel.kt` — `powerManager`/`batteryManager` → computed getters.

## Verification
- **Compile gate:** CI runs `:feature:ar` Kotlin compilation.
- **On-device / behavior:** the NPE path is removed because there is no longer a nullable delegate to dereference during construction; `appContext` is always present. Thermal/power-save/low-battery throttling continues to work (same `getSystemService` instance, same listener lifecycle). The other two `by lazy` props in the class (`evalProbe`, `evalRecorder`) are declared before the collectors and aren't in the throttle path, so they're unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3bkLPqDMuhhdvyDZ45mKC)_

## Summary by Sourcery

Prevent ArViewModel construction from crashing due to a null PowerManager/BatteryManager reference when throttle-setting flows emit during initialization.

Bug Fixes:
- Resolve intermittent NullPointerException in ArViewModel caused by accessing lazily-initialized power and battery managers before their delegates are set.

Enhancements:
- Use computed getter properties for PowerManager and BatteryManager to ensure safe access during ViewModel construction while preserving system service identity.