### PR TITLE
Remove all -PversionBuild overrides; build auto-increments versionBuild every build

### DIFF
--- a/.github/workflows/merged-build.yml
+++ b/.github/workflows/merged-build.yml
@@ -146,10 +146,9 @@ jobs:
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
         run: |
           set +e
-          export BUILD_NUMBER=$(git rev-list --count HEAD)
 
           # Build the APK (signing comes from the env-driven signingConfigs.release in Gradle)
-          ./gradlew assembleDebug -PversionBuild=$BUILD_NUMBER --build-cache > build.log 2>&1
+          ./gradlew assembleDebug --build-cache > build.log 2>&1
 
           EXIT_CODE=$?
           echo "exit_code=$EXIT_CODE" >> $GITHUB_OUTPUT

--- a/.github/workflows/release-aab.yml
+++ b/.github/workflows/release-aab.yml
@@ -105,44 +105,12 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Resolve package name and bump versionCode (from version.properties)
+      - name: Resolve package name
         id: meta
         run: |
           # Read the applicationId straight from the build config (don't hardcode).
           PKG=$(grep -E 'applicationId\s*=' app/build.gradle.kts | head -n1 | sed -E 's/.*"([^"]+)".*/\1/')
           echo "package_name=$PKG" >> "$GITHUB_OUTPUT"
