### PR TITLE
Codebase audit: squash critical bugs across AR, editor, data, and co-op

### DIFF
--- a/.github/workflows/merged-build.yml
+++ b/.github/workflows/merged-build.yml
@@ -127,7 +127,12 @@ jobs:
           FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         with:
           cache-read-only: false
-          dependency-graph: true
+          # The unit-tests job already generates, submits and uploads the dependency graph for
+          # this commit; keep it disabled here so the build job doesn't submit a duplicate.
+          # 'true' is not a valid value for setup-gradle@v6 (enum: disabled / generate /
+          # generate-and-submit / generate-submit-and-upload / generate-and-upload /
+          # download-and-submit), which failed the action before the build could start.
+          dependency-graph: disabled
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -5,9 +5,13 @@
 ### Done
 
 - **CodeQL #6 — Multiplication result converted to larger type** (`core/nativebridge/src/main/cpp/SurfaceUnroller.cpp:100`). `mCount * mCount` was computed as `int` and then widened to `size_t` for the `std::vector` ctor; overflows for `mCount ≥ 46341`. Fixed by casting both operands to `std::size_t` before multiplying.
-- **Dependabot #27 — Netty HTTP header injection in HttpProxyHandler** (`io.netty:netty-handler-proxy`). Fixed by pinning `io.netty:netty-handler-proxy:4.1.134.Final` in `build.gradle.kts`. **Verified:** 4.1.134.Final addresses CVE-2025-67735 and subsequent regressions.
+- **Dependabot #27 — Netty HTTP header injection in HttpProxyHandler** (`io.netty:netty-handler-proxy`). Fixed by forcing the netty family (incl. `netty-handler-proxy`) to `4.2.15.Final` in `build.gradle.kts` `commonForcedDependencies`. **Verified:** 4.2.15.Final addresses CVE-2025-67735 and subsequent regressions.
+
+- **Dependabot #23/#24/#25 — Bouncy Castle (covert timing channel / LDAP injection / risky crypto algo).** Fixed by forcing `org.bouncycastle:{bcprov,bcpkix,bcutil}-jdk18on:1.84` in `build.gradle.kts` `commonForcedDependencies` (1.84 first patches all three; the three artifact versions must match).
 
 - **Task 17 — Co-op Implementation.** Real project serialization and spectator load implemented in `ProjectManager`. Wired `StrokeComplete` Op in `EditorViewModel` using bitmap-space mapping. Verified host-guest drawing sync logic.
+- **Co-op — Transport security & robustness.** Encrypted the peer-to-peer transport (protocol v2: token-derived AES-256-GCM per frame, nonce/proof handshake, no token on the wire) and hardened the sessions: accept-loop survives bad handshakes, ops are lossless across reconnects (seq/encode/buffer at enqueue), 15s socket read timeouts, guest re-syncs on host `sessionId` change, bounded pre-handler spectator-op buffering. Import/spectator load hardened against Zip-Slip. See `collab/` and `core/data/ProjectManager.kt`.
+- **Relocalization — Fingerprint JNI ABI.** Fixed `nativeSetWallFingerprint` silently returning null (native looked up a stale `Fingerprint` constructor descriptor after a field was added). Native now builds through a frozen `Fingerprint.fromNative` factory guarded by `FingerprintJniContractTest`.
 - **Task 15 — QR Scanner.** Integrated ZXing-based QR scanner into `MainActivity`. Search button now triggers live scanner to join sessions.
 - **Voxel Memory — Frustum Culling.** Implemented true NDC-based visible splat confidence calculation in `VoxelHash`.
 - **Relocalization — Thread Safety.** Added mutex locking to `mWallDescriptors` and `mWallKeypoints3D` in `MobileGS` to prevent races between JNI updates and the background PnP thread.
@@ -19,9 +23,18 @@
   - **Action B:** vendor the three files under `docs/vendor/` and reference local paths. Eliminates the alert and removes a runtime CDN dependency.
   - **Note:** line 7 (`https://cdn.tailwindcss.com`) is the tailwind play-CDN, which intentionally has no stable SRI hash. If it shows up as an alert, prefer Action B (vendor a built Tailwind CSS) since SRI is impractical here.
 
-- **Dependabot #25 — Bouncy Castle covert timing channel (High)** (`org.bouncycastle:bcprov-jdk18on`).
-- **Dependabot #24 — Bouncy Castle LDAP injection (Moderate)** (`org.bouncycastle:bcprov-jdk18on`).
-- **Dependabot #23 — Bouncy Castle bcpkix risky crypto algorithm (Moderate)** (`org.bouncycastle:bcpkix-jdk18on`).
-  - Bouncy Castle is **transitive** — no direct pin exists in `gradle/libs.versions.toml` or any `build.gradle.kts`. Pulled in by a dependency (likely Firebase / Play Services / something doing PKI).
-  - **Action:** run `./gradlew :app:dependencyInsight --configuration releaseRuntimeClasspath --dependency org.bouncycastle:bcprov-jdk18on` to identify the source, then either (a) bump that source dep if a newer version pulls patched BC, or (b) add `bcprov-jdk18on` and `bcpkix-jdk18on` to `commonForcedDependencies` at versions that resolve all three CVEs together (check GHSA advisories for the minimum safe version of each — the highest of the three is the floor).
-  - **Caveat:** Bouncy Castle has had breaking API changes between minor versions. After forcing, run the full test suite and verify any signing / cert / OCSP paths still work.
+  (The Bouncy Castle advisories #23/#24/#25 previously listed here are resolved — see the `1.84` force in the Done section above.)
+
+## Dead / unreachable features (audited, deliberately left as-is — decide per feature)
+
+A codebase audit found these fully-built-but-unreachable or non-functional features. They were **not** changed in the bug-squash pass (only outright bugs were), and are catalogued here for a future product decision (wire up vs. remove):
+
+- **Glasses AR session** — no entry point invokes `ArViewModel.startGlassesSession()` from `Idle` (only the post-`Active` reconnect banner does), and calibration (`ArViewModel.glassesWorldHitForTimestamp`, ~`:388`) hit-tests the same screen point for `src`/`dst`, so `Procrustes.solve` always returns identity.
+- **AR tap-to-distance UI** — reticle + per-mark distance chips are gated on `arUiState.isDepthApiSupported`, but the ARCore Depth API is deliberately disabled (`useArCoreDepthApi = false`, `ArViewModel` ~`:859`) because it starved VIO on the target hardware. The UI never renders. (Re-gating on the VIO/stereo depth that *is* available would revive it.)
+- **AR freeze-preview** — `ArViewModel.onFreezeRequested()` is never called, so `FreezePreviewScreen` and the unfreeze→`toggleImageLock` chain are dead.
+- **Per-mode transform lock** — `EditorViewModel.onToggleModeTransformLocked` and four siblings are never called from UI; `ModeAdjustment.isTransformLocked` is always false.
+- **`EditorMode.STENCIL`** — `MainActivity` immediately bounces STENCIL→MOCKUP and no route targets it; stencil generation is reachable only via the per-layer action.
+- **Empty placeholder screens** — `MockupScreen`/`OverlayScreen`/`TraceScreen` ignore all params (real rendering is in `MainScreen`).
+- **Unwired functions / dead classes** — `ArViewModel.requestExport`/`updateMaskPath`/`setPlaneConfirmationBorder`/`applyEraseToMask`; `CrashHandler` + unregistered `CrashActivity`; `WarpableImage`/`VirtualCamera`/`SurfaceUnroller`; `CollaborationManager.stopHosting()`; the dead `Tool.LIQUIFY` branch in `ImageProcessor.applyToolToBitmap`.
+- **Orphaned Vulkan splat shaders** — `core/nativebridge/src/main/assets/shaders/splat.{vert,frag}` are `#version 450` Vulkan GLSL; the Vulkan backend was removed and nothing loads them (dead APK weight).
+- **Minor** — `LocalIp` naively picks the first non-loopback IPv4 (can advertise an unreachable VPN/cellular address); `ImageProcessingUtils.convertYuvToRgbaDirect` round-trips through a Bitmap despite advertising zero-copy.

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -40,14 +40,17 @@
     native <methods>;
 }
 
