### PR TITLE
Address Play Console recommendations on release 14142

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -89,6 +89,20 @@
             </intent-filter>
         </activity>
 
+        <!--
+            ZXing's zxing-android-embedded ships a CaptureActivity declared with
+            android:screenOrientation="sensorLandscape". From Android 16 the platform
+            ignores orientation restrictions on large-screen devices (foldables, tablets),
+            which Play Console flagged on release 14142. Both scanner invocations in the
+            app already pass setOrientationLocked(false), so we can safely widen the
+            merged entry to fullUser — respects the user's system rotation-lock setting
+            on all form factors and satisfies the large-screen rule.
+        -->
+        <activity
+            android:name="com.journeyapps.barcodescanner.CaptureActivity"
+            android:screenOrientation="fullUser"
+            tools:replace="android:screenOrientation" />
+
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.fileprovider"

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/util/BitmapDecode.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/util/BitmapDecode.kt
@@ -1,0 +1,44 @@
+package com.hereliesaz.graffitixr.common.util
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+
+/**
+ * Two-pass byte-array decode with a size cap. Solves the pattern Play Console flagged on release
+ * 14142 ("manually downloading and decoding images from the network"): the co-op wire ships raw
+ * PNG bytes for `LayerBitmapReplace` ops, and a peer accidentally shipping a very large image
+ * would otherwise decode at native resolution and OOM the guest.
+ *
+ * First pass reads `outWidth`/`outHeight` with `inJustDecodeBounds = true` (no pixel allocation).
+ * Second pass decodes with an `inSampleSize` that keeps the longest edge at or under [maxDimPx].
+ * Returns null if [bytes] is not a valid image; the caller is expected to log and skip the op
+ * rather than throw across the op-apply.
+ *
+ * Doesn't try to replace an image-loading library — Coil is designed for URL/URI-driven loading
+ * and adding it here for a byte-array decode would be worse than this direct call.
+ */
+fun decodeBoundedBitmap(bytes: ByteArray, maxDimPx: Int): Bitmap? {
+    if (bytes.isEmpty() || maxDimPx <= 0) return null
+
+    // Pass 1: metadata only.
+    val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+    BitmapFactory.decodeByteArray(bytes, 0, bytes.size, bounds)
+    if (bounds.outWidth <= 0 || bounds.outHeight <= 0) return null
+
+    // Pass 2: real decode with a power-of-two sample size.
+    val decode = BitmapFactory.Options().apply {
+        inSampleSize = computeSampleSize(bounds.outWidth, bounds.outHeight, maxDimPx)
+        inPreferredConfig = Bitmap.Config.ARGB_8888
+    }
+    return BitmapFactory.decodeByteArray(bytes, 0, bytes.size, decode)
+}
+
+/**
+ * Smallest power of two that shrinks a [w] x [h] source so the longest edge fits within [maxDimPx].
+ * Returns 1 when the source already fits (no over-sampling of a small image).
+ */
+internal fun computeSampleSize(w: Int, h: Int, maxDimPx: Int): Int {
+    var sample = 1
+    while (w / sample > maxDimPx || h / sample > maxDimPx) sample *= 2
+    return sample
+}

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/util/BitmapDecode.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/util/BitmapDecode.kt
@@ -36,9 +36,15 @@ fun decodeBoundedBitmap(bytes: ByteArray, maxDimPx: Int): Bitmap? {
 /**
  * Smallest power of two that shrinks a [w] x [h] source so the longest edge fits within [maxDimPx].
  * Returns 1 when the source already fits (no over-sampling of a small image).
+ *
+ * Guarded against a runaway loop on malformed metadata: caps at `1 shl 30` so `sample *= 2` never
+ * overflows past `Int.MAX_VALUE` (which would either wrap negative → undefined BitmapFactory
+ * behaviour, or wrap through zero → division-by-zero on the next iteration).
  */
 internal fun computeSampleSize(w: Int, h: Int, maxDimPx: Int): Int {
     var sample = 1
-    while (w / sample > maxDimPx || h / sample > maxDimPx) sample *= 2
+    while ((w / sample > maxDimPx || h / sample > maxDimPx) && sample < (1 shl 30)) {
+        sample *= 2
+    }
     return sample
 }

--- a/core/common/src/test/java/com/hereliesaz/graffitixr/common/util/BitmapDecodeTest.kt
+++ b/core/common/src/test/java/com/hereliesaz/graffitixr/common/util/BitmapDecodeTest.kt
@@ -1,0 +1,47 @@
+package com.hereliesaz.graffitixr.common.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * `BitmapFactory.decodeByteArray` is Android-framework-only, so the two-pass wrapper itself is
+ * exercised by device tests. Here we lock the pure-Kotlin helper that determines the
+ * `inSampleSize` used by the second pass — this is the piece that gates the OOM risk from the
+ * co-op `LayerBitmapReplace` decode path.
+ */
+class BitmapDecodeTest {
+
+    @Test
+    fun `small image returns 1 - no over-sampling`() {
+        assertEquals(1, computeSampleSize(1000, 1000, 2000))
+        assertEquals(1, computeSampleSize(2000, 2000, 2000))
+    }
+
+    @Test
+    fun `4x oversized image samples down to 4`() {
+        // 4096 / 4 = 1024, so sample = 4 keeps the longest edge under 2000.
+        assertEquals(4, computeSampleSize(4096, 4096, 2000))
+    }
+
+    @Test
+    fun `2x oversized image samples down to 2`() {
+        // 3000 / 2 = 1500, so sample = 2 keeps the longest edge under 2000.
+        assertEquals(2, computeSampleSize(3000, 3000, 2000))
+    }
+
+    @Test
+    fun `sample size is powers of two only`() {
+        // 5000 / 4 = 1250 < 2000, so sample = 4 (not 3).
+        assertEquals(4, computeSampleSize(5000, 5000, 2000))
+        // 9000 / 8 = 1125 < 2000, so sample = 8 (not 5).
+        assertEquals(8, computeSampleSize(9000, 9000, 2000))
+    }
+
+    @Test
+    fun `non-square uses the longest edge as the constraint`() {
+        // Wide: 8000 x 400. 8000/4 = 2000, condition is strict > so sample=4 exits. Sample = 4.
+        assertEquals(4, computeSampleSize(8000, 400, 2000))
+        // Tall: 400 x 8000 — same result.
+        assertEquals(4, computeSampleSize(400, 8000, 2000))
+    }
+}

--- a/core/common/src/test/java/com/hereliesaz/graffitixr/common/util/BitmapDecodeTest.kt
+++ b/core/common/src/test/java/com/hereliesaz/graffitixr/common/util/BitmapDecodeTest.kt
@@ -44,4 +44,12 @@ class BitmapDecodeTest {
         // Tall: 400 x 8000 — same result.
         assertEquals(4, computeSampleSize(400, 8000, 2000))
     }
+
+    @Test
+    fun `pathological dimensions terminate at the overflow-guard cap`() {
+        // Malformed metadata claiming Int.MAX_VALUE dimensions would otherwise loop
+        // sample past Int.MAX_VALUE / 2 and wrap on the next doubling.
+        val result = computeSampleSize(Int.MAX_VALUE, Int.MAX_VALUE, 1)
+        assertEquals(1 shl 30, result)
+    }
 }

