### PR TITLE
First-run AR doodle onboarding demo + artwork auto-tune

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -41,6 +41,7 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -465,8 +466,15 @@ class MainActivity : ComponentActivity() {
                 // complete only once the demo reaches its lock/swap.
                 val firstRunDoodleKey = "first_run_ar_doodle"
                 val firstRunCompletedTutorials by mainViewModel.completedTutorials.collectAsState()
-                var firstRunDoodleActive by remember { mutableStateOf(false) }
-                var firstRunTriggered by remember { mutableStateOf(false) }
+                // rememberSaveable so a process/config event mid-flow doesn't reset the flags and
+                // re-trigger the gate.
+                var firstRunDoodleActive by rememberSaveable { mutableStateOf(false) }
+                // Latches true once the gate has fired this session (whether the user picks or cancels),
+                // so a later key change can't re-fire it and spawn a duplicate project. Not persisted —
+                // a fresh launch re-offers onboarding until it's actually completed.
+                var firstRunTriggered by rememberSaveable { mutableStateOf(false) }
+                // Set on a successful pick; the effect below adds the layer once the project id exists.
+                var firstRunPendingUri by rememberSaveable { mutableStateOf<Uri?>(null) }
                 val firstRunScribble = remember { com.hereliesaz.graffitixr.onboarding.ScribbleGenerator.generate() }
                 val firstRunScribbleBitmap = remember(firstRunScribble) {
                     com.hereliesaz.graffitixr.onboarding.renderScribbleBitmap(firstRunScribble, 512)
@@ -474,15 +482,28 @@ class MainActivity : ComponentActivity() {
 
                 val firstRunImagePicker = rememberLauncherForActivityResult(ActivityResultContracts.PickVisualMedia()) { uri ->
                     if (uri != null) {
-                        editorViewModel.onAddLayer(uri)
+                        // Create the project only now (on a real pick) so cancelling leaves no stray
+                        // untitled project. The layer is added by the effect below once the project id
+                        // has propagated — onAddLayer no-ops on a null projectId, so we can't add here.
+                        dashboardViewModel.createAndOpenProject()
+                        firstRunPendingUri = uri
                         firstRunDoodleActive = true
                         navController.navigate(EditorMode.AR.name) {
                             popUpTo(LIBRARY_ROUTE) { inclusive = true }
                             launchSingleTop = true
                         }
-                    } else {
-                        // Cancelled the picker — abandon first-run silently, land on the library.
-                        firstRunTriggered = false
+                    }
+                    // Cancel: firstRunTriggered stays true, so the gate won't re-fire this session; the
+                    // user lands on the library. No project was created.
+                }
+
+                // Add the picked layer once the auto-created project's id is live (avoids the
+                // create-vs-add race where onAddLayer would silently drop the layer).
+                LaunchedEffect(firstRunPendingUri, editorUiState.projectId) {
+                    val uri = firstRunPendingUri
+                    if (uri != null && editorUiState.projectId != null) {
+                        editorViewModel.onAddLayer(uri)
+                        firstRunPendingUri = null
                     }
                 }
 
@@ -495,7 +516,6 @@ class MainActivity : ComponentActivity() {
                         currentRoute == LIBRARY_ROUTE
                     ) {
                         firstRunTriggered = true
-                        dashboardViewModel.createAndOpenProject()
                         firstRunImagePicker.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
                     }
                 }

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -500,6 +500,11 @@ class MainActivity : ComponentActivity() {
                     }
                 }
 
+                // Drive the headless fingerprint-build orchestration in the AR VM with the phase.
+                LaunchedEffect(firstRunDoodleActive) {
+                    arViewModel.setDoodlePhase(firstRunDoodleActive)
+                }
+
                 // Lock reached: clear the doodle phase (normal composite resumes, swapping the scribble
                 // for the user's artwork) and never show onboarding again.
                 LaunchedEffect(arUiState.doodleLocked) {

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -458,6 +458,57 @@ class MainActivity : ComponentActivity() {
                     }
                 }
 
+                // --- First-run AR doodle onboarding coordinator ---
+                // Strictly contained: the whole flow is gated behind the tutorial key + ARCore
+                // availability + camera permission. If any condition fails it's a complete no-op and
+                // normal library startup is byte-for-byte unchanged. The tutorial key is marked
+                // complete only once the demo reaches its lock/swap.
+                val firstRunDoodleKey = "first_run_ar_doodle"
+                val firstRunCompletedTutorials by mainViewModel.completedTutorials.collectAsState()
+                var firstRunDoodleActive by remember { mutableStateOf(false) }
+                var firstRunTriggered by remember { mutableStateOf(false) }
+                val firstRunScribble = remember { com.hereliesaz.graffitixr.onboarding.ScribbleGenerator.generate() }
+                val firstRunScribbleBitmap = remember(firstRunScribble) {
+                    com.hereliesaz.graffitixr.onboarding.renderScribbleBitmap(firstRunScribble, 512)
+                }
+
+                val firstRunImagePicker = rememberLauncherForActivityResult(ActivityResultContracts.PickVisualMedia()) { uri ->
+                    if (uri != null) {
+                        editorViewModel.onAddLayer(uri)
+                        firstRunDoodleActive = true
+                        navController.navigate(EditorMode.AR.name) {
+                            popUpTo(LIBRARY_ROUTE) { inclusive = true }
+                            launchSingleTop = true
+                        }
+                    } else {
+                        // Cancelled the picker — abandon first-run silently, land on the library.
+                        firstRunTriggered = false
+                    }
+                }
+
+                LaunchedEffect(arUiState.isArCoreAvailabilityResolved, firstRunCompletedTutorials, hasCameraPermission, currentRoute) {
+                    if (!firstRunTriggered &&
+                        firstRunDoodleKey !in firstRunCompletedTutorials &&
+                        arUiState.isArCoreAvailabilityResolved &&
+                        arUiState.isArCoreAvailable &&
+                        hasCameraPermission &&
+                        currentRoute == LIBRARY_ROUTE
+                    ) {
+                        firstRunTriggered = true
+                        dashboardViewModel.createAndOpenProject()
+                        firstRunImagePicker.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
+                    }
+                }
+
+                // Lock reached: clear the doodle phase (normal composite resumes, swapping the scribble
+                // for the user's artwork) and never show onboarding again.
+                LaunchedEffect(arUiState.doodleLocked) {
+                    if (firstRunDoodleActive && arUiState.doodleLocked) {
+                        firstRunDoodleActive = false
+                        mainViewModel.markTutorialCompletePersistent(firstRunDoodleKey)
+                    }
+                }
+
                 var showDesignInstructionsDialog by remember { mutableStateOf(false) }
 
                 // Auto-activate the first layer as soon as one exists — don't wait for
@@ -623,7 +674,9 @@ class MainActivity : ComponentActivity() {
                             slamManager = slamManager,
                             hasCameraPermission = hasCameraPermission,
                             cameraController = cameraController,
-                            onRendererCreated = { _ -> }
+                            onRendererCreated = { _ -> },
+                            doodlePhaseActive = firstRunDoodleActive,
+                            doodleScribbleBitmap = firstRunScribbleBitmap
                         )
 
                     }
@@ -683,6 +736,20 @@ class MainActivity : ComponentActivity() {
                                     arExplainerDismissedThisSession = true
                                     mainViewModel.markTutorialCompletePersistent(arExplainerKey)
                                 }
+                            )
+                        }
+
+                        // First-run doodle coaching layer — over the AR camera feed while the demo runs.
+                        if (firstRunDoodleActive &&
+                            !showSettings &&
+                            editorUiState.editorMode == EditorMode.AR
+                        ) {
+                            com.hereliesaz.graffitixr.onboarding.FirstRunOnboardingOverlay(
+                                scribble = firstRunScribble,
+                                isArReady = arUiState.isArReady,
+                                planeDetected = arUiState.planeDetected,
+                                title = "Doodle this on your wall or canvas",
+                                movementHint = arUiState.scanHint ?: "Slowly move your device in a circle",
                             )
                         }
 

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -530,6 +530,8 @@ class MainActivity : ComponentActivity() {
                 LaunchedEffect(arUiState.doodleLocked) {
                     if (firstRunDoodleActive && arUiState.doodleLocked) {
                         firstRunDoodleActive = false
+                        // Pre-set the adjustment knobs to read well against the wall we captured.
+                        editorViewModel.autoTuneActiveLayer(arUiState.doodleWallStats)
                         mainViewModel.markTutorialCompletePersistent(firstRunDoodleKey)
                     }
                 }

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
@@ -301,6 +301,12 @@ fun MainScreen(
                                 },
                                 onPlaneDetected = {
                                     arViewModel.onFirstPlaneDetected()
+                                },
+                                onDoodleLockProgress = { stability ->
+                                    arViewModel.onDoodleLockProgress(stability)
+                                },
+                                onDoodleLocked = {
+                                    arViewModel.onDoodleLocked()
                                 }
                             )
                             renderer.hideVisualization = isExporting

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
@@ -70,7 +70,13 @@ fun MainScreen(
     hasCameraPermission: Boolean,
     cameraController: androidx.camera.view.LifecycleCameraController,
     onRendererCreated: (ArRenderer) -> Unit,
-    isExporting: Boolean = false
+    isExporting: Boolean = false,
+    // First-run doodle demo: while active, the AR overlay shows this scribble bitmap (the thing the
+    // user copies onto the wall) instead of the layer composite, and the renderer runs the
+    // auto-anchor + hold-lock. On lock the host clears the flag and the normal composite resumes,
+    // swapping the scribble for the user's artwork. Defaulted off — no effect on the normal path.
+    doodlePhaseActive: Boolean = false,
+    doodleScribbleBitmap: android.graphics.Bitmap? = null
 ) {
     val activeLayer = uiState.layers.find { it.id == uiState.activeLayerId }
     val isImageLocked = activeLayer?.isImageLocked ?: false
@@ -257,7 +263,17 @@ fun MainScreen(
                             listOf(it.brightness, it.contrast, it.saturation, it.opacity, it.isInverted)
                         }
                     }