-
-          # versionBuild in version.properties IS the Android versionCode (single source of truth).
-          # Increment it here and, on a publish run, commit it back (see "Persist bumped versionCode")
-          # so every Play upload is strictly higher than the last. This replaces the old
-          # `git rev-list --count HEAD + 10000`, which was not unique per upload: a re-run, a second
-          # dispatch from the same HEAD, or building a non-tip commit all reproduced an already-used
-          # code (Play rejects with "Version code N has already been used").
-          CUR=$(grep -E '^versionBuild=' version.properties | cut -d'=' -f2 | tr -d '\r ')
-          VERSION_CODE=$(( CUR + 1 ))
-          sed -i -E "s/^versionBuild=.*/versionBuild=${VERSION_CODE}/" version.properties
-          echo "version_code=$VERSION_CODE" >> "$GITHUB_OUTPUT"
-
-          # versionName patch also comes from version.properties.
-          VERSION_PATCH=$(grep -E '^versionPatch=' version.properties | cut -d'=' -f2 | tr -d '\r ')
-          echo "version_patch=$VERSION_PATCH" >> "$GITHUB_OUTPUT"
-          echo "Package: $PKG  versionCode: $VERSION_CODE  versionPatch: $VERSION_PATCH"
-
-      - name: Persist bumped versionCode
-        # Only on a real publish: commit the incremented version.properties back so the next upload is
-        # strictly higher. Done BEFORE the build/upload so a number is never re-used even if a later
-        # step fails (a skipped number is harmless; a duplicate is not). [skip ci] stops a re-trigger.
-        if: ${{ inputs.publish }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add version.properties
-          if git diff --cached --quiet; then
-            echo "version.properties unchanged — nothing to persist"
-          else
-            git commit -m "ci: bump versionBuild to ${{ steps.meta.outputs.version_code }} [skip ci]"
-            git push origin "HEAD:${{ github.ref_name }}"
-          fi
 
       - name: Build Release AAB (signed)
         env:
@@ -153,8 +121,26 @@ jobs:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+        # No -PversionBuild override: build.gradle.kts auto-increments versionBuild in
+        # version.properties on every build. The persist step below commits that bump back.
         run: |
-          ./gradlew bundleRelease -PversionBuild=${{ steps.meta.outputs.version_code }} -PversionPatch=${{ steps.meta.outputs.version_patch }}
+          ./gradlew bundleRelease
+
+      - name: Persist auto-incremented versionCode
+        # Commit the version.properties bump that the build just made, so the next release is strictly
+        # higher. Publish runs only; [skip ci] (and the push-trigger paths-ignore) stop a re-trigger.
+        if: ${{ inputs.publish }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add version.properties
+          if git diff --cached --quiet; then
+            echo "version.properties unchanged — nothing to persist"
+          else
+            NEW=$(grep -E '^versionBuild=' version.properties | cut -d'=' -f2 | tr -d '\r ')
+            git commit -m "ci: versionBuild=${NEW} [skip ci]"
+            git push origin "HEAD:${{ github.ref_name }}"
+          fi
 
       - name: Upload AAB artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/release-apk.yml
+++ b/.github/workflows/release-apk.yml
@@ -80,11 +80,9 @@ jobs:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+        # No -PversionBuild override: build.gradle.kts auto-increments versionBuild on every build.
         run: |
-          # versionCode comes from version.properties (versionBuild) — the single source of truth,
-          # bumped + persisted by the Play (AAB) workflow. This GitHub-release APK only reads it.
-          VERSION_BUILD=$(grep -E '^versionBuild=' version.properties | cut -d'=' -f2 | tr -d '\r ')
-          ./gradlew assembleRelease -PversionBuild=$VERSION_BUILD
+          ./gradlew assembleRelease
 
       - name: Prepare Release
         env:

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,14 +34,6 @@ val localProperties = Properties().apply {
 //   - versionPatch  -> the patch segment of the versionName. Increments each compile, but resets to
 //                      0 when versionMinor was bumped since the last build (a new minor starts at .0).
 //                      versionMinorLast tracks the minor we last built so that reset is automatic.
-// An explicit `-PversionBuild=<n>` override always wins (CI passes the incremented versionBuild read
-// from version.properties — see release-aab.yml, which also commits that value back so it persists);
-// when present we do NOT auto-increment or rewrite the file here, so the build uses exactly <n>.
-val versionBuildOverride = project.findProperty("versionBuild")?.toString()?.toIntOrNull()
-// Likewise `-PversionPatch=<n>` sets the versionName patch segment (CI passes version.properties'
-// versionPatch — see release-aab.yml). When EITHER override is present the file is left untouched.
-val versionPatchOverride = project.findProperty("versionPatch")?.toString()?.toIntOrNull()
-
 // True when the requested tasks actually compile/assemble the app — not a sync, `tasks`, `clean`,
 // a `--dry-run`, or a diagnostic like `buildEnvironment`/`buildHealth`. Build verbs are matched as a
 // prefix and the `build` lifecycle task exactly, so diagnostics that merely contain "build" don't trip it.
@@ -60,10 +52,10 @@ val verMinor = versionProps.getProperty("versionMinor", "0")
 val lastMinor = versionProps.getProperty("versionMinorLast", verMinor)
 val isMinorBumped = verMinor != lastMinor
 
-var currentVersionCode = versionBuildOverride ?: versionProps.getProperty("versionBuild", "1").toInt()
-var currentPatch = versionPatchOverride ?: if (isMinorBumped) 0 else versionProps.getProperty("versionPatch", "0").toInt()
+var currentVersionCode = versionProps.getProperty("versionBuild", "1").toInt()
+var currentPatch = if (isMinorBumped) 0 else versionProps.getProperty("versionPatch", "0").toInt()
 
-if (versionBuildOverride == null && versionPatchOverride == null && isBuilding) {
+if (isBuilding) {
     currentVersionCode++ // build never resets
     // A minor bump makes this build the new minor's .0; otherwise advance the patch.
     if (!isMinorBumped) currentPatch++


### PR DESCRIPTION
## What

`build.gradle.kts` auto-increments `versionBuild` (and `versionPatch`) in `version.properties` on **every build**. CI was passing `-PversionBuild`, which suppressed that and forced a commit-count value — the cause of the duplicate "Version code already used" failures. Remove the override everywhere.

- **`app/build.gradle.kts`** — dropped the `versionBuild`/`versionPatch` override handling. The auto-increment block now always runs on a build.
- **`.github/workflows/release-aab.yml`** — no `-P` override; `./gradlew bundleRelease` auto-increments, then a publish run commits the bumped `version.properties` back (`[skip ci]`) so it persists and the next release is strictly higher.
- **`.github/workflows/release-apk.yml`** — dropped `-PversionBuild`.
- **`.github/workflows/merged-build.yml`** — dropped the now-dead `-PversionBuild`.

`version.properties` is at `versionBuild=14137`, so the next build auto-increments to **14138** (> the already-used 14137).

## Verify
- Dispatch the AAB workflow (`publish: true`): build log shows `versionCode 14138`, Play accepts it, and a `ci: versionBuild=14138 [skip ci]` commit lands on `main`. Next dispatch → 14139, and so on.
- ⚠️ The persist step pushes to `main`; if branch protection blocks the github-actions bot it fails there (before upload, so no number wasted) — allow the bot to push or swap to a PAT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3bkLPqDMuhhdvyDZ45mKC)_

## Summary by Sourcery

Remove CI and Gradle property overrides for versionBuild/versionPatch so that the app build script always auto-increments version metadata from version.properties on every build, with publish workflows persisting the updated version back to the main branch.

Bug Fixes:
- Ensure Android versionCode is always unique across Play Store uploads by relying on automatic versionBuild increments instead of commit-count or manual overrides.

Enhancements:
- Simplify app Gradle configuration by removing versionBuild/versionPatch property override handling and always incrementing version values during real builds.
- Streamline release workflows by delegating versionCode management to the build script and adding a publish-only step that commits the auto-incremented version.properties back to the repository.

Build:
- Update Gradle invocations in release AAB/APK and merged-build workflows to drop -PversionBuild/-PversionPatch overrides and use the auto-incremented version metadata from version.properties.

CI:
- Adjust release-aab workflow to persist the build-generated versionBuild to main only on publish runs, avoiding duplicate version codes while preventing unnecessary CI retriggers.