### PR TITLE
Version bump on every compile; Play upload timeout guard; persist-push retry

### DIFF
--- a/.github/scripts/play_multitrack_publish.py
+++ b/.github/scripts/play_multitrack_publish.py
@@ -21,7 +21,9 @@ import json
 import os
 import sys
 
+import httplib2
 from google.oauth2 import service_account
+from google_auth_httplib2 import AuthorizedHttp
 from googleapiclient.discovery import build
 from googleapiclient.http import MediaFileUpload
 
@@ -38,6 +40,19 @@ TARGETS = [
 
 SCOPES = ["https://www.googleapis.com/auth/androidpublisher"]
 
+# httplib2's default socket timeout is None (system default, often ~2 min), which trips the
+# TimeoutError we hit on release 14148 while Play digested a ~155MB AAB upload chunk. 10 min
+# is plenty for any single chunk read.
+HTTP_TIMEOUT_S = 600
+
+# Chunk-level retry count on transient upload failures (5xx, connection errors, timeouts).
+# googleapiclient's `.execute(num_retries=N)` retries with exponential backoff.
+UPLOAD_RETRIES = 5
+
+# Smaller chunks = shorter individual reads = smaller per-chunk timeout risk. Default is 100MB
+# which is too big when Play's edge is slow. 4MB is standard for resumable uploads.
+UPLOAD_CHUNK_SIZE = 4 * 1024 * 1024
+
 
 def main() -> None:
     pkg = os.environ["PACKAGE_NAME"]
@@ -52,7 +67,8 @@ def main() -> None:
     creds = service_account.Credentials.from_service_account_info(
         json.loads(creds_json), scopes=SCOPES,
     )
-    svc = build("androidpublisher", "v3", credentials=creds, cache_discovery=False)
+    authed_http = AuthorizedHttp(creds, http=httplib2.Http(timeout=HTTP_TIMEOUT_S))
+    svc = build("androidpublisher", "v3", http=authed_http, cache_discovery=False)
 
     # Play's concurrent-active-edits quota is small — if we fail between insert and commit,
     # the open edit sits on the quota until Play garbage-collects it. Delete it on any
@@ -63,10 +79,17 @@ def main() -> None:
         edit_id = edit["id"]
         print(f"::notice::Opened Play edit {edit_id}")
 
-        media = MediaFileUpload(aab, mimetype="application/octet-stream", resumable=True)
+        media = MediaFileUpload(
+            aab,
+            mimetype="application/octet-stream",
+            resumable=True,
+            chunksize=UPLOAD_CHUNK_SIZE,
+        )
+        # num_retries=N retries individual chunk uploads with exponential backoff on 5xx and
+        # transport errors — including the socket-read TimeoutError we hit on release 14148.
         bundle = svc.edits().bundles().upload(
             packageName=pkg, editId=edit_id, media_body=media,
-        ).execute()
+        ).execute(num_retries=UPLOAD_RETRIES)
         version_code = bundle["versionCode"]
         print(f"::notice::Uploaded AAB versionCode={version_code} ({aab})")
 

