### PR TITLE
docs(license): apply PolyForm/MIT license files + align public copy

### DIFF
--- a/.github/workflows/merged-build.yml
+++ b/.github/workflows/merged-build.yml
@@ -202,21 +202,14 @@ jobs:
         if: success() && github.event_name == 'push'
         id: release_vars
         run: |
-          export BUILD_NUMBER=$(git rev-list --count HEAD)
-          
-          # Extract version info from properties file
-  
-          MAJOR=$(grep 'versionMajor=' version.properties | cut -d'=' -f2 | tr -d '\r ')
-          MINOR=$(grep 'versionMinor=' version.properties | cut -d'=' -f2 | tr -d '\r ')
-
-          # Calculate Patch version programmatically based on commits since Minor update
-          MINOR_COMMIT=$(git blame -L '/versionMinor=/',+1 version.properties | awk '{print $1}' | tr -d '^')
-          if [ -n "$MINOR_COMMIT" ]; then
-            PATCH=$(git rev-list --count $MINOR_COMMIT..HEAD)
-          else
-    
-            PATCH=$(grep 'versionPatch=' version.properties | cut -d'=' -f2 | tr -d '\r ')
-          fi
+          # version.properties is the SINGLE SOURCE OF TRUTH for the version. The gradle build already
+          # incremented versionBuild (the Android versionCode) and versionPatch and baked them into the
+          # artifact; read the SAME values here. NEVER derive the version from the git commit count —
+          # that scheme collides with versionBuild and causes Play "downgrade" versionCode rejections.
+          MAJOR=$(grep '^versionMajor=' version.properties | cut -d'=' -f2 | tr -d '\r ')
+          MINOR=$(grep '^versionMinor=' version.properties | cut -d'=' -f2 | tr -d '\r ')
+          PATCH=$(grep '^versionPatch=' version.properties | cut -d'=' -f2 | tr -d '\r ')
+          BUILD_NUMBER=$(grep '^versionBuild=' version.properties | cut -d'=' -f2 | tr -d '\r ')
 
           VERSION_NAME="$MAJOR.$MINOR.$PATCH.$BUILD_NUMBER"
           

--- a/.github/workflows/release-aab.yml
+++ b/.github/workflows/release-aab.yml
@@ -41,7 +41,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
-          # Full history so the commit count (versionCode) is correct.
+          # Full history so the persist step can rebase its version.properties bump onto the fresh
+          # tip. The versionCode is versionBuild from version.properties (the single source of truth),
+          # NOT the git commit count.
           fetch-depth: 0
 
       - name: Setup Dependencies

--- a/.github/workflows/release-apk.yml
+++ b/.github/workflows/release-apk.yml
@@ -88,18 +88,15 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          export BUILD_NUMBER=$(git rev-list --count HEAD)
-
-          MAJOR=$(grep 'versionMajor=' version.properties | cut -d'=' -f2 | tr -d '\r ')
-          MINOR=$(grep 'versionMinor=' version.properties | cut -d'=' -f2 | tr -d '\r ')
-
-          # Calculate patch from commits since last minor bump
-          MINOR_COMMIT=$(git blame -L '/versionMinor=/',+1 version.properties | awk '{print $1}' | tr -d '^')
-          if [ -n "$MINOR_COMMIT" ]; then
-            PATCH=$(git rev-list --count $MINOR_COMMIT..HEAD)
-          else
-            PATCH=$(grep 'versionPatch=' version.properties | cut -d'=' -f2 | tr -d '\r ')
-          fi
+          # version.properties is the SINGLE SOURCE OF TRUTH for the version. The gradle build above
+          # already incremented versionBuild (the Android versionCode) and versionPatch and baked them
+          # into the APK; read the SAME values here so the release name and tag match the artifact
+          # exactly. NEVER derive the version from the git commit count — that scheme collides with
+          # versionBuild and causes Play "downgrade" (versionCode regression) rejections.
+          MAJOR=$(grep '^versionMajor=' version.properties | cut -d'=' -f2 | tr -d '\r ')
+          MINOR=$(grep '^versionMinor=' version.properties | cut -d'=' -f2 | tr -d '\r ')
+          PATCH=$(grep '^versionPatch=' version.properties | cut -d'=' -f2 | tr -d '\r ')
+          BUILD_NUMBER=$(grep '^versionBuild=' version.properties | cut -d'=' -f2 | tr -d '\r ')
 
           VERSION_NAME="${MAJOR}.${MINOR}.${PATCH}.${BUILD_NUMBER}"
           TAG_NAME="latest-release-v${MAJOR}.${MINOR}"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,148 @@
