### PR TITLE
Clarify AzNavRail catalog comment: classic Android library, not CMP

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -72,18 +72,17 @@ androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecyc
 androidx-lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "lifecycle" }
 androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycle" }
 arcore-client = { group = "com.google.ar", name = "core", version.ref = "arcore" }
-# Depend on the `aznavrail` Android library submodule directly, NOT the root aggregator
-# `com.github.HereLiesAz:AzNavRail`. From the Compose-Multiplatform releases the root artifact is
-# a plain Maven POM (no Gradle Module Metadata) that flat-lists every platform artifact — including
-# `aznavrail-cmp-wasm-js`, a wasm-only klib with no Android variant. With no module metadata at the
-# root, Gradle can't do variant selection and tries to resolve ALL of them, so the wasm klib fails
-# the whole build ("No matching variant ... platform.type 'wasm'").
+# AzNavRail — use the CLASSIC ANDROID LIBRARY (`aznavrail`), never the Compose-Multiplatform build.
+# The AzNavRail release publishes several artifacts side by side; `aznavrail` (type aar) is the
+# normal Android library and the ONLY one that carries the DSL this app uses (AzNavHostKt —
+# AzHostActivityLayout, azConfig, azTheme, azAdvanced, AzNavHostScope, …).
 #
-# `aznavrail` is the full Android library: it carries the DSL the app uses (AzNavHostKt —
-# AzHostActivityLayout, azConfig, azTheme, azAdvanced, AzNavHostScope, …) and publishes proper
-# module metadata (androidJvm variants; transitively brings coil-compose). NOTE the sibling
-# `aznavrail-cmp-android` artifact is an incomplete Compose-Multiplatform target that is MISSING
-# AzNavHostKt, so it does NOT satisfy our usage — do not switch to it.
+# Do NOT depend on the root aggregator `com.github.HereLiesAz:AzNavRail`: it is a bare Maven POM
+# (no Gradle Module Metadata) that flat-lists every platform artifact, including the wasm-only
+# `aznavrail-cmp-wasm-js` klib — Gradle then can't pick a variant and the build dies with
+# "No matching variant ... platform.type 'wasm'". Do NOT use `aznavrail-cmp-android` either: that
+# is the Compose-Multiplatform Android target and it is MISSING AzNavHostKt. `aznavrail` is the
+# normal Android library and resolves cleanly (androidJvm module metadata; brings coil-compose).
 az-nav-rail = { group = "com.github.HereLiesAz.AzNavRail", name = "aznavrail", version.ref = "azNavRail" }
 coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
 google-accompanist-permissions = { group = "com.google.accompanist", name = "accompanist-permissions", version.ref = "accompanistPermissions" }


### PR DESCRIPTION
## Summary

Comment-only change in `gradle/libs.versions.toml`. No dependency change.

Main already depends on the **classic Android library** `com.github.HereLiesAz.AzNavRail:aznavrail` at the **latest version (10.33)** — I verified the artifact (324 classes, full `AzNavHostKt` DSL, no wasm) and that it builds green (`:app:testDebugUnitTest` + the full module sweep). The previous catalog comment led with Compose-Multiplatform framing, which read as "we're on CMP". This rewrites it to state plainly:

- `aznavrail` **is** the normal Android library (type `aar`) and the only artifact carrying the DSL the app uses.
- Do **not** use the root aggregator POM `com.github.HereLiesAz:AzNavRail` (bare POM → pulls the wasm klib → build dies).
- Do **not** use `aznavrail-cmp-android` (the CMP target, missing `AzNavHostKt`).

## Test plan

- [x] Confirmed `aznavrail-10.33.aar` is the classic library (has `AzNavHostKt`, 324 classes, no wasm variant).
- [x] `:app:testDebugUnitTest` green on 10.33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBwsyyWbkuTH9QV27ZnmVU)_