### PR TITLE
Fan out publish to all four Play tracks (internal completed, others draft)

### DIFF
--- a/.github/scripts/play_multitrack_publish.py
+++ b/.github/scripts/play_multitrack_publish.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Publish one AAB to multiple Play tracks with per-track status.
+
+Model: one Play Developer API edit → one bundles.upload → N tracks.update
+calls (each with its own release object carrying its own status) → one
+commit. `r0adkll/upload-google-play@v1` forces a single global status per
+call, so it can't do the internal=completed + others=draft fan-out this
+script does in one edit transaction.
+
+Env inputs (all required):
+    PACKAGE_NAME               applicationId, e.g. com.hereliesaz.graffitixr
+    AAB_GLOB                   glob resolving to exactly one .aab
+    PLAY_SERVICE_ACCOUNT_JSON  raw JSON contents of the service-account key
+
+Non-zero exit on any failure — release-aab.yml's `steps.play-upload.outcome`
+gate reads that as "don't advance versionBuild in main" and the fail-loudly
+step re-annotates the run.
+"""
+import glob
+import json
+import os
+import sys
+
+from google.oauth2 import service_account
+from googleapiclient.discovery import build
+from googleapiclient.http import MediaFileUpload
+
+# (track_slug, release_status). `internal` goes live immediately; the other
+# three land as drafts so a human promotes them from the Play Console when
+# ready. Slugs are Play's defaults — override here if the app has custom
+# closed-testing tracks (Play Console → Testing → Closed testing → track ID).
+TARGETS = [
+    ("internal",   "completed"),
+    ("alpha",      "draft"),   # closed testing
+    ("beta",       "draft"),   # open testing
+    ("production", "draft"),
+]
+
+SCOPES = ["https://www.googleapis.com/auth/androidpublisher"]
+
+
+def main() -> None:
+    pkg = os.environ["PACKAGE_NAME"]
+    aab_glob = os.environ["AAB_GLOB"]
+    creds_json = os.environ["PLAY_SERVICE_ACCOUNT_JSON"]
+
+    aabs = sorted(glob.glob(aab_glob))
+    if len(aabs) != 1:
+        sys.exit(f"Expected exactly one AAB from {aab_glob!r}, found {aabs}")
+    aab = aabs[0]
+
+    creds = service_account.Credentials.from_service_account_info(
+        json.loads(creds_json), scopes=SCOPES,
+    )
+    svc = build("androidpublisher", "v3", credentials=creds, cache_discovery=False)
+
+    edit = svc.edits().insert(packageName=pkg, body={}).execute()
+    edit_id = edit["id"]
+    print(f"::notice::Opened Play edit {edit_id}")
+
+    media = MediaFileUpload(aab, mimetype="application/octet-stream", resumable=True)
+    bundle = svc.edits().bundles().upload(
+        packageName=pkg, editId=edit_id, media_body=media,
+    ).execute()
+    version_code = bundle["versionCode"]
+    print(f"::notice::Uploaded AAB versionCode={version_code} ({aab})")
+
+    for track, status in TARGETS:
+        svc.edits().tracks().update(
+            packageName=pkg,
+            editId=edit_id,
+            track=track,
+            body={
+                "track": track,
+                "releases": [{
+                    "status": status,
+                    "versionCodes": [str(version_code)],
+                }],
+            },
+        ).execute()
+        print(f"::notice::Assigned versionCode={version_code} to '{track}' as {status}")
+
+    svc.edits().commit(packageName=pkg, editId=edit_id).execute()
+    print(f"::notice::Committed edit {edit_id} — versionCode={version_code} live on internal, draft on the rest")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/release-aab.yml
+++ b/.github/workflows/release-aab.yml
@@ -1,11 +1,14 @@
 name: Build & Publish AAB (Play)
 
-# Manually-triggered workflow that builds a SIGNED Android App Bundle and,
-# optionally, publishes it to Google Play via the Play Developer API.
-#
-# Safe by default: it builds + uploads the .aab as a workflow artifact only.
-# Publishing to Play happens ONLY when `publish` is set to true, and defaults
-# to the internal track with draft status.
+# Builds a SIGNED Android App Bundle and, when publishing is on, fans the same AAB out to
+# every Play track in one edit transaction:
+#     internal   → completed  (auto-rolled out, same as before)
+#     alpha      → draft      (closed testing, staged for manual promotion)
+#     beta       → draft      (open testing,   staged for manual promotion)
+#     production → draft      (production,     staged for manual promotion)
+# The track fan-out is hardcoded in .github/scripts/play_multitrack_publish.py — the
+# workflow just decides whether to run it. `publish=false` on manual dispatch skips the
+# Play step entirely (build + artifact only).
 on:
   push:
     # Auto-publish on merges to main only. Feature-branch pushes would otherwise trigger a
@@ -18,22 +21,6 @@ on:
       - version.properties
   workflow_dispatch:
     inputs:
-      track:
-        description: "Play track to publish to"
-        type: choice
-        default: internal
-        options:
-          - internal
-          - alpha
-          - beta
-          - production
-      status:
-        description: "Release status on the chosen track"
-        type: choice
-        default: completed
-        options:
-          - draft
-          - completed
       publish:
         description: "Publish to Play? (off = build + upload .aab artifact only)"
         type: boolean
@@ -140,22 +127,24 @@ jobs:
           path: app/build/outputs/bundle/release/*.aab
           if-no-files-found: error
 
-      - name: Publish to Google Play
-        # Auto-publish on push to main (internal / completed); manual dispatch respects the
-        # publish flag and its own track/status inputs. `inputs.X || 'default'` falls through
-        # on push events where inputs.* are null.
+      - name: Publish to Google Play (internal completed + alpha/beta/prod draft)
+        # r0adkll/upload-google-play@v1 forces a single status per call, so it can't do the
+        # mixed internal=completed + others=draft fan-out we want in one Play edit. The script
+        # opens one edit, uploads the AAB once, creates four releases (one per track, each
+        # with its own status), and commits.
         #
-        # id + outcome is checked by the persist step below so a failed upload does NOT advance
-        # versionBuild in main.
+        # id + outcome is checked by the persist step below so a failed publish does NOT
+        # advance versionBuild in main.
         id: play-upload
         if: ${{ github.event_name == 'push' || inputs.publish }}
-        uses: r0adkll/upload-google-play@v1
-        with:
-          serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
-          packageName: ${{ steps.meta.outputs.package_name }}
-          releaseFiles: app/build/outputs/bundle/release/*.aab
-          track: ${{ inputs.track || 'internal' }}
-          status: ${{ inputs.status || 'completed' }}
+        env:
+          PACKAGE_NAME: ${{ steps.meta.outputs.package_name }}
+          AAB_GLOB: app/build/outputs/bundle/release/*.aab
+          PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+        run: |
+          # Python 3 is preinstalled on ubuntu-latest; just pull the two client libs.
+          pip install --quiet google-api-python-client google-auth
+          python .github/scripts/play_multitrack_publish.py
 
       - name: Persist auto-incremented versionCode
         # Commit the version.properties bump that the build just made, so the next release is
@@ -177,12 +166,12 @@ jobs:
           fi
 
       - name: Fail loudly if Play upload didn't succeed
-        # r0adkll fails the job on API errors, but the ::error:: annotation surfaces the reason
-        # in the Actions summary — no digging through the r0adkll step's output required. The
-        # exit 1 is redundant with r0adkll's own failure but keeps the "failed run" reading
-        # unambiguous even if a future edit accidentally weakens the upload step's semantics.
-        # Skipped runs (publish=false on manual dispatch) don't trip this.
+        # The script fails the job on any API error, but the ::error:: annotation surfaces the
+        # reason in the Actions summary — no digging through the upload step's output required.
+        # The exit 1 is redundant with the script's own failure but keeps the "failed run"
+        # reading unambiguous even if a future edit accidentally weakens the upload step's
+        # semantics. Skipped runs (publish=false on manual dispatch) don't trip this.
         if: ${{ always() && steps.play-upload.outcome != 'success' && steps.play-upload.outcome != 'skipped' }}
         run: |
-          echo "::error title=Play upload failed::AAB did not land on the '${{ inputs.track || 'internal' }}' track. Workflow is FAILED — versionBuild in main was NOT advanced. Re-run after fixing the upload." >&2
+          echo "::error title=Play upload failed::AAB did not land on all target tracks. Workflow is FAILED — versionBuild in main was NOT advanced. Re-run after fixing the upload." >&2
           exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,10 @@ local.properties
 *.apk
 *.aab
 
+# Python bytecode cache (e.g. from py_compile on .github/scripts/)
+__pycache__/
+*.pyc
+
 # Log files
 *.log
 


### PR DESCRIPTION
## Summary

Every push to main should stage the AAB on **all four** Play tracks in one shot:

| Track | Status |
|---|---|
| `internal` | **completed** (auto-rolled out, same as today) |
| `alpha` (closed testing) | **draft** |
| `beta` (open testing) | **draft** |
| `production` | **draft** |

The three drafts sit ready in Play Console for manual promotion when you want.

## How

`r0adkll/upload-google-play@v1` can't do mixed status: its plural `tracks` input forces a single global `status`, and it has no clean "release-only" mode to skip re-uploading the AAB. So the step is now a small Python script that talks to the Play Developer API directly:

- One `edits.insert`
- One `bundles.upload`
- Four `tracks.update` calls (each with its own release + per-track status)
- One `edits.commit`

Script: `.github/scripts/play_multitrack_publish.py` — ~50 lines using `google-api-python-client` + `google-auth`. Same `PLAY_SERVICE_ACCOUNT_JSON` secret; no new perms.

## Gating and failure semantics unchanged

The workflow step keeps `id: play-upload` and the same `if:` guard, so PR #1733's plumbing still fires:

- `steps.play-upload.outcome == 'success'` gates the `versionBuild` persist commit (a failed publish does **not** advance `versionBuild` in `main`).
- The `Fail loudly if Play upload didn't succeed` step re-annotates the run with an `::error::` message and `exit 1`.

The vestigial `workflow_dispatch` inputs `track` / `status` are retired (the fan-out is now fixed). `publish` (skip-Play-entirely switch) stays.

## Assumptions (flag before first merge)

- **Closed-testing slug = `alpha`.** Play's default. If the app has a custom-named closed track (Play Console → Testing → Closed testing → track ID), update `TARGETS` in the script — one line.
- **Production accepts a draft on first attempt.** If Play enforces a graduation flow that rejects a draft on production without a prior rollout, we'll see it in the first run's logs and can gate the production line.
- Same service-account permissions (`androidpublisher` scope) — no new secrets or perms.

## Test plan

- [x] YAML dry-parse of `release-aab.yml` (`python -c "import yaml; yaml.safe_load(open(...))"`)
- [x] Python syntax check on the script (`python -m py_compile`)
- [ ] Manual dispatch `publish=false` → build succeeds, Play step **skipped**, no version-bump commit. Job green.
- [ ] Real merge to main: script logs 6 `::notice::` lines (open edit, upload, 4 track assigns, commit); `ci: versionBuild=…` commit lands on main **after** the Play step; Play Console shows the versionCode live on internal + draft on alpha/beta/production.
- [ ] Failure smoke on a scratch branch (tamper the JSON secret): script raises → `outcome != 'success'` → no version-bump on main → fail-loudly re-annotates → job RED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBwsyyWbkuTH9QV27ZnmVU)_