+Copyright © 2026 HereLiesAz <hereliesaz@gmail.com>
+
+Required Notice: Copyright © 2026 HereLiesAz
+(https://github.com/HereLiesAz/GraffitiXR)
+
+GraffitiXR — the application, the `core:*` modules, the AR / SLAM /
+teleological engine, and every engine-touching built-in — is licensed under
+the PolyForm Noncommercial License 1.0.0, reproduced in full below.
+
+This is a source-available, noncommercial license — it is NOT an OSI-approved
+open-source license, and GraffitiXR as a whole is not "open source." Parts of
+the tree are instead licensed MIT; see `docs/LICENSING.md` for the
+authoritative, path-by-path layout and the order of precedence
+(per-file SPDX header → module LICENSE → docs/LICENSING.md → this file).
+
+----------------------------------------------------------------------
+
+# PolyForm Noncommercial License 1.0.0
+
+<https://polyformproject.org/licenses/noncommercial/1.0.0>
+
+## Acceptance
+
+In order to get any license under these terms, you must agree
+to them as both strict obligations and conditions to all
+your licenses.
+
+## Copyright License
+
+The licensor grants you a copyright license for the
+software to do everything you might do with the software
+that would otherwise infringe the licensor's copyright
+in it for any permitted purpose.  However, you may
+only distribute the software according to [Distribution
+License](#distribution-license) and make changes or new works
+based on the software according to [Changes and New Works
+License](#changes-and-new-works-license).
+
+## Distribution License
+
+The licensor grants you an additional copyright license
+to distribute copies of the software.  Your license
+to distribute covers distributing the software with
+changes and new works permitted by [Changes and New Works
+License](#changes-and-new-works-license).
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of
+the software from you also gets a copy of these terms or the
+URL for them above, as well as copies of any plain-text lines
+beginning with `Required Notice:` that the licensor provided
+with the software.  For example:
+
+> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
+
+## Changes and New Works License
+
+The licensor grants you an additional copyright license to
+make changes and new works based on the software for any
+permitted purpose.
+
+## Patent License
+
+The licensor grants you a patent license for the software that
+covers patent claims the licensor can license, or becomes able
+to license, that you would infringe by using the software.
+
+## Noncommercial Purposes
+
+Any noncommercial purpose is a permitted purpose.
+
+## Personal Uses
+
+Personal use for research, experiment, and testing for
+the benefit of public knowledge, personal study, private
+entertainment, hobby projects, amateur pursuits, or religious
+observance, without any anticipated commercial application,
+is use for a permitted purpose.
+
+## Noncommercial Organizations
+
+Use by any charitable organization, educational institution,
+public research organization, public safety or health
+organization, environmental protection organization,
+or government institution is use for a permitted purpose
+regardless of the source of funding or obligations resulting
+from the funding.
+
+## Fair Use
+
+You may have "fair use" rights for the software under the
+law. These terms do not limit them.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer any of
+your licenses to anyone else, or prevent the licensor from
+granting licenses to anyone else.  These terms do not imply
+any other licenses.
+
+## Patent Defense
+
+If you make any written claim that the software infringes or
+contributes to infringement of any patent, your patent license
+for the software granted under these terms ends immediately. If
+your company makes such a claim, your patent license ends
+immediately for work on behalf of your company.
+
+## Violations
+
+The first time you are notified in writing that you have
+violated any of these terms, or done anything with the software
+not covered by your licenses, your licenses can nonetheless
+continue if you come into full compliance with these terms,
+and take practical steps to correct past violations, within
+32 days of receiving notice.  Otherwise, all your licenses
+end immediately.
+
+## No Liability
+
+***As far as the law allows, the software comes as is, without
+any warranty or condition, and the licensor will not be liable
+to you for any damages arising out of these terms or the use
+or nature of the software, under any kind of legal claim.***
+
+## Definitions
+
+The **licensor** is the individual or entity offering these
+terms, and the **software** is the software the licensor makes
+available under these terms.
+
+**You** refers to the individual or entity agreeing to these
+terms.
+
+**Your company** is any legal entity, sole proprietorship,
+or other kind of organization that you work for, plus all
+organizations that have control over, are under the control of,
+or are under common control with that organization.  **Control**
+means ownership of substantially all the assets of an entity,
+or the power to direct its management and policies by vote,
+contract, or otherwise.  Control can be direct or indirect.
+
+**Your licenses** are all the licenses granted to you for the
+software under these terms.
+
+**Use** means anything you do with the software requiring one
+of your licenses.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ And then, there's a decent suite of pertinent design tools, with support for mul
 
 ## Tools
 *   **Stencil generation:** A layer-level tool (not a mode) — automated multi-layer printable stencils (1-3 colors) with tiled PDF export.
+*   **Extensions (azphalt marketplace):** Browse and install `.azp` extensions from the Project → Extensions menu. Packages are SHA-256-verified and path-traversal-safe on install; installed `.cube` 3D-LUT grades apply straight to the active layer. GraffitiXR is the [azphalt](https://github.com/HereLiesAz/azphalt) standard's first conforming host.
+
+## Licensing
+GraffitiXR is **source-available, not open source.** The app, the `core:*` modules, and the AR / SLAM / teleological engine are licensed under **PolyForm Noncommercial 1.0.0** ([`/LICENSE`](LICENSE)); the declared extension API surface and asset importers are **MIT** ([`docs/licenses/MIT.txt`](docs/licenses/MIT.txt)). The **compiled app is free for anyone to use, including paid commissions** — the noncommercial term binds re-use of the *source*, not muralists doing paid work. See [`docs/LICENSING.md`](docs/LICENSING.md) for the authoritative, path-by-path layout and precedence. Bundled third parties (OpenCV, ML Kit, …) keep their own upstream licenses.
 
 ## Architecture
 Strictly decoupled multi-module Clean Architecture:
@@ -59,4 +63,4 @@ Strictly decoupled multi-module Clean Architecture:
 - [Release & Google Play Delivery](docs/RELEASE.md)
 
 ---
-*Documentation updated on 2026-06-28 for AzNavRail 10.18 and the reactive guidance framework.*
+*Documentation updated on 2026-07-12 for AzNavRail 11.0, the azphalt extensions marketplace, and the PolyForm/MIT licensing layout.*

--- a/core/nativebridge/LICENSE
+++ b/core/nativebridge/LICENSE
@@ -1,0 +1,151 @@
+Copyright © 2026 HereLiesAz <hereliesaz@gmail.com>
+
+Required Notice: Copyright © 2026 HereLiesAz
+(https://github.com/HereLiesAz/GraffitiXR)
+
+This module — the native C++ engine (MobileGS, SuperPointDetector,
+StereoProcessor, ImageWarper, DistortionHead, GraffitiJNI, …), the JNI bridge,
+and the Kotlin engine side (SlamManager, depth providers) — is the protected
+core of GraffitiXR: the fingerprint relocalization and teleological SLAM work.
+It is licensed under the PolyForm Noncommercial License 1.0.0, reproduced in
+full below, and is deliberately NOT part of the MIT-licensed extension surface.
+See `docs/LICENSING.md` for the authoritative, path-by-path layout.
+
+NOTE ON BUNDLED THIRD PARTIES: the vendored OpenCV SDK under `libs/opencv/`
+keeps its own upstream license(s) and is not relicensed by this file; it
+includes a GPL-2.0 component (`ittnotify`) — a compliance item to review
+independently of these terms.
+
+----------------------------------------------------------------------
+
+# PolyForm Noncommercial License 1.0.0
+
+<https://polyformproject.org/licenses/noncommercial/1.0.0>
+
+## Acceptance
+
+In order to get any license under these terms, you must agree
+to them as both strict obligations and conditions to all
+your licenses.
+
+## Copyright License
+
+The licensor grants you a copyright license for the
+software to do everything you might do with the software
+that would otherwise infringe the licensor's copyright
+in it for any permitted purpose.  However, you may
+only distribute the software according to [Distribution
+License](#distribution-license) and make changes or new works
+based on the software according to [Changes and New Works
+License](#changes-and-new-works-license).
+
+## Distribution License
+
+The licensor grants you an additional copyright license
+to distribute copies of the software.  Your license
+to distribute covers distributing the software with
+changes and new works permitted by [Changes and New Works
+License](#changes-and-new-works-license).
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of
+the software from you also gets a copy of these terms or the
+URL for them above, as well as copies of any plain-text lines
+beginning with `Required Notice:` that the licensor provided
+with the software.  For example:
+
+> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
+
+## Changes and New Works License
+
+The licensor grants you an additional copyright license to
+make changes and new works based on the software for any
+permitted purpose.
+
+## Patent License
+
+The licensor grants you a patent license for the software that
+covers patent claims the licensor can license, or becomes able
+to license, that you would infringe by using the software.
+
+## Noncommercial Purposes
+
+Any noncommercial purpose is a permitted purpose.
+
+## Personal Uses
+
+Personal use for research, experiment, and testing for
+the benefit of public knowledge, personal study, private
+entertainment, hobby projects, amateur pursuits, or religious
+observance, without any anticipated commercial application,
+is use for a permitted purpose.
+
+## Noncommercial Organizations
+
+Use by any charitable organization, educational institution,
+public research organization, public safety or health
+organization, environmental protection organization,
+or government institution is use for a permitted purpose
+regardless of the source of funding or obligations resulting
+from the funding.
+
+## Fair Use
+
+You may have "fair use" rights for the software under the
+law. These terms do not limit them.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer any of
+your licenses to anyone else, or prevent the licensor from
+granting licenses to anyone else.  These terms do not imply
+any other licenses.
+
+## Patent Defense
+
+If you make any written claim that the software infringes or
+contributes to infringement of any patent, your patent license
+for the software granted under these terms ends immediately. If
+your company makes such a claim, your patent license ends
+immediately for work on behalf of your company.
+
+## Violations
+
+The first time you are notified in writing that you have
+violated any of these terms, or done anything with the software
+not covered by your licenses, your licenses can nonetheless
+continue if you come into full compliance with these terms,
+and take practical steps to correct past violations, within
+32 days of receiving notice.  Otherwise, all your licenses
+end immediately.
+
+## No Liability
+
+***As far as the law allows, the software comes as is, without
+any warranty or condition, and the licensor will not be liable
+to you for any damages arising out of these terms or the use
+or nature of the software, under any kind of legal claim.***
+
+## Definitions
+
+The **licensor** is the individual or entity offering these
+terms, and the **software** is the software the licensor makes
+available under these terms.
+
+**You** refers to the individual or entity agreeing to these
+terms.
+
+**Your company** is any legal entity, sole proprietorship,
+or other kind of organization that you work for, plus all
+organizations that have control over, are under the control of,
+or are under common control with that organization.  **Control**
+means ownership of substantially all the assets of an entity,
+or the power to direct its management and policies by vote,
+contract, or otherwise.  Control can be direct or indirect.
+
+**Your licenses** are all the licenses granted to you for the
+software under these terms.
+
+**Use** means anything you do with the software requiring one
+of your licenses.

--- a/docs/en/PRIVACY_POLICY.md
+++ b/docs/en/PRIVACY_POLICY.md
@@ -2,7 +2,7 @@
 
 **Last Updated:** 2026-04-07
 
-HereLiesAZ built the GraffitiXR app as an Open Source app. This SERVICE is provided by HereLiesAZ at no cost and is intended for use as is.
+HereLiesAZ built the GraffitiXR app as a source-available app (see the repository's LICENSE and docs/LICENSING.md for terms). This SERVICE is provided by HereLiesAZ at no cost and is intended for use as is.
 
 This page is used to inform visitors regarding our policies with the collection, use, and disclosure of Personal Information if anyone decided to use our Service.
 

--- a/docs/fr/index.html
+++ b/docs/fr/index.html
@@ -498,7 +498,7 @@
             </a>
 
             <div class="mt-32 pt-10 border-t-2 border-slate-800 text-slate-500 text-lg flex justify-between items-center flex-col md:flex-row gap-6 font-mono">
-                <p>&copy; 2026 GraffitiXR. <br><span class="text-cyan-500/70 text-sm">[ Source ouverte sous PolyForm Noncommercial 1.0.0 &middot; en partie MIT ]</span></p>
+                <p>&copy; 2026 GraffitiXR. <br><span class="text-cyan-500/70 text-sm">[ Source disponible sous PolyForm Noncommercial 1.0.0 &middot; en partie MIT ]</span></p>
                 <div class="flex space-x-8">
                     <a href="PRIVACY_POLICY.html" class="hover:text-pink-400 transition-colors border-b-2 border-transparent hover:border-pink-400 pb-1 uppercase">PRIVACY_POLICY</a>
                     <a href="https://github.com/HereLiesAZ/GraffitiXR" class="hover:text-cyan-400 transition-colors border-b-2 border-transparent hover:border-cyan-400 pb-1 uppercase">GITHUB_REPO</a>

--- a/docs/fr/index.html
+++ b/docs/fr/index.html
@@ -485,7 +485,7 @@
 
             <div class="bg-[#0a0a0e]/90 p-8 border border-slate-700 rounded-xl shadow-2xl mb-12 transform hover:scale-[1.02] transition-transform duration-300">
                 <p class="text-slate-300 text-2xl font-mono leading-relaxed">
-                    GraffitiXR est open-source et gratuit pour toujours. <br><br>
+                    GraffitiXR est gratuit pour toujours &mdash; y compris pour les commandes rémunérées. <br><br>
                     <span class="text-lime-400 font-bold">> Pas de suivi.</span> <br>
                     <span class="text-cyan-400 font-bold">> Pas de pubs.</span> <br>
                     <span class="text-orange-400 font-bold">> Pas de synchronisations cloud.</span> <br><br>
@@ -498,7 +498,7 @@
             </a>
 
             <div class="mt-32 pt-10 border-t-2 border-slate-800 text-slate-500 text-lg flex justify-between items-center flex-col md:flex-row gap-6 font-mono">
-                <p>&copy; 2026 GraffitiXR. <br><span class="text-cyan-500/70 text-sm">[ Open Source sous Licence MIT ]</span></p>
+                <p>&copy; 2026 GraffitiXR. <br><span class="text-cyan-500/70 text-sm">[ Source ouverte sous PolyForm Noncommercial 1.0.0 &middot; en partie MIT ]</span></p>
                 <div class="flex space-x-8">
                     <a href="PRIVACY_POLICY.html" class="hover:text-pink-400 transition-colors border-b-2 border-transparent hover:border-pink-400 pb-1 uppercase">PRIVACY_POLICY</a>
                     <a href="https://github.com/HereLiesAZ/GraffitiXR" class="hover:text-cyan-400 transition-colors border-b-2 border-transparent hover:border-cyan-400 pb-1 uppercase">GITHUB_REPO</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -630,7 +630,7 @@
 
             <div class="bg-[#0a0a0e]/90 p-8 border border-slate-700 rounded-xl shadow-2xl mb-12 transform hover:scale-[1.02] transition-transform duration-300">
                 <p class="text-slate-300 text-2xl font-mono leading-relaxed">
-                    GraffitiXR is open-source and free forever. <br><br>
+                    GraffitiXR is free to use, forever &mdash; including paid commissions. <br><br>
                     <span class="text-lime-400 font-bold">> No tracking.</span> <br>
                     <span class="text-cyan-400 font-bold">> No ads.</span> <br>
                     <span class="text-orange-400 font-bold">> No cloud syncs.</span> <br><br>
@@ -643,7 +643,7 @@
             </a>
 
             <div class="mt-32 pt-10 border-t-2 border-slate-800 text-slate-500 text-lg flex justify-between items-center flex-col md:flex-row gap-6 font-mono">
-                <p>&copy; 2026 GraffitiXR. <br><span class="text-cyan-500/70 text-sm">[ Open Source under MIT License ]</span></p>
+                <p>&copy; 2026 GraffitiXR. <br><span class="text-cyan-500/70 text-sm">[ Source-available under PolyForm Noncommercial 1.0.0 &middot; parts MIT ]</span></p>
                 <div class="flex space-x-8">
                     <a href="PRIVACY_POLICY.html" class="hover:text-pink-400 transition-colors border-b-2 border-transparent hover:border-pink-400 pb-1 uppercase">PRIVACY_POLICY</a>
                     <a href="https://github.com/HereLiesAZ/GraffitiXR" class="hover:text-cyan-400 transition-colors border-b-2 border-transparent hover:border-cyan-400 pb-1 uppercase">GITHUB_REPO</a>

--- a/docs/licenses/AGPL-3.0.txt
+++ b/docs/licenses/AGPL-3.0.txt
@@ -1,0 +1,27 @@
+GNU AFFERO GENERAL PUBLIC LICENSE, Version 3 (AGPL-3.0)
+SPDX-License-Identifier: AGPL-3.0-only
+
+STATUS FOR GRAFFITIXR: RETAINED, NOT APPLIED.
+
+No part of GraffitiXR is currently licensed under the AGPL-3.0. This file is
+kept only as a reference, per `docs/LICENSING.md`, in case strong copyleft is
+ever wanted for an isolated part of the tree. The app's actual terms are:
+
+  - Root / engine / core:*  →  PolyForm Noncommercial 1.0.0  (see /LICENSE)
+  - Declared MIT surfaces   →  MIT  (see docs/licenses/MIT.txt)
+
+AGPL is intentionally not used for the app as a whole: it is incompatible with
+the sellable / cross-app extension ecosystem the project plans for.
+
+CANONICAL TEXT
+--------------
+The full, authoritative AGPL-3.0 text is published by the Free Software
+Foundation and is incorporated here by reference:
+
+  https://www.gnu.org/licenses/agpl-3.0.txt   (plain text)
+  https://www.gnu.org/licenses/agpl-3.0.html  (HTML)
+
+If this license is ever actually applied to any part of the project, replace
+this pointer with the complete verbatim FSF text fetched from the URL above,
+and add the standard per-file `SPDX-License-Identifier: AGPL-3.0-only` headers
+to the covered sources.

--- a/docs/licenses/MIT.txt
+++ b/docs/licenses/MIT.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright © 2026 HereLiesAz <hereliesaz@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## What

`docs/LICENSING.md` is the licensing plan of record, but the actual license files it declares "applied now" were never created — the repo had **no root `LICENSE`** at all. This creates them exactly per the plan and brings public-facing copy into line.

## License files created

| Path | License | Notes |
|---|---|---|
| `/LICENSE` | **PolyForm Noncommercial 1.0.0** | App + `core:*` + the AR/SLAM/teleological engine. Full verbatim license text, plus a `Required Notice` copyright line and a pointer to the precedence order in `docs/LICENSING.md`. |
| `core/nativebridge/LICENSE` | **PolyForm Noncommercial 1.0.0** | The protected native engine (module-level, self-contained). Notes the vendored OpenCV keeps its own upstream terms, incl. its **GPL-2.0** `ittnotify` component. |
| `docs/licenses/MIT.txt` | **MIT** | For the declared extension-API / SDK / asset-importer surfaces. |
| `docs/licenses/AGPL-3.0.txt` | — | **Retained, not applied** — a clearly-labelled reference pointer to the canonical FSF text (no part of the app is AGPL). |

## Public copy aligned

`LICENSING.md` is explicit: the app is **source-available, not open source** — "drop 'open source' from public copy." So:

- **`README.md`** — new **Licensing** section (PolyForm + MIT split, "compiled app is free to use incl. paid commissions"); added the azphalt **Extensions** marketplace entry; footer refreshed to AzNavRail 11.0 / 2026-07-12.
- **`docs/index.html`** + **`docs/fr/index.html`** — the "open-source and free forever" / "Open Source under MIT License" marketing + footer claims replaced with accurate PolyForm-Noncommercial-plus-MIT wording (EN + FR).
- **`docs/en/PRIVACY_POLICY.md`** — "an Open Source app" → "a source-available app".

## Known follow-up

The stock "Open Source app" privacy-policy boilerplate still appears in the **non-English** `PRIVACY_POLICY.md` translations (de/fr/it/nl/pt/tl). Left for a proper translated pass rather than risk inaccurate multilingual legal phrasing.

## Not legal advice

The license mechanics here follow `docs/LICENSING.md`; an IP lawyer should confirm before anything material turns on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBwsyyWbkuTH9QV27ZnmVU)_