--- a/.github/workflows/release-aab.yml
+++ b/.github/workflows/release-aab.yml
@@ -143,8 +143,10 @@ jobs:
           AAB_GLOB: app/build/outputs/bundle/release/*.aab
           PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
         run: |
-          # Python 3 is preinstalled on ubuntu-latest; just pull the two client libs.
-          pip install --quiet google-api-python-client google-auth
+          # Python 3 is preinstalled on ubuntu-latest. google-auth-httplib2 and httplib2 are
+          # transitive deps of google-api-python-client but naming them keeps the intent clear
+          # (the script imports both directly to configure a longer socket timeout).
+          pip install --quiet google-api-python-client google-auth google-auth-httplib2 httplib2
           python .github/scripts/play_multitrack_publish.py
 
       - name: Persist auto-incremented versionCode
@@ -153,6 +155,10 @@ jobs:
         # build so main's versionBuild never falls behind the numbers the build has already
         # burned — a failed Play upload does NOT stall the version stream. [skip ci] (and the
         # push-trigger paths-ignore) stop a re-trigger.
+        #
+        # main can advance under us mid-run (another workflow, a merged PR). Retry loop
+        # rebases onto the fresh tip and re-pushes — version.properties only ever monotonically
+        # bumps and this workflow is the sole writer, so the rebase is always trivial.
         if: ${{ always() && (github.event_name == 'push' || inputs.publish) }}
         run: |
           git config user.name "github-actions[bot]"
@@ -160,11 +166,30 @@ jobs:
           git add version.properties
           if git diff --cached --quiet; then
             echo "version.properties unchanged — nothing to persist"
-          else
-            NEW=$(grep -E '^versionBuild=' version.properties | cut -d'=' -f2 | tr -d '\r ')
-            git commit -m "ci: versionBuild=${NEW} [skip ci]"
-            git push origin "HEAD:${{ github.ref_name }}"
+            exit 0
           fi
+          NEW=$(grep -E '^versionBuild=' version.properties | cut -d'=' -f2 | tr -d '\r ')
+          git commit -m "ci: versionBuild=${NEW} [skip ci]"
+          BRANCH="${{ github.ref_name }}"
+          for attempt in 1 2 3 4 5; do
+            if git push origin "HEAD:${BRANCH}"; then
+              echo "Pushed versionBuild=${NEW} on attempt ${attempt}"
+              exit 0
+            fi
+            echo "::warning::Push rejected on attempt ${attempt}; rebasing onto origin/${BRANCH} and retrying"
+            git fetch origin "${BRANCH}"
+            # Rebase our single commit onto the fresh tip. -X theirs keeps the incoming version
+            # if a concurrent bump got there first — since versionBuild is monotonically
+            # increasing and we've already burned this number locally, letting theirs win here
+            # is safe: the very next build will re-bump past both.
+            if ! git rebase -X theirs "origin/${BRANCH}"; then
+              git rebase --abort || true
+              echo "::error::Rebase failed on attempt ${attempt}"
+              exit 1
+            fi
+          done
+          echo "::error::Could not push versionBuild=${NEW} after 5 attempts"
+          exit 1
 
       - name: Fail loudly if Play upload didn't succeed
         # The script fails the job on any API error, but the ::error:: annotation surfaces the

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -45,7 +45,7 @@ val localProperties = Properties().apply {
 val startParameter = gradle.startParameter
 val buildVerbs = listOf(
     "assemble", "bundle", "install", "package", "compile",
-    "test", "check", "lint", "verify", "connectedtest", "run",
+    "test", "check", "lint", "verify", "connected", "run",
 )
 val isBuilding = !startParameter.isDryRun && startParameter.taskNames.any { taskName ->
     val task = taskName.substringAfterLast(':').lowercase()

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -28,17 +28,25 @@ val localProperties = Properties().apply {
     }
 }
 
-// Version resolution. On EVERY compile (any build type, any machine) both the build number and the
-// patch are incremented:
+// Version resolution. On EVERY compile (any build type, any machine, any Gradle task that will
+// actually compile bytecode) both the build number and the patch are incremented:
 //   - versionBuild  -> the Android versionCode. Monotonic; NEVER resets.
 //   - versionPatch  -> the patch segment of the versionName. Increments each compile, but resets to
 //                      0 when versionMinor was bumped since the last build (a new minor starts at .0).
 //                      versionMinorLast tracks the minor we last built so that reset is automatic.
-// True when the requested tasks actually compile/assemble the app — not a sync, `tasks`, `clean`,
-// a `--dry-run`, or a diagnostic like `buildEnvironment`/`buildHealth`. Build verbs are matched as a
-// prefix and the `build` lifecycle task exactly, so diagnostics that merely contain "build" don't trip it.
+// True when the requested tasks will trigger real compilation — not a sync, `tasks`, `clean`,
+// a `--dry-run`, or a diagnostic like `buildEnvironment`/`buildHealth`. Build verbs cover every
+// entry point that transitively invokes a KotlinCompile / JavaCompile task on this project: the
+// full android build lifecycle (assemble/bundle/install/package), explicit compile invocations,
+// unit-test / instrumented-test / verification tasks (test/check/lint/verify/connectedTest — all
+// depend on compileDebugKotlin / compileReleaseKotlin), and `run` for library modules. Verbs are
+// matched as a prefix on the leaf task name and the `build` lifecycle task is matched exactly, so
+// diagnostics that merely contain "build" don't trip it.
 val startParameter = gradle.startParameter
-val buildVerbs = listOf("assemble", "bundle", "install", "package", "compile")
+val buildVerbs = listOf(
+    "assemble", "bundle", "install", "package", "compile",
+    "test", "check", "lint", "verify", "connectedtest", "run",
+)
 val isBuilding = !startParameter.isDryRun && startParameter.taskNames.any { taskName ->
     val task = taskName.substringAfterLast(':').lowercase()
     task == "build" || buildVerbs.any { task.startsWith(it) }


### PR DESCRIPTION
## Summary

Three fixes hit by the last main run.

### 1. `versionBuild` now advances on every compile — including `test`, `check`, `lint`

`app/build.gradle.kts` `isBuilding` was gated on `assemble/bundle/install/package/compile` only. `./gradlew test` triggers `compileDebugKotlin` transitively but slipped the gate, so unit-test runs left `versionBuild` unchanged. Broadened `buildVerbs` to include `test`, `check`, `lint`, `verify`, `connectedTest`, `run` — every Gradle entry point that will actually compile bytecode now advances the version, at the Gradle level.

### 2. Play upload no longer dies on a slow chunk

Release 14148 died at `edits.bundles.upload` with `TimeoutError: The read operation timed out` in `httplib2.socket.recv_into`. Three changes in `.github/scripts/play_multitrack_publish.py`:

- Configure `httplib2.Http(timeout=600)` (default was system default, ~2min).
- `.execute(num_retries=5)` on the upload — googleapiclient retries individual resumable chunks on 5xx / transport errors with exponential backoff.
- `MediaFileUpload(chunksize=4 * 1024 * 1024)` — smaller chunks = shorter per-chunk reads = smaller per-chunk timeout window.

### 3. Persist-push retries on non-fast-forward

The `Persist auto-incremented versionCode` step in `release-aab.yml` got `! [rejected]  HEAD -> main (non-fast-forward)` because main advanced under the run. Wrapped the push in a 5-attempt retry loop that rebases onto the fresh origin tip with `-X theirs` between attempts. `versionBuild` is monotonically increasing and this workflow is the sole writer of `version.properties`, so keeping the incoming value on a rebase conflict is always safe — the next build will re-bump past both.

## Test plan

- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/release-aab.yml'))"` — YAML valid.
- [x] `python -m py_compile .github/scripts/play_multitrack_publish.py` — clean.
- [ ] Next merge to main: bundleRelease succeeds, Play upload completes (or retries and completes), persist step commits + pushes even if main advanced.
- [ ] `./gradlew test` on a fresh checkout: `versionBuild` advances in `version.properties`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBwsyyWbkuTH9QV27ZnmVU)_