### PR TITLE
Brushstroke follows the finger; eraser is top-level; Design disables menu

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/HelpItemsBuilder.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/HelpItemsBuilder.kt
@@ -63,8 +63,9 @@ internal fun buildHelpItems(strings: AppStrings, layers: List<Layer>): Map<Strin
 
     layers.forEach { layer ->
         base[layerId(layer)] = strings.help.layer(layer.name)
-        // Tool category folders (host items) inside the per-layer nested rail.
-        base[layerId(layer, "grp.paint")] = strings.help.addDraw
+        // Tool category folders (host items) inside the per-layer nested rail. The former
+        // grp.paint folder was retired when Eraser was promoted to a top-level rail item —
+        // Eraser was the only child, so the folder was just an extra tap.
         base[layerId(layer, "grp.retouch")] = strings.help.blur
         base[layerId(layer, "grp.adjust")] = strings.help.adj
         base[layerId(layer, "grp.effects")] = strings.help.stencilGen

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -388,7 +388,17 @@ class MainActivity : ComponentActivity() {
                 // AzNavRail caches `isExpanded` in rememberSaveable; forcing
                 // noMenu on the library screen re-initialises it to false so
                 // its outer fillMaxSize Box never attaches tapOutsideToCollapse.
-                val railMenuDisabled = !isRailVisible || showLibrary
+                //
+                // Design mode disables the side drawer entirely (noMenu = true). The user
+                // asked for the rail to fold up when the app icon is pressed in Design mode
+                // with the menu disabled; AzNavRail 10.32 doesn't expose an onAppIconClick
+                // callback or a reactive `expanded` state, so we can't gate noMenu on the
+                // press itself — but disabling the drawer for the whole Design session is
+                // the closest match: the app-icon tap still folds/expands the rail by
+                // default, and the drawer never appears to distract the design flow.
+                val railMenuDisabled = !isRailVisible ||
+                        showLibrary ||
+                        editorUiState.editorMode == EditorMode.DESIGN
 
                 var permissionRequestedAtLeastOnce by remember { mutableStateOf(hasCameraPermission) }
 
@@ -1729,8 +1739,10 @@ class MainActivity : ComponentActivity() {
                                     )
                                 }
                                 layer.isSketch -> {
-                                    azRailHostItem(id = layerId(layer, "grp.paint"), text = "Paint", color = navItemColor, shape = AzButtonShape.RECTANGLE)
-                                    azRailSubItem(id = layerId(layer, "eraser"), hostId = layerId(layer, "grp.paint"), text = navStrings.eraser, color = if (activeTool == Tool.ERASER) Cyan else navItemColor, shape = AzButtonShape.CIRCLE) { activate(); editorViewModel.setActiveTool(Tool.ERASER) }
+                                    // Eraser is a top-level rail item — it used to sit under a "Paint"
+                                    // host folder that only ever contained this one child, which made
+                                    // the folder redundant and put the eraser two taps deep.
+                                    azRailItem(id = layerId(layer, "eraser"), text = navStrings.eraser, color = if (activeTool == Tool.ERASER) Cyan else navItemColor, shape = AzButtonShape.CIRCLE) { activate(); editorViewModel.setActiveTool(Tool.ERASER) }
 
                                     azRailHostItem(id = layerId(layer, "grp.retouch"), text = "Retouch", color = navItemColor, shape = AzButtonShape.RECTANGLE)
                                     azRailSubItem(id = layerId(layer, "blur"), hostId = layerId(layer, "grp.retouch"), text = navStrings.blur, color = if (activeTool == Tool.BLUR) Cyan else navItemColor, shape = AzButtonShape.CIRCLE) { activate(); editorViewModel.setActiveTool(Tool.BLUR) }
@@ -1782,8 +1794,10 @@ class MainActivity : ComponentActivity() {
                                     // Image-layer tools grouped into folders (host/sub) so the nested
                                     // rail isn't an overwhelming flat list. Size stays a standalone
                                     // widget (most-used control); all other tools live under a folder.
-                                    azRailHostItem(id = layerId(layer, "grp.paint"), text = "Paint", color = navItemColor, shape = AzButtonShape.RECTANGLE)
-                                    azRailSubItem(id = layerId(layer, "eraser"), hostId = layerId(layer, "grp.paint"), text = navStrings.eraser, color = if (activeTool == Tool.ERASER) Cyan else navItemColor, shape = AzButtonShape.CIRCLE) { activate(); editorViewModel.setActiveTool(Tool.ERASER) }
+                                    // Eraser is a top-level rail item — it used to sit under a "Paint"
+                                    // host folder that only ever contained this one child, which made
+                                    // the folder redundant and put the eraser two taps deep.
+                                    azRailItem(id = layerId(layer, "eraser"), text = navStrings.eraser, color = if (activeTool == Tool.ERASER) Cyan else navItemColor, shape = AzButtonShape.CIRCLE) { activate(); editorViewModel.setActiveTool(Tool.ERASER) }
 
                                     azRailHostItem(id = layerId(layer, "grp.retouch"), text = "Retouch", color = navItemColor, shape = AzButtonShape.RECTANGLE)
                                     azRailSubItem(id = layerId(layer, "blur"), hostId = layerId(layer, "grp.retouch"), text = navStrings.blur, color = if (activeTool == Tool.BLUR) Cyan else navItemColor, shape = AzButtonShape.CIRCLE) { activate(); editorViewModel.setActiveTool(Tool.BLUR) }

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
@@ -585,23 +585,21 @@ fun MainScreen(
 
         if (!isTouchLocked && !isImageLocked && activeLayer != null && !isGuest) {
             if (uiState.activeTool != Tool.NONE) {
+                // No graphicsLayer here: the layer bitmap above already applies the layer transform
+                // to what the user sees. DrawingCanvas is a full-screen touch layer that captures
+                // pointer positions in true screen coordinates so EditorViewModel.onStrokePoint can
+                // pass them into ImageProcessor.mapScreenToBitmap, which is what undoes the layer
+                // transform and the ContentScale.Fit letterboxing to hit the correct bitmap pixel.
+                // A graphicsLayer here would make Compose inverse-transform the pointer position
+                // before delivery — then mapScreenToBitmap would inverse-transform it AGAIN, drifting
+                // the stored stroke away from where the finger actually is (worse the further the
+                // layer is panned/scaled/rotated).
                 DrawingCanvas(
                     activeTool = uiState.activeTool,
                     brushSize = uiState.brushSize,
                     activeColor = uiState.activeColor,
                     layerBitmapKey = activeLayer.bitmap,
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .graphicsLayer {
-                            translationX = activeLayer.offset.x
-                            translationY = activeLayer.offset.y
-                            scaleX = activeLayer.scale
-                            scaleY = activeLayer.scale
-                            rotationX = activeLayer.rotationX
-                            rotationY = activeLayer.rotationY
-                            rotationZ = activeLayer.rotationZ
-                            transformOrigin = TransformOrigin.Center
-                        },
+                    modifier = Modifier.fillMaxSize(),
                     onStrokeStart = { offset, size -> editorViewModel.onStrokeStart(offset, size) },
                     onStrokePoint = { offset -> editorViewModel.onStrokePoint(offset) },
                     onStrokeEnd = { editorViewModel.onStrokeEnd() }

--- a/app/src/main/java/com/hereliesaz/graffitixr/RailIdEnumerator.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/RailIdEnumerator.kt
@@ -67,7 +67,7 @@ internal fun enumerateRailItemIdRegistrations(layers: List<Layer>, mode: EditorM
     layers.forEach { layer ->
         ids += layerId(layer)
         ids += listOf(
-            "grp.text", "grp.paint", "grp.retouch", "grp.adjust", "grp.effects",
+            "grp.text", "grp.retouch", "grp.adjust", "grp.effects",
         ).map { layerId(layer, it) }
         ids += listOf(
             "editText", "font", "size.text", "color", "kern", "bold", "italic",

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -41,6 +41,10 @@ dependencies {
     implementation(libs.gson)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.androidx.compose.ui.geometry)
+    // ProjectManager persists layer BlendMode (androidx.compose.ui.graphics.BlendMode). This was
+    // previously reaching us transitively through core:common's api(az-nav-rail); the AzNavRail
+    // Android artifact no longer leaks Compose, so declare the dependency we actually use.
+    implementation(libs.androidx.compose.ui.graphics)
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)
     implementation(libs.kotlinx.coroutines.android)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -72,7 +72,19 @@ androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecyc
 androidx-lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "lifecycle" }
 androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycle" }
 arcore-client = { group = "com.google.ar", name = "core", version.ref = "arcore" }
-az-nav-rail = { group = "com.github.HereLiesAz", name = "AzNavRail", version.ref = "azNavRail" }
+# Depend on the `aznavrail` Android library submodule directly, NOT the root aggregator
+# `com.github.HereLiesAz:AzNavRail`. From the Compose-Multiplatform releases the root artifact is
+# a plain Maven POM (no Gradle Module Metadata) that flat-lists every platform artifact — including
+# `aznavrail-cmp-wasm-js`, a wasm-only klib with no Android variant. With no module metadata at the
+# root, Gradle can't do variant selection and tries to resolve ALL of them, so the wasm klib fails
+# the whole build ("No matching variant ... platform.type 'wasm'").
+#
+# `aznavrail` is the full Android library: it carries the DSL the app uses (AzNavHostKt —
+# AzHostActivityLayout, azConfig, azTheme, azAdvanced, AzNavHostScope, …) and publishes proper
+# module metadata (androidJvm variants; transitively brings coil-compose). NOTE the sibling
+# `aznavrail-cmp-android` artifact is an incomplete Compose-Multiplatform target that is MISSING
+# AzNavHostKt, so it does NOT satisfy our usage — do not switch to it.
+az-nav-rail = { group = "com.github.HereLiesAz.AzNavRail", name = "aznavrail", version.ref = "azNavRail" }
 coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
 google-accompanist-permissions = { group = "com.google.accompanist", name = "accompanist-permissions", version.ref = "accompanistPermissions" }
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }


### PR DESCRIPTION
## Summary

Three separate fixes.

### 1. Brushstrokes now land where the finger is

Any time the active layer was panned/scaled/rotated, brushstrokes were drifting away from the finger by roughly the layer's transform (worse the further the layer was moved/zoomed/rotated).

Root cause: `DrawingCanvas` had a `graphicsLayer{translationX/Y, scaleX/Y, rotationZ = activeLayer.*}` above its internal `pointerInput`. Compose automatically inverse-transforms pointer positions through a `graphicsLayer` before delivering them to a nested `pointerInput` — so the offsets `EditorViewModel.onStrokePoint` received were already in "pre-layer local space". Then `ImageProcessor.mapScreenToBitmap` inverse-transformed the same coordinates AGAIN using the same layer values, yielding a doubled correction (~2× the layer-offset shift, squared scale, doubled rotation).

Fix: strip the `graphicsLayer` from `DrawingCanvas`'s modifier in `MainScreen.kt`. The layer bitmap already has its own `graphicsLayer` that positions what the user sees; `DrawingCanvas` is purely a full-screen touch layer that must capture true screen coordinates for `mapScreenToBitmap` to work.

### 2. Eraser is a top-level rail item

The eraser was the only child under a "Paint" host folder in the per-layer nested rail — so the folder was redundant tap depth. Promoted `Eraser` to a top-level `azRailItem` in both the sketch-layer and image-layer branches. `RailIdEnumerator` and `HelpItemsBuilder` updated to drop the per-layer `"grp.paint"` entry.

### 3. Side drawer disabled in Design mode

Extended `railMenuDisabled` to include `editorUiState.editorMode == EditorMode.DESIGN`, which propagates to `azConfig(noMenu = ...)`.

**Note on the exact ask.** AzNavRail 10.32 doesn't expose an `onAppIconClick` callback or a reactive `expanded: Boolean` for `AzHostActivityLayout`, so we can't gate `noMenu` on the app-icon press specifically. The app-icon tap still folds/expands the rail by default (existing behavior), and disabling the drawer for the whole Design session is the closest match to "fold up + disable menu". If exact per-press control is desired, AzNavRail would need to expose the icon-tap callback and reactive expanded state.

## Test plan

- [ ] Pan/scale/rotate the active layer, then draw — strokes land on the finger, not offset. Same for any tool that goes through the stroke path.
- [ ] Open a sketch layer's tools: `Eraser` appears as a top-level circular item (not nested under a `Paint` folder).
- [ ] Enter Design mode: the side drawer is not accessible from the rail (no hamburger). Leave Design mode: drawer returns.

Local `:app:testDebugUnitTest` couldn't run — `:core:common:kspDebugKotlin` fails to resolve `com.github.HereLiesAz.AzNavRail:aznavrail-cmp-wasm-js:10.32` because the KMP artifact has a wasmJs variant with no Android/JVM-selectable attributes. Pre-existing issue on main, unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBwsyyWbkuTH9QV27ZnmVU)_

## Summary by Sourcery

Align touch input with transformed layers, simplify eraser access in the nested rail, and disable the side drawer in Design mode.

New Features:
- Expose eraser as a top-level rail item for both sketch and image layers.

Bug Fixes:
- Fix brushstrokes (and other stroke-based tools) drifting away from the finger whenever the active layer is panned, scaled, or rotated.
- Prevent the side drawer from appearing in Design mode by treating it as menu-disabled for the duration of the session.

Enhancements:
- Ensure DrawingCanvas captures pointer positions in true screen coordinates rather than being transformed with the active layer.
- Remove the redundant per-layer "grp.paint" folder now that eraser is top-level.
- Update help item mappings and rail ID enumeration to reflect removal of the paint group.