-# Keep model classes constructed directly from native code via JNI NewObject.
-# R8 will otherwise strip primary constructors that have no Kotlin/Java
-# reachability — the native code calls them but R8 doesn't see those calls,
-# so it removes the constructor and `GetMethodID` returns null at runtime,
-# crashing with `JNI DETECTED ERROR IN APPLICATION: mid == null`.
+# Keep model classes constructed directly from native code via JNI.
+# R8 will otherwise strip members that have no Kotlin/Java reachability — the
+# native code calls them but R8 doesn't see those calls, so it removes them and
+# `GetMethodID`/`GetStaticMethodID` returns null at runtime, crashing with
+# `JNI DETECTED ERROR IN APPLICATION: mid == null`.
+# GraffitiJNI.cpp builds Fingerprints via the frozen static factory
+# Fingerprint.fromNative (see Fingerprint.JNI_FACTORY_DESCRIPTOR).
 -keep class com.hereliesaz.graffitixr.common.model.Fingerprint { *; }
 -keepclassmembers class com.hereliesaz.graffitixr.common.model.Fingerprint {
     <init>(...);
+    public static ** fromNative(...);
 }
 
 # General Safety for Native Methods

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -436,7 +436,8 @@ class MainActivity : ComponentActivity() {
                 }
 
                 LaunchedEffect(arViewModel, editorViewModel) {
-                    arViewModel.spectatorOpHandler = { op -> editorViewModel.applySpectatorOp(op) }
+                    // Also flushes, in order, any spectator ops that arrived before this effect ran.
+                    arViewModel.setSpectatorOpHandler { op -> editorViewModel.applySpectatorOp(op) }
                 }
 
                 val overlayImagePicker = rememberLauncherForActivityResult(ActivityResultContracts.PickVisualMedia()) { uri ->

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,7 +35,8 @@ buildscript {
     )
 
     // Protobuf is intentionally pinned to TWO different versions: the buildscript classpath needs
-    // 3.25.5 for AGP 9.0.1, while the application runtime needs the 4.x line for security fixes.
+    // 3.25.5 for the current AGP (see gradle/libs.versions.toml), while the application runtime
+    // needs the 4.x line for security fixes.
     // These are named (not inline literals) so the split is explicit in one place and a future edit
     // can't silently collide them. See the resolutionStrategy blocks below and in allprojects.
     val protobufBuildscriptVersion = "3.25.5"
@@ -58,7 +59,7 @@ buildscript {
         resolutionStrategy {
             // Force common dependencies
             commonForcedDependencies.forEach { force(it) }
-            // AGP 9.0.1 requires Protobuf 3.25.5 in the buildscript classpath
+            // The current AGP requires Protobuf 3.25.5 in the buildscript classpath
             protobufModules.forEach { force("$it:$protobufBuildscriptVersion") }
         }
     }

--- a/collab/src/main/java/com/hereliesaz/graffitixr/core/collaboration/CollaborationManager.kt
+++ b/collab/src/main/java/com/hereliesaz/graffitixr/core/collaboration/CollaborationManager.kt
@@ -4,6 +4,7 @@ import com.hereliesaz.graffitixr.common.model.CoopSessionState
 import com.hereliesaz.graffitixr.common.model.Op
 import com.hereliesaz.graffitixr.core.collaboration.session.GuestSession
 import com.hereliesaz.graffitixr.core.collaboration.session.HostSession
+import com.hereliesaz.graffitixr.core.collaboration.wire.ProtocolVersion
 import com.hereliesaz.graffitixr.core.collaboration.wire.QrPayload
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -38,7 +39,7 @@ class CollaborationManager @Inject constructor() {
         fingerprintBytes: ByteArray,
         projectBytes: ByteArray,
         localDeviceName: String,
-        protocolVersion: Int = 1,
+        protocolVersion: Int = ProtocolVersion.CURRENT,
     ): String {
         check(hostSession == null && guestSession == null) { "already in a session" }
         val token = QrPayload.newToken()

--- a/collab/src/main/java/com/hereliesaz/graffitixr/core/collaboration/session/GuestSession.kt
+++ b/collab/src/main/java/com/hereliesaz/graffitixr/core/collaboration/session/GuestSession.kt
@@ -30,6 +30,8 @@ internal class GuestSession(
     @Volatile private var sessionId: String? = null
     @Volatile private var lastAppliedSeq: Long = 0L
     private var socket: Socket? = null
+
+    private fun randomNonce(): ByteArray = ByteArray(16).also { java.security.SecureRandom().nextBytes(it) }
     // Guards the check-then-set phase transition in attemptReconnect(): the inbound loop and a
     // failed PONG write can race into it, and without the lock each would run its own full
     // reconnect loop against the same host.
@@ -39,11 +41,20 @@ internal class GuestSession(
     // both write to the same OutputStream, so without this lock their frames interleave.
     private val writeMutex = Mutex()
 
-    private suspend fun writeFrame(output: OutputStream, type: FrameType, payload: ByteArray) {
+    // Seal-then-write every post-handshake frame under the write lock (also serializes crypto's
+    // send counter across the inbound-PONG and DELTA_ACK loops).
+    private suspend fun writeSecure(output: OutputStream, crypto: SessionCrypto, type: FrameType, payload: ByteArray) {
         writeMutex.withLock {
-            Frame.write(output, type, payload)
+            Frame.write(output, FrameType.ENC, crypto.seal(type, payload))
             output.flush()
         }
+    }
+
+    // Read one post-handshake frame: it must be an ENC envelope; open it to the inner frame.
+    private fun readSecure(input: InputStream, crypto: SessionCrypto): Frame.FrameRead? {
+        val frame = Frame.read(input) ?: return null
+        if (frame.type != FrameType.ENC) throw java.io.IOException("expected ENC frame, got ${frame.type}")
+        return crypto.open(frame.payload)
     }
 
     suspend fun connect() {
@@ -76,13 +87,18 @@ internal class GuestSession(
             val input = s.getInputStream()
             val output = s.getOutputStream()
 
-            // Send HELLO.
+            // Send HELLO. The token is never transmitted; prove knowledge of it with an HMAC over
+            // a fresh nonce that also seeds the per-connection key schedule.
+            val prk = SessionCrypto.prk(token)
+            val guestNonce = randomNonce()
+            val proof = SessionCrypto.helloProof(prk, guestNonce)
             Frame.write(
                 output,
                 FrameType.HELLO,
                 OpCodec.encode(
                     HelloPayload(
-                        token = token,
+                        guestNonce = guestNonce,
+                        proof = proof,
                         clientVersion = protocolVersion,
                         deviceName = localDeviceName,
                         lastAppliedSeq = if (isReconnect) lastAppliedSeq else 0L,
@@ -95,6 +111,15 @@ internal class GuestSession(
             when (response.type) {
                 FrameType.HELLO_OK -> {
                     val helloOk = OpCodec.decode<HelloOkPayload>(response.payload)
+                    // Authenticate the host before trusting any bulk data: it must prove token
+                    // knowledge bound to both nonces.
+                    val expectedHostProof = SessionCrypto.helloOkProof(prk, helloOk.hostNonce, guestNonce)
+                    if (!java.security.MessageDigest.isEqual(helloOk.hostProof, expectedHostProof)) {
+                        try { s.close() } catch (_: Exception) {}
+                        socket = null
+                        close(CoopSessionState.EndReason.BadToken)
+                        return false
+                    }
                     if (isReconnect && sessionId != null && helloOk.sessionId != sessionId) {
                         // The host restarted with a fresh session (new seq space and empty
                         // DeltaBuffer): resuming with our lastAppliedSeq would make the host
@@ -108,12 +133,13 @@ internal class GuestSession(
                         return false
                     }
                     sessionId = helloOk.sessionId
+                    val crypto = SessionCrypto.forGuest(token, helloOk.sessionId, guestNonce, helloOk.hostNonce)
                     if (!isReconnect) {
-                        receiveBulk(input, output)
+                        receiveBulk(input, output, crypto)
                     }
                     _state.value = CoopSessionState.Connected(peerName = "host")
                     phase = Phase.Live
-                    livePhase(input, output)
+                    livePhase(input, output, crypto)
                     true
                 }
                 FrameType.HELLO_REJECTED -> {
@@ -141,31 +167,30 @@ internal class GuestSession(
         }
     }
 
-    private suspend fun receiveBulk(input: InputStream, output: OutputStream) {
-        val begin = Frame.read(input) ?: error("EOF in bulk")
+    private suspend fun receiveBulk(input: InputStream, output: OutputStream, crypto: SessionCrypto) {
+        val begin = readSecure(input, crypto) ?: error("EOF in bulk")
         require(begin.type == FrameType.BULK_BEGIN)
         val beginPayload = OpCodec.decode<BulkBeginPayload>(begin.payload)
 
-        val fingerprint = receiveChunked(input, FrameType.BULK_FINGERPRINT, beginPayload.fingerprintBytes)
-        val project = receiveChunked(input, FrameType.BULK_PROJECT, beginPayload.projectBytes)
+        val fingerprint = receiveChunked(input, crypto, FrameType.BULK_FINGERPRINT, beginPayload.fingerprintBytes)
+        val project = receiveChunked(input, crypto, FrameType.BULK_PROJECT, beginPayload.projectBytes)
 
-        val end = Frame.read(input) ?: error("EOF before BULK_END")
+        val end = readSecure(input, crypto) ?: error("EOF before BULK_END")
         require(end.type == FrameType.BULK_END)
 
-        Frame.write(output, FrameType.BULK_ACK, OpCodec.encode(BulkAckPayload(0L)))
-        output.flush()
+        writeSecure(output, crypto, FrameType.BULK_ACK, OpCodec.encode(BulkAckPayload(0L)))
 
         onBulkReceived(fingerprint, project)
     }
 
-    private fun receiveChunked(input: InputStream, expectedType: FrameType, totalBytes: Int): ByteArray {
+    private fun receiveChunked(input: InputStream, crypto: SessionCrypto, expectedType: FrameType, totalBytes: Int): ByteArray {
         // totalBytes is peer-declared: reject negative/absurd sizes before allocating
         // (NegativeArraySize / OOM).
         require(totalBytes in 0..Limits.MAX_BULK_BYTES) { "invalid bulk size $totalBytes" }
         val buffer = ByteArray(totalBytes)
         var offset = 0
         while (offset < totalBytes) {
-            val frame = Frame.read(input) ?: error("EOF mid-bulk")
+            val frame = readSecure(input, crypto) ?: error("EOF mid-bulk")
             require(frame.type == expectedType) { "expected $expectedType, got ${frame.type}" }
             // A chunk running past the declared size means the stream is misaligned with the
             // BULK_BEGIN header; silently truncating (the old minOf clamp) would desync every
@@ -181,11 +206,11 @@ internal class GuestSession(
         return buffer
     }
 
-    private suspend fun livePhase(input: InputStream, output: OutputStream) {
+    private suspend fun livePhase(input: InputStream, output: OutputStream, crypto: SessionCrypto) {
         scope.launch {
             while (scope.isActive) {
                 val frame = try {
-                    Frame.read(input) ?: run {
+                    readSecure(input, crypto) ?: run {
                         attemptReconnect(); return@launch
                     }
                 } catch (e: Exception) {
@@ -202,7 +227,7 @@ internal class GuestSession(
                     FrameType.PING -> {
                         val ping = OpCodec.decode<PingPayload>(frame.payload)
                         try {
-                            writeFrame(output, FrameType.PONG, OpCodec.encode(ping))
+                            writeSecure(output, crypto, FrameType.PONG, OpCodec.encode(ping))
                         } catch (e: Exception) {
                             attemptReconnect(); return@launch
                         }
@@ -221,7 +246,7 @@ internal class GuestSession(
             while (scope.isActive) {
                 delay(1_000)
                 try {
-                    writeFrame(output, FrameType.DELTA_ACK, OpCodec.encode(DeltaAckPayload(lastAppliedSeq)))
+                    writeSecure(output, crypto, FrameType.DELTA_ACK, OpCodec.encode(DeltaAckPayload(lastAppliedSeq)))
                 } catch (_: Exception) {
                     return@launch
                 }

--- a/collab/src/main/java/com/hereliesaz/graffitixr/core/collaboration/session/GuestSession.kt
+++ b/collab/src/main/java/com/hereliesaz/graffitixr/core/collaboration/session/GuestSession.kt
@@ -27,9 +27,13 @@ internal class GuestSession(
 ) : Session() {
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-    private var sessionId: String? = null
+    @Volatile private var sessionId: String? = null
     @Volatile private var lastAppliedSeq: Long = 0L
     private var socket: Socket? = null
+    // Guards the check-then-set phase transition in attemptReconnect(): the inbound loop and a
+    // failed PONG write can race into it, and without the lock each would run its own full
+    // reconnect loop against the same host.
+    private val phaseLock = Any()
 
     // Serializes writes to the host: the inbound loop (PONG) and the periodic DELTA_ACK loop
     // both write to the same OutputStream, so without this lock their frames interleave.
@@ -65,6 +69,10 @@ internal class GuestSession(
             // the local would leak one FD per failed attempt across the reconnect loop.
             socket = s
             s.connect(java.net.InetSocketAddress(host, port), 5000)
+            // Bound every read (handshake, bulk, live). The host sends PING every 5s, so 15s of
+            // silence means a dead/half-open host — without this, Frame.read blocks forever and
+            // the reconnect path never triggers.
+            s.soTimeout = READ_TIMEOUT_MS
             val input = s.getInputStream()
             val output = s.getOutputStream()
 
@@ -87,6 +95,18 @@ internal class GuestSession(
             when (response.type) {
                 FrameType.HELLO_OK -> {
                     val helloOk = OpCodec.decode<HelloOkPayload>(response.payload)
+                    if (isReconnect && sessionId != null && helloOk.sessionId != sessionId) {
+                        // The host restarted with a fresh session (new seq space and empty
+                        // DeltaBuffer): resuming with our lastAppliedSeq would make the host
+                        // replay nothing and leave this guest silently desynced. Reset local
+                        // resume state and fail this attempt — the reconnect loop retries as a
+                        // fresh join (lastAppliedSeq == 0), which triggers a full bulk re-sync.
+                        sessionId = null
+                        lastAppliedSeq = 0L
+                        try { s.close() } catch (_: Exception) {}
+                        socket = null
+                        return false
+                    }
                     sessionId = helloOk.sessionId
                     if (!isReconnect) {
                         receiveBulk(input, output)
@@ -140,17 +160,23 @@ internal class GuestSession(
 
     private fun receiveChunked(input: InputStream, expectedType: FrameType, totalBytes: Int): ByteArray {
         // totalBytes is peer-declared: reject negative/absurd sizes before allocating
-        // (NegativeArraySize / OOM), and never copy past the declared end even if a chunk
-        // overshoots (ArrayIndexOutOfBounds).
-        require(totalBytes in 0..MAX_BULK_BYTES) { "invalid bulk size $totalBytes" }
+        // (NegativeArraySize / OOM).
+        require(totalBytes in 0..Limits.MAX_BULK_BYTES) { "invalid bulk size $totalBytes" }
         val buffer = ByteArray(totalBytes)
         var offset = 0
         while (offset < totalBytes) {
             val frame = Frame.read(input) ?: error("EOF mid-bulk")
             require(frame.type == expectedType) { "expected $expectedType, got ${frame.type}" }
-            val len = minOf(frame.payload.size, totalBytes - offset)
-            System.arraycopy(frame.payload, 0, buffer, offset, len)
-            offset += len
+            // A chunk running past the declared size means the stream is misaligned with the
+            // BULK_BEGIN header; silently truncating (the old minOf clamp) would desync every
+            // subsequent frame boundary. Fail the transfer instead.
+            if (frame.payload.size > totalBytes - offset) {
+                throw java.io.IOException(
+                    "bulk chunk overruns declared size: ${frame.payload.size} > ${totalBytes - offset} remaining",
+                )
+            }
+            System.arraycopy(frame.payload, 0, buffer, offset, frame.payload.size)
+            offset += frame.payload.size
         }
         return buffer
     }
@@ -204,8 +230,12 @@ internal class GuestSession(
     }
 
     private suspend fun attemptReconnect() {
-        if (phase == Phase.Ended) return
-        phase = Phase.Reconnecting
+        // Atomic check-then-set: the inbound loop and a failed PONG write can both land here;
+        // only the first caller may run the reconnect loop.
+        synchronized(phaseLock) {
+            if (phase == Phase.Reconnecting || phase == Phase.Ended) return
+            phase = Phase.Reconnecting
+        }
         _state.value = CoopSessionState.Reconnecting
         try { socket?.close() } catch (_: Exception) {}
         socket = null
@@ -214,8 +244,9 @@ internal class GuestSession(
             delay(reconnectIntervalMs)
             // connectLoop returns true only once the live phase is running again. (It no longer
             // throws, so the previous single-shot try/return bug — which gave up after one
-            // attempt — is gone.)
-            if (connectLoop(isReconnect = true)) return
+            // attempt — is gone.) isReconnect follows lastAppliedSeq so that a sessionId-mismatch
+            // reset (see connectLoop) downgrades the next attempt to a fresh full join.
+            if (connectLoop(isReconnect = lastAppliedSeq > 0L)) return
             // A terminal rejection during reconnect already closed the session.
             if (phase == Phase.Ended) return
         }
@@ -230,7 +261,8 @@ internal class GuestSession(
     }
 
     private companion object {
-        // Generous cap on a full project bulk transfer; rejects malformed/hostile declared sizes.
-        const val MAX_BULK_BYTES = 256 * 1024 * 1024
+        // The host sends PING every 5s (plus deltas), so 15s of read silence means a dead or
+        // half-open host. Mirrors HostSession.READ_TIMEOUT_MS.
+        const val READ_TIMEOUT_MS = 15_000
     }
 }

--- a/collab/src/main/java/com/hereliesaz/graffitixr/core/collaboration/session/HostSession.kt
+++ b/collab/src/main/java/com/hereliesaz/graffitixr/core/collaboration/session/HostSession.kt
@@ -16,6 +16,7 @@ import com.hereliesaz.graffitixr.core.collaboration.wire.HelloRejectedPayload
 import com.hereliesaz.graffitixr.core.collaboration.wire.Limits
 import com.hereliesaz.graffitixr.core.collaboration.wire.OpCodec
 import com.hereliesaz.graffitixr.core.collaboration.wire.PingPayload
+import com.hereliesaz.graffitixr.core.collaboration.wire.SessionCrypto
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -81,6 +82,8 @@ internal class HostSession(
 
     @Volatile private var serverSocket: ServerSocket? = null
     @Volatile private var clientSocket: Socket? = null
+    // Crypto for the current live connection, so close()/BYE can seal on the active channel.
+    @Volatile private var activeCrypto: SessionCrypto? = null
     @Volatile private var lastAppliedSeq: Long = 0L
     private var liveJob: Job? = null
 
@@ -90,11 +93,20 @@ internal class HostSession(
     // corrupt the wire framing.
     private val writeMutex = Mutex()
 
-    private suspend fun writeFrame(output: OutputStream, type: FrameType, payload: ByteArray) {
+    // Seal-then-write every post-handshake frame under the write lock. The lock also serializes
+    // access to crypto's send counter (each of the outbound/inbound/heartbeat loops writes here).
+    private suspend fun writeSecure(output: OutputStream, crypto: SessionCrypto, type: FrameType, payload: ByteArray) {
         writeMutex.withLock {
-            Frame.write(output, type, payload)
+            Frame.write(output, FrameType.ENC, crypto.seal(type, payload))
             output.flush()
         }
+    }
+
+    // Read one post-handshake frame: it must be an ENC envelope; open it to the inner frame.
+    private fun readSecure(input: java.io.InputStream, crypto: SessionCrypto): Frame.FrameRead? {
+        val frame = Frame.read(input) ?: return null
+        if (frame.type != FrameType.ENC) throw java.io.IOException("expected ENC frame, got ${frame.type}")
+        return crypto.open(frame.payload)
     }
 
     fun port(): Int = serverSocket?.localPort
@@ -171,14 +183,16 @@ internal class HostSession(
 
         val helloFrame = Frame.read(input) ?: return socket.close()
         if (helloFrame.type != FrameType.HELLO) {
-            sendBye(output, CoopSessionState.EndReason.ProtocolError)
+            sendBye(output, CoopSessionState.EndReason.ProtocolError, crypto = null)
             socket.close(); return
         }
         val hello = OpCodec.decode<HelloPayload>(helloFrame.payload)
 
-        // Constant-time comparison: String.equals short-circuits on the first differing byte,
-        // which leaks token prefix length as a timing side channel.
-        if (!java.security.MessageDigest.isEqual(hello.token.toByteArray(), token.toByteArray())) {
+        // Verify the guest's proof of token knowledge (constant-time). The token itself is never
+        // transmitted; proof = HMAC(prk(token), "gxr/hello" || guestNonce).
+        val prk = SessionCrypto.prk(token)
+        val expectedProof = SessionCrypto.helloProof(prk, hello.guestNonce)
+        if (!java.security.MessageDigest.isEqual(hello.proof, expectedProof)) {
             Frame.write(
                 output,
                 FrameType.HELLO_REJECTED,
@@ -207,11 +221,23 @@ internal class HostSession(
             output.flush(); socket.close(); return
         }
 
-        // Accept.
+        // Accept. Build the per-connection crypto from token + both nonces (fresh keys every
+        // connection) and prove host identity to the guest before any bulk data.
+        val hostNonce = randomNonce()
+        val hostProof = SessionCrypto.helloOkProof(prk, hostNonce, hello.guestNonce)
+        val crypto = SessionCrypto.forHost(token, sessionId, hello.guestNonce, hostNonce)
+        activeCrypto = crypto
         Frame.write(
             output,
             FrameType.HELLO_OK,
-            OpCodec.encode(HelloOkPayload(sessionId = sessionId, protocolVersion = protocolVersion)),
+            OpCodec.encode(
+                HelloOkPayload(
+                    sessionId = sessionId,
+                    protocolVersion = protocolVersion,
+                    hostNonce = hostNonce,
+                    hostProof = hostProof,
+                )
+            ),
         )
         output.flush()
 
@@ -225,16 +251,11 @@ internal class HostSession(
             // `seq > lastAppliedSeq` filter makes the duplicates harmless, and this replay
             // completes before the live outbound loop starts, so ordering holds.
             deltaBuffer.opsAfter(lastAppliedSeq).forEach { (seq, op) ->
-                Frame.write(
-                    output,
-                    FrameType.DELTA,
-                    OpCodec.encode(DeltaPayload(seq, op)),
-                )
+                writeSecure(output, crypto, FrameType.DELTA, OpCodec.encode(DeltaPayload(seq, op)))
             }
-            output.flush()
         } else {
             // Bulk transfer.
-            sendBulk(output)
+            sendBulk(output, crypto)
         }
 
         _state.value = CoopSessionState.Connected(peerName = hello.deviceName)
@@ -245,17 +266,18 @@ internal class HostSession(
         liveJob?.cancelAndJoin()
         liveJob = scope.launch {
             coroutineScope {
-                launch { outboundLoop(output) }
-                launch { inboundLoop(input, output) }
-                launch { heartbeatLoop(output) }
+                launch { outboundLoop(output, crypto) }
+                launch { inboundLoop(input, output, crypto) }
+                launch { heartbeatLoop(output, crypto) }
             }
         }
     }
 
-    private suspend fun sendBulk(output: OutputStream) {
-        Frame.write(
-            output,
-            FrameType.BULK_BEGIN,
+    private fun randomNonce(): ByteArray = ByteArray(16).also { java.security.SecureRandom().nextBytes(it) }
+
+    private suspend fun sendBulk(output: OutputStream, crypto: SessionCrypto) {
+        writeSecure(
+            output, crypto, FrameType.BULK_BEGIN,
             OpCodec.encode(
                 BulkBeginPayload(
                     projectId = projectId,
@@ -266,28 +288,27 @@ internal class HostSession(
             ),
         )
         // Chunk payload into 64KB frames.
-        chunkAndWrite(output, FrameType.BULK_FINGERPRINT, fingerprintBytes)
-        chunkAndWrite(output, FrameType.BULK_PROJECT, projectBytes)
-        Frame.write(output, FrameType.BULK_END, ByteArray(0))
-        output.flush()
+        chunkAndWrite(output, crypto, FrameType.BULK_FINGERPRINT, fingerprintBytes)
+        chunkAndWrite(output, crypto, FrameType.BULK_PROJECT, projectBytes)
+        writeSecure(output, crypto, FrameType.BULK_END, ByteArray(0))
     }
 
-    private fun chunkAndWrite(output: OutputStream, type: FrameType, bytes: ByteArray) {
+    private suspend fun chunkAndWrite(output: OutputStream, crypto: SessionCrypto, type: FrameType, bytes: ByteArray) {
         val chunkSize = 64 * 1024
         var offset = 0
         while (offset < bytes.size) {
             val end = (offset + chunkSize).coerceAtMost(bytes.size)
-            Frame.write(output, type, bytes.copyOfRange(offset, end))
+            writeSecure(output, crypto, type, bytes.copyOfRange(offset, end))
             offset = end
         }
     }
 
-    private suspend fun outboundLoop(output: OutputStream) {
+    private suspend fun outboundLoop(output: OutputStream, crypto: SessionCrypto) {
         // Seq/encoding/DeltaBuffer accounting all happened in enqueueOp; this loop only ships
-        // the pre-encoded frames.
+        // the pre-encoded delta payloads, sealed here.
         for (delta in outQueue) {
             try {
-                writeFrame(output, FrameType.DELTA, delta.bytes)
+                writeSecure(output, crypto, FrameType.DELTA, delta.bytes)
             } catch (e: Exception) {
                 // Connection broken; enter reconnecting. The op stays in deltaBuffer and is
                 // replayed to the reconnecting guest from there.
@@ -297,10 +318,10 @@ internal class HostSession(
         }
     }
 
-    private suspend fun inboundLoop(input: java.io.InputStream, output: OutputStream) {
+    private suspend fun inboundLoop(input: java.io.InputStream, output: OutputStream, crypto: SessionCrypto) {
         while (scope.isActive) {
             val frame = try {
-                Frame.read(input) ?: run { enterReconnecting(); return }
+                readSecure(input, crypto) ?: run { enterReconnecting(); return }
             } catch (e: Exception) {
                 enterReconnecting(); return
             }
@@ -312,7 +333,7 @@ internal class HostSession(
                 FrameType.PING -> {
                     val ping = OpCodec.decode<PingPayload>(frame.payload)
                     try {
-                        writeFrame(output, FrameType.PONG, OpCodec.encode(ping))
+                        writeSecure(output, crypto, FrameType.PONG, OpCodec.encode(ping))
                     } catch (e: Exception) {
                         enterReconnecting(); return
                     }
@@ -326,11 +347,11 @@ internal class HostSession(
         }
     }
 
-    private suspend fun heartbeatLoop(output: OutputStream) {
+    private suspend fun heartbeatLoop(output: OutputStream, crypto: SessionCrypto) {
         while (scope.isActive) {
             delay(5_000)
             try {
-                writeFrame(output, FrameType.PING, OpCodec.encode(PingPayload(System.currentTimeMillis())))
+                writeSecure(output, crypto, FrameType.PING, OpCodec.encode(PingPayload(System.currentTimeMillis())))
             } catch (e: Exception) {
                 enterReconnecting(); return
             }
@@ -347,6 +368,9 @@ internal class HostSession(
         _state.value = CoopSessionState.Reconnecting
         val old = clientSocket
         clientSocket = null
+        // The old channel's keys/counters die with the connection; the next handshake mints fresh
+        // ones. handleConnection sets activeCrypto again before the new live loops start.
+        activeCrypto = null
         try { old?.close() } catch (_: Exception) {}
         // Stop the current live loops so the suspended outbound loop stops consuming outQueue
         // during the reconnect window; queued ops wait for the next connection's outbound loop.
@@ -364,9 +388,19 @@ internal class HostSession(
         }
     }
 
-    private fun sendBye(output: OutputStream, reason: CoopSessionState.EndReason) {
+    /**
+     * Send a BYE. Before the handshake completes (rejection paths) [crypto] is null and the BYE
+     * is plaintext; once a live connection exists it is sealed like every other frame so the
+     * guest, which only accepts ENC frames post-handshake, can act on the reason.
+     */
+    private fun sendBye(output: OutputStream, reason: CoopSessionState.EndReason, crypto: SessionCrypto?) {
         try {
-            Frame.write(output, FrameType.BYE, OpCodec.encode(ByePayload(reason)))
+            val payload = OpCodec.encode(ByePayload(reason))
+            if (crypto != null) {
+                Frame.write(output, FrameType.ENC, crypto.seal(FrameType.BYE, payload))
+            } else {
+                Frame.write(output, FrameType.BYE, payload)
+            }
             output.flush()
         } catch (_: Exception) { /* socket may already be closed */ }
     }
@@ -385,11 +419,12 @@ internal class HostSession(
             clientSocket?.let { sock ->
                 // getOutputStream() can throw if the socket is already closed; that must not
                 // skip the serverSocket/queue/scope teardown below (which would leak the port).
-                try { sendBye(sock.getOutputStream(), reason) } catch (_: Exception) {}
+                try { sendBye(sock.getOutputStream(), reason, activeCrypto) } catch (_: Exception) {}
                 try { sock.close() } catch (_: Exception) {}
             }
         } finally {
             clientSocket = null
+            activeCrypto = null
             try { serverSocket?.close() } catch (_: Exception) {}
             outQueue.close()
             deltaBuffer.clear()

--- a/collab/src/main/java/com/hereliesaz/graffitixr/core/collaboration/session/HostSession.kt
+++ b/collab/src/main/java/com/hereliesaz/graffitixr/core/collaboration/session/HostSession.kt
@@ -137,8 +137,11 @@ internal class HostSession(
      * already do.
      */
     fun enqueueOp(op: Op) {
-        if (phase == Phase.Ended) return
         synchronized(enqueueLock) {
+            // Check inside the lock: close() clears deltaBuffer under the same lock, so an append
+            // can never land after the buffer is cleared (which would leak an entry for an ended
+            // session).
+            if (phase == Phase.Ended) return
             val seq = seqCounter.incrementAndGet()
             val bytes = OpCodec.encode(DeltaPayload(seq, op))
             if (!deltaBuffer.append(seq, op, bytes.size)) {
@@ -166,9 +169,16 @@ internal class HostSession(
             try {
                 handleConnection(socket)
             } catch (e: Exception) {
-                if (clientSocket !== socket) {
-                    try { socket.close() } catch (_: Exception) {}
+                // handleConnection only throws before the live loops start (loop failures are
+                // caught inside the loops and route to enterReconnecting). If it adopted this
+                // socket (clientSocket === socket) but then threw — e.g. a write failed during
+                // bulk/replay — reset host state too, or the host stays wedged pointing at a dead
+                // socket, rejecting new guests as AlreadyHosting with no reconnect watcher running.
+                if (clientSocket === socket) {
+                    clientSocket = null
+                    activeCrypto = null
                 }
+                try { socket.close() } catch (_: Exception) {}
             }
         }
     }
@@ -426,8 +436,12 @@ internal class HostSession(
             clientSocket = null
             activeCrypto = null
             try { serverSocket?.close() } catch (_: Exception) {}
-            outQueue.close()
-            deltaBuffer.clear()
+            // Under enqueueLock so a concurrent enqueueOp (which checks phase and appends under
+            // the same lock) can't append to deltaBuffer or send after this cleanup.
+            synchronized(enqueueLock) {
+                outQueue.close()
+                deltaBuffer.clear()
+            }
             scope.cancel()
         }
     }

--- a/collab/src/main/java/com/hereliesaz/graffitixr/core/collaboration/session/HostSession.kt
+++ b/collab/src/main/java/com/hereliesaz/graffitixr/core/collaboration/session/HostSession.kt
@@ -13,6 +13,7 @@ import com.hereliesaz.graffitixr.core.collaboration.wire.FrameType
 import com.hereliesaz.graffitixr.core.collaboration.wire.HelloOkPayload
 import com.hereliesaz.graffitixr.core.collaboration.wire.HelloPayload
 import com.hereliesaz.graffitixr.core.collaboration.wire.HelloRejectedPayload
+import com.hereliesaz.graffitixr.core.collaboration.wire.Limits
 import com.hereliesaz.graffitixr.core.collaboration.wire.OpCodec
 import com.hereliesaz.graffitixr.core.collaboration.wire.PingPayload
 import kotlinx.coroutines.CoroutineScope
@@ -21,7 +22,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.cancelAndJoin
-import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
@@ -46,16 +46,36 @@ internal class HostSession(
     private val projectBytes: ByteArray,
     private val projectId: String,
     private val layerCount: Int,
-    private val opSizeEstimator: (Op) -> Int = { 256 }, // heuristic for DeltaBuffer accounting
 ) : Session() {
 
+    init {
+        // The guest rejects bulk transfers above this cap with a bare require() that surfaces as
+        // an unexplained NetworkLost on its side; failing fast here turns an oversized project
+        // into an immediate, attributable hosting error instead.
+        require(projectBytes.size <= Limits.MAX_BULK_BYTES && fingerprintBytes.size <= Limits.MAX_BULK_BYTES) {
+            "project too large to host: ${projectBytes.size}B project / ${fingerprintBytes.size}B fingerprint " +
+                "(cap ${Limits.MAX_BULK_BYTES}B)"
+        }
+    }
+
+    /** An op with its sequence number and wire encoding, fixed at enqueue time. */
+    private class EncodedDelta(val seq: Long, val bytes: ByteArray)
+
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-    // Bounded so a stalled guest can't make the host buffer ops without limit (OOM) — important now
-    // that LayerBitmapReplace ops can be large. On sustained overflow the oldest unsent ops are
-    // dropped (the guest can rejoin for a fresh snapshot) rather than exhausting memory.
-    private val outQueue: Channel<Op> = Channel(capacity = 128, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+    // Unbounded channel, but NOT unbounded memory: every element is appended to deltaBuffer
+    // first (real encoded size), whose 5 MB / 1000-op cap ends the session on overflow. The
+    // previous design (bounded 128 + DROP_OLDEST, seq assigned at send time) silently discarded
+    // ops that overflowed during a reconnect window before they ever reached the DeltaBuffer,
+    // so the guest's canvas diverged with no signal.
+    private val outQueue: Channel<EncodedDelta> = Channel(capacity = Channel.UNLIMITED)
     private val deltaBuffer = DeltaBuffer()
     private val seqCounter = AtomicLong(0L)
+    // Orders seq assignment with channel insertion so send order always matches seq order.
+    private val enqueueLock = Any()
+    // Guards the check-then-set phase transition in enterReconnecting(): outbound, inbound and
+    // heartbeat loops can all fail at once, and without the lock each would pass the phase check
+    // and launch its own 30s reconnect watcher.
+    private val phaseLock = Any()
 
     private val sessionId: String = UUID.randomUUID().toString()
 
@@ -93,9 +113,30 @@ internal class HostSession(
         ss.localPort
     }
 
-    /** Enqueue an Op to be sent to the connected guest. No-op if no guest. */
+    /**
+     * Enqueue an Op to be sent to the guest. Seq assignment, wire encoding and DeltaBuffer
+     * accounting all happen here, atomically, so every accepted op is replayable after a
+     * reconnect — nothing can be dropped between enqueue and send anymore. On DeltaBuffer
+     * overflow (guest too far behind / no guest draining) the session ends explicitly rather
+     * than diverging silently.
+     *
+     * Encoding runs on the caller's thread; ops carrying large payloads (LayerBitmapReplace)
+     * should be enqueued from a background dispatcher, which OpEmitterImpl's editor call sites
+     * already do.
+     */
     fun enqueueOp(op: Op) {
-        outQueue.trySend(op)
+        if (phase == Phase.Ended) return
+        synchronized(enqueueLock) {
+            val seq = seqCounter.incrementAndGet()
+            val bytes = OpCodec.encode(DeltaPayload(seq, op))
+            if (!deltaBuffer.append(seq, op, bytes.size)) {
+                // Cap exceeded: a future reconnect could not replay without a gap, so end the
+                // session per DeltaBuffer's contract rather than diverge silently.
+                scope.launch { close(CoopSessionState.EndReason.NetworkLost) }
+                return
+            }
+            outQueue.trySend(EncodedDelta(seq, bytes))
+        }
     }
 
     private suspend fun acceptLoop(ss: ServerSocket) {
@@ -107,11 +148,24 @@ internal class HostSession(
                 _state.value = CoopSessionState.Ended(CoopSessionState.EndReason.NetworkLost)
                 return
             }
-            handleConnection(socket)
+            // A failed handshake (peer vanished mid-HELLO, garbage payload, write error) must
+            // never kill this loop: before this guard, a single flaky or hostile client
+            // permanently disabled hosting and leaked its socket.
+            try {
+                handleConnection(socket)
+            } catch (e: Exception) {
+                if (clientSocket !== socket) {
+                    try { socket.close() } catch (_: Exception) {}
+                }
+            }
         }
     }
 
     private suspend fun handleConnection(socket: Socket) {
+        // Bound every read on this connection (handshake and live). Guests ack every 1s and
+        // answer PINGs sent every 5s, so 15s of silence means a dead/half-open peer — without
+        // this, Frame.read blocks forever and a vanished guest is never detected.
+        socket.soTimeout = READ_TIMEOUT_MS
         val input = socket.getInputStream()
         val output = socket.getOutputStream()
 
@@ -122,7 +176,9 @@ internal class HostSession(
         }
         val hello = OpCodec.decode<HelloPayload>(helloFrame.payload)
 
-        if (hello.token != token) {
+        // Constant-time comparison: String.equals short-circuits on the first differing byte,
+        // which leaks token prefix length as a timing side channel.
+        if (!java.security.MessageDigest.isEqual(hello.token.toByteArray(), token.toByteArray())) {
             Frame.write(
                 output,
                 FrameType.HELLO_REJECTED,
@@ -164,7 +220,10 @@ internal class HostSession(
         lastAppliedSeq = hello.lastAppliedSeq
 
         if (isReconnect) {
-            // Replay buffered deltas after lastAppliedSeq.
+            // Replay buffered deltas after lastAppliedSeq. Since seqs are assigned at enqueue,
+            // this may overlap ops still sitting unsent in outQueue; the guest's monotonic
+            // `seq > lastAppliedSeq` filter makes the duplicates harmless, and this replay
+            // completes before the live outbound loop starts, so ordering holds.
             deltaBuffer.opsAfter(lastAppliedSeq).forEach { (seq, op) ->
                 Frame.write(
                     output,
@@ -224,19 +283,14 @@ internal class HostSession(
     }
 
     private suspend fun outboundLoop(output: OutputStream) {
-        for (op in outQueue) {
-            val seq = seqCounter.incrementAndGet()
-            val payload = OpCodec.encode(DeltaPayload(seq, op))
-            if (!deltaBuffer.append(seq, op, opSizeEstimator(op))) {
-                // Buffer cap exceeded: a future reconnect could not replay without a gap,
-                // so end the session per DeltaBuffer's contract rather than diverge silently.
-                close(CoopSessionState.EndReason.NetworkLost)
-                return
-            }
+        // Seq/encoding/DeltaBuffer accounting all happened in enqueueOp; this loop only ships
+        // the pre-encoded frames.
+        for (delta in outQueue) {
             try {
-                writeFrame(output, FrameType.DELTA, payload)
+                writeFrame(output, FrameType.DELTA, delta.bytes)
             } catch (e: Exception) {
-                // Connection broken; enter reconnecting.
+                // Connection broken; enter reconnecting. The op stays in deltaBuffer and is
+                // replayed to the reconnecting guest from there.
                 enterReconnecting()
                 return
             }
@@ -284,8 +338,12 @@ internal class HostSession(
     }
 
     private fun enterReconnecting() {
-        if (phase == Phase.Reconnecting || phase == Phase.Ended) return
-        phase = Phase.Reconnecting
+        // Atomic check-then-set: concurrent failures in the outbound/inbound/heartbeat loops
+        // must collapse into a single transition (and a single 30s timeout watcher below).
+        synchronized(phaseLock) {
+            if (phase == Phase.Reconnecting || phase == Phase.Ended) return
+            phase = Phase.Reconnecting
+        }
         _state.value = CoopSessionState.Reconnecting
         val old = clientSocket
         clientSocket = null
@@ -311,6 +369,13 @@ internal class HostSession(
             Frame.write(output, FrameType.BYE, OpCodec.encode(ByePayload(reason)))
             output.flush()
         } catch (_: Exception) { /* socket may already be closed */ }
+    }
+
+    private companion object {
+        // Guests ack every 1s and answer 5s PINGs, so 15s of read silence means a dead or
+        // half-open peer. Also bounds handshake reads in handleConnection, so a stalled
+        // client can block the accept loop for at most this long.
+        const val READ_TIMEOUT_MS = 15_000
     }
 
     override suspend fun close(reason: CoopSessionState.EndReason) {

--- a/collab/src/main/java/com/hereliesaz/graffitixr/core/collaboration/wire/FrameType.kt
+++ b/collab/src/main/java/com/hereliesaz/graffitixr/core/collaboration/wire/FrameType.kt
@@ -13,7 +13,12 @@ internal enum class FrameType(val code: Byte) {
     DELTA_ACK(0x31),
     PING(0x40),
     PONG(0x41),
-    BYE(0x50);
+    BYE(0x50),
+
+    // Encrypted envelope. After the handshake, every frame in both directions is an ENC frame
+    // whose payload is an AES-256-GCM sealed inner frame (see SessionCrypto). The plaintext
+    // handshake frames above (HELLO / HELLO_OK / HELLO_REJECTED) are the only exceptions.
+    ENC(0x60);
 
     companion object {
         private val byCode = entries.associateBy { it.code }

--- a/collab/src/main/java/com/hereliesaz/graffitixr/core/collaboration/wire/HandshakePayloads.kt
+++ b/collab/src/main/java/com/hereliesaz/graffitixr/core/collaboration/wire/HandshakePayloads.kt
@@ -4,19 +4,64 @@ import com.hereliesaz.graffitixr.common.model.CoopSessionState
 import com.hereliesaz.graffitixr.common.model.Op
 import kotlinx.serialization.Serializable
 
+/**
+ * Guest→host handshake — the only guest-authored plaintext frame. The token is never transmitted;
+ * [proof] = HMAC(prk(token), "gxr/hello" || guestNonce) proves knowledge of it, and [guestNonce]
+ * seeds the per-connection key schedule. Every frame after this is encrypted (FrameType.ENC).
+ */
 @Serializable
 internal data class HelloPayload(
-    val token: String,
+    val guestNonce: ByteArray,
+    val proof: ByteArray,
     val clientVersion: Int,
     val deviceName: String,
     val lastAppliedSeq: Long = 0L,
-)
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is HelloPayload) return false
+        return guestNonce.contentEquals(other.guestNonce) && proof.contentEquals(other.proof) &&
+            clientVersion == other.clientVersion && deviceName == other.deviceName &&
+            lastAppliedSeq == other.lastAppliedSeq
+    }
 
+    override fun hashCode(): Int {
+        var result = guestNonce.contentHashCode()
+        result = 31 * result + proof.contentHashCode()
+        result = 31 * result + clientVersion
+        result = 31 * result + deviceName.hashCode()
+        result = 31 * result + lastAppliedSeq.hashCode()
+        return result
+    }
+}
+
+/**
+ * Host→guest handshake reply. [hostNonce] completes the key schedule and [hostProof] =
+ * HMAC(prk, "gxr/hello-ok" || hostNonce || guestNonce) lets the guest authenticate the host
+ * before trusting any bulk data.
+ */
 @Serializable
 internal data class HelloOkPayload(
     val sessionId: String,
     val protocolVersion: Int,
-)
+    val hostNonce: ByteArray,
+    val hostProof: ByteArray,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is HelloOkPayload) return false
+        return sessionId == other.sessionId && protocolVersion == other.protocolVersion &&
+            hostNonce.contentEquals(other.hostNonce) && hostProof.contentEquals(other.hostProof)
+    }
+
+    override fun hashCode(): Int {
+        var result = sessionId.hashCode()
+        result = 31 * result + protocolVersion
+        result = 31 * result + hostNonce.contentHashCode()
+        result = 31 * result + hostProof.contentHashCode()
+        return result
+    }
+}
 
 @Serializable
 internal data class HelloRejectedPayload(val reason: RejectReason) {

--- a/collab/src/main/java/com/hereliesaz/graffitixr/core/collaboration/wire/Hkdf.kt
+++ b/collab/src/main/java/com/hereliesaz/graffitixr/core/collaboration/wire/Hkdf.kt
@@ -1,0 +1,44 @@
+package com.hereliesaz.graffitixr.core.collaboration.wire
+
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * HKDF (RFC 5869) over HMAC-SHA256. Hand-rolled because the JCE exposes no HKDF on minSdk 26;
+ * it is a thin wrapper over `Mac("HmacSHA256")` and is covered against the RFC test vectors.
+ */
+internal object Hkdf {
+
+    private const val HMAC = "HmacSHA256"
+    private const val HASH_LEN = 32
+
+    /** HKDF-Extract: PRK = HMAC(salt, ikm). An all-zero salt is used when [salt] is empty. */
+    fun extract(salt: ByteArray, ikm: ByteArray): ByteArray {
+        val key = if (salt.isEmpty()) ByteArray(HASH_LEN) else salt
+        return hmac(key, ikm)
+    }
+
+    /** HKDF-Expand: derive [length] bytes of key material from [prk] and context [info]. */
+    fun expand(prk: ByteArray, info: ByteArray, length: Int): ByteArray {
+        require(length in 0..(255 * HASH_LEN)) { "HKDF length $length out of range" }
+        val out = ByteArray(length)
+        var t = ByteArray(0)
+        var pos = 0
+        var counter = 1
+        while (pos < length) {
+            val mac = Mac.getInstance(HMAC).apply { init(SecretKeySpec(prk, HMAC)) }
+            mac.update(t)
+            mac.update(info)
+            mac.update(counter.toByte())
+            t = mac.doFinal()
+            val n = minOf(t.size, length - pos)
+            System.arraycopy(t, 0, out, pos, n)
+            pos += n
+            counter++
+        }
+        return out
+    }
+
+    fun hmac(key: ByteArray, data: ByteArray): ByteArray =
+        Mac.getInstance(HMAC).apply { init(SecretKeySpec(key, HMAC)) }.doFinal(data)
+}

--- a/collab/src/main/java/com/hereliesaz/graffitixr/core/collaboration/wire/Limits.kt
+++ b/collab/src/main/java/com/hereliesaz/graffitixr/core/collaboration/wire/Limits.kt
@@ -1,0 +1,10 @@
+package com.hereliesaz.graffitixr.core.collaboration.wire
+
+/**
+ * Wire-level size limits shared by both ends of the protocol, so the host never offers a bulk
+ * transfer the guest is guaranteed to reject.
+ */
+internal object Limits {
+    /** Generous cap on a full project bulk transfer; rejects malformed/hostile declared sizes. */
+    const val MAX_BULK_BYTES: Int = 256 * 1024 * 1024
+}

--- a/collab/src/main/java/com/hereliesaz/graffitixr/core/collaboration/wire/ProtocolVersion.kt
+++ b/collab/src/main/java/com/hereliesaz/graffitixr/core/collaboration/wire/ProtocolVersion.kt
@@ -1,0 +1,12 @@
+package com.hereliesaz.graffitixr.core.collaboration.wire
+
+/**
+ * Co-op wire protocol version, carried in the QR payload and the HELLO handshake. Peers whose
+ * versions differ are rejected with [HelloRejectedPayload.RejectReason.VersionMismatch].
+ *
+ * v2 introduced the token-derived AES-256-GCM transport (SessionCrypto) and the nonce/proof
+ * handshake, so a v1 (plaintext) peer can never establish a session with a v2 peer.
+ */
+internal object ProtocolVersion {
+    const val CURRENT: Int = 2
+}

--- a/collab/src/main/java/com/hereliesaz/graffitixr/core/collaboration/wire/SessionCrypto.kt
+++ b/collab/src/main/java/com/hereliesaz/graffitixr/core/collaboration/wire/SessionCrypto.kt
@@ -1,0 +1,149 @@
+package com.hereliesaz.graffitixr.core.collaboration.wire
+
+import java.nio.charset.StandardCharsets
+import javax.crypto.Cipher
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * Per-connection authenticated encryption for the co-op transport.
+ *
+ * The QR token (128-bit SecureRandom, delivered out-of-band by the camera) is the trust root. It
+ * is never sent on the wire; the handshake proves knowledge of it with an HMAC over fresh nonces,
+ * and both ends derive matching AES-256-GCM keys from token + both nonces via HKDF. After the
+ * handshake every frame is wrapped in a [FrameType.ENC] frame whose payload is
+ * `[8-byte send counter big-endian][GCM(ciphertext||tag)]`, with the inner plaintext being
+ * `[1-byte inner FrameType][inner payload]`. The counter is the GCM nonce input and the AAD, and
+ * is required to strictly increase on receive (reject replay/reorder). Keys and counters are fresh
+ * on every (re)connection, so a nonce is never reused under a key.
+ */
+internal class SessionCrypto private constructor(
+    private val sendKey: ByteArray,
+    private val recvKey: ByteArray,
+    private val sendIvSalt: ByteArray, // 12 bytes
+    private val recvIvSalt: ByteArray, // 12 bytes
+) {
+    private var sendCounter: Long = 0
+    private var lastRecvCounter: Long = -1
+
+    /** Wrap ([type], [payload]) into an ENC frame payload. Not thread-safe; callers serialize. */
+    fun seal(type: FrameType, payload: ByteArray): ByteArray {
+        val counter = sendCounter++
+        val counterBytes = counter.toBigEndianBytes()
+        val inner = ByteArray(1 + payload.size)
+        inner[0] = type.code
+        System.arraycopy(payload, 0, inner, 1, payload.size)
+
+        val cipher = Cipher.getInstance(TRANSFORMATION)
+        cipher.init(
+            Cipher.ENCRYPT_MODE,
+            SecretKeySpec(sendKey, "AES"),
+            GCMParameterSpec(TAG_BITS, ivFor(sendIvSalt, counterBytes)),
+        )
+        cipher.updateAAD(counterBytes)
+        val ct = cipher.doFinal(inner)
+
+        val out = ByteArray(COUNTER_BYTES + ct.size)
+        System.arraycopy(counterBytes, 0, out, 0, COUNTER_BYTES)
+        System.arraycopy(ct, 0, out, COUNTER_BYTES, ct.size)
+        return out
+    }
+
+    /** Decrypt an ENC frame payload back into the inner (type, payload). Throws on tamper/replay. */
+    fun open(encPayload: ByteArray): Frame.FrameRead {
+        if (encPayload.size < COUNTER_BYTES + TAG_BITS / 8) {
+            throw javax.crypto.AEADBadTagException("ENC payload too short")
+        }
+        val counterBytes = encPayload.copyOfRange(0, COUNTER_BYTES)
+        val counter = counterBytes.toLongBigEndian()
+        if (counter <= lastRecvCounter) {
+            throw javax.crypto.AEADBadTagException("replayed or reordered ENC counter $counter")
+        }
+        val ct = encPayload.copyOfRange(COUNTER_BYTES, encPayload.size)
+
+        val cipher = Cipher.getInstance(TRANSFORMATION)
+        cipher.init(
+            Cipher.DECRYPT_MODE,
+            SecretKeySpec(recvKey, "AES"),
+            GCMParameterSpec(TAG_BITS, ivFor(recvIvSalt, counterBytes)),
+        )
+        cipher.updateAAD(counterBytes)
+        val inner = cipher.doFinal(ct) // throws AEADBadTagException on tamper/wrong key
+
+        if (inner.isEmpty()) throw javax.crypto.AEADBadTagException("empty inner frame")
+        val type = FrameType.ofCode(inner[0])
+            ?: throw javax.crypto.AEADBadTagException("unknown inner frame type 0x${inner[0].toString(16)}")
+        lastRecvCounter = counter
+        return Frame.FrameRead(type, inner.copyOfRange(1, inner.size))
+    }
+
+    private fun ivFor(salt: ByteArray, counterBytes: ByteArray): ByteArray {
+        // 12-byte IV: low 8 bytes of the salt XOR the counter. Distinct per message under a key.
+        val iv = salt.copyOf()
+        for (i in 0 until COUNTER_BYTES) {
+            iv[IV_BYTES - COUNTER_BYTES + i] = (iv[IV_BYTES - COUNTER_BYTES + i].toInt() xor counterBytes[i].toInt()).toByte()
+        }
+        return iv
+    }
+
+    companion object {
+        private const val TRANSFORMATION = "AES/GCM/NoPadding"
+        private const val TAG_BITS = 128
+        private const val IV_BYTES = 12
+        private const val COUNTER_BYTES = 8
+        private const val KEY_BYTES = 32
+
+        private val EXTRACT_SALT = "GraffitiXR-coop-v2".toByteArray(StandardCharsets.UTF_8)
+
+        /** Pseudo-random key derived from the shared token; input to the proofs and key schedule. */
+        fun prk(token: String): ByteArray =
+            Hkdf.extract(EXTRACT_SALT, token.toByteArray(StandardCharsets.UTF_8))
+
+        /** Guest→host handshake proof of token knowledge, bound to the guest's nonce. */
+        fun helloProof(prk: ByteArray, guestNonce: ByteArray): ByteArray =
+            Hkdf.hmac(prk, "gxr/hello".toByteArray(StandardCharsets.UTF_8) + guestNonce)
+
+        /** Host→guest handshake proof, binding both nonces so the guest authenticates the host. */
+        fun helloOkProof(prk: ByteArray, hostNonce: ByteArray, guestNonce: ByteArray): ByteArray =
+            Hkdf.hmac(prk, "gxr/hello-ok".toByteArray(StandardCharsets.UTF_8) + hostNonce + guestNonce)
+
+        fun forHost(token: String, sessionId: String, guestNonce: ByteArray, hostNonce: ByteArray): SessionCrypto {
+            val k = keyMaterial(token, sessionId, guestNonce, hostNonce)
+            return SessionCrypto(
+                sendKey = k.copyOfRange(0, 32),           // host→guest
+                recvKey = k.copyOfRange(32, 64),          // guest→host
+                sendIvSalt = k.copyOfRange(64, 76),
+                recvIvSalt = k.copyOfRange(76, 88),
+            )
+        }
+
+        fun forGuest(token: String, sessionId: String, guestNonce: ByteArray, hostNonce: ByteArray): SessionCrypto {
+            val k = keyMaterial(token, sessionId, guestNonce, hostNonce)
+            return SessionCrypto(
+                sendKey = k.copyOfRange(32, 64),          // guest→host
+                recvKey = k.copyOfRange(0, 32),           // host→guest
+                sendIvSalt = k.copyOfRange(76, 88),
+                recvIvSalt = k.copyOfRange(64, 76),
+            )
+        }
+
+        private fun keyMaterial(token: String, sessionId: String, guestNonce: ByteArray, hostNonce: ByteArray): ByteArray {
+            val prk = Hkdf.extract(guestNonce + hostNonce, token.toByteArray(StandardCharsets.UTF_8))
+            val info = "gxr/keys".toByteArray(StandardCharsets.UTF_8) + sessionId.toByteArray(StandardCharsets.UTF_8)
+            // 2 * 32-byte keys + 2 * 12-byte IV salts.
+            return Hkdf.expand(prk, info, 2 * KEY_BYTES + 2 * IV_BYTES)
+        }
+
+        private fun Long.toBigEndianBytes(): ByteArray {
+            val b = ByteArray(COUNTER_BYTES)
+            for (i in 0 until COUNTER_BYTES) b[i] = (this shr (8 * (COUNTER_BYTES - 1 - i))).toByte()
+            return b
+        }
+
+        private fun ByteArray.toLongBigEndian(): Long {
+            var v = 0L
+            for (i in 0 until COUNTER_BYTES) v = (v shl 8) or (this[i].toLong() and 0xFF)
+            return v
+        }
+    }
+}

--- a/collab/src/test/java/com/hereliesaz/graffitixr/core/collaboration/EncryptedTransportTest.kt
+++ b/collab/src/test/java/com/hereliesaz/graffitixr/core/collaboration/EncryptedTransportTest.kt
@@ -1,0 +1,145 @@
+package com.hereliesaz.graffitixr.core.collaboration
+
+import com.hereliesaz.graffitixr.common.model.CoopSessionState
+import com.hereliesaz.graffitixr.common.model.Layer
+import com.hereliesaz.graffitixr.common.model.Op
+import com.hereliesaz.graffitixr.core.collaboration.session.GuestSession
+import com.hereliesaz.graffitixr.core.collaboration.session.HostSession
+import java.io.ByteArrayOutputStream
+import java.net.ServerSocket
+import java.net.Socket
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class EncryptedTransportTest {
+
+    private fun newHost(
+        token: String,
+        project: ByteArray = ByteArray(256) { (it * 3).toByte() },
+    ) = HostSession(
+        token = token,
+        protocolVersion = 2,
+        localDeviceName = "host",
+        fingerprintBytes = ByteArray(64) { it.toByte() },
+        projectBytes = project,
+        projectId = "p1",
+        layerCount = 0,
+    )
+
+    private fun newGuest(
+        port: Int,
+        token: String,
+        onOp: suspend (Op) -> Unit = {},
+        onBulk: suspend (ByteArray, ByteArray) -> Unit = { _, _ -> },
+    ) = GuestSession(
+        host = "127.0.0.1",
+        port = port,
+        token = token,
+        protocolVersion = 2,
+        localDeviceName = "guest",
+        onBulkReceived = onBulk,
+        onOp = onOp,
+        reconnectWindowMs = 2_000L,
+        reconnectIntervalMs = 200L,
+    )
+
+    @Test
+    fun `wrong token is rejected and the host keeps hosting`() = runBlocking {
+        val host = newHost(token = "correct")
+        val port = host.startListening()
+
+        val badGuest = newGuest(port, token = "wrong")
+        badGuest.connect()
+        val ended = withTimeout(10_000) { badGuest.state.first { it is CoopSessionState.Ended } }
+        assertTrue((ended as CoopSessionState.Ended).reason == CoopSessionState.EndReason.BadToken)
+
+        // A correct-token guest can still join afterward.
+        var bulkOk = false
+        val goodGuest = newGuest(port, token = "correct", onBulk = { _, _ -> bulkOk = true })
+        goodGuest.connect()
+        withTimeout(10_000) { while (!bulkOk) delay(50) }
+
+        host.close(CoopSessionState.EndReason.UserLeft)
+        goodGuest.close(CoopSessionState.EndReason.UserLeft)
+    }
+
+    @Test
+    fun `an on-path eavesdropper sees only ciphertext`() = runBlocking {
+        val marker = "TOP-SECRET-MURAL-MARKER"
+        val project = ByteArray(4096).also {
+            System.arraycopy(marker.toByteArray(), 0, it, 1000, marker.length)
+        }
+        val host = newHost(token = "tok", project = project)
+        val hostPort = host.startListening()
+
+        // A transparent TCP proxy between guest and host that copies every byte in both
+        // directions into `wire`. This is exactly what an on-path attacker on shared Wi-Fi sees.
+        val wire = ByteArrayOutputStream()
+        val proxy = ServerSocket(0)
+        val proxyPort = proxy.localPort
+        val proxyThread = Thread {
+            try {
+                proxy.accept().use { downstream ->
+                    Socket("127.0.0.1", hostPort).use { upstream ->
+                        val g2h = pump(downstream, upstream, wire)
+                        val h2g = pump(upstream, downstream, wire)
+                        g2h.join(8_000); h2g.join(8_000)
+                    }
+                }
+            } catch (_: Exception) { /* closed at teardown */ }
+        }
+        proxyThread.isDaemon = true
+        proxyThread.start()
+
+        var bulkOk = false
+        val received = mutableListOf<Op>()
+        val guest = newGuest(
+            proxyPort,
+            token = "tok",
+            onBulk = { _, _ -> bulkOk = true },
+            onOp = { op -> synchronized(received) { received.add(op) } },
+        )
+        guest.connect()
+        withTimeout(10_000) { while (!bulkOk) delay(50) }
+
+        host.enqueueOp(Op.LayerAdd(Layer(id = marker, name = "n")))
+        withTimeout(10_000) {
+            while (synchronized(received) { received.none { (it as? Op.LayerAdd)?.layer?.id == marker } }) delay(50)
+        }
+        // Let the proxy flush the delta bytes it forwarded.
+        delay(300)
+
+        val onWire = synchronized(wire) { String(wire.toByteArray(), Charsets.ISO_8859_1) }
+        assertTrue("proxy should have observed traffic", onWire.isNotEmpty())
+        assertFalse("marker leaked in cleartext on the wire", onWire.contains(marker))
+
+        host.close(CoopSessionState.EndReason.UserLeft)
+        guest.close(CoopSessionState.EndReason.UserLeft)
+        proxy.close()
+    }
+
+    private fun pump(from: Socket, to: Socket, capture: ByteArrayOutputStream): Thread {
+        val t = Thread {
+            try {
+                val buf = ByteArray(8192)
+                val input = from.getInputStream()
+                val output = to.getOutputStream()
+                while (true) {
+                    val n = input.read(buf)
+                    if (n < 0) break
+                    synchronized(capture) { capture.write(buf, 0, n) }
+                    output.write(buf, 0, n)
+                    output.flush()
+                }
+            } catch (_: Exception) { /* peer closed */ }
+        }
+        t.isDaemon = true
+        t.start()
+        return t
+    }
+}

--- a/collab/src/test/java/com/hereliesaz/graffitixr/core/collaboration/SessionRobustnessTest.kt
+++ b/collab/src/test/java/com/hereliesaz/graffitixr/core/collaboration/SessionRobustnessTest.kt
@@ -1,0 +1,226 @@
+package com.hereliesaz.graffitixr.core.collaboration
+
+import com.hereliesaz.graffitixr.common.model.CoopSessionState
+import com.hereliesaz.graffitixr.common.model.Layer
+import com.hereliesaz.graffitixr.common.model.Op
+import com.hereliesaz.graffitixr.core.collaboration.session.GuestSession
+import com.hereliesaz.graffitixr.core.collaboration.session.HostSession
+import com.hereliesaz.graffitixr.core.collaboration.wire.BulkBeginPayload
+import com.hereliesaz.graffitixr.core.collaboration.wire.DeltaPayload
+import com.hereliesaz.graffitixr.core.collaboration.wire.Frame
+import com.hereliesaz.graffitixr.core.collaboration.wire.FrameType
+import com.hereliesaz.graffitixr.core.collaboration.wire.HelloOkPayload
+import com.hereliesaz.graffitixr.core.collaboration.wire.HelloPayload
+import com.hereliesaz.graffitixr.core.collaboration.wire.OpCodec
+import java.net.ServerSocket
+import java.net.Socket
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Real-socket regression tests for the collab robustness fixes. */
+class SessionRobustnessTest {
+
+    private fun newHost(
+        fingerprint: ByteArray = ByteArray(128) { it.toByte() },
+        project: ByteArray = ByteArray(256) { (it * 3).toByte() },
+    ) = HostSession(
+        token = "tok",
+        protocolVersion = 1,
+        localDeviceName = "host",
+        fingerprintBytes = fingerprint,
+        projectBytes = project,
+        projectId = "p1",
+        layerCount = 0,
+    )
+
+    @Test
+    fun `host keeps accepting after a garbage handshake`() = runBlocking {
+        val host = newHost()
+        val port = host.startListening()
+
+        // A hostile/broken client: valid length prefix, valid HELLO type, garbage payload —
+        // OpCodec.decode throws inside handleConnection. Before the accept-loop guard this
+        // exception killed the accept coroutine and hosting was permanently dead.
+        Socket("127.0.0.1", port).use { s ->
+            val out = java.io.DataOutputStream(s.getOutputStream())
+            out.writeInt(1 + 4)          // length = type byte + 4 payload bytes
+            out.writeByte(0x10)          // FrameType.HELLO
+            out.write(byteArrayOf(0x7F, 0x00, 0x42, 0x13)) // not a HelloPayload
+            out.flush()
+        }
+        // And one that vanishes mid-handshake (clean EOF path).
+        Socket("127.0.0.1", port).close()
+
+        // A real guest must still be able to join.
+        var bulkOk = false
+        val guest = GuestSession(
+            host = "127.0.0.1",
+            port = port,
+            token = "tok",
+            protocolVersion = 1,
+            localDeviceName = "guest",
+            onBulkReceived = { _, _ -> bulkOk = true },
+            onOp = { },
+        )
+        guest.connect()
+        withTimeout(10_000) { while (!bulkOk) delay(50) }
+
+        host.close(CoopSessionState.EndReason.UserLeft)
+        guest.close(CoopSessionState.EndReason.UserLeft)
+    }
+
+    @Test
+    fun `ops enqueued during a reconnect window all arrive after reconnect`() = runBlocking {
+        val host = newHost()
+        val port = host.startListening()
+
+        val received = mutableListOf<Op>()
+        var bulkOk = false
+        val guest = GuestSession(
+            host = "127.0.0.1",
+            port = port,
+            token = "tok",
+            protocolVersion = 1,
+            localDeviceName = "guest",
+            onBulkReceived = { _, _ -> bulkOk = true },
+            onOp = { op -> synchronized(received) { received.add(op) } },
+            reconnectWindowMs = 15_000L,
+            reconnectIntervalMs = 300L,
+        )
+        guest.connect()
+        withTimeout(10_000) { while (!bulkOk) delay(50) }
+
+        repeat(5) { i -> host.enqueueOp(Op.LayerAdd(Layer(id = "L$i", name = "n$i"))) }
+        withTimeout(10_000) { while (synchronized(received) { received.size } < 5) delay(50) }
+
+        // Sever the connection out from under the guest.
+        val socketField = GuestSession::class.java.getDeclaredField("socket")
+        socketField.isAccessible = true
+        (socketField.get(guest) as? Socket)?.close()
+
+        // Keep painting during the outage. Before seq-at-enqueue these overflowed the bounded
+        // outbound channel (DROP_OLDEST) without ever reaching the DeltaBuffer and were lost.
+        repeat(20) { i -> host.enqueueOp(Op.LayerAdd(Layer(id = "L${5 + i}", name = "n${5 + i}"))) }
+
+        withTimeout(20_000) { while (synchronized(received) { received.size } < 25) delay(100) }
+
+        val ids = synchronized(received) { received.map { (it as Op.LayerAdd).layer.id } }
+        assertEquals((0 until 25).map { "L$it" }, ids)
+
+        host.close(CoopSessionState.EndReason.UserLeft)
+        guest.close(CoopSessionState.EndReason.UserLeft)
+    }
+
+    @Test
+    fun `delta buffer overflow by real op bytes ends the session explicitly`() = runBlocking {
+        val host = newHost()
+        host.startListening()
+
+        // Three ~2MB bitmap ops blow the 5MB DeltaBuffer cap. Under the old 256-bytes-per-op
+        // estimate these were accounted as ~768B total and the host kept buffering toward OOM.
+        repeat(3) { i ->
+            host.enqueueOp(Op.LayerBitmapReplace(layerId = "L$i", png = ByteArray(2 * 1024 * 1024)))
+        }
+
+        val end = withTimeout(10_000) { host.state.first { it is CoopSessionState.Ended } }
+        assertTrue(end is CoopSessionState.Ended)
+    }
+
+    @Test
+    fun `delta buffer op-count overflow ends the session explicitly`() = runBlocking {
+        val host = newHost()
+        host.startListening()
+
+        repeat(1_001) { i -> host.enqueueOp(Op.LayerAdd(Layer(id = "L$i", name = "n$i"))) }
+
+        val end = withTimeout(10_000) { host.state.first { it is CoopSessionState.Ended } }
+        assertTrue(end is CoopSessionState.Ended)
+    }
+
+    @Test
+    fun `guest re-syncs with a fresh bulk when the host sessionId changes across a reconnect`() = runBlocking {
+        val server = ServerSocket(0)
+        val port = server.localPort
+        val helloSeqs = mutableListOf<Long>()
+        var bulkCount = 0
+
+        // Hand-rolled wire-speaking host: same port across "restarts", new sessionId after the
+        // first connection — the shape of a host app relaunch reusing a QR.
+        fun serveOnce(sessionId: String, sendDeltaAndDie: Boolean) {
+            val sock = server.accept()
+            sock.soTimeout = 10_000
+            val input = sock.getInputStream()
+            val output = sock.getOutputStream()
+
+            val hello = Frame.read(input) ?: error("no HELLO")
+            assertEquals(FrameType.HELLO, hello.type)
+            val payload = OpCodec.decode<HelloPayload>(hello.payload)
+            synchronized(helloSeqs) { helloSeqs.add(payload.lastAppliedSeq) }
+
+            Frame.write(output, FrameType.HELLO_OK, OpCodec.encode(HelloOkPayload(sessionId, 1)))
+            output.flush()
+
+            if (payload.lastAppliedSeq == 0L) {
+                Frame.write(
+                    output,
+                    FrameType.BULK_BEGIN,
+                    OpCodec.encode(BulkBeginPayload("p1", 0, 0, 0)),
+                )
+                Frame.write(output, FrameType.BULK_END, ByteArray(0))
+                output.flush()
+                val ack = Frame.read(input) ?: error("no BULK_ACK")
+                assertEquals(FrameType.BULK_ACK, ack.type)
+            }
+
+            if (sendDeltaAndDie) {
+                // Give the guest a nonzero lastAppliedSeq so its next attempt is a resume.
+                Frame.write(
+                    output,
+                    FrameType.DELTA,
+                    OpCodec.encode(DeltaPayload(1L, Op.LayerAdd(Layer(id = "X", name = "x")))),
+                )
+                output.flush()
+                Thread.sleep(300)
+            }
+            sock.close()
+        }
+
+        val fakeHost = Thread {
+            try {
+                serveOnce(sessionId = "session-A", sendDeltaAndDie = true) // fresh join, then dies
+                serveOnce(sessionId = "session-B", sendDeltaAndDie = false) // resume attempt -> mismatch
+                serveOnce(sessionId = "session-B", sendDeltaAndDie = false) // fresh re-join
+            } catch (_: Exception) { /* assertions re-checked on the main thread below */ }
+        }
+        fakeHost.start()
+
+        val guest = GuestSession(
+            host = "127.0.0.1",
+            port = port,
+            token = "tok",
+            protocolVersion = 1,
+            localDeviceName = "guest",
+            onBulkReceived = { _, _ -> bulkCount++ },
+            onOp = { },
+            reconnectWindowMs = 15_000L,
+            reconnectIntervalMs = 200L,
+        )
+        guest.connect()
+
+        withTimeout(20_000) { while (bulkCount < 2) delay(100) }
+        fakeHost.join(10_000)
+
+        // Attempt 1: fresh join (0). Attempt 2: resume with the applied delta (1) — rejected by
+        // the sessionId check. Attempt 3: downgraded to a fresh join (0) => full bulk re-sync.
+        assertEquals(listOf(0L, 1L, 0L), synchronized(helloSeqs) { helloSeqs.toList() })
+        assertEquals(2, bulkCount)
+
+        guest.close(CoopSessionState.EndReason.UserLeft)
+        server.close()
+    }
+}

--- a/collab/src/test/java/com/hereliesaz/graffitixr/core/collaboration/SessionRobustnessTest.kt
+++ b/collab/src/test/java/com/hereliesaz/graffitixr/core/collaboration/SessionRobustnessTest.kt
@@ -12,6 +12,7 @@ import com.hereliesaz.graffitixr.core.collaboration.wire.FrameType
 import com.hereliesaz.graffitixr.core.collaboration.wire.HelloOkPayload
 import com.hereliesaz.graffitixr.core.collaboration.wire.HelloPayload
 import com.hereliesaz.graffitixr.core.collaboration.wire.OpCodec
+import com.hereliesaz.graffitixr.core.collaboration.wire.SessionCrypto
 import java.net.ServerSocket
 import java.net.Socket
 import kotlinx.coroutines.delay
@@ -149,8 +150,11 @@ class SessionRobustnessTest {
         val helloSeqs = mutableListOf<Long>()
         var bulkCount = 0
 
+        val token = "tok"
+
         // Hand-rolled wire-speaking host: same port across "restarts", new sessionId after the
-        // first connection — the shape of a host app relaunch reusing a QR.
+        // first connection — the shape of a host app relaunch reusing a QR. Speaks the full v2
+        // handshake (nonce/proof) and encrypts post-handshake frames, like a real host.
         fun serveOnce(sessionId: String, sendDeltaAndDie: Boolean) {
             val sock = server.accept()
             sock.soTimeout = 10_000
@@ -162,29 +166,35 @@ class SessionRobustnessTest {
             val payload = OpCodec.decode<HelloPayload>(hello.payload)
             synchronized(helloSeqs) { helloSeqs.add(payload.lastAppliedSeq) }
 
-            Frame.write(output, FrameType.HELLO_OK, OpCodec.encode(HelloOkPayload(sessionId, 1)))
+            val prk = SessionCrypto.prk(token)
+            val hostNonce = ByteArray(16) { it.toByte() }
+            val hostProof = SessionCrypto.helloOkProof(prk, hostNonce, payload.guestNonce)
+            Frame.write(
+                output,
+                FrameType.HELLO_OK,
+                OpCodec.encode(HelloOkPayload(sessionId, 1, hostNonce, hostProof)),
+            )
             output.flush()
+            val crypto = SessionCrypto.forHost(token, sessionId, payload.guestNonce, hostNonce)
+
+            fun writeEnc(type: FrameType, p: ByteArray) {
+                Frame.write(output, FrameType.ENC, crypto.seal(type, p)); output.flush()
+            }
+            fun readEnc(): Frame.FrameRead = crypto.open((Frame.read(input) ?: error("EOF")).payload)
 
             if (payload.lastAppliedSeq == 0L) {
-                Frame.write(
-                    output,
-                    FrameType.BULK_BEGIN,
-                    OpCodec.encode(BulkBeginPayload("p1", 0, 0, 0)),
-                )
-                Frame.write(output, FrameType.BULK_END, ByteArray(0))
-                output.flush()
-                val ack = Frame.read(input) ?: error("no BULK_ACK")
+                writeEnc(FrameType.BULK_BEGIN, OpCodec.encode(BulkBeginPayload("p1", 0, 0, 0)))
+                writeEnc(FrameType.BULK_END, ByteArray(0))
+                val ack = readEnc()
                 assertEquals(FrameType.BULK_ACK, ack.type)
             }
 
             if (sendDeltaAndDie) {
                 // Give the guest a nonzero lastAppliedSeq so its next attempt is a resume.
-                Frame.write(
-                    output,
+                writeEnc(
                     FrameType.DELTA,
                     OpCodec.encode(DeltaPayload(1L, Op.LayerAdd(Layer(id = "X", name = "x")))),
                 )
-                output.flush()
                 Thread.sleep(300)
             }
             sock.close()

--- a/collab/src/test/java/com/hereliesaz/graffitixr/core/collaboration/wire/HkdfTest.kt
+++ b/collab/src/test/java/com/hereliesaz/graffitixr/core/collaboration/wire/HkdfTest.kt
@@ -1,0 +1,47 @@
+package com.hereliesaz.graffitixr.core.collaboration.wire
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/** RFC 5869 test vectors for HKDF-SHA256. */
+class HkdfTest {
+
+    private fun hex(s: String): ByteArray {
+        val clean = s.replace(" ", "")
+        return ByteArray(clean.length / 2) { ((clean[it * 2].digitToInt(16) shl 4) or clean[it * 2 + 1].digitToInt(16)).toByte() }
+    }
+
+    private fun ByteArray.hex(): String = joinToString("") { "%02x".format(it) }
+
+    @Test
+    fun `RFC 5869 test case 1`() {
+        val ikm = hex("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b")
+        val salt = hex("000102030405060708090a0b0c")
+        val info = hex("f0f1f2f3f4f5f6f7f8f9")
+        val prk = Hkdf.extract(salt, ikm)
+        assertEquals(
+            "077709362c2e32df0ddc3f0dc47bba6390b6c73bb50f9c3122ec844ad7c2b3e5",
+            prk.hex(),
+        )
+        val okm = Hkdf.expand(prk, info, 42)
+        assertEquals(
+            "3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865",
+            okm.hex(),
+        )
+    }
+
+    @Test
+    fun `RFC 5869 test case 3 empty salt and info`() {
+        val ikm = hex("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b")
+        val prk = Hkdf.extract(ByteArray(0), ikm)
+        assertEquals(
+            "19ef24a32c717b167f33a91d6f648bdf96596776afdb6377ac434c1c293ccb04",
+            prk.hex(),
+        )
+        val okm = Hkdf.expand(prk, ByteArray(0), 42)
+        assertEquals(
+            "8da4e775a563c18f715f802a063c5a31b8a11f5c5ee1879ec3454e5f3c738d2d9d201395faa4b61a96c8",
+            okm.hex(),
+        )
+    }
+}

--- a/collab/src/test/java/com/hereliesaz/graffitixr/core/collaboration/wire/OpCodecTest.kt
+++ b/collab/src/test/java/com/hereliesaz/graffitixr/core/collaboration/wire/OpCodecTest.kt
@@ -10,8 +10,24 @@ class OpCodecTest {
 
     @Test
     fun `Hello round-trips`() {
-        val original = HelloPayload(token = "abc", clientVersion = 1, deviceName = "Pixel")
+        val original = HelloPayload(
+            guestNonce = ByteArray(16) { it.toByte() },
+            proof = ByteArray(32) { (it * 3).toByte() },
+            clientVersion = 2,
+            deviceName = "Pixel",
+        )
         assertEquals(original, OpCodec.decode<HelloPayload>(OpCodec.encode(original)))
+    }
+
+    @Test
+    fun `HelloOk round-trips`() {
+        val original = HelloOkPayload(
+            sessionId = "sid",
+            protocolVersion = 2,
+            hostNonce = ByteArray(16) { (it + 1).toByte() },
+            hostProof = ByteArray(32) { (it * 5).toByte() },
+        )
+        assertEquals(original, OpCodec.decode<HelloOkPayload>(OpCodec.encode(original)))
     }
 
     @Test

--- a/collab/src/test/java/com/hereliesaz/graffitixr/core/collaboration/wire/SessionCryptoTest.kt
+++ b/collab/src/test/java/com/hereliesaz/graffitixr/core/collaboration/wire/SessionCryptoTest.kt
@@ -1,0 +1,82 @@
+package com.hereliesaz.graffitixr.core.collaboration.wire
+
+import javax.crypto.AEADBadTagException
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class SessionCryptoTest {
+
+    private val token = "shared-qr-token"
+    private val sessionId = "sid-123"
+    private val guestNonce = ByteArray(16) { it.toByte() }
+    private val hostNonce = ByteArray(16) { (it * 2 + 1).toByte() }
+
+    private fun pair(): Pair<SessionCrypto, SessionCrypto> =
+        SessionCrypto.forHost(token, sessionId, guestNonce, hostNonce) to
+            SessionCrypto.forGuest(token, sessionId, guestNonce, hostNonce)
+
+    @Test
+    fun `host to guest round-trips`() {
+        val (host, guest) = pair()
+        val payload = byteArrayOf(1, 2, 3, 4, 5)
+        val opened = guest.open(host.seal(FrameType.DELTA, payload))
+        assertEquals(FrameType.DELTA, opened.type)
+        assertArrayEquals(payload, opened.payload)
+    }
+
+    @Test
+    fun `guest to host round-trips on the reverse keys`() {
+        val (host, guest) = pair()
+        val payload = byteArrayOf(9, 8, 7)
+        val opened = host.open(guest.seal(FrameType.DELTA_ACK, payload))
+        assertEquals(FrameType.DELTA_ACK, opened.type)
+        assertArrayEquals(payload, opened.payload)
+    }
+
+    @Test
+    fun `tampered ciphertext fails authentication`() {
+        val (host, guest) = pair()
+        val sealed = host.seal(FrameType.DELTA, byteArrayOf(1, 2, 3))
+        sealed[sealed.size - 1] = (sealed[sealed.size - 1].toInt() xor 0x01).toByte()
+        assertThrows(AEADBadTagException::class.java) { guest.open(sealed) }
+    }
+
+    @Test
+    fun `wrong token cannot decrypt`() {
+        val host = SessionCrypto.forHost(token, sessionId, guestNonce, hostNonce)
+        val wrongGuest = SessionCrypto.forGuest("different-token", sessionId, guestNonce, hostNonce)
+        assertThrows(AEADBadTagException::class.java) {
+            wrongGuest.open(host.seal(FrameType.DELTA, byteArrayOf(1)))
+        }
+    }
+
+    @Test
+    fun `replayed counter is rejected`() {
+        val (host, guest) = pair()
+        val first = host.seal(FrameType.PING, byteArrayOf(0))
+        host.seal(FrameType.PING, byteArrayOf(0)) // advance host counter
+        guest.open(first)
+        // Re-delivering the first frame (counter now <= lastRecv) must be refused.
+        assertThrows(AEADBadTagException::class.java) { guest.open(first) }
+    }
+
+    @Test
+    fun `direction keys differ so a frame cannot be opened with the sender's own crypto`() {
+        val (host, _) = pair()
+        val sealed = host.seal(FrameType.DELTA, byteArrayOf(4, 2))
+        // Host's recv key is the guest→host key, not its own send key.
+        assertThrows(AEADBadTagException::class.java) { host.open(sealed) }
+    }
+
+    @Test
+    fun `each message uses a distinct nonce`() {
+        val (host, _) = pair()
+        val a = host.seal(FrameType.DELTA, byteArrayOf(0))
+        val b = host.seal(FrameType.DELTA, byteArrayOf(0))
+        // Same plaintext, different counter => different first 8 (counter) and ciphertext bytes.
+        assertFalse(a.contentEquals(b))
+    }
+}

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/Fingerprint.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/Fingerprint.kt
@@ -54,6 +54,45 @@ data class Fingerprint(
         result = 31 * result + markCenterLocal.hashCode()
         return result
     }
+
+    companion object {
+        /**
+         * FROZEN JNI ABI — `buildFingerprintObject` in GraffitiJNI.cpp constructs Fingerprints
+         * through [fromNative] by this exact name/descriptor. The raw constructor must never be
+         * used from JNI: Kotlin default parameters don't emit reduced-arity JVM overloads, so
+         * every field added to the data class silently broke the native lookup (twice now:
+         * patchData, then markCenterLocal) and setWallFingerprint returned null on every capture.
+         *
+         * Never change [fromNative]'s signature. Add new Fingerprint fields with defaults and,
+         * if native code must supply them, introduce a NEW factory with its own frozen descriptor.
+         * FingerprintJniContractTest asserts the descriptor below matches the compiled method.
+         */
+        const val JNI_FACTORY_NAME = "fromNative"
+        const val JNI_FACTORY_DESCRIPTOR =
+            "(Ljava/util/List;Ljava/util/List;[BIII[BLjava/util/List;)" +
+                "Lcom/hereliesaz/graffitixr/common/model/Fingerprint;"
+
+        @JvmStatic
+        fun fromNative(
+            keypoints: List<KeyPoint>,
+            points3d: List<Float>,
+            descriptorsData: ByteArray,
+            descriptorsRows: Int,
+            descriptorsCols: Int,
+            descriptorsType: Int,
+            patchData: ByteArray,
+            markCenterLocal: List<Float>,
+        ): Fingerprint = Fingerprint(
+            keypoints = keypoints,
+            points3d = points3d,
+            descriptorsData = descriptorsData,
+            descriptorsRows = descriptorsRows,
+            descriptorsCols = descriptorsCols,
+            descriptorsType = descriptorsType,
+            patchData = patchData,
+            markCenterLocal = markCenterLocal,
+        )
+    }
 }
 
 /** Value-equality for OpenCV KeyPoints (which compare by reference): all geometric fields match. */

--- a/core/common/src/test/java/com/hereliesaz/graffitixr/common/model/FingerprintJniContractTest.kt
+++ b/core/common/src/test/java/com/hereliesaz/graffitixr/common/model/FingerprintJniContractTest.kt
@@ -1,0 +1,95 @@
+package com.hereliesaz.graffitixr.common.model
+
+import java.lang.reflect.Method
+import java.lang.reflect.Modifier
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.opencv.core.KeyPoint
+
+/**
+ * Guards the frozen JNI ABI between GraffitiJNI.cpp and [Fingerprint.fromNative].
+ *
+ * `buildFingerprintObject` (C++) looks the factory up by the exact name/descriptor in
+ * [Fingerprint.JNI_FACTORY_NAME]/[Fingerprint.JNI_FACTORY_DESCRIPTOR]. Editing the factory's
+ * signature — or reverting native code to the raw constructor, whose descriptor changes whenever
+ * a defaulted field is added to the data class — silently breaks wall-fingerprint capture: the
+ * native lookup returns null and setWallFingerprint yields null on every call. That exact failure
+ * has shipped twice (patchData, then markCenterLocal). If this test fails, fix the factory back
+ * to the frozen signature or add a NEW factory for the new shape and update GraffitiJNI.cpp in
+ * the same change.
+ */
+class FingerprintJniContractTest {
+
+    @Test
+    fun `fromNative exists, is static, and matches the frozen JNI descriptor`() {
+        val method = Fingerprint::class.java.methods.singleOrNull {
+            it.name == Fingerprint.JNI_FACTORY_NAME && Modifier.isStatic(it.modifiers)
+        }
+        assertNotNull(
+            "Fingerprint must expose exactly one static ${Fingerprint.JNI_FACTORY_NAME} — " +
+                "GraffitiJNI.cpp resolves it with GetStaticMethodID",
+            method,
+        )
+        assertEquals(Fingerprint.JNI_FACTORY_DESCRIPTOR, jniDescriptorOf(method!!))
+    }
+
+    @Test
+    fun `fromNative passes every field through unchanged`() {
+        val keypoints = listOf(KeyPoint(1f, 2f, 3f, 4f, 5f, 6, 7))
+        val points3d = listOf(0.5f, -1.5f, 2f)
+        val descriptors = byteArrayOf(1, 2, 3, 4)
+        val patch = byteArrayOf(9, 8)
+        val center = listOf(0.1f, 0.2f, 0.3f)
+
+        val fp = Fingerprint.fromNative(keypoints, points3d, descriptors, 2, 2, 0, patch, center)
+
+        assertEquals(keypoints, fp.keypoints)
+        assertEquals(points3d, fp.points3d)
+        assertArrayEquals(descriptors, fp.descriptorsData)
+        assertEquals(2, fp.descriptorsRows)
+        assertEquals(2, fp.descriptorsCols)
+        assertEquals(0, fp.descriptorsType)
+        assertArrayEquals(patch, fp.patchData)
+        assertEquals(center, fp.markCenterLocal)
+    }
+
+    @Test
+    fun `descriptor constant itself stays frozen`() {
+        // Belt and braces: if someone "helpfully" regenerates the constant to match a changed
+        // signature, this literal still fails the build until GraffitiJNI.cpp is reconciled.
+        assertEquals(
+            "(Ljava/util/List;Ljava/util/List;[BIII[BLjava/util/List;)" +
+                "Lcom/hereliesaz/graffitixr/common/model/Fingerprint;",
+            Fingerprint.JNI_FACTORY_DESCRIPTOR,
+        )
+        assertEquals("fromNative", Fingerprint.JNI_FACTORY_NAME)
+    }
+
+    /** Builds the JNI method descriptor for [method] from its erased parameter/return types. */
+    private fun jniDescriptorOf(method: Method): String =
+        method.parameterTypes.joinToString(prefix = "(", postfix = ")", separator = "") {
+            jniTypeOf(it)
+        } + jniTypeOf(method.returnType)
+
+    private fun jniTypeOf(type: Class<*>): String = when {
+        type == Void.TYPE -> "V"
+        type == Boolean::class.javaPrimitiveType -> "Z"
+        type == Byte::class.javaPrimitiveType -> "B"
+        type == Char::class.javaPrimitiveType -> "C"
+        type == Short::class.javaPrimitiveType -> "S"
+        type == Int::class.javaPrimitiveType -> "I"
+        type == Long::class.javaPrimitiveType -> "J"
+        type == Float::class.javaPrimitiveType -> "F"
+        type == Double::class.javaPrimitiveType -> "D"
+        type.isArray -> "[" + jniTypeOf(type.componentType!!)
+        else -> "L" + type.name.replace('.', '/') + ";"
+    }
+
+    init {
+        // Sanity for the helper itself, so descriptor mismatches always mean a real ABI change.
+        assertTrue(jniTypeOf(ByteArray::class.java) == "[B")
+    }
+}

--- a/core/data/src/main/java/com/hereliesaz/graffitixr/data/ProjectManager.kt
+++ b/core/data/src/main/java/com/hereliesaz/graffitixr/data/ProjectManager.kt
@@ -49,6 +49,15 @@ class ProjectManager @Inject constructor(
         encodeDefaults = true
     }
 
+    companion object {
+        /**
+         * Cap on total decompressed bytes accepted from an imported/peer-received `.gxr` archive.
+         * Both sources are untrusted (a shared file, or the co-op wire), so a zip bomb must not
+         * be able to fill the app sandbox. Generous vs. real projects (multi-layer PNGs).
+         */
+        private const val MAX_IMPORT_BYTES = 512L * 1024 * 1024
+    }
+
     fun getProjectList(context: Context): List<String> {
         val projectsDir = File(context.filesDir, "projects")
         if (!projectsDir.exists()) return emptyList()
@@ -175,7 +184,13 @@ class ProjectManager @Inject constructor(
 
         return@withContext try {
             val jsonString = projectFile.readText()
-            val projectData = migrateIfNeeded(context, json.decodeFromString<GraffitiProject>(jsonString))
+            val decoded = json.decodeFromString<GraffitiProject>(jsonString)
+            val projectData = migrateInMemory(decoded)
+            if (projectData !== decoded) {
+                // Persist the migration only on a full load — loadProjectMetadata stays read-only.
+                saveProject(context, projectData)
+                Log.i("ProjectManager", "Migrated legacyVisuals for project ${projectData.id}")
+            }
 
             val targetBitmaps = projectData.targetImageUris.mapNotNull { uri ->
                 ImageUtils.loadBitmapSync(context, uri)
@@ -196,14 +211,21 @@ class ProjectManager @Inject constructor(
         return@withContext try {
             val jsonString = projectFile.readText()
             val project = json.decodeFromString<GraffitiProject>(jsonString)
-            migrateIfNeeded(context, project)
+            // In-memory migration only: this is a read path (dashboard listing) and must not
+            // write to disk — the persisted migration happens in loadProject.
+            migrateInMemory(project)
         } catch (e: Exception) {
             Log.e("ProjectManager", "Failed to load project metadata", e)
             null
         }
     }
 
-    private suspend fun migrateIfNeeded(context: Context, project: GraffitiProject): GraffitiProject {
+    /**
+     * Applies the legacyVisuals→layers migration purely in memory. Returns [project] itself
+     * (same reference) when no migration is needed, so callers can detect change by identity
+     * and decide whether to persist.
+     */
+    private fun migrateInMemory(project: GraffitiProject): GraffitiProject {
         val lv = project.legacyVisuals
         val defaults = LegacyVisuals()
         if (lv == defaults) return project
@@ -252,10 +274,7 @@ class ProjectManager @Inject constructor(
             else -> project.layers
         }
 
-        val migrated = project.copy(layers = migratedLayers, legacyVisuals = defaults)
-        saveProject(context, migrated)
-        Log.i("ProjectManager", "Migrated legacyVisuals for project ${project.id}")
-        return migrated
+        return project.copy(layers = migratedLayers, legacyVisuals = defaults)
     }
 
     private fun OverlayLayer.hasDefaultVisuals(): Boolean {
@@ -281,11 +300,14 @@ class ProjectManager @Inject constructor(
     }
 
     suspend fun importProjectFromUri(context: Context, uri: Uri): GraffitiProject? = withContext(Dispatchers.IO) {
+        var extractedFiles: Map<String, File> = emptyMap()
         return@withContext try {
             context.contentResolver.openInputStream(uri)?.use { inputStream ->
                 ZipInputStream(inputStream).use { zis ->
                     var projectData: GraffitiProject? = null
-                    val extractedFiles = mutableMapOf<String, File>()
+                    val extracted = mutableMapOf<String, File>()
+                    extractedFiles = extracted
+                    var totalBytes = 0L
 
                     var entry = zis.nextEntry
                     while (entry != null) {
@@ -294,6 +316,11 @@ class ProjectManager @Inject constructor(
 
                         if (!entry.isDirectory && relativeName.isNotEmpty()) {
                             val bytes = zis.readBytes()
+                            totalBytes += bytes.size
+                            if (totalBytes > MAX_IMPORT_BYTES) {
+                                Log.e("ProjectManager", "Import aborted: archive exceeds $MAX_IMPORT_BYTES bytes")
+                                return@use null
+                            }
                             if (relativeName == "project.json") {
                                 try {
                                     projectData = json.decodeFromString<GraffitiProject>(bytes.decodeToString())
@@ -301,7 +328,7 @@ class ProjectManager @Inject constructor(
                                     Log.e("ProjectManager", "Failed to parse project.json", e)
                                 }
                             }
-                            extractedFiles[relativeName] = File.createTempFile("gxr_", null, context.cacheDir).also {
+                            extracted[relativeName] = File.createTempFile("gxr_", null, context.cacheDir).also {
                                 it.writeBytes(bytes)
                             }
                         }
@@ -310,10 +337,22 @@ class ProjectManager @Inject constructor(
                     }
 
                     val project = projectData ?: return@use null
+                    // project.id comes from the (untrusted) archive and becomes a path segment.
+                    if (!isSafeProjectId(project.id)) {
+                        Log.e("ProjectManager", "Import rejected: unsafe project id")
+                        return@use null
+                    }
                     val destDir = File(context.filesDir, "projects/${project.id}").also { it.mkdirs() }
 
-                    for ((name, tmpFile) in extractedFiles) {
-                        val dest = File(destDir, name)
+                    for ((name, tmpFile) in extracted) {
+                        // Zip-Slip guard: entry names are attacker-controlled and may contain
+                        // ".." components that escape destDir.
+                        val dest = resolveInside(destDir, name)
+                        if (dest == null) {
+                            Log.w("ProjectManager", "Skipping zip entry escaping project dir: $name")
+                            tmpFile.delete()
+                            continue
+                        }
                         dest.parentFile?.mkdirs()
                         // renameTo can silently fail across filesystems (cache vs files dir) or when
                         // the destination exists — fall back to an explicit copy so an imported
@@ -331,8 +370,28 @@ class ProjectManager @Inject constructor(
         } catch (e: Exception) {
             Log.e("ProjectManager", "Import failed", e)
             null
+        } finally {
+            // Temp files are only renamed away on the success path; clear any stragglers.
+            extractedFiles.values.forEach { if (it.exists()) it.delete() }
         }
     }
+
+    /**
+     * Resolves [entryName] to a file under [destDir], or null if the name (via ".." components,
+     * absolute paths, etc.) would escape it — the Zip-Slip attack. Canonical-path prefix check.
+     */
+    private fun resolveInside(destDir: File, entryName: String): File? {
+        val candidate = File(destDir, entryName)
+        val canonical = candidate.canonicalPath
+        return if (canonical.startsWith(destDir.canonicalPath + File.separator)) candidate else null
+    }
+
+    /**
+     * Project ids become a path segment under filesDir/projects; ids parsed out of imported or
+     * peer-received archives must not be able to traverse out of it.
+     */
+    private fun isSafeProjectId(id: String): Boolean =
+        id.isNotEmpty() && id.length <= 128 && id.all { it.isLetterOrDigit() || it == '_' || it == '-' }
 
     private fun ComposeBlendMode.toModelBlendMode(): ModelBlendMode = when (this) {
         ComposeBlendMode.Multiply   -> ModelBlendMode.Multiply
@@ -400,12 +459,18 @@ class ProjectManager @Inject constructor(
                 ZipInputStream(bytes.inputStream()).use { zis ->
                     var projectData: GraffitiProject? = null
                     val extractedFiles = mutableMapOf<String, ByteArray>()
+                    var totalBytes = 0L
 
                     var entry = zis.nextEntry
                     while (entry != null) {
                         val name = entry.name
                         if (!entry.isDirectory && name.isNotEmpty()) {
                             val fileBytes = zis.readBytes()
+                            totalBytes += fileBytes.size
+                            if (totalBytes > MAX_IMPORT_BYTES) {
+                                Log.e("ProjectManager", "Spectator load aborted: archive exceeds $MAX_IMPORT_BYTES bytes")
+                                return@use
+                            }
                             if (name == "project.json") {
                                 projectData = json.decodeFromString<GraffitiProject>(fileBytes.decodeToString())
                             }
@@ -416,10 +481,19 @@ class ProjectManager @Inject constructor(
                     }
 
                     val project = projectData ?: return@use
+                    // The archive arrived over the co-op wire — id and entry names are untrusted.
+                    if (!isSafeProjectId(project.id)) {
+                        Log.e("ProjectManager", "Spectator load rejected: unsafe project id")
+                        return@use
+                    }
                     val destDir = File(context.filesDir, "projects/${project.id}").also { it.mkdirs() }
 
                     for ((name, fileBytes) in extractedFiles) {
-                        val dest = File(destDir, name)
+                        val dest = resolveInside(destDir, name)
+                        if (dest == null) {
+                            Log.w("ProjectManager", "Skipping zip entry escaping project dir: $name")
+                            continue
+                        }
                         dest.parentFile?.mkdirs()
                         dest.writeBytes(fileBytes)
                     }

--- a/core/data/src/test/java/com/hereliesaz/graffitixr/data/ProjectManagerTest.kt
+++ b/core/data/src/test/java/com/hereliesaz/graffitixr/data/ProjectManagerTest.kt
@@ -7,7 +7,12 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -31,10 +36,19 @@ class ProjectManagerTest {
 
         mockContext = mockk(relaxed = true)
         every { mockContext.filesDir } returns tempFilesDir
+        every { mockContext.cacheDir } returns File(tempFilesDir, "cache").also { it.mkdirs() }
 
         mockkStatic(Uri::class)
         every { Uri.parse(any()) } returns mockk(relaxed = true)
         every { Uri.fromFile(any()) } returns mockk(relaxed = true)
+
+        // The hardened import/spectator paths log skipped hostile entries; android.util.Log is
+        // not available in plain JVM tests.
+        mockkStatic(android.util.Log::class)
+        every { android.util.Log.e(any(), any()) } returns 0
+        every { android.util.Log.e(any(), any(), any()) } returns 0
+        every { android.util.Log.w(any(), any<String>()) } returns 0
+        every { android.util.Log.i(any(), any()) } returns 0
 
         uriProvider = mockk(relaxed = true)
         val projectRepositoryProvider = mockk<javax.inject.Provider<com.hereliesaz.graffitixr.domain.repository.ProjectRepository>>(relaxed = true)
@@ -45,6 +59,7 @@ class ProjectManagerTest {
     fun teardown() {
         tempFilesDir.deleteRecursively()
         unmockkStatic(Uri::class)
+        unmockkStatic(android.util.Log::class)
     }
 
     @Test
@@ -94,5 +109,104 @@ class ProjectManagerTest {
 
         val result = manager.importProjectFromUri(mockContext, mockUri)
         assertNull(result)
+    }
+
+    // --- Zip-Slip / hostile-archive hardening ---
+
+    private fun zipOf(vararg entries: Pair<String, ByteArray>): ByteArray {
+        val baos = java.io.ByteArrayOutputStream()
+        java.util.zip.ZipOutputStream(baos).use { zos ->
+            for ((name, bytes) in entries) {
+                zos.putNextEntry(java.util.zip.ZipEntry(name))
+                zos.write(bytes)
+                zos.closeEntry()
+            }
+        }
+        return baos.toByteArray()
+    }
+
+    private fun projectJson(id: String) = """{"id":"$id","name":"evil"}""".toByteArray()
+
+    private suspend fun importZip(zipBytes: ByteArray): GraffitiProject? {
+        val mockUri = mockk<Uri>(relaxed = true)
+        val mockResolver = mockk<android.content.ContentResolver>(relaxed = true)
+        every { mockContext.contentResolver } returns mockResolver
+        every { mockResolver.openInputStream(any()) } returns zipBytes.inputStream()
+        return manager.importProjectFromUri(mockContext, mockUri)
+    }
+
+    @Test
+    fun `import skips zip entries that escape the project directory`() = runTest {
+        val evilTarget = File(tempFilesDir.parentFile, "gxr_zip_slip_escape.txt")
+        evilTarget.delete()
+        // Entry names get their first path segment stripped on import, so both hostile shapes
+        // must be caught: a "../" chain surviving the strip, nested under a decoy segment.
+        val depth = "../".repeat(6)
+        val zip = zipOf(
+            "project.json" to projectJson("safe_project"),
+            "x/$depth${evilTarget.name}" to "pwned".toByteArray(),
+            "innocent.png" to byteArrayOf(1, 2, 3),
+        )
+
+        val result = importZip(zip)
+
+        assertFalse("hostile entry must not be written outside filesDir", evilTarget.exists())
+        // The import itself succeeds minus the hostile entry.
+        assertEquals("safe_project", result?.id)
+        assertTrue(File(tempFilesDir, "projects/safe_project/innocent.png").exists())
+        assertFalse(
+            File(tempFilesDir, "projects/safe_project").walkTopDown().any { it.name == evilTarget.name },
+        )
+    }
+
+    @Test
+    fun `import rejects archives with a path-traversal project id`() = runTest {
+        val result = importZip(zipOf("project.json" to projectJson("../escape")))
+        assertNull("hostile project.id must reject the whole import", result)
+        assertFalse(File(tempFilesDir, "escape").exists())
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `loadAsSpectator skips escaping entries and rejects hostile ids`() = runTest {
+        Dispatchers.setMain(UnconfinedTestDispatcher(testScheduler))
+        try {
+            val evilTarget = File(tempFilesDir.parentFile, "gxr_spectator_escape.txt")
+            evilTarget.delete()
+
+            // Hostile id: nothing may be created for it.
+            manager.loadAsSpectator(zipOf("project.json" to projectJson("../spec_escape")))
+            assertFalse(File(tempFilesDir, "spec_escape").exists())
+
+            // Escaping entry: skipped, rest of the project loads. Spectator zips keep raw entry
+            // names (no first-segment strip), so a bare "../" chain is the attack shape here.
+            val depth = "../".repeat(6)
+            manager.loadAsSpectator(
+                zipOf(
+                    "project.json" to projectJson("spec_safe"),
+                    "$depth${evilTarget.name}" to "pwned".toByteArray(),
+                    "layer.png" to byteArrayOf(7),
+                ),
+            )
+            assertFalse(evilTarget.exists())
+            assertTrue(File(tempFilesDir, "projects/spec_safe/layer.png").exists())
+        } finally {
+            Dispatchers.resetMain()
+        }
+    }
+
+    @Test
+    fun `loadProjectMetadata does not write the migrated project back to disk`() = runTest {
+        // A "legacy" project: non-default legacyVisuals triggers the in-memory migration.
+        val projectDir = File(tempFilesDir, "projects/legacy_project").also { it.mkdirs() }
+        val legacyJson = """{"id":"legacy_project","name":"Old","legacyVisuals":{"scale":2.0}}"""
+        val projectFile = File(projectDir, "project.json")
+        projectFile.writeText(legacyJson)
+
+        val metadata = manager.loadProjectMetadata(mockContext, "legacy_project")
+
+        assertEquals("legacy_project", metadata?.id)
+        // Read path must be side-effect free: bytes on disk untouched.
+        assertEquals(legacyJson, projectFile.readText())
     }
 }

--- a/core/design/src/main/res/values-de/strings.xml
+++ b/core/design/src/main/res/values-de/strings.xml
@@ -602,4 +602,7 @@
     <string name="tut_isolate_subject_text">Verwendet KI, um den Hintergrund automatisch zu entfernen und nur das Hauptmotiv des Bildes zu hinterlassen.</string>
     <string name="tut_best_results_title">Beste Ergebnisse</string>
     <string name="tut_best_results_text">Funktioniert am besten bei Fotos mit einem klaren Motiv vor einem einfachen oder kontrastierenden Hintergrund. Komplexe Szenen mit unruhigen Hintergründen erfordern möglicherweise manuelle Nachbesserungen mit dem Radiergummi.</string>
+    <string name="settings_scan_mode_voxel_hash">Voxel-Hash</string>
+    <string name="settings_scan_mode_surface_mesh">Oberflächennetz</string>
+    <string name="settings_mural_method_label">Mural-Engine</string>
 </resources>

--- a/core/design/src/main/res/values-es/strings.xml
+++ b/core/design/src/main/res/values-es/strings.xml
@@ -602,4 +602,7 @@
     <string name="tut_isolate_subject_text">Utiliza IA para eliminar automáticamente el fondo, dejando solo el sujeto principal de la imagen.</string>
     <string name="tut_best_results_title">Mejores Resultados</string>
     <string name="tut_best_results_text">Funciona mejor en fotos con un sujeto claro sobre un fondo liso o contrastante. Las escenas complejas con fondos ocupados pueden necesitar retoques manuales con el borrador.</string>
+    <string name="settings_scan_mode_voxel_hash">Hash de vóxeles</string>
+    <string name="settings_scan_mode_surface_mesh">Malla de superficie</string>
+    <string name="settings_mural_method_label">Motor de mural</string>
 </resources>

--- a/core/design/src/main/res/values-fr/strings.xml
+++ b/core/design/src/main/res/values-fr/strings.xml
@@ -106,4 +106,7 @@
     <!-- Content Descriptions -->
     <string name="desc_bg_mockup">Maquette d\'arrière-plan</string>
     <string name="desc_segmentation_preview">Aperçu de la segmentation</string>
+    <string name="settings_scan_mode_voxel_hash">Hachage de voxels</string>
+    <string name="settings_scan_mode_surface_mesh">Maillage de surface</string>
+    <string name="settings_mural_method_label">Moteur de fresque</string>
 </resources>

--- a/core/design/src/main/res/values-hu/strings.xml
+++ b/core/design/src/main/res/values-hu/strings.xml
@@ -602,4 +602,7 @@
     <string name="tut_isolate_subject_text">A mesterséges intelligenciát használja a háttér automatikus eltávolítására, így csak a kép fő témája marad.</string>
     <string name="tut_best_results_title">Legjobb Eredmények</string>
     <string name="tut_best_results_text">A legjobban azokon a fotókon működik, amelyeken tiszta téma van sima vagy kontrasztos háttér előtt. A zsúfolt hátterű összetett jelenetek manuális javítást igényelhetnek a radírral.</string>
+    <string name="settings_scan_mode_voxel_hash">Voxel-hash</string>
+    <string name="settings_scan_mode_surface_mesh">Felületháló</string>
+    <string name="settings_mural_method_label">Falfestmény-motor</string>
 </resources>

--- a/core/design/src/main/res/values-it/strings.xml
+++ b/core/design/src/main/res/values-it/strings.xml
@@ -602,4 +602,7 @@
     <string name="tut_isolate_subject_text">Usa l\'IA per rimuovere automaticamente lo sfondo, lasciando solo il soggetto principale dell\'immagine.</string>
     <string name="tut_best_results_title">Migliori Risultati</string>
     <string name="tut_best_results_text">Funziona meglio su foto con un soggetto chiaro su uno sfondo liscio o contrastante. Scene complesse con sfondi disordinati potrebbero richiedere ritocchi manuali con la gomma.</string>
+    <string name="settings_scan_mode_voxel_hash">Voxel hash</string>
+    <string name="settings_scan_mode_surface_mesh">Mesh di superficie</string>
+    <string name="settings_mural_method_label">Motore murale</string>
 </resources>

--- a/core/design/src/main/res/values-ja/strings.xml
+++ b/core/design/src/main/res/values-ja/strings.xml
@@ -620,4 +620,7 @@
     <string name="tut_isolate_subject_text">AIを使用して自動的に背景を削除し、画像のメインの被写体のみを残します。</string>
     <string name="tut_best_results_title">最高の結果</string>
     <string name="tut_best_results_text">無地または対照的な背景に対して明確な被写体がある写真に最適です。背景が複雑なシーンでは、消しゴムを使用した手動のタッチアップが必要になる場合があります。</string>
+    <string name="settings_scan_mode_voxel_hash">ボクセルハッシュ</string>
+    <string name="settings_scan_mode_surface_mesh">サーフェスメッシュ</string>
+    <string name="settings_mural_method_label">ミューラルエンジン</string>
 </resources>

--- a/core/design/src/main/res/values-nl/strings.xml
+++ b/core/design/src/main/res/values-nl/strings.xml
@@ -602,4 +602,7 @@
     <string name="tut_isolate_subject_text">Gebruikt AI om de achtergrond automatisch te verwijderen, waardoor alleen het hoofdonderwerp van de afbeelding overblijft.</string>
     <string name="tut_best_results_title">Beste resultaten</string>
     <string name="tut_best_results_text">Werkt het beste op foto\'s met een duidelijk onderwerp tegen een effen of contrasterende achtergrond. Complexe scènes met drukke achtergronden moeten mogelijk handmatig worden bijgewerkt met de gum.</string>
+    <string name="settings_scan_mode_voxel_hash">Voxel-hash</string>
+    <string name="settings_scan_mode_surface_mesh">Oppervlaktemesh</string>
+    <string name="settings_mural_method_label">Muurschildering-engine</string>
 </resources>

--- a/core/design/src/main/res/values-no/strings.xml
+++ b/core/design/src/main/res/values-no/strings.xml
@@ -602,4 +602,7 @@
     <string name="tut_isolate_subject_text">Bruker AI for automatisk å fjerne bakgrunnen, og etterlater bare hovedmotivet i bildet.</string>
     <string name="tut_best_results_title">Beste resultater</string>
     <string name="tut_best_results_text">Fungerer best på bilder med et klart motiv mot en vanlig eller kontrastfylt bakgrunn. Komplekse scener med opptatt bakgrunn kan trenge manuelle bearbeiding med viskelæret.</string>
+    <string name="settings_scan_mode_voxel_hash">Voxel-hash</string>
+    <string name="settings_scan_mode_surface_mesh">Overflatenett</string>
+    <string name="settings_mural_method_label">Veggmaleri-motor</string>
 </resources>

--- a/core/design/src/main/res/values-pt/strings.xml
+++ b/core/design/src/main/res/values-pt/strings.xml
@@ -602,4 +602,7 @@
     <string name="tut_isolate_subject_text">Usa IA para remover automaticamente o fundo, deixando apenas o objeto principal da imagem.</string>
     <string name="tut_best_results_title">Melhores Resultados</string>
     <string name="tut_best_results_text">Funciona melhor em fotos com um objeto nítido em um fundo liso ou contrastante. Cenas complexas com fundos muito detalhados podem precisar de retoques manuais com a borracha.</string>
+    <string name="settings_scan_mode_voxel_hash">Hash de voxels</string>
+    <string name="settings_scan_mode_surface_mesh">Malha de superfície</string>
+    <string name="settings_mural_method_label">Motor de mural</string>
 </resources>

--- a/core/design/src/main/res/values-ru/strings.xml
+++ b/core/design/src/main/res/values-ru/strings.xml
@@ -602,4 +602,7 @@
     <string name="tut_isolate_subject_text">Использует искусственный интеллект для автоматического удаления фона, оставляя только основной объект изображения.</string>
     <string name="tut_best_results_title">Лучшие результаты</string>
     <string name="tut_best_results_text">Лучше всего работает на фотографиях с четким объектом на однотонном или контрастном фоне. </string>
+    <string name="settings_scan_mode_voxel_hash">Воксельный хеш</string>
+    <string name="settings_scan_mode_surface_mesh">Поверхностная сетка</string>
+    <string name="settings_mural_method_label">Движок мурала</string>
 </resources>

--- a/core/design/src/main/res/values-sv/strings.xml
+++ b/core/design/src/main/res/values-sv/strings.xml
@@ -602,4 +602,7 @@
     <string name="tut_isolate_subject_text">Använder AI för att automatiskt ta bort bakgrunden, vilket bara lämnar bildens huvudmotiv.</string>
     <string name="tut_best_results_title">Bästa resultat</string>
     <string name="tut_best_results_text">Fungerar bäst på foton med ett tydligt motiv mot en vanlig eller kontrasterande bakgrund. Komplexa scener med upptagen bakgrund kan behöva korrigeras manuellt med suddgummi.</string>
+    <string name="settings_scan_mode_voxel_hash">Voxel-hash</string>
+    <string name="settings_scan_mode_surface_mesh">Ytnät</string>
+    <string name="settings_mural_method_label">Väggmålningsmotor</string>
 </resources>

--- a/core/design/src/main/res/values-zh-rCN/strings.xml
+++ b/core/design/src/main/res/values-zh-rCN/strings.xml
@@ -620,4 +620,7 @@
     <string name="tut_isolate_subject_text">使用 AI 自动移除背景，仅保留图像的主要主体。</string>
     <string name="tut_best_results_title">最佳效果</string>
     <string name="tut_best_results_text">在具有清晰主体和纯色或对比色背景的照片上效果最佳。背景杂乱的复杂场景可能需要使用橡皮擦进行手动修饰。</string>
+    <string name="settings_scan_mode_voxel_hash">体素哈希</string>
+    <string name="settings_scan_mode_surface_mesh">表面网格</string>
+    <string name="settings_mural_method_label">壁画引擎</string>
 </resources>

--- a/core/design/src/main/res/values-zh-rHK/strings.xml
+++ b/core/design/src/main/res/values-zh-rHK/strings.xml
@@ -602,4 +602,7 @@
     <string name="tut_isolate_subject_text">利用AI自動去除背景，只留下影像的主要主體。</string>
     <string name="tut_best_results_title">最佳結果</string>
     <string name="tut_best_results_text">最適合拍攝主題清晰、背景簡單或對比鮮明的照片。背景複雜的複雜場景可能需要使用橡皮擦進行手動修飾。</string>
+    <string name="settings_scan_mode_voxel_hash">體素雜湊</string>
+    <string name="settings_scan_mode_surface_mesh">表面網格</string>
+    <string name="settings_mural_method_label">壁畫引擎</string>
 </resources>

--- a/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
+++ b/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
@@ -893,8 +893,10 @@ jobject buildFingerprintObject(JNIEnv* env, const MobileGS::FingerprintData& fd)
     jmethodID kpCtor = env->GetMethodID(kpClass, "<init>", "(FFFFFII)V");
     if (!kpCtor) return bail("KeyPoint ctor");
     jobject kpList = env->NewObject(listClass, listCtor, (jint)fd.keypoints.size());
+    if (!kpList) return bail("keypoint list alloc");
     for (const auto& kp : fd.keypoints) {
         jobject jkp = env->NewObject(kpClass, kpCtor, kp.pt.x, kp.pt.y, kp.size, kp.angle, kp.response, (jint)kp.octave, (jint)kp.class_id);
+        if (!jkp) return bail("KeyPoint alloc");
         env->CallBooleanMethod(kpList, addMethod, jkp);
         env->DeleteLocalRef(jkp);
     }
@@ -905,8 +907,10 @@ jobject buildFingerprintObject(JNIEnv* env, const MobileGS::FingerprintData& fd)
     jmethodID floatCtor = env->GetMethodID(floatClass, "<init>", "(F)V");
     if (!floatCtor) return bail("Float(f) ctor");
     jobject ptsList = env->NewObject(listClass, listCtor, (jint)fd.points3d.size());
+    if (!ptsList) return bail("points3d list alloc");
     for (float f : fd.points3d) {
         jobject jf = env->NewObject(floatClass, floatCtor, f);
+        if (!jf) return bail("Float alloc");
         env->CallBooleanMethod(ptsList, addMethod, jf);
         env->DeleteLocalRef(jf);
     }
@@ -914,25 +918,35 @@ jobject buildFingerprintObject(JNIEnv* env, const MobileGS::FingerprintData& fd)
     // DescriptorsData: byte[]
     jsize descSize = fd.descriptors.total() * fd.descriptors.elemSize();
     jbyteArray descArray = env->NewByteArray(descSize);
+    if (!descArray) return bail("descriptor array alloc");
     env->SetByteArrayRegion(descArray, 0, descSize, (const jbyte*)fd.descriptors.data);
+    if (env->ExceptionCheck()) return bail("descriptor array copy");
 
     jclass fpClass = env->FindClass("com/hereliesaz/graffitixr/common/model/Fingerprint");
     if (!fpClass) return bail("Fingerprint class");
-    // Fingerprint's Kotlin primary constructor takes 7 params:
-    //   (List keypoints, List points3d, byte[] descriptorsData, int rows, int cols, int type,
-    //    byte[] patchData)
-    // The two params with defaults (points3d, patchData) do NOT produce a 6-arg JVM overload, so
-    // the descriptor MUST include the trailing [B. The old 6-arg lookup never matched, GetMethodID
-    // returned null, and setWallFingerprint silently produced null on every call.
-    jmethodID fpCtor = env->GetMethodID(fpClass, "<init>", "(Ljava/util/List;Ljava/util/List;[BIII[B)V");
-    if (!fpCtor) return bail("Fingerprint(List,List,[B,I,I,I,[B) ctor");
+    // FROZEN JNI ABI: construct via the static factory Fingerprint.fromNative, never the raw
+    // constructor. Kotlin default parameters don't emit reduced-arity JVM overloads, so every
+    // field added to the data class changed the constructor descriptor and broke this lookup
+    // (twice: patchData, then markCenterLocal), making setWallFingerprint return null on every
+    // capture. The factory signature is frozen — mirrored by Fingerprint.JNI_FACTORY_DESCRIPTOR
+    // and asserted by FingerprintJniContractTest — so new Kotlin fields can't break it again.
+    jmethodID fpFactory = env->GetStaticMethodID(
+            fpClass, "fromNative",
+            "(Ljava/util/List;Ljava/util/List;[BIII[BLjava/util/List;)Lcom/hereliesaz/graffitixr/common/model/Fingerprint;");
+    if (!fpFactory) return bail("Fingerprint.fromNative factory");
 
     // patchData (the distortion-head patch): this native path produces none — FingerprintData has
     // no patch field — so pass an empty array, matching the Kotlin default `patchData = ByteArray(0)`.
     jbyteArray patchArray = env->NewByteArray(0);
     if (!patchArray) return bail("patchArray alloc");
-    jobject fpObj = env->NewObject(fpClass, fpCtor, kpList, ptsList, descArray,
-                                   fd.descriptors.rows, fd.descriptors.cols, fd.descriptors.type(), patchArray);
+    // markCenterLocal: FingerprintData carries no marks centroid (it is computed Kotlin-side by
+    // MetricFingerprintBuilder), so pass an empty list, matching the Kotlin default.
+    jobject centerList = env->NewObject(listClass, listCtor, (jint)0);
+    if (!centerList) return bail("markCenterLocal list alloc");
+    jobject fpObj = env->CallStaticObjectMethod(fpClass, fpFactory, kpList, ptsList, descArray,
+                                                fd.descriptors.rows, fd.descriptors.cols, fd.descriptors.type(),
+                                                patchArray, centerList);
+    if (env->ExceptionCheck() || !fpObj) return bail("Fingerprint.fromNative call");
 
     return fpObj;
 }

--- a/core/nativebridge/src/main/cpp/ImageWarper.cpp
+++ b/core/nativebridge/src/main/cpp/ImageWarper.cpp
@@ -189,6 +189,10 @@ void ImageWarper::applyLiquify(const std::vector<glm::vec2>& stroke, float brush
 
 void ImageWarper::draw(int viewportWidth, int viewportHeight) {
     std::lock_guard<std::mutex> lock(mMutex);
+    drawLocked(viewportWidth, viewportHeight);
+}
+
+void ImageWarper::drawLocked(int viewportWidth, int viewportHeight) {
     if (!mInitialized || !mTextureId) return;
 
     if (mMeshDirty) {
@@ -224,7 +228,9 @@ void ImageWarper::bakeToBitmap(uint8_t* outData) {
     if (!mFbo || !mOffscreenTexture) return;
 
     glBindFramebuffer(GL_FRAMEBUFFER, mFbo);
-    draw(mWidth, mHeight);
+    // drawLocked, not draw(): mMutex is already held and is non-recursive —
+    // calling the public draw() here deadlocked the GL thread on bake.
+    drawLocked(mWidth, mHeight);
 
     glReadPixels(0, 0, mWidth, mHeight, GL_RGBA, GL_UNSIGNED_BYTE, outData);
 

--- a/core/nativebridge/src/main/cpp/MobileGS.cpp
+++ b/core/nativebridge/src/main/cpp/MobileGS.cpp
@@ -919,7 +919,13 @@ void MobileGS::scheduleRelocCheck(const cv::Mat& f) {
     // live-camera PnP relocalization never ran. Throttles to the reloc thread's consume rate: while a
     // request is still pending we skip, so we only copy a frame when the worker is ready for the next.
     if (f.empty() || !mRelocEnabled) return;
-    if (mWallDescriptors.empty()) return; // nothing to match against yet
+    {
+        // mWallDescriptors is reassigned under mMutex (generateFingerprint / restore paths /
+        // self-grow); an unlocked empty() probe races those cv::Mat header writes. Scoped so it
+        // never nests with mRelocMutex below.
+        std::lock_guard<std::mutex> lock(mMutex);
+        if (mWallDescriptors.empty()) return; // nothing to match against yet
+    }
     {
         std::lock_guard<std::mutex> lock(mRelocMutex);
         if (mRelocRequested) return;

--- a/core/nativebridge/src/main/cpp/include/ImageWarper.h
+++ b/core/nativebridge/src/main/cpp/include/ImageWarper.h
@@ -18,7 +18,9 @@ public:
     void reset();
 
 private:
-    void updateMesh();
+    // Body of draw(); caller must hold mMutex (which is non-recursive, so
+    // bakeToBitmap can't call the public draw() while holding the lock).
+    void drawLocked(int viewportWidth, int viewportHeight);
     void initShaders();
 
     int mWidth = 0;

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -112,13 +112,21 @@ class ArViewModel @Inject constructor(
     private val MAX_PENDING_SPECTATOR_OPS = 128
 
     fun setSpectatorOpHandler(handler: (com.hereliesaz.graffitixr.common.model.Op) -> Unit) {
-        val backlog: List<com.hereliesaz.graffitixr.common.model.Op>
-        synchronized(pendingSpectatorOps) {
-            spectatorOpHandler = handler
-            backlog = pendingSpectatorOps.toList()
-            pendingSpectatorOps.clear()
+        // Drain the backlog fully *before* publishing the handler. If we published first and then
+        // drained, an op arriving on the network thread mid-drain would see a non-null handler and
+        // run ahead of the still-queued backlog ops, desyncing the canvas. Publishing only once the
+        // queue is empty keeps strict FIFO: anything arriving during the drain is appended (handler
+        // still null) and picked up by the loop.
+        while (true) {
+            val op = synchronized(pendingSpectatorOps) {
+                if (pendingSpectatorOps.isEmpty()) {
+                    spectatorOpHandler = handler
+                    return
+                }
+                pendingSpectatorOps.removeFirst()
+            }
+            handler(op)
         }
-        backlog.forEach(handler)
     }
 
     /** Invokes the handler, or buffers the op (drop-oldest past the cap) until one is wired. */

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -95,11 +95,46 @@ class ArViewModel @Inject constructor(
     val hostQrPayload: StateFlow<String?> = _hostQrPayload
 
     /**
-     * Set by MainActivity to route incoming spectator Ops to EditorViewModel
-     * without ArViewModel knowing about the editor module. Avoids the
-     * ViewModel-of-ViewModel anti-pattern.
+     * Routes incoming spectator Ops to EditorViewModel without ArViewModel knowing about the
+     * editor module (avoids the ViewModel-of-ViewModel anti-pattern). Set by MainActivity via
+     * [setSpectatorOpHandler].
+     *
+     * Ops that arrive before the handler is wired (the host can start emitting deltas the moment
+     * the guest connects, while the handler is assigned from a Compose LaunchedEffect) are held
+     * in [pendingSpectatorOps] and replayed in order once the handler lands — they used to be
+     * logged and permanently dropped, silently desyncing the guest canvas.
      */
-    @Volatile var spectatorOpHandler: ((com.hereliesaz.graffitixr.common.model.Op) -> Unit)? = null
+    @Volatile private var spectatorOpHandler: ((com.hereliesaz.graffitixr.common.model.Op) -> Unit)? = null
+
+    // Guarded by synchronized(pendingSpectatorOps). Bounded so early LayerBitmapReplace payloads
+    // can't pin unbounded memory if the handler never arrives.
+    private val pendingSpectatorOps = ArrayDeque<com.hereliesaz.graffitixr.common.model.Op>()
+    private val MAX_PENDING_SPECTATOR_OPS = 128
+
+    fun setSpectatorOpHandler(handler: (com.hereliesaz.graffitixr.common.model.Op) -> Unit) {
+        val backlog: List<com.hereliesaz.graffitixr.common.model.Op>
+        synchronized(pendingSpectatorOps) {
+            spectatorOpHandler = handler
+            backlog = pendingSpectatorOps.toList()
+            pendingSpectatorOps.clear()
+        }
+        backlog.forEach(handler)
+    }
+
+    /** Invokes the handler, or buffers the op (drop-oldest past the cap) until one is wired. */
+    private fun dispatchSpectatorOp(op: com.hereliesaz.graffitixr.common.model.Op) {
+        val handler = synchronized(pendingSpectatorOps) {
+            spectatorOpHandler ?: run {
+                if (pendingSpectatorOps.size >= MAX_PENDING_SPECTATOR_OPS) {
+                    pendingSpectatorOps.removeFirst()
+                    android.util.Log.w("ArViewModel", "Pending spectator op buffer full — dropping oldest")
+                }
+                pendingSpectatorOps.addLast(op)
+                null
+            }
+        }
+        handler?.invoke(op)
+    }
 
     // ── Glasses session state ─────────────────────────────────────────────────
     private val _glassesSessionState: MutableStateFlow<GlassesSessionState> =
@@ -173,11 +208,7 @@ class ArViewModel @Inject constructor(
                         slamManager.alignToPeer(fingerprint)
                         projectManager.loadAsSpectator(project)
                     },
-                    onOp = { op ->
-                        val handler = spectatorOpHandler
-                        if (handler != null) handler(op)
-                        else android.util.Log.w("ArViewModel", "Spectator op dropped — handler not wired yet: $op")
-                    },
+                    onOp = { op -> dispatchSpectatorOp(op) },
                 )
                 _uiState.update { it.copy(coopRole = com.hereliesaz.graffitixr.common.model.CoopRole.GUEST) }
                 observeCoopState()

--- a/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/LayerStore.kt
+++ b/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/LayerStore.kt
@@ -12,6 +12,9 @@ import java.util.concurrent.ConcurrentHashMap
  *
  * ConcurrentHashMap because these are read/written from the project-collect coroutine, stroke
  * handlers, and the main thread (the previous plain maps threw ConcurrentModificationException).
+ * The map only protects its own structure, though — each per-layer stroke list is additionally
+ * guarded by synchronizing on the list itself, and [strokes] hands out snapshot copies, never
+ * the live list (background compositing iterates while strokes land on other threads).
  * The compositing of base + strokes into a display bitmap stays in the ViewModel — it needs the
  * UiState, OpenCV/SLAM, and persistence — this class only owns the caches.
  */
@@ -31,12 +34,25 @@ internal class LayerStore {
 
     fun base(layerId: String): Bitmap? = baseBitmaps[layerId]
 
-    /** The strokes for [layerId] in application order (empty if the layer is unknown). */
-    fun strokes(layerId: String): List<StrokeCommand> = layerStrokes[layerId] ?: emptyList()
+    /**
+     * The strokes for [layerId] in application order (empty if the layer is unknown).
+     *
+     * Returns a snapshot copy: the live list keeps mutating on other threads (stroke handlers on
+     * main, spectator-op replay) while DrawingEngine.composite iterates the result on
+     * Dispatchers.Default — handing out the live list threw ConcurrentModificationException.
+     * Stroke lists are small path metadata, so the copy is negligible next to compositing.
+     */
+    fun strokes(layerId: String): List<StrokeCommand> {
+        val list = layerStrokes[layerId] ?: return emptyList()
+        return synchronized(list) { list.toList() }
+    }
 
     /** Appends [command] to [layerId]'s strokes, creating the list if absent. */
     fun addStroke(layerId: String, command: StrokeCommand) {
-        layerStrokes.getOrPut(layerId) { mutableListOf() }.add(command)
+        // computeIfAbsent, not getOrPut: getOrPut on a ConcurrentHashMap is check-then-act, so two
+        // racing first-strokes could each install their own list and one stroke would vanish.
+        val list = layerStrokes.computeIfAbsent(layerId) { mutableListOf() }
+        synchronized(list) { list.add(command) }
     }
 
     /**
@@ -46,7 +62,9 @@ internal class LayerStore {
      */
     fun removeLastStroke(layerId: String): Boolean {
         val list = layerStrokes[layerId] ?: return false
-        if (list.isNotEmpty()) list.removeAt(list.lastIndex)
+        synchronized(list) {
+            if (list.isNotEmpty()) list.removeAt(list.lastIndex)
+        }
         return true
     }
 

--- a/feature/editor/src/test/java/com/hereliesaz/graffitixr/feature/editor/LayerStoreTest.kt
+++ b/feature/editor/src/test/java/com/hereliesaz/graffitixr/feature/editor/LayerStoreTest.kt
@@ -97,4 +97,67 @@ class LayerStoreTest {
         assertNull(store.base("a"))
         assertTrue(store.strokes("b").isEmpty())
     }
+
+    @Test
+    fun `concurrent adds and iteration never throw ConcurrentModificationException`() {
+        // Regression: strokes() used to return the live MutableList, so compositing on
+        // Dispatchers.Default iterated it while stroke handlers appended on other threads.
+        val iterations = 5_000
+        val writerError = java.util.concurrent.atomic.AtomicReference<Throwable?>(null)
+        val readerError = java.util.concurrent.atomic.AtomicReference<Throwable?>(null)
+        val start = java.util.concurrent.CountDownLatch(1)
+
+        val writer = Thread {
+            try {
+                start.await()
+                repeat(iterations) {
+                    store.addStroke("hot", stroke())
+                    if (it % 100 == 0) store.removeLastStroke("hot")
+                }
+            } catch (t: Throwable) {
+                writerError.set(t)
+            }
+        }
+        val reader = Thread {
+            try {
+                start.await()
+                repeat(iterations) {
+                    // Full iteration of the snapshot, like DrawingEngine.composite does.
+                    var count = 0
+                    for (s in store.strokes("hot")) count++
+                    check(count >= 0)
+                }
+            } catch (t: Throwable) {
+                readerError.set(t)
+            }
+        }
+
+        writer.start(); reader.start()
+        start.countDown()
+        writer.join(30_000); reader.join(30_000)
+
+        assertNull("writer thread failed: ${writerError.get()}", writerError.get())
+        assertNull("reader thread failed: ${readerError.get()}", readerError.get())
+        assertTrue(store.strokes("hot").isNotEmpty())
+    }
+
+    @Test
+    fun `racing first strokes on a fresh layer never lose a stroke`() {
+        // Regression: getOrPut on ConcurrentHashMap is check-then-act; two racing first-strokes
+        // could each install their own list, dropping one stroke.
+        repeat(200) { round ->
+            val layer = "fresh-$round"
+            val start = java.util.concurrent.CountDownLatch(1)
+            val threads = (0 until 2).map {
+                Thread {
+                    start.await()
+                    store.addStroke(layer, stroke())
+                }
+            }
+            threads.forEach { it.start() }
+            start.countDown()
+            threads.forEach { it.join(10_000) }
+            assertEquals("round $round lost a stroke", 2, store.strokes(layer).size)
+        }
+    }
 }


### PR DESCRIPTION
## Context

A full audit of the first-party codebase (app + feature modules, core modules + native C++, collab + build/docs) turned up ~40 issues. This PR fixes the outright bugs — with the two priority areas, **AR/tracking** and **collaboration/sync**, getting the deepest work — and adds transport encryption to the co-op module. Dead/unreachable features were **deliberately left untouched** and catalogued in `BACKLOG.md` for a separate product decision.

Vendored code under `libs/` and `core/nativebridge/libs/` was not modified.

## What's fixed (by commit)

**Native / JNI (AR relocalization was silently broken)**
- `nativeSetWallFingerprint` returned `null` on **every** wall-fingerprint capture: the C++ looked up a 7-param `Fingerprint` constructor descriptor, but the Kotlin data class grew an 8th field (`markCenterLocal`) and Kotlin defaults emit no reduced-arity overload — so relocalization never worked for new targets (the second time this bug class shipped). Native now builds through a **frozen `Fingerprint.fromNative` factory**, guarded by `FingerprintJniContractTest` so signature drift fails the JVM tests instead of breaking AR at runtime.
- `ImageWarper::bakeToBitmap` **deadlocked** the GL thread (locked a non-recursive mutex, then called `draw()` which re-locked it) → ANR on Liquify bake. Extracted `drawLocked()`.
- `MobileGS::scheduleRelocCheck` read `mWallDescriptors` without the mutex (data race); plus null-guards on JNI allocations in `buildFingerprintObject`.

**Data-layer security**
- **Zip-Slip**: `importProjectFromUri` and `loadAsSpectator` (the latter reachable from a co-op peer over the wire) wrote ZIP entries without neutralizing `../`. All extraction now goes through a canonical-path containment check; `project.id` from the untrusted archive is validated before becoming a path segment; total decompressed size is capped (zip bombs).
- `loadProjectMetadata` no longer persists the migration to disk mid-read.

**Editor**
- `LayerStore.strokes()` handed out the live `MutableList`, which background compositing iterated while stroke handlers/spectator replay mutated it → `ConcurrentModificationException`. Now returns a snapshot; all mutations synchronize; `addStroke` uses `computeIfAbsent`.

**Co-op robustness**
- Host accept loop **survives bad handshakes** (a single garbled/dropped HELLO used to permanently disable hosting and leak the socket).
- **Lossless reconnect**: seq assignment + encoding + `DeltaBuffer` accounting moved to enqueue time, so ops can no longer be silently dropped during a reconnect window; the dead `opSizeEstimator` (hardcoded 256 B → multi-MB bitmap ops drifted toward OOM) is gone and memory is bounded by the real-byte buffer cap.
- **15 s socket read timeouts** on both ends (half-open connections used to block forever).
- Guest validates `sessionId` on reconnect → full re-sync against a restarted host instead of silent desync.
- Bounded, in-order buffering of spectator ops that arrive before the handler is wired (were logged and dropped).
- Atomic reconnect guards, bulk chunk-overrun is now a protocol error, host-side bulk cap, constant-time token compare.

**Co-op transport encryption (protocol v2)**
- Traffic was plaintext TCP. Now every frame after the handshake is **AES-256-GCM** sealed, keyed via HKDF-SHA256 from the QR token + fresh per-connection nonces. The token is never transmitted; the handshake is a nonce/HMAC proof (mutual: the guest authenticates the host before trusting bulk data). Protocol bumped 1→2 (old plaintext peers cleanly rejected). No new pairing UX, no new dependency.

**Strings / docs / CI**
- Added the three settings labels to all 13 `core/design` locale files (they existed only in the base file → every non-English device fell back to English).
- Corrected stale `BACKLOG.md` entries (netty/Bouncy Castle already pinned), removed an empty committed `.bat`, de-staled AGP version comments.
- Fixed `dependency-graph: true` (invalid enum value for `setup-gradle@v6`) that was failing CI setup; the unit-tests job already submits the graph.

## Testing

New/extended JVM unit tests, all green locally:
- `FingerprintJniContractTest` (JNI ABI contract), `ProjectManagerTest` (Zip-Slip / hostile id / read-only metadata), `LayerStoreTest` (concurrency stress), `SessionRobustnessTest` (garbage-handshake survival, reconnect replay, buffer overflow, sessionId re-sync), `HkdfTest` (RFC 5869 vectors), `SessionCryptoTest`, `EncryptedTransportTest` (wrong-token rejection + on-path eavesdropper sees only ciphertext).

Verified: `./gradlew testDebugUnitTest` across the affected modules and `:core:nativebridge:assembleDebug` (native C++ compile). Full device runtime smoke for the AR fingerprint path needs hardware and is noted for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EBwsyyWbkuTH9QV27ZnmVU

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBwsyyWbkuTH9QV27ZnmVU)_

## Summary by Sourcery

Harden co-op networking, AR fingerprinting, and project import against reliability, security, and concurrency issues discovered in a cross-module audit.

New Features:
- Introduce encrypted co-op transport using a token-derived AES-256-GCM protocol v2 with mutual handshake proofs and HKDF-based key schedule.
- Add shared wire and import size limits to bound bulk project transfers and decompression from untrusted archives.

Bug Fixes:
- Fix AR relocalization by routing native fingerprint construction through a frozen Fingerprint.fromNative JNI factory and guarding the JNI ABI with tests.
- Prevent GL-thread deadlocks in liquify baking by avoiding re-entrant locking in ImageWarper.
- Eliminate data races in AR relocalization scheduling by synchronizing access to wall descriptors in MobileGS.
- Harden project import and spectator load paths against Zip-Slip, hostile project IDs, and zip bombs, and keep metadata loads read-only.
- Stop ConcurrentModificationException and lost strokes in the editor by snapshotting stroke lists and making layer stroke mutations thread-safe.
- Ensure host accept loop survives bad or partial handshakes so hosting is not permanently disabled by a faulty client.
- Make co-op sessions robust to reconnects by assigning sequence numbers and buffering at enqueue time with explicit overflow termination, and by enforcing socket read timeouts and atomic reconnect state transitions.
- Ensure guests re-sync correctly when the host session restarts by validating session IDs and falling back to full bulk reloads.
- Buffer early spectator operations until the handler is wired so guests do not silently miss ops.

Enhancements:
- Encrypt all post-handshake co-op frames inside a new ENC envelope type and add constant-time token verification and replay-resistant counters.
- Refine co-op bulk-transfer handling with bounded in-order buffering, bulk size validation, and shared protocol limits.
- Clarify buildscript dependency forcing and update backlog documentation to reflect resolved Netty and Bouncy Castle advisories.
- Improve JNI null-safety by checking allocations and copies when building fingerprint objects.
- Adjust ProGuard rules to keep the Fingerprint JNI factory method used from native code.

Build:
- Clarify Protobuf version pinning comments to align with the current AGP requirements.

CI:
- Fix GitHub Actions Gradle setup configuration by disabling an invalid dependency-graph mode that was breaking the merged build workflow.

Documentation:
- Update BACKLOG to document resolved dependency security issues, newly hardened co-op and relocalization behavior, and catalogued dead or unreachable features.

Tests:
- Add extensive JVM tests for ProjectManager import/spectator hardening and metadata migration side effects.
- Add stress tests for LayerStore concurrency to ensure safe iteration and stroke insertion under load.
- Introduce SessionRobustnessTest and EncryptedTransportTest to cover handshake failure recovery, reconnect semantics, buffer overflow handling, and encrypted transport behavior.
- Add HKDF and SessionCrypto unit tests, including RFC 5869 vectors and replay/tamper resistance checks.
- Add FingerprintJniContractTest to lock the JNI factory signature and field mapping for AR fingerprints.

Chores:
- Add missing localized strings for mural engine and scan mode settings across all supported locales.