-                    LaunchedEffect(visibleLayers, arUiState.isAnchorEstablished, arToneKey) {
+                    LaunchedEffect(visibleLayers, arUiState.isAnchorEstablished, arToneKey, doodlePhaseActive, doodleScribbleBitmap) {
+                        // Doodle phase: the wall shows the scribble the user is copying, not their
+                        // artwork. Once the anchor exists, push the scribble and hold — the host swaps
+                        // to the artwork by clearing doodlePhaseActive (this effect then re-runs and
+                        // falls through to the normal composite below).
+                        if (doodlePhaseActive && doodleScribbleBitmap != null) {
+                            if (arUiState.isAnchorEstablished) {
+                                rendererRef.value?.updateOverlayBitmap(doodleScribbleBitmap)
+                            }
+                            return@LaunchedEffect
+                        }
                         if (!arUiState.isAnchorEstablished || visibleLayers.isEmpty()) {
                             rendererRef.value?.updateOverlayBitmap(null)
                             return@LaunchedEffect
@@ -333,6 +349,7 @@ fun MainScreen(
                                 r.hideVisualization = isExporting
                                 r.visitedSectorsMask = arUiState.visitedSectorsMask
                                 r.scanPhase = arUiState.scanPhase
+                                r.doodleLockActive = doodlePhaseActive
                                 // Independent in-world perception layers (Settings, default on).
                                 r.showFeaturePoints = uiState.showFeaturePoints
                                 r.showPlaneGrids = uiState.showPlaneGrids

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
@@ -298,6 +298,9 @@ fun MainScreen(
                                 },
                                 onAnchorEstablished = {
                                     arViewModel.onPrimaryAnchorEstablished()
+                                },
+                                onPlaneDetected = {
+                                    arViewModel.onFirstPlaneDetected()
                                 }
                             )
                             renderer.hideVisualization = isExporting

--- a/app/src/main/java/com/hereliesaz/graffitixr/onboarding/FirstRunOnboardingOverlay.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/onboarding/FirstRunOnboardingOverlay.kt
@@ -1,0 +1,149 @@
+package com.hereliesaz.graffitixr.onboarding
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.BiasAlignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.delay
+
+/**
+ * First-run AR coaching layer, drawn as a full-screen sibling over the GL camera surface. Staged:
+ *
+ *  1. "Doodle this on your wall or canvas" appears centred, alone, for [TITLE_HOLD_MS].
+ *  2. The title animates up to the top and the generated [scribble] fades in below it — this is the
+ *     reference the user copies onto their real wall.
+ *  3. Once ARCore is ready ([isArReady]) but no surface has been found yet ([planeDetected] false),
+ *     movement guidance ([movementHint]) + a rotating hint icon appear below the scribble. They
+ *     disappear the moment a surface is found, so the user isn't nagged once tracking is working.
+ *
+ * This layer shows the scribble + coaching only; latching the overlay onto the drawn marks and the
+ * swap to the user's artwork are the next phase. The caller is responsible for only composing this
+ * during the first-run flow (no other modal open).
+ */
+@Composable
+fun FirstRunOnboardingOverlay(
+    scribble: Scribble,
+    isArReady: Boolean,
+    planeDetected: Boolean,
+    title: String,
+    movementHint: String,
+    modifier: Modifier = Modifier,
+) {
+    var titleAtTop by remember { mutableStateOf(false) }
+    LaunchedEffectHold { titleAtTop = true }
+
+    // -1 = top, 0 = centre. The title starts centred, then rises to make room for the scribble.
+    val titleBias by animateFloatAsState(
+        targetValue = if (titleAtTop) -0.86f else 0f,
+        animationSpec = tween(durationMillis = 600),
+        label = "onboardingTitleBias",
+    )
+
+    Box(modifier.fillMaxSize()) {
+        Text(
+            text = title,
+            color = Color.White,
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.SemiBold,
+            textAlign = TextAlign.Center,
+            modifier = Modifier
+                .align(BiasAlignment(0f, titleBias))
+                .fillMaxWidth()
+                .padding(horizontal = 32.dp, vertical = 24.dp),
+        )
+
+        // The scribble reference occupies the centre once the title has cleared out.
+        AnimatedVisibility(
+            visible = titleAtTop,
+            enter = fadeIn(tween(500)),
+            exit = fadeOut(),
+            modifier = Modifier.align(Alignment.Center),
+        ) {
+            ScribbleView(
+                scribble = scribble,
+                modifier = Modifier.size(240.dp),
+            )
+        }
+
+        // Movement guidance: only while ARCore is up but hasn't found a surface yet.
+        AnimatedVisibility(
+            visible = titleAtTop && isArReady && !planeDetected,
+            enter = fadeIn(tween(400)),
+            exit = fadeOut(tween(300)),
+            modifier = Modifier.align(BiasAlignment(0f, 0.72f)),
+        ) {
+            MovementGuidance(movementHint)
+        }
+    }
+}
+
+@Composable
+private fun MovementGuidance(hint: String) {
+    val transition = rememberInfiniteTransition(label = "moveHint")
+    val angle by transition.animateFloat(
+        initialValue = 0f,
+        targetValue = 360f,
+        animationSpec = infiniteRepeatable(tween(2200, easing = LinearEasing), RepeatMode.Restart),
+        label = "moveHintAngle",
+    )
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 32.dp),
+    ) {
+        Icon(
+            imageVector = Icons.Filled.Refresh,
+            contentDescription = null,
+            tint = Color.White,
+            modifier = Modifier.size(40.dp).rotate(angle),
+        )
+        Text(
+            text = hint,
+            color = Color.White,
+            style = MaterialTheme.typography.bodyLarge,
+            textAlign = TextAlign.Center,
+        )
+    }
+}
+
+/** Holds for [TITLE_HOLD_MS] then invokes [onElapsed] once. Extracted so the delay reads clearly. */
+@Composable
+private fun LaunchedEffectHold(onElapsed: () -> Unit) {
+    androidx.compose.runtime.LaunchedEffect(Unit) {
+        delay(TITLE_HOLD_MS)
+        onElapsed()
+    }
+}
+
+private const val TITLE_HOLD_MS = 1000L

--- a/app/src/main/java/com/hereliesaz/graffitixr/onboarding/FirstRunOnboardingOverlay.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/onboarding/FirstRunOnboardingOverlay.kt
@@ -61,7 +61,10 @@ fun FirstRunOnboardingOverlay(
     modifier: Modifier = Modifier,
 ) {
     var titleAtTop by remember { mutableStateOf(false) }
-    LaunchedEffectHold { titleAtTop = true }
+    androidx.compose.runtime.LaunchedEffect(Unit) {
+        delay(TITLE_HOLD_MS)
+        titleAtTop = true
+    }
 
     // -1 = top, 0 = centre. The title starts centred, then rises to make room for the scribble.
     val titleBias by animateFloatAsState(
@@ -134,15 +137,6 @@ private fun MovementGuidance(hint: String) {
             style = MaterialTheme.typography.bodyLarge,
             textAlign = TextAlign.Center,
         )
-    }
-}
-
-/** Holds for [TITLE_HOLD_MS] then invokes [onElapsed] once. Extracted so the delay reads clearly. */
-@Composable
-private fun LaunchedEffectHold(onElapsed: () -> Unit) {
-    androidx.compose.runtime.LaunchedEffect(Unit) {
-        delay(TITLE_HOLD_MS)
-        onElapsed()
     }
 }
 

--- a/app/src/main/java/com/hereliesaz/graffitixr/onboarding/ScribbleGenerator.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/onboarding/ScribbleGenerator.kt
@@ -1,0 +1,118 @@
+package com.hereliesaz.graffitixr.onboarding
+
+import kotlin.math.cos
+import kotlin.math.hypot
+import kotlin.math.sin
+import kotlin.random.Random
+
+/**
+ * A single character placed in the onboarding scribble, expressed in a normalized [0,1] x [0,1]
+ * canvas so the renderer can scale it to any size. [sizeFrac] is the glyph box edge as a fraction
+ * of the canvas' smaller dimension; the glyph's circular footprint (used for the overlap rule) has
+ * radius `sizeFrac / 2` around ([cx], [cy]).
+ */
+data class ScribbleGlyph(
+    val char: Char,
+    val cx: Float,
+    val cy: Float,
+    val rotationDeg: Float,
+    val sizeFrac: Float,
+)
+
+/** An ordered set of overlapping glyphs forming one connected scribble. */
+data class Scribble(val glyphs: List<ScribbleGlyph>)
+
+/**
+ * Generates the random "doodle this" scribble shown at first run: a small cluster of characters
+ * (letters, digits, symbols) at random positions and rotations, with the rule that **every glyph
+ * overlaps at least one other** so the result reads as a single connected mark rather than scattered
+ * confetti. A complexity cap ([MAX_GLYPHS]) keeps it drawable in a few seconds regardless of the
+ * user's utensil.
+ *
+ * Pure and deterministic given a seeded [Random], so the placement logic is unit-testable without
+ * Android. Rendering (rotation, stroke) is the caller's job.
+ */
+object ScribbleGenerator {
+
+    /** Complexity cap — more than this becomes an unreadable tangle nobody wants to copy. */
+    const val MAX_GLYPHS = 7
+    const val MIN_GLYPHS = 3
+
+    private val ALPHABET: List<Char> =
+        (('A'..'Z') + ('a'..'z') + ('2'..'9') + listOf('#', '@', '&', '%', '*', '?', '!', '+', '=')).toList()
+
+    // Glyph footprint size range, as a fraction of the canvas' smaller edge.
+    private const val MIN_SIZE = 0.14f
+    private const val MAX_SIZE = 0.24f
+
+    // Keep centres inside a margin so rotated glyphs don't clip the canvas edge.
+    private const val MARGIN = 0.16f
+
+    // A new glyph is dropped this fraction of (r_self + r_neighbor) from a chosen neighbour's
+    // centre. < 1.0 forces the footprints to overlap (two circles overlap iff centre distance is
+    // below the radius sum); the range keeps the overlap visible but not fully concentric.
+    private const val MIN_OVERLAP_SPACING = 0.45f
+    private const val MAX_OVERLAP_SPACING = 0.80f
+
+    /**
+     * @param random seeded for determinism/testability.
+     * @param glyphCount desired glyph count; coerced into [[MIN_GLYPHS], [MAX_GLYPHS]].
+     */
+    fun generate(
+        random: Random = Random.Default,
+        glyphCount: Int = random.nextInt(MIN_GLYPHS, MAX_GLYPHS + 1),
+    ): Scribble {
+        val n = glyphCount.coerceIn(MIN_GLYPHS, MAX_GLYPHS)
+        val glyphs = ArrayList<ScribbleGlyph>(n)
+
+        // Seed glyph near centre with a little jitter.
+        glyphs += ScribbleGlyph(
+            char = ALPHABET.random(random),
+            cx = 0.5f + random.nextFloat() * 0.1f - 0.05f,
+            cy = 0.5f + random.nextFloat() * 0.1f - 0.05f,
+            rotationDeg = randomRotation(random),
+            sizeFrac = randomSize(random),
+        )
+
+        while (glyphs.size < n) {
+            val neighbor = glyphs[random.nextInt(glyphs.size)]
+            val size = randomSize(random)
+            val rSelf = size / 2f
+            val rNeighbor = neighbor.sizeFrac / 2f
+            val spacing = MIN_OVERLAP_SPACING + random.nextFloat() * (MAX_OVERLAP_SPACING - MIN_OVERLAP_SPACING)
+            val dist = (rSelf + rNeighbor) * spacing
+            val angle = random.nextFloat() * (2f * Math.PI.toFloat())
+
+            // Offset from the neighbour. `dist < rSelf + rNeighbor` (spacing < 1) guarantees the
+            // footprints overlap. To keep the glyph on-canvas WITHOUT shrinking that distance (which
+            // could break the overlap), mirror the offset on any axis that would leave the margin —
+            // reflection preserves |offset|, so overlap with the neighbour is retained exactly. With
+            // dist <= MAX_SIZE (0.24) and a [MARGIN, 1-MARGIN] band of width 0.68 > 2*0.24, at least
+            // one direction per axis always lands in-bounds.
+            var dx = cos(angle) * dist
+            var dy = sin(angle) * dist
+            if (neighbor.cx + dx !in MARGIN..(1f - MARGIN)) dx = -dx
+            if (neighbor.cy + dy !in MARGIN..(1f - MARGIN)) dy = -dy
+
+            glyphs += ScribbleGlyph(
+                char = ALPHABET.random(random),
+                cx = neighbor.cx + dx,
+                cy = neighbor.cy + dy,
+                rotationDeg = randomRotation(random),
+                sizeFrac = size,
+            )
+        }
+
+        return Scribble(glyphs)
+    }
+
+    /** True iff glyph [a]'s circular footprint overlaps glyph [b]'s (centre distance < radius sum). */
+    fun overlaps(a: ScribbleGlyph, b: ScribbleGlyph): Boolean {
+        val centreDist = hypot(a.cx - b.cx, a.cy - b.cy)
+        return centreDist < (a.sizeFrac / 2f + b.sizeFrac / 2f)
+    }
+
+    private fun randomRotation(random: Random): Float = random.nextFloat() * 360f
+
+    private fun randomSize(random: Random): Float = MIN_SIZE + random.nextFloat() * (MAX_SIZE - MIN_SIZE)
+}

--- a/app/src/main/java/com/hereliesaz/graffitixr/onboarding/ScribbleView.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/onboarding/ScribbleView.kt
@@ -1,0 +1,56 @@
+package com.hereliesaz.graffitixr.onboarding
+
+import android.graphics.Paint
+import androidx.compose.foundation.Canvas
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.graphics.toArgb
+import kotlin.math.min
+
+/**
+ * Renders a [Scribble] — the glyphs are laid out in a normalized [0,1] square, so this scales the
+ * generator's output to whatever box the caller gives it. Each glyph is drawn centred on its
+ * ([ScribbleGlyph.cx], [ScribbleGlyph.cy]) and rotated by [ScribbleGlyph.rotationDeg]. A soft shadow
+ * keeps it legible over the live camera feed behind the overlay.
+ */
+@Composable
+fun ScribbleView(
+    scribble: Scribble,
+    modifier: Modifier = Modifier,
+    color: Color = Color.White,
+) {
+    val paint = remember(color) {
+        Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            this.color = color.toArgb()
+            textAlign = Paint.Align.CENTER
+            style = Paint.Style.FILL
+            isFakeBoldText = true
+            setShadowLayer(12f, 0f, 0f, android.graphics.Color.argb(200, 0, 0, 0))
+        }
+    }
+
+    Canvas(modifier) {
+        val w = size.width
+        val h = size.height
+        val edge = min(w, h)
+        drawIntoCanvas { canvas ->
+            val nc = canvas.nativeCanvas
+            scribble.glyphs.forEach { g ->
+                val px = g.cx * w
+                val py = g.cy * h
+                paint.textSize = g.sizeFrac * edge
+                val fm = paint.fontMetrics
+                // Paint draws text on the baseline; offset so the glyph's visual middle sits at py.
+                val baselineY = py - (fm.ascent + fm.descent) / 2f
+                nc.save()
+                nc.rotate(g.rotationDeg, px, py)
+                nc.drawText(g.char.toString(), px, baselineY, paint)
+                nc.restore()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/hereliesaz/graffitixr/onboarding/ScribbleView.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/onboarding/ScribbleView.kt
@@ -32,6 +32,9 @@ fun ScribbleView(
             setShadowLayer(12f, 0f, 0f, android.graphics.Color.argb(200, 0, 0, 0))
         }
     }
+    // Reused across glyphs and frames — the `paint.fontMetrics` getter allocates a fresh object each
+    // call, which we don't want in a continuously-rendered overlay's draw loop.
+    val fontMetrics = remember { Paint.FontMetrics() }
 
     Canvas(modifier) {
         val w = size.width
@@ -43,9 +46,9 @@ fun ScribbleView(
                 val px = g.cx * w
                 val py = g.cy * h
                 paint.textSize = g.sizeFrac * edge
-                val fm = paint.fontMetrics
+                paint.getFontMetrics(fontMetrics)
                 // Paint draws text on the baseline; offset so the glyph's visual middle sits at py.
-                val baselineY = py - (fm.ascent + fm.descent) / 2f
+                val baselineY = py - (fontMetrics.ascent + fontMetrics.descent) / 2f
                 nc.save()
                 nc.rotate(g.rotationDeg, px, py)
                 nc.drawText(g.char.toString(), px, baselineY, paint)

--- a/app/src/main/java/com/hereliesaz/graffitixr/onboarding/ScribbleView.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/onboarding/ScribbleView.kt
@@ -1,5 +1,7 @@
 package com.hereliesaz.graffitixr.onboarding
 
+import android.graphics.Bitmap
+import android.graphics.Canvas as AndroidCanvas
 import android.graphics.Paint
 import androidx.compose.foundation.Canvas
 import androidx.compose.runtime.Composable
@@ -41,19 +43,47 @@ fun ScribbleView(
         val h = size.height
         val edge = min(w, h)
         drawIntoCanvas { canvas ->
-            val nc = canvas.nativeCanvas
-            scribble.glyphs.forEach { g ->
-                val px = g.cx * w
-                val py = g.cy * h
-                paint.textSize = g.sizeFrac * edge
-                paint.getFontMetrics(fontMetrics)
-                // Paint draws text on the baseline; offset so the glyph's visual middle sits at py.
-                val baselineY = py - (fontMetrics.ascent + fontMetrics.descent) / 2f
-                nc.save()
-                nc.rotate(g.rotationDeg, px, py)
-                nc.drawText(g.char.toString(), px, baselineY, paint)
-                nc.restore()
-            }
+            drawScribble(canvas.nativeCanvas, scribble, w, h, edge, paint, fontMetrics)
         }
+    }
+}
+
+/**
+ * Rasterizes a [Scribble] into a transparent square [Bitmap] of [sizePx] — used as the AR overlay
+ * texture during the first-run doodle demo. Same glyph layout/rotation as [ScribbleView]; drawn
+ * as filled white so it reads on the wall (the overlay renderer applies it as a texture).
+ */
+fun renderScribbleBitmap(scribble: Scribble, sizePx: Int, color: Color = Color.White): Bitmap {
+    val bmp = Bitmap.createBitmap(sizePx, sizePx, Bitmap.Config.ARGB_8888)
+    val paint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        this.color = color.toArgb()
+        textAlign = Paint.Align.CENTER
+        style = Paint.Style.FILL
+        isFakeBoldText = true
+    }
+    drawScribble(AndroidCanvas(bmp), scribble, sizePx.toFloat(), sizePx.toFloat(), sizePx.toFloat(), paint, Paint.FontMetrics())
+    return bmp
+}
+
+private fun drawScribble(
+    nc: AndroidCanvas,
+    scribble: Scribble,
+    w: Float,
+    h: Float,
+    edge: Float,
+    paint: Paint,
+    fontMetrics: Paint.FontMetrics,
+) {
+    scribble.glyphs.forEach { g ->
+        val px = g.cx * w
+        val py = g.cy * h
+        paint.textSize = g.sizeFrac * edge
+        paint.getFontMetrics(fontMetrics)
+        // Paint draws text on the baseline; offset so the glyph's visual middle sits at py.
+        val baselineY = py - (fontMetrics.ascent + fontMetrics.descent) / 2f
+        nc.save()
+        nc.rotate(g.rotationDeg, px, py)
+        nc.drawText(g.char.toString(), px, baselineY, paint)
+        nc.restore()
     }
 }

--- a/app/src/test/java/com/hereliesaz/graffitixr/onboarding/ScribbleGeneratorTest.kt
+++ b/app/src/test/java/com/hereliesaz/graffitixr/onboarding/ScribbleGeneratorTest.kt
@@ -1,0 +1,69 @@
+package com.hereliesaz.graffitixr.onboarding
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.random.Random
+
+class ScribbleGeneratorTest {
+
+    // Cover a wide, fixed seed range so the placement invariants are checked deterministically
+    // (no flakiness) across many random layouts.
+    private val seeds = 0L until 2000L
+
+    @Test
+    fun `glyph count respects the complexity cap and floor`() {
+        seeds.forEach { seed ->
+            val s = ScribbleGenerator.generate(Random(seed))
+            assertTrue(
+                "seed=$seed count=${s.glyphs.size}",
+                s.glyphs.size in ScribbleGenerator.MIN_GLYPHS..ScribbleGenerator.MAX_GLYPHS,
+            )
+        }
+    }
+
+    @Test
+    fun `explicit glyphCount is coerced into the allowed band`() {
+        assertEquals(ScribbleGenerator.MIN_GLYPHS, ScribbleGenerator.generate(Random(1), glyphCount = 0).glyphs.size)
+        assertEquals(ScribbleGenerator.MAX_GLYPHS, ScribbleGenerator.generate(Random(1), glyphCount = 99).glyphs.size)
+    }
+
+    @Test
+    fun `every glyph centre stays within the canvas`() {
+        seeds.forEach { seed ->
+            ScribbleGenerator.generate(Random(seed)).glyphs.forEach { g ->
+                assertTrue("seed=$seed cx=${g.cx}", g.cx in 0f..1f)
+                assertTrue("seed=$seed cy=${g.cy}", g.cy in 0f..1f)
+            }
+        }
+    }
+
+    @Test
+    fun `every glyph overlaps at least one other glyph`() {
+        seeds.forEach { seed ->
+            val glyphs = ScribbleGenerator.generate(Random(seed)).glyphs
+            glyphs.forEachIndexed { i, g ->
+                val hasOverlap = glyphs.withIndex().any { (j, other) ->
+                    j != i && ScribbleGenerator.overlaps(g, other)
+                }
+                assertTrue("seed=$seed glyph[$i]='${g.char}' has no overlapping neighbour", hasOverlap)
+            }
+        }
+    }
+
+    @Test
+    fun `same seed yields identical scribble`() {
+        val a = ScribbleGenerator.generate(Random(42))
+        val b = ScribbleGenerator.generate(Random(42))
+        assertEquals(a, b)
+    }
+
+    @Test
+    fun `rotation is within a full turn`() {
+        seeds.forEach { seed ->
+            ScribbleGenerator.generate(Random(seed)).glyphs.forEach { g ->
+                assertTrue("seed=$seed rot=${g.rotationDeg}", g.rotationDeg in 0f..360f)
+            }
+        }
+    }
+}

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/UiState.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/UiState.kt
@@ -31,6 +31,12 @@ data class ArUiState(
     // True once a target fingerprint has been saved to the current project.
     // Controls whether artwork is rendered in AR space (via OverlayRenderer).
     val isAnchorEstablished: Boolean = false,
+    // First-run onboarding signals. isArReady flips true the first frame ARCore reports TRACKING
+    // (ARCore has finished initializing); planeDetected flips true the first time a tracking plane
+    // is found. Both are latching (never reset within a session) and drive the onboarding overlay's
+    // stage transitions (show movement guidance until a surface appears, etc.).
+    val isArReady: Boolean = false,
+    val planeDetected: Boolean = false,
     val isFlashlightOn: Boolean = false,
     val lightLevel: Float = 1.0f,
     val tempCaptureBitmap: Bitmap? = null,

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/UiState.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/UiState.kt
@@ -41,6 +41,8 @@ data class ArUiState(
     // indicator), and a latching flag set once it has held long enough to swap in the user's artwork.
     val doodleLockStability: Float = 0f,
     val doodleLocked: Boolean = false,
+    // Wall stats from the doodle capture, used to auto-tune the artwork's adjustments on the swap.
+    val doodleWallStats: com.hereliesaz.graffitixr.common.util.ImageStats? = null,
     val isFlashlightOn: Boolean = false,
     val lightLevel: Float = 1.0f,
     val tempCaptureBitmap: Bitmap? = null,

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/UiState.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/UiState.kt
@@ -37,6 +37,10 @@ data class ArUiState(
     // stage transitions (show movement guidance until a surface appears, etc.).
     val isArReady: Boolean = false,
     val planeDetected: Boolean = false,
+    // First-run doodle demo: 0..1 "how steadily is the scribble overlay holding" (drives a hold-steady
+    // indicator), and a latching flag set once it has held long enough to swap in the user's artwork.
+    val doodleLockStability: Float = 0f,
+    val doodleLocked: Boolean = false,
     val isFlashlightOn: Boolean = false,
     val lightLevel: Float = 1.0f,
     val tempCaptureBitmap: Bitmap? = null,

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/util/AutoTune.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/util/AutoTune.kt
@@ -1,0 +1,120 @@
+package com.hereliesaz.graffitixr.common.util
+
+import kotlin.math.abs
+import kotlin.math.sqrt
+
+/**
+ * Summary statistics of an image region, in 0..255 space. [luminance] is Rec.601; [contrast] is the
+ * luminance standard deviation. Computed over opaque pixels only (transparent artwork pixels don't
+ * describe the artwork).
+ */
+data class ImageStats(
+    val meanR: Float,
+    val meanG: Float,
+    val meanB: Float,
+    val luminance: Float,
+    val contrast: Float,
+) {
+    companion object {
+        val NEUTRAL = ImageStats(128f, 128f, 128f, 128f, 0f)
+    }
+}
+
+/**
+ * Adjustment values in the exact conventions `createColorMatrix` + the layer opacity use:
+ * [brightness] additive (0 neutral), [contrast]/[saturation]/[colorBalance*] multiplicative
+ * (1 neutral), [opacity] 0..1. Fed straight into the layer's adjustment setters.
+ */
+data class AutoTuneResult(
+    val opacity: Float,
+    val brightness: Float,
+    val contrast: Float,
+    val saturation: Float,
+    val colorBalanceR: Float,
+    val colorBalanceG: Float,
+    val colorBalanceB: Float,
+)
+
+/**
+ * Pure luminance/colour statistics over ARGB pixels. Transparent pixels (alpha below [minAlpha]) are
+ * skipped so isolated artwork is measured by its visible ink, not its empty margins. Returns
+ * [ImageStats.NEUTRAL] when nothing is opaque. Kept Android-free so both the wall-frame and artwork
+ * paths, and the tests, share one implementation.
+ */
+fun computeImageStats(pixels: IntArray, minAlpha: Int = 16): ImageStats {
+    var sr = 0.0
+    var sg = 0.0
+    var sb = 0.0
+    var sl = 0.0
+    var sll = 0.0
+    var n = 0
+    for (p in pixels) {
+        val a = (p ushr 24) and 0xFF
+        if (a < minAlpha) continue
+        val r = (p ushr 16) and 0xFF
+        val g = (p ushr 8) and 0xFF
+        val b = p and 0xFF
+        val lum = 0.299 * r + 0.587 * g + 0.114 * b
+        sr += r; sg += g; sb += b; sl += lum; sll += lum * lum
+        n++
+    }
+    if (n == 0) return ImageStats.NEUTRAL
+    val inv = 1.0 / n
+    val ml = sl * inv
+    val variance = (sll * inv - ml * ml).coerceAtLeast(0.0)
+    return ImageStats(
+        meanR = (sr * inv).toFloat(),
+        meanG = (sg * inv).toFloat(),
+        meanB = (sb * inv).toFloat(),
+        luminance = ml.toFloat(),
+        contrast = sqrt(variance).toFloat(),
+    )
+}
+
+/**
+ * Derives "optimal" starting adjustments so freshly-placed artwork reads well against the wall it's
+ * projected onto. Conservative and clamped — a sensible first pass the user then fine-tunes with the
+ * knobs, not a final grade. Heuristics:
+ *  - **opacity**: busier walls (higher [ImageStats.contrast]) get slightly more opaque art so the
+ *    wall texture doesn't show through and fight the design.
+ *  - **brightness**: nudge the art's luminance toward the wall's so it reads as painted-on, not pasted.
+ *  - **contrast**: gently lift low-contrast art.
+ *  - **saturation**: a modest pop, more when the wall is drab.
+ *  - **colour balance**: tint the art toward the wall's colour cast so it integrates under that light.
+ */
+fun computeAutoTune(wall: ImageStats, art: ImageStats): AutoTuneResult {
+    val opacity = (0.9f - (wall.contrast / 128f) * 0.25f).coerceIn(0.6f, 0.9f)
+
+    val lumDelta = (wall.luminance - art.luminance) / 255f
+    val brightness = (lumDelta * 0.25f).coerceIn(-0.2f, 0.2f)
+
+    val contrast = (1f + ((60f - art.contrast).coerceAtLeast(0f) / 60f) * 0.25f).coerceIn(1f, 1.25f)
+
+    val wallColorfulness = colorfulness(wall)
+    val saturation = (1.1f + (1f - wallColorfulness) * 0.15f).coerceIn(1.0f, 1.3f)
+
+    val wallMean = ((wall.meanR + wall.meanG + wall.meanB) / 3f).coerceAtLeast(1f)
+    val cbR = castNudge(wall.meanR / wallMean)
+    val cbG = castNudge(wall.meanG / wallMean)
+    val cbB = castNudge(wall.meanB / wallMean)
+
+    return AutoTuneResult(
+        opacity = opacity,
+        brightness = brightness,
+        contrast = contrast,
+        saturation = saturation,
+        colorBalanceR = cbR,
+        colorBalanceG = cbG,
+        colorBalanceB = cbB,
+    )
+}
+
+/** 0..1 how far the mean colour departs from grey — 0 for a neutral wall, higher for a coloured one. */
+private fun colorfulness(s: ImageStats): Float {
+    val mean = (s.meanR + s.meanG + s.meanB) / 3f
+    val spread = (abs(s.meanR - mean) + abs(s.meanG - mean) + abs(s.meanB - mean)) / 3f
+    return (spread / 64f).coerceIn(0f, 1f)
+}
+
+/** Turn a per-channel wall-cast ratio (channel/meanChannel, ~1 = neutral) into a gentle, clamped tint. */
+private fun castNudge(ratio: Float): Float = (1f + (ratio - 1f) * 0.5f).coerceIn(0.85f, 1.15f)

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/util/BitmapStats.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/util/BitmapStats.kt
@@ -1,0 +1,20 @@
+package com.hereliesaz.graffitixr.common.util
+
+import android.graphics.Bitmap
+
+/**
+ * Android bridge for [computeImageStats]: downsamples to at most [sampleEdge] on the long side (stats
+ * don't need full resolution and a 4K frame would allocate a 30MB IntArray) and reads the pixels.
+ * Keeps [computeImageStats] itself Android-free and unit-testable.
+ */
+fun Bitmap.imageStats(sampleEdge: Int = 64): ImageStats {
+    val longest = maxOf(width, height)
+    val scaled = if (longest > sampleEdge) {
+        val s = sampleEdge.toFloat() / longest
+        Bitmap.createScaledBitmap(this, (width * s).toInt().coerceAtLeast(1), (height * s).toInt().coerceAtLeast(1), true)
+    } else this
+    val px = IntArray(scaled.width * scaled.height)
+    scaled.getPixels(px, 0, scaled.width, 0, 0, scaled.width, scaled.height)
+    if (scaled !== this) scaled.recycle()
+    return computeImageStats(px)
+}

--- a/core/common/src/test/java/com/hereliesaz/graffitixr/common/util/AutoTuneTest.kt
+++ b/core/common/src/test/java/com/hereliesaz/graffitixr/common/util/AutoTuneTest.kt
@@ -1,0 +1,89 @@
+package com.hereliesaz.graffitixr.common.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AutoTuneTest {
+
+    private fun argb(a: Int, r: Int, g: Int, b: Int): Int =
+        (a shl 24) or (r shl 16) or (g shl 8) or b
+
+    @Test
+    fun `stats over a flat grey are that grey with zero contrast`() {
+        val px = IntArray(100) { argb(255, 100, 100, 100) }
+        val s = computeImageStats(px)
+        assertEquals(100f, s.meanR, 0.5f)
+        assertEquals(100f, s.luminance, 0.5f)
+        assertEquals(0f, s.contrast, 0.5f)
+    }
+
+    @Test
+    fun `transparent pixels are ignored`() {
+        // Half opaque white, half transparent black — mean should reflect white only.
+        val px = IntArray(100) { i -> if (i < 50) argb(255, 200, 200, 200) else argb(0, 0, 0, 0) }
+        val s = computeImageStats(px)
+        assertEquals(200f, s.meanR, 0.5f)
+    }
+
+    @Test
+    fun `all-transparent yields neutral`() {
+        val px = IntArray(50) { argb(0, 255, 255, 255) }
+        assertEquals(ImageStats.NEUTRAL, computeImageStats(px))
+    }
+
+    @Test
+    fun `contrast reflects luminance spread`() {
+        // Half black, half white → high stddev.
+        val px = IntArray(100) { i -> if (i < 50) argb(255, 0, 0, 0) else argb(255, 255, 255, 255) }
+        val s = computeImageStats(px)
+        assertTrue("contrast=${s.contrast}", s.contrast > 100f)
+    }
+
+    @Test
+    fun `all outputs are within the documented clamps`() {
+        val walls = listOf(
+            ImageStats(20f, 20f, 20f, 20f, 5f),      // dark, flat
+            ImageStats(240f, 240f, 240f, 240f, 3f),  // bright, flat
+            ImageStats(180f, 90f, 60f, 110f, 70f),   // warm, busy
+        )
+        val arts = listOf(
+            ImageStats(128f, 128f, 128f, 128f, 10f),
+            ImageStats(200f, 50f, 50f, 90f, 55f),
+        )
+        for (w in walls) for (a in arts) {
+            val r = computeAutoTune(w, a)
+            assertTrue(r.opacity in 0.6f..0.9f)
+            assertTrue(r.brightness in -0.2f..0.2f)
+            assertTrue(r.contrast in 1f..1.25f)
+            assertTrue(r.saturation in 1.0f..1.3f)
+            assertTrue(r.colorBalanceR in 0.85f..1.15f)
+            assertTrue(r.colorBalanceG in 0.85f..1.15f)
+            assertTrue(r.colorBalanceB in 0.85f..1.15f)
+        }
+    }
+
+    @Test
+    fun `dark wall pulls bright art darker`() {
+        val darkWall = ImageStats(20f, 20f, 20f, 20f, 5f)
+        val brightArt = ImageStats(220f, 220f, 220f, 220f, 10f)
+        assertTrue(computeAutoTune(darkWall, brightArt).brightness < 0f)
+    }
+
+    @Test
+    fun `warm wall tints art warm - R up, B down`() {
+        val warmWall = ImageStats(200f, 110f, 60f, 120f, 20f)
+        val art = ImageStats(128f, 128f, 128f, 128f, 20f)
+        val r = computeAutoTune(warmWall, art)
+        assertTrue("cbR=${r.colorBalanceR}", r.colorBalanceR > 1f)
+        assertTrue("cbB=${r.colorBalanceB}", r.colorBalanceB < 1f)
+    }
+
+    @Test
+    fun `busy wall is more opaque than flat wall`() {
+        val flat = ImageStats(128f, 128f, 128f, 128f, 2f)
+        val busy = ImageStats(128f, 128f, 128f, 128f, 100f)
+        val art = ImageStats(128f, 128f, 128f, 128f, 20f)
+        assertTrue(computeAutoTune(busy, art).opacity < computeAutoTune(flat, art).opacity)
+    }
+}

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/AnchorLockTracker.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/AnchorLockTracker.kt
@@ -1,0 +1,91 @@
+package com.hereliesaz.graffitixr.feature.ar
+
+import kotlin.math.sqrt
+
+/**
+ * Pragmatic "has the overlay anchored to one spot?" gate for the first-run doodle demo.
+ *
+ * Fed the anchor's world-space translation once per frame, it keeps a sliding window of the last
+ * [windowSize] positions and reports [locked] once the window is full AND its spatial jitter — the
+ * farthest any sample sits from the window centroid — has stayed under [jitterThresholdMeters]. A
+ * full 30-sample window at ~30 fps means the anchor held one location for ~1 second, which is the
+ * "consistently anchored" signal we swap the scribble for the user's artwork on.
+ *
+ * [locked] latches: once true it stays true until [reset], so a single post-lock jitter frame can't
+ * un-fire the swap mid-transition. Pure/deterministic and Android-free for unit testing; the choice
+ * of a pragmatic jitter gate (vs. bootstrapping a fingerprint and gating on PnP pose stability) is
+ * deliberate — see PR notes.
+ */
+class AnchorLockTracker(
+    private val windowSize: Int = 30,
+    private val jitterThresholdMeters: Float = 0.01f,
+) {
+    init {
+        require(windowSize >= 2) { "windowSize must be >= 2, was $windowSize" }
+        require(jitterThresholdMeters > 0f) { "jitterThresholdMeters must be > 0" }
+    }
+
+    private val xs = FloatArray(windowSize)
+    private val ys = FloatArray(windowSize)
+    private val zs = FloatArray(windowSize)
+    private var count = 0
+    private var head = 0
+
+    /** True once the anchor has held one spot for a full window; latches until [reset]. */
+    var locked = false
+        private set
+
+    /** Farthest sample from the window centroid, in meters. `Float.MAX_VALUE` until the window fills. */
+    var jitterMeters = Float.MAX_VALUE
+        private set
+
+    /** 0..1 "how still is it" for UI (1 = dead still). 0 until the window fills. */
+    var stability = 0f
+        private set
+
+    fun reset() {
+        count = 0
+        head = 0
+        locked = false
+        jitterMeters = Float.MAX_VALUE
+        stability = 0f
+    }
+
+    /** Feed one anchor world position; returns the current [locked] state. */
+    fun update(x: Float, y: Float, z: Float): Boolean {
+        xs[head] = x
+        ys[head] = y
+        zs[head] = z
+        head = (head + 1) % windowSize
+        if (count < windowSize) count++
+        recompute()
+        return locked
+    }
+
+    private fun recompute() {
+        if (count < windowSize) {
+            jitterMeters = Float.MAX_VALUE
+            stability = 0f
+            return
+        }
+        var cx = 0f
+        var cy = 0f
+        var cz = 0f
+        for (i in 0 until windowSize) {
+            cx += xs[i]; cy += ys[i]; cz += zs[i]
+        }
+        cx /= windowSize; cy /= windowSize; cz /= windowSize
+
+        var maxD = 0f
+        for (i in 0 until windowSize) {
+            val dx = xs[i] - cx
+            val dy = ys[i] - cy
+            val dz = zs[i] - cz
+            val d = sqrt(dx * dx + dy * dy + dz * dz)
+            if (d > maxD) maxD = d
+        }
+        jitterMeters = maxD
+        stability = (1f - maxD / jitterThresholdMeters).coerceIn(0f, 1f)
+        if (maxD < jitterThresholdMeters) locked = true
+    }
+}

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -20,6 +20,7 @@ import androidx.lifecycle.viewModelScope
 import com.google.ar.core.CameraConfig
 import com.google.ar.core.CameraConfigFilter
 import com.hereliesaz.graffitixr.common.DispatcherProvider
+import com.hereliesaz.graffitixr.common.util.imageStats
 import com.hereliesaz.graffitixr.feature.ar.anchor.MetricFingerprintBuilder
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.isActive
@@ -1983,6 +1984,11 @@ class ArViewModel @Inject constructor(
         val anchor = slamManager.getAnchorTransform()
         viewModelScope.launch(Dispatchers.IO) {
             try {
+                // Capture the wall's colour/luminance so the artwork can be auto-tuned to it on the
+                // swap. Computed every attempt so it's fresh even on the timeout (no-fingerprint) path.
+                val wallStats = rotated.imageStats()
+                _uiState.update { it.copy(doodleWallStats = wallStats) }
+
                 val fp = MetricFingerprintBuilder.buildSingle(
                     slamManager, rotated, viewMatrix, intr, planePoint, planeNormal, anchor
                 )

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -1412,6 +1412,8 @@ class ArViewModel @Inject constructor(
             }
             state.copy(
                 isScanning = isTracking,
+                // Latches true on the first TRACKING frame — "ARCore has finished initializing".
+                isArReady = state.isArReady || isTracking,
                 splatCount = splatCount,
                 immutableSplatCount = immutableSplatCount,
                 isDepthApiSupported = isDepthApiSupported,
@@ -1877,6 +1879,15 @@ class ArViewModel @Inject constructor(
      */
     fun onPrimaryAnchorEstablished() {
         _uiState.update { it.copy(isAnchorEstablished = true) }
+    }
+
+    /**
+     * Fired once by the renderer (GL thread) when the first tracking plane appears. Latches
+     * [ArUiState.planeDetected] so the onboarding overlay can drop the "move your device" guidance.
+     * MutableStateFlow.update is thread-safe, matching onPrimaryAnchorEstablished above.
+     */
+    fun onFirstPlaneDetected() {
+        _uiState.update { if (it.planeDetected) it else it.copy(planeDetected = true) }
     }
 
     fun appendDiag(text: String) {

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -1890,6 +1890,16 @@ class ArViewModel @Inject constructor(
         _uiState.update { if (it.planeDetected) it else it.copy(planeDetected = true) }
     }
 
+    /** Doodle demo (GL thread): report anchor-hold stability for the hold-steady indicator. */
+    fun onDoodleLockProgress(stability: Float) {
+        _uiState.update { it.copy(doodleLockStability = stability) }
+    }
+
+    /** Doodle demo (GL thread): the overlay has held one spot long enough — trigger the artwork swap. */
+    fun onDoodleLocked() {
+        _uiState.update { if (it.doodleLocked) it else it.copy(doodleLocked = true) }
+    }
+
     fun appendDiag(text: String) {
         _uiState.update { state ->
             val existing = state.diagLog?.lines() ?: emptyList()

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -1629,8 +1629,10 @@ class ArViewModel @Inject constructor(
         wallPlane: FloatArray? = null
     ) {
         // Doodle demo: a headless capture (no tap, no review) — build the fingerprint from the
-        // drawing and return before the normal capture/review flow runs.
+        // drawing and return before the normal capture/review flow runs. Clear the capture-request
+        // flag ourselves (the normal paths below do this) so the renderer isn't re-armed every frame.
         if (doodlePhaseActive && !doodleFingerprintBuilt) {
+            onCaptureRequestHandled()
             buildDoodleFingerprint(bitmap, intrinsics, viewMatrix, displayRotation)
             return
         }
@@ -1916,8 +1918,12 @@ class ArViewModel @Inject constructor(
         // After this long without a relocalization lock (featureless wall), place on the plain anchor.
         const val DOODLE_LOCK_TIMEOUT_MS = 30_000L
     }
-    private var doodlePhaseActive = false
-    private var doodleFingerprintBuilt = false
+    // @Volatile: written on main (setDoodlePhase) / IO (build result) and read on the GL thread
+    // (onTargetCaptured), so the GL thread must observe the latest value.
+    @Volatile private var doodlePhaseActive = false
+    @Volatile private var doodleFingerprintBuilt = false
+    // Guards against re-entrant builds if captures arrive faster than a build completes.
+    @Volatile private var doodleBuildInFlight = false
     private var doodleCaptureJob: Job? = null
 
     /**
@@ -1959,12 +1965,15 @@ class ArViewModel @Inject constructor(
 
     /** Build a fingerprint from a headless doodle capture; sets doodleFingerprintBuilt on success. */
     private fun buildDoodleFingerprint(bitmap: Bitmap, intrinsics: FloatArray?, viewMatrix: FloatArray, displayRotation: Int) {
+        // Only one build in flight — captures can arrive faster than a native build completes.
+        if (doodleBuildInFlight) return
         val plane = renderer?.doodleWallPlane
         val intr = intrinsics
         if (plane == null || plane.size < 6 || intr == null) {
             slamManager.setMappingPaused(false)
             return
         }
+        doodleBuildInFlight = true
         val rotated = if (displayRotation != 0) {
             val m = android.graphics.Matrix().apply { postRotate(displayRotation.toFloat()) }
             Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, m, true)
@@ -1985,6 +1994,7 @@ class ArViewModel @Inject constructor(
                 // wedge SLAM with mapping paused for the rest of the session.
                 slamManager.setMappingPaused(false)
                 slamManager.setSplatsVisible(true)
+                doodleBuildInFlight = false
             }
         }
     }

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -1911,6 +1911,11 @@ class ArViewModel @Inject constructor(
     }
 
     // --- Doodle demo: headless fingerprint build ---
+    private companion object {
+        const val DOODLE_CAPTURE_INTERVAL_MS = 2500L
+        // After this long without a relocalization lock (featureless wall), place on the plain anchor.
+        const val DOODLE_LOCK_TIMEOUT_MS = 30_000L
+    }
     private var doodlePhaseActive = false
     private var doodleFingerprintBuilt = false
     private var doodleCaptureJob: Job? = null
@@ -1929,12 +1934,20 @@ class ArViewModel @Inject constructor(
             doodleFingerprintBuilt = false
             slamManager.overlayMarkCenterLocal = null
             doodleCaptureJob = viewModelScope.launch {
-                while (isActive && doodlePhaseActive && !doodleFingerprintBuilt) {
-                    delay(2500)
-                    if (_uiState.value.isAnchorEstablished && !doodleFingerprintBuilt &&
-                        renderer?.doodleWallPlane != null
-                    ) {
+                // Deadline starts once we actually have an anchor to build against.
+                var deadlineMs = 0L
+                while (isActive && doodlePhaseActive && !_uiState.value.doodleLocked) {
+                    delay(DOODLE_CAPTURE_INTERVAL_MS)
+                    if (!_uiState.value.isAnchorEstablished || renderer?.doodleWallPlane == null) continue
+                    if (deadlineMs == 0L) deadlineMs = System.currentTimeMillis() + DOODLE_LOCK_TIMEOUT_MS
+                    if (!doodleFingerprintBuilt) {
                         requestCapture() // no onScreenTap → no tap; onTargetCaptured builds headlessly
+                    }
+                    // Graceful fallback: on a featureless wall relocalization may never converge. Rather
+                    // than hang forever, after the timeout place the artwork on the plain anchor so the
+                    // user still ends up with art stuck to the wall.
+                    if (System.currentTimeMillis() >= deadlineMs && !_uiState.value.doodleLocked) {
+                        onDoodleLocked()
                     }
                 }
             }
@@ -1960,13 +1973,19 @@ class ArViewModel @Inject constructor(
         val planeNormal = floatArrayOf(plane[3], plane[4], plane[5])
         val anchor = slamManager.getAnchorTransform()
         viewModelScope.launch(Dispatchers.IO) {
-            val fp = MetricFingerprintBuilder.buildSingle(
-                slamManager, rotated, viewMatrix, intr, planePoint, planeNormal, anchor
-            )
-            if (fp != null) doodleFingerprintBuilt = true
-            // Resume mapping that requestCapture paused, regardless of outcome.
-            slamManager.setMappingPaused(false)
-            slamManager.setSplatsVisible(true)
+            try {
+                val fp = MetricFingerprintBuilder.buildSingle(
+                    slamManager, rotated, viewMatrix, intr, planePoint, planeNormal, anchor
+                )
+                if (fp != null) doodleFingerprintBuilt = true
+            } catch (t: Throwable) {
+                android.util.Log.w("ArViewModel", "Doodle fingerprint build failed", t)
+            } finally {
+                // Always resume the mapping that requestCapture paused — otherwise a throw would
+                // wedge SLAM with mapping paused for the rest of the session.
+                slamManager.setMappingPaused(false)
+                slamManager.setSplatsVisible(true)
+            }
         }
     }
 

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -20,6 +20,9 @@ import androidx.lifecycle.viewModelScope
 import com.google.ar.core.CameraConfig
 import com.google.ar.core.CameraConfigFilter
 import com.hereliesaz.graffitixr.common.DispatcherProvider
+import com.hereliesaz.graffitixr.feature.ar.anchor.MetricFingerprintBuilder
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.isActive
 import com.google.ar.core.Config
 import com.google.ar.core.Session
 import com.google.ar.core.TrackingState
@@ -1625,6 +1628,13 @@ class ArViewModel @Inject constructor(
         tapDistanceMeters: Float,
         wallPlane: FloatArray? = null
     ) {
+        // Doodle demo: a headless capture (no tap, no review) — build the fingerprint from the
+        // drawing and return before the normal capture/review flow runs.
+        if (doodlePhaseActive && !doodleFingerprintBuilt) {
+            buildDoodleFingerprint(bitmap, intrinsics, viewMatrix, displayRotation)
+            return
+        }
+
         val tapPos = pendingTapPosition
         val extent = computePhysicalExtent(depthBuffer, depthBufW, depthBufH, colorW, colorH, intrinsics, depthBufStride)
 
@@ -1898,6 +1908,66 @@ class ArViewModel @Inject constructor(
     /** Doodle demo (GL thread): the overlay has held one spot long enough — trigger the artwork swap. */
     fun onDoodleLocked() {
         _uiState.update { if (it.doodleLocked) it else it.copy(doodleLocked = true) }
+    }
+
+    // --- Doodle demo: headless fingerprint build ---
+    private var doodlePhaseActive = false
+    private var doodleFingerprintBuilt = false
+    private var doodleCaptureJob: Job? = null
+
+    /**
+     * Host tells us when the first-run doodle overlay is up. While active we periodically capture the
+     * live frame (no tap) and try to build a wall fingerprint from whatever the user has drawn; the
+     * builder returns null until there's enough texture, so this self-times to "they've drawn enough".
+     * Once a fingerprint is set, native relocalization + self-grow run automatically and the renderer's
+     * inlier-gated lock can fire. Purist teleological path — the fingerprint IS the demo.
+     */
+    fun setDoodlePhase(active: Boolean) {
+        if (doodlePhaseActive == active) return
+        doodlePhaseActive = active
+        if (active) {
+            doodleFingerprintBuilt = false
+            slamManager.overlayMarkCenterLocal = null
+            doodleCaptureJob = viewModelScope.launch {
+                while (isActive && doodlePhaseActive && !doodleFingerprintBuilt) {
+                    delay(2500)
+                    if (_uiState.value.isAnchorEstablished && !doodleFingerprintBuilt &&
+                        renderer?.doodleWallPlane != null
+                    ) {
+                        requestCapture() // no onScreenTap → no tap; onTargetCaptured builds headlessly
+                    }
+                }
+            }
+        } else {
+            doodleCaptureJob?.cancel()
+            doodleCaptureJob = null
+        }
+    }
+
+    /** Build a fingerprint from a headless doodle capture; sets doodleFingerprintBuilt on success. */
+    private fun buildDoodleFingerprint(bitmap: Bitmap, intrinsics: FloatArray?, viewMatrix: FloatArray, displayRotation: Int) {
+        val plane = renderer?.doodleWallPlane
+        val intr = intrinsics
+        if (plane == null || plane.size < 6 || intr == null) {
+            slamManager.setMappingPaused(false)
+            return
+        }
+        val rotated = if (displayRotation != 0) {
+            val m = android.graphics.Matrix().apply { postRotate(displayRotation.toFloat()) }
+            Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, m, true)
+        } else bitmap
+        val planePoint = floatArrayOf(plane[0], plane[1], plane[2])
+        val planeNormal = floatArrayOf(plane[3], plane[4], plane[5])
+        val anchor = slamManager.getAnchorTransform()
+        viewModelScope.launch(Dispatchers.IO) {
+            val fp = MetricFingerprintBuilder.buildSingle(
+                slamManager, rotated, viewMatrix, intr, planePoint, planeNormal, anchor
+            )
+            if (fp != null) doodleFingerprintBuilt = true
+            // Resume mapping that requestCapture paused, regardless of outcome.
+            slamManager.setMappingPaused(false)
+            slamManager.setSplatsVisible(true)
+        }
     }
 
     fun appendDiag(text: String) {

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -278,7 +278,6 @@ class ArRenderer(
     // when active the renderer auto-establishes a wall anchor, and (once the host has built a
     // fingerprint from the user's drawing) tracks the fused mark-PnP pose, firing onDoodleLocked when
     // it holds steady AND relocalization is confident (DOODLE_MIN_RELOC_INLIERS).
-    var doodleLockActive = false
     private val anchorLockTracker = AnchorLockTracker()
     private var doodleLockReported = false
     private var doodleAutoAnchorRequested = false
@@ -288,6 +287,21 @@ class ArRenderer(
     @Volatile
     var doodleWallPlane: FloatArray? = null
         private set
+
+    // @Volatile: set on the UI thread (MainScreen update), read on the GL thread. Setting it true
+    // after it was false (a fresh onboarding on this renderer instance) clears the one-shot latches so
+    // the auto-anchor + lock can run again — otherwise a retried phase would be permanently disabled.
+    @Volatile
+    var doodleLockActive: Boolean = false
+        set(value) {
+            if (value && !field) {
+                doodleLockReported = false
+                doodleAutoAnchorRequested = false
+                doodleWallPlane = null
+                anchorLockTracker.reset()
+            }
+            field = value
+        }
     // Render-thread stall watchdog. The GL thread can block inside session.update() forever when the
     // camera never feeds ARCore; a side thread watches these markers and reports the stuck step on
     // screen (the blocked GL thread can't report for itself).

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -44,6 +44,10 @@ class ArRenderer(
     // created. The ViewModel uses this to flip ArUiState.isAnchorEstablished,
     // which in turn unlocks the Design rail and advances scanPhase to COMPLETE.
     private val onAnchorEstablished: () -> Unit = {},
+    // Fired once on the GL thread the first time a tracking plane is found. The
+    // ViewModel flips ArUiState.planeDetected so first-run onboarding can drop
+    // the "move your device" guidance once a surface exists.
+    private val onPlaneDetected: () -> Unit = {},
     // Fired from the GL thread when ARCore has been stuck not-tracking for a
     // sustained run of frames (true) or recovers (false). MainScreen uses this
     // to drop the GLSurfaceView render mode to WHEN_DIRTY so the saturated
@@ -261,6 +265,8 @@ class ArRenderer(
     // if no camera frame has arrived a few seconds after the session started driving.
     private var camStreamReported = false
     private var camStallWarned = false
+    // One-shot: true once the first tracking plane has been reported via onPlaneDetected.
+    private var planeDetectedReported = false
     // Render-thread stall watchdog. The GL thread can block inside session.update() forever when the
     // camera never feeds ARCore; a side thread watches these markers and reports the stuck step on
     // screen (the blocked GL thread can't report for itself).
@@ -936,6 +942,19 @@ class ArRenderer(
 
             lastStep = "slamCamera"
             val isTracking = camera.trackingState == TrackingState.TRACKING
+
+            // First-run onboarding: report the first tracking plane exactly once. getAllTrackables is
+            // not free, so only poll (throttled) until we've reported, then this is a single boolean
+            // check per frame forever after.
+            if (!planeDetectedReported && isTracking && frameCount % 30 == 0) {
+                val hasPlane = activeSession.getAllTrackables(com.google.ar.core.Plane::class.java)
+                    .any { it.trackingState == TrackingState.TRACKING && it.subsumedBy == null }
+                if (hasPlane) {
+                    planeDetectedReported = true
+                    onPlaneDetected()
+                }
+            }
+
             // Adaptive idle gating: skip the heavy native SLAM/VIO map integration on gated idle
             // frames (projection locked + phone still). session.update() above still ran, so ARCore's
             // pose keeps advancing and the first heavy frame after resume re-feeds a correct pose.

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -15,6 +15,7 @@ import com.hereliesaz.graffitixr.common.model.ArScanMode
 import com.hereliesaz.graffitixr.common.model.MuralMethod
 import com.hereliesaz.graffitixr.common.model.ScanPhase
 import com.hereliesaz.graffitixr.nativebridge.YuvConverter
+import com.hereliesaz.graffitixr.feature.ar.AnchorLockTracker
 import com.hereliesaz.graffitixr.feature.ar.DisplayRotationHelper
 import com.hereliesaz.graffitixr.feature.ar.anchor.AnchorOrchestrator
 import com.hereliesaz.graffitixr.nativebridge.SlamManager
@@ -48,6 +49,11 @@ class ArRenderer(
     // ViewModel flips ArUiState.planeDetected so first-run onboarding can drop
     // the "move your device" guidance once a surface exists.
     private val onPlaneDetected: () -> Unit = {},
+    // First-run doodle demo: reports the anchor-hold stability (0..1) as the user
+    // draws, and fires once when the overlay has held one spot long enough to swap
+    // the scribble for the user's artwork. Both no-op outside the doodle phase.
+    private val onDoodleLockProgress: (Float) -> Unit = {},
+    private val onDoodleLocked: () -> Unit = {},
     // Fired from the GL thread when ARCore has been stuck not-tracking for a
     // sustained run of frames (true) or recovers (false). MainScreen uses this
     // to drop the GLSurfaceView render mode to WHEN_DIRTY so the saturated
@@ -267,6 +273,17 @@ class ArRenderer(
     private var camStallWarned = false
     // One-shot: true once the first tracking plane has been reported via onPlaneDetected.
     private var planeDetectedReported = false
+
+    // First-run doodle demo. doodleLockActive is set by the host while the onboarding overlay is up;
+    // when active the renderer auto-establishes a wall anchor (no capture/fingerprint), tracks how
+    // steadily it holds, and fires onDoodleLocked once it has held past DOODLE_MIN_DRAW_MS. The
+    // min-dwell exists because a fresh ARCore anchor is stable immediately — without it the lock would
+    // fire before the user has drawn. (Purist upgrade: gate on mark-relocalization pose stability.)
+    var doodleLockActive = false
+    private val anchorLockTracker = AnchorLockTracker()
+    private var doodleAnchorStartMs = 0L
+    private var doodleLockReported = false
+    private var doodleAutoAnchorRequested = false
     // Render-thread stall watchdog. The GL thread can block inside session.update() forever when the
     // camera never feeds ARCore; a side thread watches these markers and reports the stuck step on
     // screen (the blocked GL thread can't report for itself).
@@ -796,6 +813,16 @@ class ArRenderer(
             // Scan-time plane grids are now drawn with the throttled perception layers (see "debugView").
 
             lastStep = "anchorEstablish"
+            // First-run doodle demo: once a surface exists and we're tracking, auto-establish the
+            // wall anchor (same path as a capture confirm, minus the fingerprint) so the scribble has
+            // somewhere to stick. One-shot per doodle session.
+            if (doodleLockActive && !anchorEstablished && !pendingAnchorEstablishment &&
+                !doodleAutoAnchorRequested && planeDetectedReported &&
+                frame.camera.trackingState == TrackingState.TRACKING
+            ) {
+                doodleAutoAnchorRequested = true
+                pendingAnchorEstablishment = true
+            }
             if (pendingAnchorEstablishment) {
                 pendingAnchorEstablishment = false
                 try {
@@ -1024,6 +1051,20 @@ class ArRenderer(
                     confGlobal = 1f,
                 )
             } else backbone
+
+            // First-run doodle demo: feed the anchor's world translation to the lock tracker while the
+            // overlay holds. Once it has held steady past the min-draw dwell, fire the swap once.
+            if (doodleLockActive && anchorEstablished && !doodleLockReported) {
+                if (doodleAnchorStartMs == 0L) doodleAnchorStartMs = System.currentTimeMillis()
+                anchorLockTracker.update(anchorMatrix[12], anchorMatrix[13], anchorMatrix[14])
+                if (frameCount % 4 == 0) onDoodleLockProgress(anchorLockTracker.stability)
+                val heldLongEnough =
+                    System.currentTimeMillis() - doodleAnchorStartMs >= DOODLE_MIN_DRAW_MS
+                if (anchorLockTracker.locked && heldLongEnough) {
+                    doodleLockReported = true
+                    onDoodleLocked()
+                }
+            }
 
             // Throttle UI and distance updates to 15Hz to match SLAM processing frequency and reduce state churn.
             lastStep = "uiTick"
@@ -1826,6 +1867,10 @@ class ArRenderer(
     }
 
     private companion object {
+        // Minimum time the doodle anchor must hold before the scribble->artwork swap can fire, so a
+        // freshly-created (already-stable) ARCore anchor doesn't lock before the user has drawn.
+        const val DOODLE_MIN_DRAW_MS = 3000L
+
         // Multiplier for the overlay half-extent to derive the camera distance used in the
         // 2D perspective content rotation (matching Compose's graphicsLayer rotationX/Y).
         // Higher values → subtler perspective; lower → more dramatic. 3.0 gives a moderate

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -275,15 +275,19 @@ class ArRenderer(
     private var planeDetectedReported = false
 
     // First-run doodle demo. doodleLockActive is set by the host while the onboarding overlay is up;
-    // when active the renderer auto-establishes a wall anchor (no capture/fingerprint), tracks how
-    // steadily it holds, and fires onDoodleLocked once it has held past DOODLE_MIN_DRAW_MS. The
-    // min-dwell exists because a fresh ARCore anchor is stable immediately — without it the lock would
-    // fire before the user has drawn. (Purist upgrade: gate on mark-relocalization pose stability.)
+    // when active the renderer auto-establishes a wall anchor, and (once the host has built a
+    // fingerprint from the user's drawing) tracks the fused mark-PnP pose, firing onDoodleLocked when
+    // it holds steady AND relocalization is confident (DOODLE_MIN_RELOC_INLIERS).
     var doodleLockActive = false
     private val anchorLockTracker = AnchorLockTracker()
-    private var doodleAnchorStartMs = 0L
     private var doodleLockReported = false
     private var doodleAutoAnchorRequested = false
+    // Wall plane the doodle anchor landed on: [px,py,pz, nx,ny,nz] in world space. Written on the GL
+    // thread at anchor establishment, read off-thread by ArViewModel to build the fingerprint from the
+    // user's drawing (no tap). Volatile for safe publication across threads.
+    @Volatile
+    var doodleWallPlane: FloatArray? = null
+        private set
     // Render-thread stall watchdog. The GL thread can block inside session.update() forever when the
     // camera never feeds ARCore; a side thread watches these markers and reports the stuck step on
     // screen (the blocked GL thread can't report for itself).
@@ -924,6 +928,14 @@ class ArRenderer(
                         anchorSurfaceNormal[0] = 0f; anchorSurfaceNormal[1] = 0f; anchorSurfaceNormal[2] = 0f
                     }
                     slamManager.updateAnchorTransform(anchorModelMatrix)
+                    // Doodle demo: publish the wall plane (anchor point + surface normal) so the
+                    // ViewModel can build a fingerprint from the drawing and relocalize against it.
+                    if (doodleLockActive) {
+                        doodleWallPlane = floatArrayOf(
+                            anchorModelMatrix[12], anchorModelMatrix[13], anchorModelMatrix[14],
+                            anchorSurfaceNormal[0], anchorSurfaceNormal[1], anchorSurfaceNormal[2],
+                        )
+                    }
                     setPrimaryAnchor(anchor) // non-null: the fallback branch always creates one
                     anchorEstablished = true
                     hideVisualization = true
@@ -1055,12 +1067,16 @@ class ArRenderer(
             // First-run doodle demo: feed the anchor's world translation to the lock tracker while the
             // overlay holds. Once it has held steady past the min-draw dwell, fire the swap once.
             if (doodleLockActive && anchorEstablished && !doodleLockReported) {
-                if (doodleAnchorStartMs == 0L) doodleAnchorStartMs = System.currentTimeMillis()
+                // anchorMatrix is the FUSED pose — once a fingerprint has been built from the user's
+                // drawing, poseFusion folds the mark-PnP relocalization correction into it, so the
+                // tracker is measuring relocalization stability, not raw ARCore anchor. Gate the swap
+                // on BOTH a still fused pose AND a confident relock (PnP inliers), so the lock only
+                // fires when the teleological SLAM has genuinely latched onto the drawn marks. On a
+                // blank wall relocalization stays weak until the user draws, so this self-times.
                 anchorLockTracker.update(anchorMatrix[12], anchorMatrix[13], anchorMatrix[14])
                 if (frameCount % 4 == 0) onDoodleLockProgress(anchorLockTracker.stability)
-                val heldLongEnough =
-                    System.currentTimeMillis() - doodleAnchorStartMs >= DOODLE_MIN_DRAW_MS
-                if (anchorLockTracker.locked && heldLongEnough) {
+                val relocInliers = slamManager.getRelocResult()[16].toInt()
+                if (anchorLockTracker.locked && relocInliers >= DOODLE_MIN_RELOC_INLIERS) {
                     doodleLockReported = true
                     onDoodleLocked()
                 }
@@ -1867,9 +1883,9 @@ class ArRenderer(
     }
 
     private companion object {
-        // Minimum time the doodle anchor must hold before the scribble->artwork swap can fire, so a
-        // freshly-created (already-stable) ARCore anchor doesn't lock before the user has drawn.
-        const val DOODLE_MIN_DRAW_MS = 3000L
+        // PnP inlier floor for the doodle swap — self-grow itself trusts a relock at >= 20 inliers
+        // (MobileGS), so the same bar means "relocalization has confidently latched onto the marks".
+        const val DOODLE_MIN_RELOC_INLIERS = 20
 
         // Multiplier for the overlay half-extent to derive the camera distance used in the
         // 2D perspective content rotation (matching Compose's graphicsLayer rotationX/Y).

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/AnchorLockTrackerTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/AnchorLockTrackerTest.kt
@@ -1,0 +1,75 @@
+package com.hereliesaz.graffitixr.feature.ar
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AnchorLockTrackerTest {
+
+    @Test
+    fun `does not lock before the window fills`() {
+        val t = AnchorLockTracker(windowSize = 30, jitterThresholdMeters = 0.01f)
+        repeat(29) { assertFalse(t.update(1f, 2f, 3f)) }
+        assertFalse(t.locked)
+        assertEquals(0f, t.stability, 0f)
+    }
+
+    @Test
+    fun `locks when a full window holds one spot`() {
+        val t = AnchorLockTracker(windowSize = 30, jitterThresholdMeters = 0.01f)
+        var locked = false
+        repeat(30) { locked = t.update(1f, 2f, 3f) }
+        assertTrue(locked)
+        assertTrue(t.locked)
+        assertEquals(0f, t.jitterMeters, 1e-6f)
+        assertEquals(1f, t.stability, 1e-6f)
+    }
+
+    @Test
+    fun `does not lock while jitter exceeds threshold`() {
+        val t = AnchorLockTracker(windowSize = 10, jitterThresholdMeters = 0.01f)
+        // Alternate positions 5cm apart — well beyond the 1cm threshold.
+        repeat(40) { i ->
+            val x = if (i % 2 == 0) 0f else 0.05f
+            t.update(x, 0f, 0f)
+        }
+        assertFalse(t.locked)
+        assertTrue(t.jitterMeters > 0.01f)
+    }
+
+    @Test
+    fun `small jitter within threshold still locks`() {
+        val t = AnchorLockTracker(windowSize = 10, jitterThresholdMeters = 0.01f)
+        // +/- 2mm around a point → max radius ~2mm < 1cm.
+        repeat(10) { i ->
+            val x = if (i % 2 == 0) 0f else 0.002f
+            t.update(x, 0f, 0f)
+        }
+        assertTrue(t.locked)
+    }
+
+    @Test
+    fun `lock latches through a later jitter spike`() {
+        val t = AnchorLockTracker(windowSize = 10, jitterThresholdMeters = 0.01f)
+        repeat(10) { t.update(0f, 0f, 0f) }
+        assertTrue(t.locked)
+        // A big move afterwards must NOT un-lock (swap is mid-flight).
+        repeat(10) { t.update(1f, 1f, 1f) }
+        assertTrue(t.locked)
+    }
+
+    @Test
+    fun `reset clears lock and window`() {
+        val t = AnchorLockTracker(windowSize = 5, jitterThresholdMeters = 0.01f)
+        repeat(5) { t.update(0f, 0f, 0f) }
+        assertTrue(t.locked)
+        t.reset()
+        assertFalse(t.locked)
+        assertEquals(0f, t.stability, 0f)
+        // After reset it needs a fresh full window before locking again.
+        repeat(4) { t.update(0f, 0f, 0f) }
+        assertFalse(t.locked)
+        assertTrue(t.update(0f, 0f, 0f))
+    }
+}

--- a/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/EditorViewModel.kt
+++ b/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/EditorViewModel.kt
@@ -21,7 +21,9 @@ import com.hereliesaz.graffitixr.common.DispatcherProvider
 import com.hereliesaz.graffitixr.common.coop.OpEmitter
 import com.hereliesaz.graffitixr.common.model.*
 import com.hereliesaz.graffitixr.common.util.ImageUtils
+import com.hereliesaz.graffitixr.common.util.computeAutoTune
 import com.hereliesaz.graffitixr.common.util.decodeBoundedBitmap
+import com.hereliesaz.graffitixr.common.util.imageStats
 import com.hereliesaz.graffitixr.common.util.saveBitmapToGallery
 import com.hereliesaz.graffitixr.domain.repository.ProjectRepository
 import com.hereliesaz.graffitixr.domain.repository.SettingsRepository
@@ -1153,6 +1155,31 @@ class EditorViewModel @Inject constructor(
     override fun onColorBalanceRChanged(v: Float) = dispatch(EditorIntent.SetColorBalanceR(v))
     override fun onColorBalanceGChanged(v: Float) = dispatch(EditorIntent.SetColorBalanceG(v))
     override fun onColorBalanceBChanged(v: Float) = dispatch(EditorIntent.SetColorBalanceB(v))
+
+    /**
+     * First-run doodle demo: on the scribble->artwork swap, pre-set the adjustment knobs to values
+     * that read well against the wall. Combines [wall] (from the doodle capture) with the active
+     * layer's own colour/contrast and applies through the existing setters (which route the
+     * multiplicative/additive knobs to the AR mode-adjustment and colour balance to the layer, exactly
+     * as the AR composite consumes them). A starting point the user then fine-tunes — not a hard grade.
+     */
+    fun autoTuneActiveLayer(wall: com.hereliesaz.graffitixr.common.util.ImageStats?) {
+        if (wall == null) return
+        val bitmap = _uiState.value.layers.find { it.id == _uiState.value.activeLayerId }?.bitmap ?: return
+        viewModelScope.launch(dispatchers.default) {
+            val art = bitmap.imageStats()
+            val t = computeAutoTune(wall, art)
+            withContext(dispatchers.main) {
+                onOpacityChanged(t.opacity)
+                onBrightnessChanged(t.brightness)
+                onContrastChanged(t.contrast)
+                onSaturationChanged(t.saturation)
+                onColorBalanceRChanged(t.colorBalanceR)
+                onColorBalanceGChanged(t.colorBalanceG)
+                onColorBalanceBChanged(t.colorBalanceB)
+            }
+        }
+    }
     override fun onScaleChanged(s: Float) = dispatch(EditorIntent.SetScale(s))
     override fun onOffsetChanged(o: Offset) = dispatch(EditorIntent.AddOffset(o))
 


### PR DESCRIPTION
## Summary

The first-run AR "doodle-lock" onboarding demo, end to end, plus artwork auto-tune. A cold-install user picks an image, is asked to "doodle this on your wall or canvas" and shown a random scribble, draws it on the real wall; GraffitiXR's **teleological relocalization locks onto their drawing**, the scribble swaps for their artwork, and the artwork's knobs are **pre-tuned to the wall** — the moat made visible in the first 60 seconds.

## The flow

1. **Gated routing** (`MainActivity`, strictly contained) — behind `first_run_ar_doodle ∉ completedTutorials && ARCore available && camera granted && at library`. Any failed condition is a **no-op**; normal startup is unchanged. Project is created only on a real pick (cancel leaves none); the layer is added once its project id is live (no race).
2. **Coaching overlay** — "Doodle this…" (1s) → rises while the scribble fades in → movement guidance while `isArReady && !planeDetected`.
3. **Scribble on the wall** — hot-swap overlay texture; renderer auto-anchors and publishes the wall plane.
4. **Teleological lock** — the ViewModel periodically captures (no tap) and builds a wall **fingerprint** from the drawing (`buildSingle`); returns null until there's enough ink, so it self-times. Relocalization + self-grow then run and tighten. Swap fires when the fused pose is steady **and** `getRelocResult` inliers ≥ 20. A 30s timeout falls back to the plain anchor on a featureless wall.
5. **Swap + auto-tune** — scribble → artwork, and `computeAutoTune(wall, art)` pre-sets opacity/brightness/contrast/saturation/colour-balance so it reads against the wall. Tutorial marked complete.

## Design arc (why it's the purist path)

Started as a pragmatic anchor-stability gate, then switched to gating on **real relocalization** so the demo shows the app's differentiator, not generic ARCore anchoring. The `AnchorLockTracker` reads the fused pose, so once a fingerprint exists it measures relocalization stability for free.

## Hardening (adversarial self-review, in lieu of a device)

Fixed 5 real bugs a review surfaced: runaway captures (uncleared `isCaptureRequested` + single-in-flight build guard), cross-thread visibility (`@Volatile` on the doodle flags), gate re-fire / duplicate projects (create-on-pick + `rememberSaveable` + session latch), stale renderer one-shots on retry (reset on the phase rising edge), and a create-vs-add project race (deferred `onAddLayer`).

## Building blocks (all unit-tested)

`ScribbleGenerator` (2,000 seeds) · `AnchorLockTracker` · `computeImageStats`/`computeAutoTune` · `ScribbleView`/`renderScribbleBitmap` · `FirstRunOnboardingOverlay` · `Bitmap.imageStats`

## Test plan

- [x] `ScribbleGeneratorTest`, `AnchorLockTrackerTest`, `AutoTuneTest` green; `:core:common` / `:feature:ar` / `:feature:editor` / `:app` unit tests green; full compile.
- [ ] **Device** (the real validation + tuning): first-run gate → picker → AR → scribble on wall → draw → fingerprint builds → relocalization locks → swap to artwork with auto-tuned knobs → tutorial complete. Tune capture cadence (2.5s), inlier bar (20), lock timeout (30s), and the auto-tune heuristic. Confirm normal non-first-run startup is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)