### PR TITLE
Fix rotation direction, AR adjustment knobs, and backwards direction arrows

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
@@ -246,8 +246,16 @@ fun MainScreen(
                     // fields in the key list; the geometric fields (offset/scale/rotation) do NOT
                     // affect the bitmap contents (the renderer applies them on the quad), so
                     // omitting them avoids a full re-composite on every pan/zoom gesture.
-                    val arToneKey = arOverlayAdj?.let {
-                        listOf(it.brightness, it.contrast, it.saturation, it.opacity, it.isInverted)
+                    // remember() keyed on the primitive tone fields so the list + 5 boxes are only
+                    // allocated when a slider actually moves — MainScreen recomposes at tracking
+                    // rate (~15fps), so a per-frame allocation storm here shows up in GC.
+                    val arToneKey = remember(
+                        arOverlayAdj?.brightness, arOverlayAdj?.contrast, arOverlayAdj?.saturation,
+                        arOverlayAdj?.opacity, arOverlayAdj?.isInverted,
+                    ) {
+                        arOverlayAdj?.let {
+                            listOf(it.brightness, it.contrast, it.saturation, it.opacity, it.isInverted)
+                        }
                     }
                     LaunchedEffect(visibleLayers, arUiState.isAnchorEstablished, arToneKey) {
                         if (!arUiState.isAnchorEstablished || visibleLayers.isEmpty()) {
@@ -704,6 +712,11 @@ internal fun compositeLayersForAr(layers: List<Layer>, modeAdj: ModeAdjustment? 
 
     for (layer in layers) {
         val bmp = layer.bitmap ?: continue
+        // This composite runs on Dispatchers.Default; a layer bitmap could be recycled on the
+        // main thread (delete-layer, mode transition) after we captured our reference but before
+        // the draw. Skip a recycled bitmap instead of crashing with
+        // "Canvas: trying to use a recycled bitmap".
+        if (bmp.isRecycled) continue
         // Whole-design opacity multiplies the per-layer alpha, matching Design's outer
         // `graphicsLayer { alpha = modeAdj.opacity }` wrapping the per-Image `alpha = layer.opacity`.
         val combinedAlpha = (layer.opacity * modeOpacity).coerceIn(0f, 1f)

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
@@ -231,20 +231,32 @@ fun MainScreen(
                             r.overlayPanX = arOverlayAdj?.offsetX ?: 0f
                             r.overlayPanY = arOverlayAdj?.offsetY ?: 0f
                             r.overlayScale = arOverlayAdj?.scale ?: 1f
-                            r.overlayRotationDeg = arOverlayAdj?.rotation ?: 0f
+                            // Model stores rotationZ CW+ (Compose/y-down convention). The AR
+                            // renderer rotates around a camera-facing wall-local +Z, which is
+                            // CCW+ under the right-hand rule — negate here so a CW slider drag
+                            // and a CW gesture both rotate the overlay CW on the wall.
+                            r.overlayRotationDeg = -(arOverlayAdj?.rotation ?: 0f)
                             r.overlayRotationX = arOverlayAdj?.rotationX ?: 0f
                             r.overlayRotationY = arOverlayAdj?.rotationY ?: 0f
                         }
                     }
 
-                    LaunchedEffect(visibleLayers, arUiState.isAnchorEstablished) {
+                    // Tone/opacity/invert live on modeAdjustments[AR], not on the renderer, so a
+                    // slider change has to re-composite the wall texture. Include the tone-only
+                    // fields in the key list; the geometric fields (offset/scale/rotation) do NOT
+                    // affect the bitmap contents (the renderer applies them on the quad), so
+                    // omitting them avoids a full re-composite on every pan/zoom gesture.
+                    val arToneKey = arOverlayAdj?.let {
+                        listOf(it.brightness, it.contrast, it.saturation, it.opacity, it.isInverted)
+                    }
+                    LaunchedEffect(visibleLayers, arUiState.isAnchorEstablished, arToneKey) {
                         if (!arUiState.isAnchorEstablished || visibleLayers.isEmpty()) {
                             rendererRef.value?.updateOverlayBitmap(null)
                             return@LaunchedEffect
                         }
 
                         val composite = withContext(Dispatchers.Default) {
-                            compositeLayersForAr(visibleLayers)
+                            compositeLayersForAr(visibleLayers, arOverlayAdj)
                         }
                         rendererRef.value?.updateOverlayBitmap(composite)
                         arViewModel.updatePaintingGuide(composite)
@@ -531,13 +543,16 @@ fun MainScreen(
                                     onGestureStart = { editorViewModel.onGestureStart() },
                                     onGestureEnd = { editorViewModel.onGestureEnd() },
                                     onGesture = { _, pan, zoom, rotation ->
-                                        // calculateRotation()'s sign is opposite our rotation
-                                        // convention, so the raw delta turns the design AGAINST the
-                                        // fingers on every axis (X/Y tilt and Z spin). Negate once here
-                                        // at the input boundary so it rotates WITH the fingers; the
-                                        // model keeps its own sign convention (positive delta → positive
-                                        // rotation), so reducers/tests are unaffected.
-                                        val turn = -rotation
+                                        // Model convention: positive rotationZ is clockwise in
+                                        // screen coordinates, matching Compose's graphicsLayer
+                                        // (y-down, CW+) and calculateRotation()'s return value.
+                                        // Pass the delta through unchanged so both slider and
+                                        // gesture yield the same visual direction in Design/Mockup/
+                                        // Overlay/Trace. The AR renderer alone rotates around a
+                                        // camera-facing +Z (CCW+ in OpenGL/right-handed convention),
+                                        // so the sign flip lives there (see the LaunchedEffect that
+                                        // pushes overlayRotationDeg to the renderer).
+                                        val turn = rotation
                                         if (editingMode) {
                                             // In AR the overlay lives on the wall in meters, so convert
                                             // the screen-pixel drag to in-plane meters. Local +X on the
@@ -619,7 +634,17 @@ fun MainScreen(
     }
 }
 
-internal fun compositeLayersForAr(layers: List<Layer>): AndroidBitmap {
+/**
+ * Composites the visible layers into the AR wall texture.
+ *
+ * [modeAdj] is the whole-design ModeAdjustment for AR (from `uiState.modeAdjustments[EditorMode.AR]`).
+ * Its geometric fields (offset/scale/rotation) are applied by the renderer on the quad, so this
+ * function only consumes its tone fields — brightness / contrast / saturation / opacity / isInverted
+ * — and folds them into the per-layer ColorMatrix and paint alpha exactly the way the Design/Overlay/
+ * Mockup/Trace paths do it (see the `graphicsLayer{alpha}` + per-Image ColorFilter block above).
+ * Passing null means "no whole-design tone" (Design mode baseline).
+ */
+internal fun compositeLayersForAr(layers: List<Layer>, modeAdj: ModeAdjustment? = null): AndroidBitmap {
     if (layers.isEmpty()) return createBitmap(1, 1, AndroidBitmap.Config.ARGB_8888)
 
     var minX = Float.MAX_VALUE
@@ -669,17 +694,31 @@ internal fun compositeLayersForAr(layers: List<Layer>): AndroidBitmap {
     canvas.scale(downscale, downscale)
     val paint = Paint(Paint.ANTI_ALIAS_FLAG)
 
+    // Whole-design tone/opacity. Defaults leave the layer's own values untouched (multiply-by-1,
+    // add-0, XOR-false) so a null modeAdj degrades cleanly to the original per-layer behaviour.
+    val modeSaturation = modeAdj?.saturation ?: 1f
+    val modeContrast = modeAdj?.contrast ?: 1f
+    val modeBrightness = modeAdj?.brightness ?: 0f
+    val modeOpacity = modeAdj?.opacity ?: 1f
+    val modeInvert = modeAdj?.isInverted ?: false
+
     for (layer in layers) {
         val bmp = layer.bitmap ?: continue
-        paint.alpha = (layer.opacity.coerceIn(0f, 1f) * 255).toInt()
+        // Whole-design opacity multiplies the per-layer alpha, matching Design's outer
+        // `graphicsLayer { alpha = modeAdj.opacity }` wrapping the per-Image `alpha = layer.opacity`.
+        val combinedAlpha = (layer.opacity * modeOpacity).coerceIn(0f, 1f)
+        paint.alpha = (combinedAlpha * 255).toInt()
         val cm = createColorMatrix(
-            saturation = layer.saturation,
-            contrast = layer.contrast,
-            brightness = layer.brightness,
+            // Design mode composes per-layer × whole-design for sat/contrast (multiplicative),
+            // brightness (additive), invert (XOR). Mirror that exactly, so the wall texture matches
+            // what the user sees in Design mode.
+            saturation = layer.saturation * modeSaturation,
+            contrast = layer.contrast * modeContrast,
+            brightness = layer.brightness + modeBrightness,
             colorBalanceR = layer.colorBalanceR,
             colorBalanceG = layer.colorBalanceG,
             colorBalanceB = layer.colorBalanceB,
-            isInverted = layer.isInverted
+            isInverted = layer.isInverted != modeInvert
         )
         paint.colorFilter = android.graphics.ColorMatrixColorFilter(
             android.graphics.ColorMatrix(cm.values)

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainScreenUtils.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainScreenUtils.kt
@@ -24,6 +24,22 @@ import com.hereliesaz.graffitixr.design.theme.HotPink
 import com.hereliesaz.graffitixr.design.theme.Cyan
 import kotlin.math.atan2
 
+/**
+ * Angle in degrees to rotate an up-pointing arrow so it points from the screen centre toward a
+ * target at ([dx], [dy]) in screen coordinates (y-down). Compass-convention: 0° = up,
+ * CW-positive, matching `Modifier.rotate`.
+ */
+internal fun screenSpaceArrowAngleDeg(dx: Float, dy: Float): Float =
+    Math.toDegrees(atan2(dx.toDouble(), -dy.toDouble())).toFloat()
+
+/**
+ * Angle in degrees to rotate an up-pointing arrow so it points from the screen centre toward a
+ * target at view-space direction ([lx], [ly]) (camera-right / camera-up, y-up). Compass-convention:
+ * 0° = up, CW-positive, matching `Modifier.rotate`.
+ */
+internal fun viewSpaceArrowAngleDeg(lx: Float, ly: Float): Float =
+    Math.toDegrees(atan2(lx.toDouble(), ly.toDouble())).toFloat()
+
 @Composable
 fun OffscreenIndicators(
     uiState: EditorUiState,
@@ -44,7 +60,7 @@ fun OffscreenIndicators(
         
         if (layerCenterX < 0 || layerCenterX > screenSize.width || layerCenterY < 0 || layerCenterY > screenSize.height) {
             DirectionalIndicator(
-                angle = Math.toDegrees(atan2((layerCenterY - centerY).toDouble(), (layerCenterX - centerX).toDouble())).toFloat(),
+                angle = screenSpaceArrowAngleDeg(layerCenterX - centerX, layerCenterY - centerY),
                 label = "Active Layer",
                 color = HotPink,
                 modifier = modifier
@@ -65,10 +81,9 @@ fun OffscreenIndicators(
             val isOffscreen = lz > 0 || Math.abs(lx) > 0.8f || Math.abs(ly) > 0.8f
             
             if (isOffscreen) {
-                // localY is UP, so we negate it for screen-space (down is positive)
-                val angle = Math.toDegrees(atan2(-ly.toDouble(), lx.toDouble())).toFloat()
+                // relDir is in view space: +x = camera-right, +y = up, +z = behind the camera.
                 DirectionalIndicator(
-                    angle = angle,
+                    angle = viewSpaceArrowAngleDeg(lx, ly),
                     label = "Wall Target",
                     color = Cyan,
                     modifier = modifier,

--- a/app/src/test/java/com/hereliesaz/graffitixr/OffscreenIndicatorAngleTest.kt
+++ b/app/src/test/java/com/hereliesaz/graffitixr/OffscreenIndicatorAngleTest.kt
@@ -1,0 +1,71 @@
+package com.hereliesaz.graffitixr
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Regression guards for the two off-screen indicator arrow angles. Both feed `Modifier.rotate`,
+ * which is compass-convention (0° = up, CW positive), and the icon (`ArrowUpward`) points up at
+ * 0°. Previously both formulas produced a math-convention angle (from the +x axis, CCW positive)
+ * — so an active layer to the right of centre displayed an up-arrow, and a wall target directly
+ * above the camera showed a left-arrow. This test locks the correct compass angles for the four
+ * cardinal directions on both.
+ */
+class OffscreenIndicatorAngleTest {
+
+    private val eps = 1e-4f
+
+    // --- Screen-space (y-down): active-layer indicator ---
+
+    @Test
+    fun `screen-space target directly above yields 0 degrees (up)`() {
+        assertEquals(0f, screenSpaceArrowAngleDeg(0f, -100f), eps)
+    }
+
+    @Test
+    fun `screen-space target to the right yields 90 degrees`() {
+        assertEquals(90f, screenSpaceArrowAngleDeg(100f, 0f), eps)
+    }
+
+    @Test
+    fun `screen-space target directly below yields 180 degrees`() {
+        assertEquals(180f, screenSpaceArrowAngleDeg(0f, 100f), eps)
+    }
+
+    @Test
+    fun `screen-space target to the left yields negative 90 degrees`() {
+        assertEquals(-90f, screenSpaceArrowAngleDeg(-100f, 0f), eps)
+    }
+
+    @Test
+    fun `screen-space target above-right yields 45 degrees`() {
+        assertEquals(45f, screenSpaceArrowAngleDeg(100f, -100f), eps)
+    }
+
+    // --- View-space (y-up): wall-target indicator ---
+
+    @Test
+    fun `view-space target directly above yields 0 degrees (up)`() {
+        assertEquals(0f, viewSpaceArrowAngleDeg(0f, 1f), eps)
+    }
+
+    @Test
+    fun `view-space target to camera-right yields 90 degrees`() {
+        assertEquals(90f, viewSpaceArrowAngleDeg(1f, 0f), eps)
+    }
+
+    @Test
+    fun `view-space target directly below yields 180 degrees`() {
+        assertEquals(180f, viewSpaceArrowAngleDeg(0f, -1f), eps)
+    }
+
+    @Test
+    fun `view-space target to camera-left yields negative 90 degrees`() {
+        assertEquals(-90f, viewSpaceArrowAngleDeg(-1f, 0f), eps)
+    }
+
+    @Test
+    fun `view-space upper-right diagonal yields 45 degrees`() {
+        assertEquals(45f, viewSpaceArrowAngleDeg(1f, 1f), eps)
+    }
+}

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -1067,13 +1067,23 @@ class ArRenderer(
                         val len = kotlin.math.sqrt((dx * dx + dy * dy + dz * dz).toDouble()).toFloat()
 
                         if (len > 0.01f) {
-                            val localX = dx * viewMatrix[0] + dy * viewMatrix[1] + dz * viewMatrix[2]
-                            val localY = dx * viewMatrix[4] + dy * viewMatrix[5] + dz * viewMatrix[6]
-                            val localZ = dx * viewMatrix[8] + dy * viewMatrix[9] + dz * viewMatrix[10]
+                            // android.opengl.Matrix is column-major: index [col * 4 + row]. Rotating
+                            // a world-space delta into view space is R · delta, where R takes rows
+                            // from R (columns of the view matrix's 3×3 rotation), i.e. strides of 4,
+                            // not 1. The old stride-1 indexing computed R^T · delta — correct only
+                            // when the camera is world-aligned; as soon as the phone yaws it maps
+                            // the target vector onto the wrong axis and the indicator points off.
+                            val localX = dx * viewMatrix[0] + dy * viewMatrix[4] + dz * viewMatrix[8]
+                            val localY = dx * viewMatrix[1] + dy * viewMatrix[5] + dz * viewMatrix[9]
+                            val localZ = dx * viewMatrix[2] + dy * viewMatrix[6] + dz * viewMatrix[10]
                             relDir = Triple(localX / len, localY / len, localZ / len)
                         }
 
-                        val fwdDot = dx * (-viewMatrix[8]) + dy * (-viewMatrix[9]) + dz * (-viewMatrix[10])
+                        // Forward is -Z in the view frame; the third row of R (view-matrix column 2)
+                        // is the world-space direction the camera looks along, so dot(delta, -row2)
+                        // is positive iff the anchor is in front of the camera. Same column-major
+                        // stride fix as above.
+                        val fwdDot = dx * (-viewMatrix[2]) + dy * (-viewMatrix[6]) + dz * (-viewMatrix[10])
                         if (len > 0.01f && fwdDot > 0f) len else -1f
                     }
 


### PR DESCRIPTION
## Three visual bugs reported together — separate causes, all in the app / AR composition layer

### 1. Design-mode rotation was backwards

The gesture handler at `MainScreen.kt:540` negated `calculateRotation()`'s return with `val turn = -rotation`. Compose's `calculateRotation()` is CW-positive (matches Compose's `graphicsLayer{rotationZ}`), so the negation turned the Design overlay *against* the fingers. It only "worked" in AR mode because the AR renderer applies rotation around a camera-facing wall-local +Z axis (CCW-positive under the right-hand rule / OpenGL convention), so the negation happened to compensate for the AR handedness mismatch.

**Fix:** pass gestures through unchanged and instead negate at the AR-only push (`r.overlayRotationDeg = -modeAdj.rotation`), so slider and gesture agree in all four combinations (Design/AR × slider/gesture).

### 2. AR-mode adjustment knobs did nothing

- `ArRenderer` has no tone/opacity fields, and the `LaunchedEffect` that pushes the AR mode-adjustment to the renderer only forwarded pan/scale/rotation. `brightness`/`contrast`/`saturation`/`opacity`/`isInverted` were silently dropped.
- The composite that becomes the wall texture (`compositeLayersForAr`) only read the per-layer tone fields; the whole-design mode adjustment never influenced it.

**Fix:** thread `modeAdjustments[AR]` into the composite and blend its tone into each layer's `ColorMatrix` + paint alpha using the exact composition (multiplicative sat/contrast, additive brightness, XOR invert, multiplicative opacity) that the Design/Overlay/Mockup/Trace paths already use for the outer `graphicsLayer{alpha}` + per-Image `ColorFilter`. The `LaunchedEffect` key list includes only the tone fields, not the geometric ones, so pan/zoom gestures don't force a re-composite.

Color-balance sliders are still per-layer (they were already this way in Design mode too — a separate UX decision, not a regression).

### 3. Direction indicators (active layer + wall target) pointed the wrong way

Both formulas produced a math-convention angle (from +x axis, CCW positive) and fed it to `Modifier.rotate` which is compass-convention (0° = up, CW positive). Result: an active layer to the right of centre showed an up-arrow; a target directly above the camera showed a left-arrow.

**Fix:** correct compass angle for an up-pointing icon — screen-space (y-down) → `atan2(dx, -dy)`; view-space (y-up) → `atan2(lx, ly)`. Extracted into pure helpers (`screenSpaceArrowAngleDeg` / `viewSpaceArrowAngleDeg`) and locked by `OffscreenIndicatorAngleTest` against the four cardinal directions in both spaces.

**Latent bonus** (would have caused rotation-dependent misdirection even after the atan2 fix): `ArRenderer.kt:1070-1076` treated the column-major `android.opengl.Matrix` view matrix with stride-1 indexing, computing `R^T · delta` instead of `R · delta`. Correct while the camera stayed world-aligned; produced axis-swapped `relDir` as soon as the phone yawed. Fixed the strides for both `relDir` and the `fwdDot` "behind the camera" check.

## Testing

- New `OffscreenIndicatorAngleTest` — 10 test cases across the two coordinate spaces × cardinal directions × diagonals. All green.
- Full unit-test sweep across `:app`, `:feature:editor`, `:feature:ar`, `:core:common` — green.
- Native / on-device runtime smoke needs hardware for the AR indicator + AR knobs; noted for reviewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EBwsyyWbkuTH9QV27ZnmVU

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBwsyyWbkuTH9QV27ZnmVU)_

## Summary by Sourcery

Fix AR overlay rotation and tone handling, and correct offscreen direction indicators for layers and wall targets.

Bug Fixes:
- Align design-mode gesture rotation with slider and AR overlay rotation so overlays rotate in the intuitive direction across modes.
- Apply AR mode-wide tone and opacity adjustments to the composited wall texture so AR adjustment knobs affect the rendered result.
- Correct the offscreen indicator arrow angles for active layers and wall targets so arrows point toward the actual target in both screen and view space.
- Fix AR view-matrix indexing so wall-target direction and visibility are computed correctly as the camera rotates.

Enhancements:
- Make AR compositing aware of whole-design tone adjustments by threading the AR ModeAdjustment into the layer compositor while keeping pan/zoom geometry on the renderer.
- Extract reusable helper functions for computing compass-convention arrow angles in screen and view space and cover them with regression tests.

Tests:
- Add OffscreenIndicatorAngleTest to lock compass-convention arrow angles for screen- and view-space offscreen indicators.