### PR TITLE
Auto-publish AAB to Play internal on merges to main

### DIFF
--- a/.github/workflows/release-aab.yml
+++ b/.github/workflows/release-aab.yml
@@ -8,6 +8,10 @@ name: Build & Publish AAB (Play)
 # to the internal track with draft status.
 on:
   push:
+    # Auto-publish on merges to main only. Feature-branch pushes would otherwise trigger a
+    # release build (and, with the gate below open, a Play upload) for every commit — wasteful
+    # and unsafe. Manual dispatch (workflow_dispatch) still works from any branch.
+    branches: [ main ]
     # Don't re-trigger on the version-bump commit this workflow pushes back (it also carries
     # [skip ci], but ignoring the path is a clean belt-and-suspenders).
     paths-ignore:
@@ -128,8 +132,10 @@ jobs:
 
       - name: Persist auto-incremented versionCode
         # Commit the version.properties bump that the build just made, so the next release is strictly
-        # higher. Publish runs only; [skip ci] (and the push-trigger paths-ignore) stop a re-trigger.
-        if: ${{ inputs.publish }}
+        # higher (Play rejects a duplicate versionCode). Runs whenever we're about to publish —
+        # every push to main, and any manual dispatch with publish=true. [skip ci] (and the
+        # push-trigger paths-ignore) stop a re-trigger.
+        if: ${{ github.event_name == 'push' || inputs.publish }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -150,11 +156,14 @@ jobs:
           if-no-files-found: error
 
       - name: Publish to Google Play
-        if: ${{ inputs.publish }}
+        # Auto-publish on push to main (internal / completed); manual dispatch respects the
+        # publish flag and its own track/status inputs. `inputs.X || 'default'` falls through
+        # on push events where inputs.* are null.
+        if: ${{ github.event_name == 'push' || inputs.publish }}
         uses: r0adkll/upload-google-play@v1
         with:
           serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
           packageName: ${{ steps.meta.outputs.package_name }}
           releaseFiles: app/build/outputs/bundle/release/*.aab
-          track: ${{ inputs.track }}
-          status: ${{ inputs.status }}
+          track: ${{ inputs.track || 'internal' }}
+          status: ${{ inputs.status || 'completed' }}


### PR DESCRIPTION
## Why

`release-aab.yml` runs on every push, builds a signed AAB, and uploads it as a workflow artifact — but never contacts Play. Both the **"Persist auto-incremented versionCode"** step and the **"Publish to Google Play"** step were gated on `${{ inputs.publish }}`, which is only populated on manual `workflow_dispatch` runs. On a `push` event `inputs.*` is null, so both steps were silently skipped. That's why merges to `main` never showed up on the Play internal track.

Persist is coupled to publish: `app/build.gradle.kts` auto-increments `versionBuild` on every build, but the "Persist" step is what commits the bump back to the repo. If we publish without persisting, the next merge would build with the same versionCode and Play would reject the upload.

## What

Single-file change to `.github/workflows/release-aab.yml`:

- **Scope the `push` trigger to `main` only.** Feature-branch pushes would otherwise trigger release builds (and, with the gate below open, Play uploads) for every commit.
- **Change the persist + publish gates** from `${{ inputs.publish }}` to `${{ github.event_name == 'push' || inputs.publish }}`. Pushes to `main` now auto-publish; manual dispatch still respects `publish=false`.
- **Default `track` to `internal` and `status` to `completed`** on push events (where `inputs.track` / `inputs.status` are null). Manual dispatch still overrides.

## Prerequisites (verify in Actions logs on first run)

Nothing else changes in this PR, but the publish step needs these repository secrets. It'll fail loudly with a clear message on the first run if any are missing.

- `KEYSTORE_RAW`, `KEYSTORE_PASSWORD`, `KEY_ALIAS`, `KEY_PASSWORD` — already used by the manual dispatch path today.
- `PLAY_SERVICE_ACCOUNT_JSON` — Google Play Developer API service account. Needs at least "Release manager" access to the app in the Play Console. The internal track may need an initial manual release before API uploads work.

## Verification

1. Merge this PR. The `Build & Publish AAB (Play)` workflow should run on the merge commit and:
   - Complete `Build Release AAB (signed)`.
   - Run `Persist auto-incremented versionCode`, which pushes a `ci: versionBuild=<N> [skip ci]` commit back to `main` without re-triggering the workflow (`paths-ignore: version.properties` + `[skip ci]`).
   - Upload the `graffitixr-release-aab` artifact.
   - Run `Publish to Google Play` green.
2. Play Console → Testing → Internal testing → Releases: the new release appears with the just-built versionCode, status "Available to testers".
3. On the next merge, confirm the versionCode is strictly higher (proves the persist step is committing correctly).
4. Rollback: dispatch the workflow manually with `publish=false` (artifact only), or halt from the Play Console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EBwsyyWbkuTH9QV27ZnmVU

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBwsyyWbkuTH9QV27ZnmVU)_

## Summary by Sourcery

Auto-publish Android App Bundle builds to the Google Play internal track on merges to main while preserving manual workflow controls.

New Features:
- Enable automatic Google Play publishing of signed AABs on pushes to the main branch, using the internal track with completed status by default.

Enhancements:
- Restrict the release workflow push trigger to the main branch to avoid unnecessary release builds and Play uploads from feature branches.
- Gate versionCode persistence and Play publishing on push events to main or an explicit manual publish flag, while defaulting track and status for non-dispatch runs.