### PR TITLE
Release Play edit on failure to avoid exhausting concurrent-edit quota

### DIFF
--- a/.github/scripts/play_multitrack_publish.py
+++ b/.github/scripts/play_multitrack_publish.py
@@ -54,34 +54,48 @@ def main() -> None:
     )
     svc = build("androidpublisher", "v3", credentials=creds, cache_discovery=False)
 
-    edit = svc.edits().insert(packageName=pkg, body={}).execute()
-    edit_id = edit["id"]
-    print(f"::notice::Opened Play edit {edit_id}")
+    # Play's concurrent-active-edits quota is small — if we fail between insert and commit,
+    # the open edit sits on the quota until Play garbage-collects it. Delete it on any
+    # exception so repeated failures don't lock us out.
+    edit_id = None
+    try:
+        edit = svc.edits().insert(packageName=pkg, body={}).execute()
+        edit_id = edit["id"]
+        print(f"::notice::Opened Play edit {edit_id}")
 
-    media = MediaFileUpload(aab, mimetype="application/octet-stream", resumable=True)
-    bundle = svc.edits().bundles().upload(
-        packageName=pkg, editId=edit_id, media_body=media,
-    ).execute()
-    version_code = bundle["versionCode"]
-    print(f"::notice::Uploaded AAB versionCode={version_code} ({aab})")
-
-    for track, status in TARGETS:
-        svc.edits().tracks().update(
-            packageName=pkg,
-            editId=edit_id,
-            track=track,
-            body={
-                "track": track,
-                "releases": [{
-                    "status": status,
-                    "versionCodes": [str(version_code)],
-                }],
-            },
+        media = MediaFileUpload(aab, mimetype="application/octet-stream", resumable=True)
+        bundle = svc.edits().bundles().upload(
+            packageName=pkg, editId=edit_id, media_body=media,
         ).execute()
-        print(f"::notice::Assigned versionCode={version_code} to '{track}' as {status}")
+        version_code = bundle["versionCode"]
+        print(f"::notice::Uploaded AAB versionCode={version_code} ({aab})")
 
-    svc.edits().commit(packageName=pkg, editId=edit_id).execute()
-    print(f"::notice::Committed edit {edit_id} — versionCode={version_code} live on internal, draft on the rest")
+        for track, status in TARGETS:
+            svc.edits().tracks().update(
+                packageName=pkg,
+                editId=edit_id,
+                track=track,
+                body={
+                    "track": track,
+                    "releases": [{
+                        "status": status,
+                        "versionCodes": [str(version_code)],
+                    }],
+                },
+            ).execute()
+            print(f"::notice::Assigned versionCode={version_code} to '{track}' as {status}")
+
+        svc.edits().commit(packageName=pkg, editId=edit_id).execute()
+        print(f"::notice::Committed edit {edit_id} — versionCode={version_code} live on internal, draft on the rest")
+    except BaseException:
+        if edit_id is not None:
+            try:
+                svc.edits().delete(packageName=pkg, editId=edit_id).execute()
+                print(f"::warning::Deleted uncommitted Play edit {edit_id} after failure", file=sys.stderr)
+            except Exception as cleanup_err:
+                # Best-effort — don't mask the original failure by raising from the cleanup path.
+                print(f"::warning::Could not delete edit {edit_id}: {cleanup_err}", file=sys.stderr)
+        raise
 
 
 if __name__ == "__main__":

--- a/.github/scripts/play_multitrack_publish.py
+++ b/.github/scripts/play_multitrack_publish.py
@@ -87,7 +87,7 @@ def main() -> None:
 
         svc.edits().commit(packageName=pkg, editId=edit_id).execute()
         print(f"::notice::Committed edit {edit_id} — versionCode={version_code} live on internal, draft on the rest")
-    except BaseException:
+    except Exception:
         if edit_id is not None:
             try:
                 svc.edits().delete(packageName=pkg, editId=edit_id).execute()


### PR DESCRIPTION
## Summary

Follow-up to just-merged PR #1734. Gemini review flagged a real bug in `play_multitrack_publish.py`: if the script fails between `edits.insert` and `edits.commit` (mid-run API error on the bundle upload or a `tracks.update` call), the open edit sits on Play's concurrent-active-edits quota (typically 10) until Play's own GC cleans it up (hours). Repeated CI failures would quickly hit "Too many uncommitted edits" and block publishing entirely.

## Fix

Wrap the insert-through-commit flow in `try/except`:

- On any exception, best-effort `edits.delete(editId=…)` to release the slot.
- If the cleanup delete itself fails, swallow it (`::warning::` to the log) so the **original** exception surfaces cleanly. That way the caller (`release-aab.yml`) still sees the non-zero exit and PR #1733's `steps.play-upload.outcome` gate correctly blocks the `versionBuild` persist commit.

## Test plan

- [x] Python syntax check on the script (`python -m py_compile`).
- [ ] Failure smoke on a scratch branch (tamper the JSON secret, or pass an unreachable package name): script raises → `edits.delete` fires → workflow step outcome != success → no version-bump on main → fail-loudly step re-annotates → job RED.
- [ ] Real publish on next merge to main: no regression — same six `::notice::` lines, versionCode on all four tracks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBwsyyWbkuTH9QV27ZnmVU)_