--- a/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/EditorViewModel.kt
+++ b/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/EditorViewModel.kt
@@ -2095,6 +2095,13 @@ class EditorViewModel @Inject constructor(
                     }
                     val base = decoded.copy(Bitmap.Config.ARGB_8888, false)
                     if (base != decoded) decoded.recycle()
+                    // Re-check the layer still exists — it can be removed while we were decoding
+                    // off-thread. Without this, `putBase` on a stale layerId would leak the base
+                    // pixel memory (nothing takes ownership of it).
+                    if (_uiState.value.layers.none { it.id == layerId }) {
+                        base.recycle()
+                        return@launch
+                    }
                     // The png is the full baked layer; replace base and drop local stroke history.
                     layerStore.putBase(layerId, base)
                     layerStore.initStrokes(layerId)

--- a/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/EditorViewModel.kt
+++ b/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/EditorViewModel.kt
@@ -21,6 +21,7 @@ import com.hereliesaz.graffitixr.common.DispatcherProvider
 import com.hereliesaz.graffitixr.common.coop.OpEmitter
 import com.hereliesaz.graffitixr.common.model.*
 import com.hereliesaz.graffitixr.common.util.ImageUtils
+import com.hereliesaz.graffitixr.common.util.decodeBoundedBitmap
 import com.hereliesaz.graffitixr.common.util.saveBitmapToGallery
 import com.hereliesaz.graffitixr.domain.repository.ProjectRepository
 import com.hereliesaz.graffitixr.domain.repository.SettingsRepository
@@ -2079,8 +2080,19 @@ class EditorViewModel @Inject constructor(
                 val layerId = op.layerId
                 if (_uiState.value.layers.none { it.id == layerId }) return
                 viewModelScope.launch(dispatchers.default) {
-                    val decoded = android.graphics.BitmapFactory.decodeByteArray(op.png, 0, op.png.size)
-                        ?: return@launch
+                    // Cap the decoded bitmap at 2x the longest screen edge — plenty for any layer
+                    // that reasonably rasterises to a screen quad, and prevents a peer accidentally
+                    // shipping a giant PNG from OOMing the guest. Log-and-skip on decode failure
+                    // rather than throwing across the op-apply.
+                    val metrics = context.resources.displayMetrics
+                    val maxDim = maxOf(metrics.widthPixels, metrics.heightPixels) * 2
+                    val decoded = decodeBoundedBitmap(op.png, maxDim) ?: run {
+                        android.util.Log.w(
+                            "EditorViewModel",
+                            "LayerBitmapReplace: skipping op for layer $layerId (decode returned null; bytes=${op.png.size})"
+                        )
+                        return@launch
+                    }
                     val base = decoded.copy(Bitmap.Config.ARGB_8888, false)
                     if (base != decoded) decoded.recycle()
                     // The png is the full baked layer; replace base and drop local stroke history.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,6 @@ constraintlayout = "2.2.1"
 coreKtx = "1.19.0"
 coroutines = "1.11.0"
 espressoCore = "3.7.0"
-firebaseBom = "34.15.0"
 gson = "2.14.0"
 hilt = "2.60"
 hiltNavigationCompose = "1.4.0"
@@ -75,8 +74,6 @@ androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "l
 arcore-client = { group = "com.google.ar", name = "core", version.ref = "arcore" }
 az-nav-rail = { group = "com.github.HereLiesAz", name = "AzNavRail", version.ref = "azNavRail" }
 coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
-firebase-analytics = { module = "com.google.firebase:firebase-analytics" }
-firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
 google-accompanist-permissions = { group = "com.google.accompanist", name = "accompanist-permissions", version.ref = "accompanistPermissions" }
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }


### PR DESCRIPTION
## Summary

Play Console flagged two items against `1.35.8 / build 14142`. This PR addresses both plus a small catalog tidy-up.

### WP1 — `CaptureActivity` orientation restriction (Android 16 large-screen rule)

ZXing's `zxing-android-embedded` ships a `CaptureActivity` declared with `android:screenOrientation="sensorLandscape"`. From Android 16, the platform ignores orientation restrictions on large-screen devices (foldables, tablets), which Play Console flagged.

`app/src/main/AndroidManifest.xml` now overrides the merged entry to `fullUser` via `tools:replace`. Both scanner invocations already pass `setOrientationLocked(false)` (`MainActivity.kt:982`, `CoopJoinQrScannerOverlay.kt:22`), so widening the orientation is safe on all callers — the launched activity respects the user's system rotation-lock setting instead of forcing landscape.

### WP2 — Defensive downsampling on co-op `LayerBitmapReplace` decode

Google's Play Console note flagged "manually downloading and decoding images from the network". A full survey turned up **no first-party HTTP-download-and-decode code path**. The plausible target is `Op.LayerBitmapReplace` in `EditorViewModel`, which decodes raw bytes off the LAN co-op socket at native resolution — a real "downloaded then decoded" pattern even though the transport isn't HTTP.

Introduces `core/common/util/BitmapDecode.decodeBoundedBitmap(bytes, maxDimPx)`:
- Pass 1 reads `outWidth/outHeight` with `inJustDecodeBounds = true` (no pixel allocation).
- Pass 2 decodes with a power-of-two `inSampleSize` that keeps the longest edge under `maxDimPx`.
- Returns `null` on invalid input — the co-op op-apply logs and skips instead of throwing.

`EditorViewModel.LayerBitmapReplace` now caps at `max(screenWidth, screenHeight) * 2` — plenty for any layer that reasonably rasterises to a screen quad, and a peer accidentally shipping a 4096×4096 PNG no longer OOMs the guest.

Not migrated to Coil: Coil is designed for URL/URI-driven loading, and adding it here for a byte-array decode would be worse than the direct call.

### WP3 — Delete dead Firebase entries from the version catalog

`gradle/libs.versions.toml` declared `firebase-bom` and `firebase-analytics` but nothing implemented them — grep for `FirebaseAuth` / `FirebaseApp` / `FirebaseAnalytics` in first-party code returns nothing. Removed to unblock accidentally introducing Firebase later.

## Test plan

- [x] `:core:common:testDebugUnitTest` (green — `BitmapDecodeTest` locks `computeSampleSize`)
- [x] `:feature:editor:testDebugUnitTest` (green)
- [ ] Device smoke: join co-op via QR on a device held in portrait — scanner opens portrait (previously forced landscape)
- [ ] Device smoke: import a project with a large-bitmap layer op — no OOM on decode
- [ ] Play Console: orientation warning goes away on next release. Image warning may or may not — if it persists, the residual is likely Coil's transitive OkHttp fetcher and needs a follow-up.

## Notes

- **`fullUser` vs `unspecified`**: both satisfy Play's requirement. `fullUser` respects the system's rotation-lock setting on all form factors; `unspecified` lets the system pick. `fullUser` is the safer default.
- **WP2 cap value**: `max(screenW, screenH) * 2` is a heuristic. If it visibly downsamples too aggressively for high-DPI displays, bump to `*4` or make it a constant on `Op.LayerBitmapReplace`.
- The pure-Kotlin `computeSampleSize` helper is unit-tested. The full two-pass `decodeBoundedBitmap` wraps `BitmapFactory.decodeByteArray`, which is Android-framework-only and exercised by device tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBwsyyWbkuTH9QV27ZnmVU)_