### PR TITLE
feat: AzNavRail 11.0 noMenu fold-up + azphalt 0.1 conformance & registry client

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -392,17 +392,16 @@ class MainActivity : ComponentActivity() {
                         !showMarketplace &&
                         !isExporting
 
-                // AzNavRail caches `isExpanded` in rememberSaveable; forcing
-                // noMenu on the library screen re-initialises it to false so
-                // its outer fillMaxSize Box never attaches tapOutsideToCollapse.
+                // noMenu (AzNavRail 11.0) removes the side drawer entirely — all entries become rail
+                // items — and makes the app-icon tap FOLD THE RAIL UP INTO THE ICON (the scope tracks
+                // this as `isFoldedUp`). That is exactly the Design-mode behaviour we want: the user
+                // asked for the rail to fold up when the app icon is pressed in Design mode with the
+                // menu disabled, and 11.0's noMenu delivers it natively (10.32 could not — it had no
+                // app-icon/expansion hook, so this used to be only an approximation).
                 //
-                // Design mode disables the side drawer entirely (noMenu = true). The user
-                // asked for the rail to fold up when the app icon is pressed in Design mode
-                // with the menu disabled; AzNavRail 10.32 doesn't expose an onAppIconClick
-                // callback or a reactive `expanded` state, so we can't gate noMenu on the
-                // press itself — but disabling the drawer for the whole Design session is
-                // the closest match: the app-icon tap still folds/expands the rail by
-                // default, and the drawer never appears to distract the design flow.
+                // We also assert noMenu while the rail is hidden or the library screen is up: forcing
+                // it there re-initialises AzNavRail's saved isExpanded to false so its outer
+                // fillMaxSize Box never attaches tapOutsideToCollapse over those screens.
                 val railMenuDisabled = !isRailVisible ||
                         showLibrary ||
                         editorUiState.editorMode == EditorMode.DESIGN

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/azphalt/AzphaltManifest.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/azphalt/AzphaltManifest.kt
@@ -3,6 +3,10 @@ package com.hereliesaz.graffitixr.common.azphalt
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+
+/** The azphalt package-format spec version GraffitiXR implements (spec/package-format.md: "0.1"). */
+const val AZPHALT_SPEC_VERSION: String = "0.1"
 
 /**
  * The azphalt `manifest.json` at the root of every `.azp` package — GraffitiXR is the standard's
@@ -76,12 +80,23 @@ enum class AssetType {
     @SerialName("lut") LUT,
     @SerialName("pattern") PATTERN,
     @SerialName("stamp") STAMP,
+    // Added in spec 0.1's asset-host guide: GLSL/ISF shaders and gl-transition transitions.
+    @SerialName("shader") SHADER,
+    @SerialName("transition") TRANSITION,
 }
 
 @Serializable
 data class AssetContribution(
     val type: AssetType,
     val path: String,
+    /**
+     * Declarative parameters for the asset (spec 0.1). For [AssetType.SHADER] this carries
+     * `format` (`"isf"` | `"glsl"`) and the shader's declared inputs; for [AssetType.TRANSITION],
+     * `format: "gl-transition"`. Modelled as raw JSON so the host reads only what it understands.
+     */
+    val params: JsonObject? = null,
+    /** Optional path to a native UI panel schema (spec/ui-schema.md), e.g. `"ui/grade.json"`. */
+    val ui: String? = null,
 )
 
 /** Shared lenient JSON — tolerates unknown/future manifest fields rather than failing to parse. */
@@ -92,3 +107,22 @@ val AzphaltJson: Json = Json {
 
 /** Parse a manifest.json string, or throw with context. */
 fun parseManifest(json: String): AzphaltManifest = AzphaltJson.decodeFromString(json)
+
+/**
+ * Whether a package declaring [compat] is compatible with the spec version this host implements
+ * ([AZPHALT_SPEC_VERSION]). The asset-host conformance suite requires validating `compat`.
+ *
+ * We enforce only a lower bound written as `">=x.y"`, `"^x.y"`, `"~x.y"`, or a bare `"x.y"`: the
+ * package is accepted when that minimum is ≤ our spec version. Anything we can't parse as a minimum
+ * (e.g. a lone upper bound `"<0.2"`) is accepted — the payload digest check is the real integrity
+ * gate, so `compat` errs toward leniency rather than rejecting a package we could actually use.
+ */
+fun isCompatibleSpec(compat: String): Boolean {
+    val m = Regex("""^\s*(?:>=|\^|~)?\s*(\d+)\.(\d+)""").find(compat) ?: return true
+    val reqMajor = m.groupValues[1].toInt()
+    val reqMinor = m.groupValues[2].toInt()
+    val specParts = AZPHALT_SPEC_VERSION.split(".")
+    val specMajor = specParts[0].toInt()
+    val specMinor = specParts.getOrElse(1) { "0" }.toInt()
+    return reqMajor < specMajor || (reqMajor == specMajor && reqMinor <= specMinor)
+}

--- a/core/common/src/test/java/com/hereliesaz/graffitixr/common/azphalt/AzphaltManifestTest.kt
+++ b/core/common/src/test/java/com/hereliesaz/graffitixr/common/azphalt/AzphaltManifestTest.kt
@@ -66,6 +66,39 @@ class AzphaltManifestTest {
     }
 
     @Test
+    fun `parses shader and transition assets with params and ui`() {
+        val m = parseManifest(
+            """
+            {
+              "azphalt": "0.1", "id": "com.fx.pack", "name": "FX", "version": "1.0.0",
+              "kind": "asset", "license": "MIT", "compat": ">=0.1",
+              "assets": [
+                { "type": "shader", "path": "assets/glow.fs", "params": { "format": "isf" }, "ui": "ui/glow.json" },
+                { "type": "transition", "path": "assets/wipe.glsl", "params": { "format": "gl-transition" } }
+              ],
+              "files": {}
+            }
+            """.trimIndent(),
+        )
+        assertEquals(AssetType.SHADER, m.assets[0].type)
+        assertEquals("ui/glow.json", m.assets[0].ui)
+        assertEquals("isf", m.assets[0].params?.get("format")?.let { it.toString().trim('"') })
+        assertEquals(AssetType.TRANSITION, m.assets[1].type)
+        assertNull(m.assets[1].ui)
+    }
+
+    @Test
+    fun `compat is validated against the implemented spec version`() {
+        assertTrue(isCompatibleSpec(">=0.1"))
+        assertTrue(isCompatibleSpec("0.1"))
+        assertTrue(isCompatibleSpec("^0.1"))
+        assertTrue(isCompatibleSpec("<0.2")) // lone upper bound → accepted (lenient)
+        assertEquals(false, isCompatibleSpec(">=0.2"))
+        assertEquals(false, isCompatibleSpec(">=1.0"))
+        assertEquals("0.1", AZPHALT_SPEC_VERSION)
+    }
+
+    @Test
     fun `carries file digests for integrity`() {
         val m = parseManifest(
             """

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     alias(libs.plugins.hilt)
     alias(libs.plugins.ksp)
     alias(libs.plugins.kotlin.parcelize)
+    alias(libs.plugins.kotlinx.serialization) // Required for @Serializable registry API models
 }
 
 android {

--- a/core/data/src/main/java/com/hereliesaz/graffitixr/data/azphalt/AzpInstaller.kt
+++ b/core/data/src/main/java/com/hereliesaz/graffitixr/data/azphalt/AzpInstaller.kt
@@ -1,6 +1,9 @@
 package com.hereliesaz.graffitixr.data.azphalt
 
+import com.hereliesaz.graffitixr.common.azphalt.AZPHALT_SPEC_VERSION
 import com.hereliesaz.graffitixr.common.azphalt.AzphaltManifest
+import com.hereliesaz.graffitixr.common.azphalt.ExtensionKind
+import com.hereliesaz.graffitixr.common.azphalt.isCompatibleSpec
 import com.hereliesaz.graffitixr.common.azphalt.parseManifest
 import java.io.File
 import java.io.InputStream
@@ -49,6 +52,26 @@ class AzpInstaller(private val extensionsRoot: File) {
             parseManifest(manifestBytes.decodeToString())
         } catch (t: Throwable) {
             throw InstallException("Invalid manifest.json: ${t.message}")
+        }
+
+        // Asset-host policy (spec/ADOPTION_ASSET_HOST.md). GraffitiXR runs no extension code, so:
+        //  - reject `kind: "code"` outright;
+        //  - a `mixed` package installs, but only its assets are ever used (its entry/runtime are
+        //    ignored downstream — the repository only reads `manifest.assets`).
+        if (manifest.kind == ExtensionKind.CODE) {
+            throw InstallException("This host installs asset extensions only; '${manifest.id}' is kind=code")
+        }
+
+        // Conformance: validate the declared spec compatibility against what this host implements.
+        if (!isCompatibleSpec(manifest.compat)) {
+            throw InstallException(
+                "Package '${manifest.id}' needs azphalt ${manifest.compat}; host implements $AZPHALT_SPEC_VERSION"
+            )
+        }
+
+        // The package format requires a LICENSE file; refuse a package that omits it.
+        if (!entries.containsKey("LICENSE")) {
+            throw InstallException("Package '${manifest.id}' is missing the required LICENSE file")
         }
 
         // Integrity: every file the manifest lists must be present and match its digest.

--- a/core/data/src/main/java/com/hereliesaz/graffitixr/data/azphalt/ExtensionRepository.kt
+++ b/core/data/src/main/java/com/hereliesaz/graffitixr/data/azphalt/ExtensionRepository.kt
@@ -33,8 +33,24 @@ class ExtensionRepository @Inject constructor(
     private val _installed = MutableStateFlow(scanInstalled())
     val installed: StateFlow<List<InstalledExtension>> = _installed.asStateFlow()
 
-    /** The catalog to browse. Bundled seed today; swap for the registry HTTP API when deployed. */
+    /** The offline catalog to browse. Bundled seed; use [catalogFromRegistry] for a live registry. */
     fun catalog(): List<MarketplaceEntry> = SEED_MARKETPLACE
+
+    /**
+     * Browse a live azphalt registry (spec/repository-api.md) instead of the bundled seed. Fetches one
+     * search page and maps each package to a catalog card whose [MarketplaceEntry.source] is its
+     * resolved `.azp` download URL — so the existing [install] path works unchanged. Blocking IO; call
+     * from a background dispatcher. [catalog] stays the offline default, so a registry outage never
+     * breaks browsing the bundled extensions.
+     */
+    fun catalogFromRegistry(
+        client: RepositoryClient,
+        query: String? = null,
+        page: Int = 1,
+    ): List<MarketplaceEntry> =
+        client.search(q = query, page = page).packages.map { pkg ->
+            pkg.toMarketplaceEntry(client.downloadUrl(pkg.id, pkg.version))
+        }
 
     fun isInstalled(id: String): Boolean = _installed.value.any { it.id == id }
 

--- a/core/data/src/main/java/com/hereliesaz/graffitixr/data/azphalt/MarketplaceEntry.kt
+++ b/core/data/src/main/java/com/hereliesaz/graffitixr/data/azphalt/MarketplaceEntry.kt
@@ -20,8 +20,12 @@ data class MarketplaceEntry(
     /** Where the .azp lives: "asset:marketplace/foo.azp" (bundled) or "https://…". */
     val source: String,
 ) {
-    /** True when GraffitiXR can install and use this today — asset LUTs. Code extensions need the JS/WASM sandbox (not yet). */
-    val installable: Boolean get() = kind == ExtensionKind.ASSET
+    /**
+     * True when GraffitiXR can install this today. As an asset-only host it takes `asset` and `mixed`
+     * packages (a mixed package installs, but only its asset contributions are used); pure `code`
+     * extensions need the JS/WASM sandbox, which isn't here yet.
+     */
+    val installable: Boolean get() = kind != ExtensionKind.CODE
 }
 
 /**

--- a/core/data/src/main/java/com/hereliesaz/graffitixr/data/azphalt/RepositoryApi.kt
+++ b/core/data/src/main/java/com/hereliesaz/graffitixr/data/azphalt/RepositoryApi.kt
@@ -1,0 +1,133 @@
+package com.hereliesaz.graffitixr.data.azphalt
+
+import com.hereliesaz.graffitixr.common.azphalt.AzphaltJson
+import com.hereliesaz.graffitixr.common.azphalt.ExtensionKind
+import kotlinx.serialization.Serializable
+import java.net.URLEncoder
+
+/**
+ * Client + models for an azphalt registry (spec/repository-api.md, format 0.1). A registry lets
+ * GraffitiXR browse and download extensions from a live server instead of the bundled seed catalog.
+ *
+ * Transport-agnostic on purpose: [httpGet] performs the actual fetch, so this is trivially unit-
+ * testable and reuses whatever HTTP stack the caller already has (GraffitiXR has no Retrofit; the
+ * caller can pass a tiny HttpURLConnection lambda). [httpGet] receives the URL and the request
+ * headers (e.g. an Authorization bearer for paid packages) and returns the response body.
+ */
+class RepositoryClient(
+    baseUrl: String,
+    private val httpGet: (url: String, headers: Map<String, String>) -> String,
+) {
+    private val base: String = baseUrl.trimEnd('/')
+
+    /** GET /.well-known/azphalt-repository.json — registry identity and capabilities. */
+    fun discover(): RepositoryInfo =
+        AzphaltJson.decodeFromString(httpGet("$base/.well-known/azphalt-repository.json", emptyMap()))
+
+    /**
+     * GET /packages — paginated search. [types] filters by contribution type (e.g. "lut", "shader",
+     * "code"); [tags] by free-form tag. Empty filters return the full catalog page.
+     */
+    fun search(
+        q: String? = null,
+        types: List<String> = emptyList(),
+        tags: List<String> = emptyList(),
+        page: Int = 1,
+    ): SearchResponse {
+        val params = buildList {
+            if (!q.isNullOrBlank()) add("q=" + enc(q))
+            if (types.isNotEmpty()) add("types=" + enc(types.joinToString(",")))
+            if (tags.isNotEmpty()) add("tags=" + enc(tags.joinToString(",")))
+            add("page=$page")
+        }.joinToString("&")
+        return AzphaltJson.decodeFromString(httpGet("$base/packages?$params", emptyMap()))
+    }
+
+    /** GET /packages/{id} — full detail and version history. */
+    fun detail(id: String): PackageDetail =
+        AzphaltJson.decodeFromString(httpGet("$base/packages/${enc(id)}", emptyMap()))
+
+    /**
+     * The download URL for a specific version's `.azp`. Handed to [ExtensionRepository.install] as the
+     * entry [MarketplaceEntry.source]; paid packages need an Authorization bearer at fetch time
+     * (the server answers 401 without a token, 402 without a license).
+     */
+    fun downloadUrl(id: String, version: String): String =
+        "$base/packages/${enc(id)}/versions/${enc(version)}/download"
+
+    private fun enc(s: String) = URLEncoder.encode(s, "UTF-8")
+}
+
+/** GET /.well-known/azphalt-repository.json */
+@Serializable
+data class RepositoryInfo(
+    val name: String,
+    val version: String,
+    val description: String? = null,
+)
+
+/** A package as it appears in a registry search result or detail response. */
+@Serializable
+data class RepositoryPackage(
+    val id: String,
+    val name: String,
+    val author: String? = null,
+    val version: String,
+    val types: List<String> = emptyList(),
+    val tags: List<String> = emptyList(),
+    val description: String? = null,
+    /** "free" or "paid"; absent is treated as free. */
+    val priceStatus: String? = null,
+)
+
+/** GET /packages — paginated. */
+@Serializable
+data class SearchResponse(
+    val packages: List<RepositoryPackage> = emptyList(),
+    val total: Int = 0,
+    val page: Int = 1,
+    val pages: Int = 1,
+)
+
+/** GET /packages/{id} — detail plus the version list (newest resolvable via [versions]). */
+@Serializable
+data class PackageDetail(
+    val id: String,
+    val name: String,
+    val author: String? = null,
+    val description: String? = null,
+    val tags: List<String> = emptyList(),
+    val types: List<String> = emptyList(),
+    val priceStatus: String? = null,
+    val versions: List<String> = emptyList(),
+)
+
+/** True when this package requires payment/entitlement to download. */
+val RepositoryPackage.isPaid: Boolean get() = priceStatus.equals("paid", ignoreCase = true)
+
+/**
+ * Map a registry package to a GraffitiXR catalog card. [downloadUrl] is the resolved `.azp` URL the
+ * installer fetches (see [RepositoryClient.downloadUrl]). Kind is inferred from [RepositoryPackage.types]:
+ * a `code` type alone is CODE, `code` alongside asset types is MIXED, anything else is ASSET.
+ */
+fun RepositoryPackage.toMarketplaceEntry(downloadUrl: String): MarketplaceEntry {
+    val hasCode = types.any { it.equals("code", ignoreCase = true) }
+    val hasAsset = types.any { !it.equals("code", ignoreCase = true) }
+    val kind = when {
+        hasCode && hasAsset -> ExtensionKind.MIXED
+        hasCode -> ExtensionKind.CODE
+        else -> ExtensionKind.ASSET
+    }
+    return MarketplaceEntry(
+        id = id,
+        name = name,
+        kind = kind,
+        author = author ?: "",
+        description = description ?: "",
+        priceLabel = if (isPaid) "Paid" else "Free",
+        downloads = 0,
+        rating = null,
+        tags = tags,
+        source = downloadUrl,
+    )
+}

--- a/core/data/src/test/java/com/hereliesaz/graffitixr/data/azphalt/AzpInstallerTest.kt
+++ b/core/data/src/test/java/com/hereliesaz/graffitixr/data/azphalt/AzpInstallerTest.kt
@@ -14,13 +14,16 @@ import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 
 /**
- * Covers [AzpInstaller]'s host safety obligations: digest verification and path-traversal defence.
+ * Covers [AzpInstaller]'s host safety and asset-host-conformance obligations: digest verification,
+ * path-traversal defence, the required LICENSE, rejecting code packages, and `compat` validation.
  * Everything here is pure JVM (zip + files + SHA-256), so it runs as a plain unit test.
  */
 class AzpInstallerTest {
 
     @get:Rule
     val tmp = TemporaryFolder()
+
+    private val license = "MIT\n".toByteArray()
 
     private fun sha256(bytes: ByteArray): String =
         MessageDigest.getInstance("SHA-256").digest(bytes)
@@ -39,19 +42,25 @@ class AzpInstallerTest {
         return out.toByteArray()
     }
 
-    private fun manifest(id: String, files: Map<String, ByteArray>): ByteArray {
+    /** A manifest.json whose `files` map is exactly [files], with the given kind/compat. */
+    private fun manifest(
+        id: String,
+        files: Map<String, ByteArray>,
+        kind: String = "asset",
+        compat: String = ">=0.1",
+    ): ByteArray {
         val filesJson = files.entries.joinToString(",") { (path, bytes) ->
             "\"$path\":\"sha256-${sha256(bytes)}\""
         }
         return """
             {
-              "azphalt": "1.0",
+              "azphalt": "0.1",
               "id": "$id",
               "name": "Test Grade",
               "version": "1.0.0",
-              "kind": "asset",
+              "kind": "$kind",
               "license": "MIT",
-              "compat": ">=1.0",
+              "compat": "$compat",
               "assets": [{ "type": "lut", "path": "assets/grade.cube" }],
               "files": { $filesJson }
             }
@@ -62,7 +71,7 @@ class AzpInstallerTest {
     fun `valid package installs and unpacks its files`() {
         val lut = "TITLE \"x\"\nLUT_3D_SIZE 2\n".toByteArray() +
             "0 0 0\n1 0 0\n0 1 0\n1 1 0\n0 0 1\n1 0 1\n0 1 1\n1 1 1\n".toByteArray()
-        val payload = mapOf("assets/grade.cube" to lut)
+        val payload = mapOf("assets/grade.cube" to lut, "LICENSE" to license)
         val bytes = zip(payload + ("manifest.json" to manifest("com.test.grade", payload)))
 
         val installer = AzpInstaller(tmp.newFolder("extensions"))
@@ -72,6 +81,7 @@ class AzpInstallerTest {
         assertEquals(123L, installed.installedAt)
         assertTrue(java.io.File(installed.filePath("assets/grade.cube")).exists())
         assertTrue(java.io.File(installed.filePath("manifest.json")).exists())
+        assertTrue(java.io.File(installed.filePath("LICENSE")).exists())
     }
 
     @Test
@@ -79,10 +89,14 @@ class AzpInstallerTest {
         val real = "real".toByteArray()
         val tampered = "tampered".toByteArray()
         // Manifest lists the digest of `real`, but the archive carries `tampered`.
-        val manifestBytes = manifest("com.test.grade", mapOf("assets/grade.cube" to real))
+        val manifestBytes = manifest(
+            "com.test.grade",
+            mapOf("assets/grade.cube" to real, "LICENSE" to license),
+        )
         val bytes = zip(mapOf(
             "manifest.json" to manifestBytes,
             "assets/grade.cube" to tampered,
+            "LICENSE" to license,
         ))
 
         val installer = AzpInstaller(tmp.newFolder("extensions"))
@@ -117,7 +131,7 @@ class AzpInstallerTest {
     @Test
     fun `unlisted file is not unpacked`() {
         val lut = "grade".toByteArray()
-        val payload = mapOf("assets/grade.cube" to lut)
+        val payload = mapOf("assets/grade.cube" to lut, "LICENSE" to license)
         // A stowaway file the manifest does not declare — it passed no digest check, so it must
         // never land on disk.
         val bytes = zip(payload + mapOf(
@@ -147,9 +161,12 @@ class AzpInstallerTest {
     @Test
     fun `manifest file listed but absent is rejected`() {
         val lut = "data".toByteArray()
-        // Manifest claims a file the archive doesn't contain.
-        val manifestBytes = manifest("com.test.grade", mapOf("assets/grade.cube" to lut))
-        val bytes = zip(mapOf("manifest.json" to manifestBytes))
+        // Manifest claims a file the archive doesn't contain (but LICENSE is present).
+        val manifestBytes = manifest(
+            "com.test.grade",
+            mapOf("assets/grade.cube" to lut, "LICENSE" to license),
+        )
+        val bytes = zip(mapOf("manifest.json" to manifestBytes, "LICENSE" to license))
 
         val installer = AzpInstaller(tmp.newFolder("extensions"))
         try {
@@ -157,6 +174,50 @@ class AzpInstallerTest {
             fail("Expected InstallException for missing payload file")
         } catch (e: AzpInstaller.InstallException) {
             assertTrue(e.message!!.contains("Missing payload file"))
+        }
+    }
+
+    @Test
+    fun `code package is rejected by the asset-only host`() {
+        val payload = mapOf("LICENSE" to license)
+        val bytes = zip(payload + ("manifest.json" to manifest("com.test.code", payload, kind = "code")))
+
+        val installer = AzpInstaller(tmp.newFolder("extensions"))
+        try {
+            installer.install(ByteArrayInputStream(bytes), nowMs = 0L)
+            fail("Expected InstallException for kind=code")
+        } catch (e: AzpInstaller.InstallException) {
+            assertTrue(e.message!!.contains("kind=code"))
+        }
+    }
+
+    @Test
+    fun `incompatible compat is rejected`() {
+        val payload = mapOf("LICENSE" to license)
+        // Needs a newer spec than this host implements (0.1).
+        val bytes = zip(payload + ("manifest.json" to manifest("com.test.future", payload, compat = ">=0.9")))
+
+        val installer = AzpInstaller(tmp.newFolder("extensions"))
+        try {
+            installer.install(ByteArrayInputStream(bytes), nowMs = 0L)
+            fail("Expected InstallException for incompatible compat")
+        } catch (e: AzpInstaller.InstallException) {
+            assertTrue(e.message!!.contains("needs azphalt"))
+        }
+    }
+
+    @Test
+    fun `package without LICENSE is rejected`() {
+        val lut = "grade".toByteArray()
+        val payload = mapOf("assets/grade.cube" to lut)
+        val bytes = zip(payload + ("manifest.json" to manifest("com.test.grade", payload)))
+
+        val installer = AzpInstaller(tmp.newFolder("extensions"))
+        try {
+            installer.install(ByteArrayInputStream(bytes), nowMs = 0L)
+            fail("Expected InstallException for missing LICENSE")
+        } catch (e: AzpInstaller.InstallException) {
+            assertTrue(e.message!!.contains("LICENSE"))
         }
     }
 }

--- a/core/data/src/test/java/com/hereliesaz/graffitixr/data/azphalt/RepositoryApiTest.kt
+++ b/core/data/src/test/java/com/hereliesaz/graffitixr/data/azphalt/RepositoryApiTest.kt
@@ -1,0 +1,84 @@
+package com.hereliesaz.graffitixr.data.azphalt
+
+import com.hereliesaz.graffitixr.common.azphalt.ExtensionKind
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Covers the azphalt registry client (spec/repository-api.md): request URLs, response parsing, and the
+ * mapping to catalog cards. Transport is faked, so this is a pure unit test.
+ */
+class RepositoryApiTest {
+
+    /** Records the URLs requested and returns canned bodies keyed by a path fragment. */
+    private class FakeHttp(private val bodies: Map<String, String>) {
+        val requested = mutableListOf<String>()
+        fun get(url: String, @Suppress("UNUSED_PARAMETER") headers: Map<String, String>): String {
+            requested += url
+            return bodies.entries.firstOrNull { url.contains(it.key) }?.value
+                ?: error("no fake body for $url")
+        }
+    }
+
+    @Test
+    fun `search parses the paginated response and hits the right URL`() {
+        val fake = FakeHttp(mapOf(
+            "/packages" to """
+                {
+                  "packages": [
+                    { "id": "com.a.lut", "name": "A LUT", "author": "A", "version": "1.2.0",
+                      "types": ["lut"], "tags": ["warm"], "priceStatus": "free" },
+                    { "id": "com.b.filter", "name": "B Filter", "author": "B", "version": "2.0.0",
+                      "types": ["code"], "priceStatus": "paid" }
+                  ],
+                  "total": 2, "page": 1, "pages": 1
+                }
+            """.trimIndent(),
+        ))
+        val client = RepositoryClient("https://reg.example/", fake::get)
+
+        val resp = client.search(q = "grade", types = listOf("lut"), page = 1)
+
+        assertEquals(2, resp.total)
+        assertEquals(1, resp.pages)
+        assertEquals("com.a.lut", resp.packages[0].id)
+        assertTrue(resp.packages[1].isPaid)
+        assertFalse(resp.packages[0].isPaid)
+        // URL is built off the trimmed base with the query params.
+        val url = fake.requested.single()
+        assertTrue(url.startsWith("https://reg.example/packages?"))
+        assertTrue(url.contains("q=grade"))
+        assertTrue(url.contains("types=lut"))
+        assertTrue(url.contains("page=1"))
+    }
+
+    @Test
+    fun `download url is well-formed and encodes segments`() {
+        val client = RepositoryClient("https://reg.example", { _, _ -> "" })
+        assertEquals(
+            "https://reg.example/packages/com.a.lut/versions/1.2.0/download",
+            client.downloadUrl("com.a.lut", "1.2.0"),
+        )
+    }
+
+    @Test
+    fun `package maps to a catalog card with kind inferred from types`() {
+        val asset = RepositoryPackage("com.a.lut", "A", version = "1.0.0", types = listOf("lut"))
+        val code = RepositoryPackage("com.b.f", "B", version = "1.0.0", types = listOf("code"))
+        val mixed = RepositoryPackage("com.c.m", "C", version = "1.0.0", types = listOf("code", "lut"))
+
+        assertEquals(ExtensionKind.ASSET, asset.toMarketplaceEntry("u").kind)
+        assertEquals(ExtensionKind.CODE, code.toMarketplaceEntry("u").kind)
+        assertEquals(ExtensionKind.MIXED, mixed.toMarketplaceEntry("u").kind)
+
+        val paidCard = RepositoryPackage("p", "P", version = "1.0.0", types = listOf("lut"), priceStatus = "paid")
+            .toMarketplaceEntry("https://reg.example/packages/p/versions/1.0.0/download")
+        assertEquals("Paid", paidCard.priceLabel)
+        assertEquals("https://reg.example/packages/p/versions/1.0.0/download", paidCard.source)
+        // Asset card is installable by this host; a pure-code one is not.
+        assertTrue(asset.toMarketplaceEntry("u").installable)
+        assertFalse(code.toMarketplaceEntry("u").installable)
+    }
+}

--- a/docs/AZNAVRAIL_COMPLETE_GUIDE.md
+++ b/docs/AZNAVRAIL_COMPLETE_GUIDE.md
@@ -78,10 +78,16 @@ Controls layout behavior and docking logic.
 azConfig(
     packButtons = packRailButtons,       // Boolean: Pack items tightly vs spaced
     dockingSide = AzDockingSide.LEFT,    // Enum: LEFT or RIGHT
-    noMenu = noMenu,                     // Boolean: Disable the side drawer entirely
+    noMenu = noMenu,                     // Boolean: Disable the side drawer; all items become rail items
     usePhysicalDocking = usePhysicalDocking // Boolean: Anchor to physical hardware edge vs visual left
 )
 ```
+
+**`noMenu` (11.0):** When `true`, the side drawer is removed — every entry is treated as a rail
+item — **and tapping the app icon folds the stationary rail up into the icon.** The scope exposes
+`var isFoldedUp: Boolean` to read/track that folded state. This is how GraffitiXR's Design mode gets
+its "tap the app icon to fold the rail away" behaviour (see `railMenuDisabled` in `MainActivity`);
+earlier releases (10.x) had no app-icon/expansion hook and could only approximate it.
 
 
 ### B. Theming (`azTheme`)

--- a/docs/azphalt-host-requests.md
+++ b/docs/azphalt-host-requests.md
@@ -1,0 +1,60 @@
+# GraffitiXR → azphalt: host requests
+
+Feedback from GraffitiXR, the azphalt standard's first conforming host, gathered while implementing
+the manifest model, the `.azp` installer, and the registry-API client. Ordered by how much each one
+blocks or improves a real host integration. Not filed against the azphalt repo — this is our wish
+list to relay.
+
+## Blocking / correctness
+
+1. **Pin the signature canonicalization.** `spec/package-format.md` says `signature.json` is an Ed25519
+   signature over "the canonical bytes of `manifest.json`," but the canonical form is undefined
+   (RFC 8785 JCS? sorted keys, specific whitespace/number formatting?). A host cannot implement
+   verification interoperably without it. **Ask:** specify the exact canonicalization and publish a
+   signed-package test vector (manifest bytes + key + expected signature). *Until this lands GraffitiXR
+   verifies payloads by SHA-256 digest only and skips signature verification — a conformance gap forced
+   by the spec, not a choice.*
+
+2. **Make the digest string format normative.** The `files` map is "path → SHA-256 digest," but the
+   digest string format isn't pinned. GraffitiXR uses `"sha256-" + lowercase hex`. **Ask:** state the
+   exact form (SRI-style `sha256-<base64>`? `sha256-<hex>`? multihash?) so hosts don't diverge and
+   silently reject each other's packages.
+
+3. **Define the `compat` grammar.** Asset hosts MUST validate `compat` against their spec version, but
+   the expression grammar isn't specified. GraffitiXR currently parses only a leading lower bound
+   (`>=x.y` / `^x.y` / `~x.y` / bare `x.y`) and is lenient about the rest. **Ask:** pin a semver-range
+   subset so host validation is interoperable.
+
+## Product value
+
+4. **Standardize a LUT `strength` parameter + its UI panel.** GraffitiXR applies `.cube` LUTs at full
+   strength; the single most common user need is a 0–100% blend. **Ask:** define an optional, normative
+   `strength` param for `lut` assets and a canonical `ui/…json` panel (a `slider`) for it, so every host
+   renders the same control and the value round-trips the same way. More generally: publish a
+   **per-asset-type `params` schema** (LUT, shader, transition, brush) — the asset-host guide names
+   `params.format` for shaders/transitions but there's no schema to validate against.
+
+5. **Add preview + popularity fields to the registry package summary.** `GET /packages` returns
+   `id/name/author/version/types/priceStatus`. A marketplace card wants a thumbnail and social proof.
+   **Ask:** add optional `iconUrl`, `previewUrl` (for LUTs, a before/after sample), `downloads`,
+   `rating`, and `updatedAt` to the package object. GraffitiXR's catalog card already has `downloads`
+   and `rating` slots sitting empty for registry results.
+
+6. **Surface required capabilities in search results.** An asset-only host (no code sandbox — GraffitiXR
+   today) needs to know *before downloading* whether a package is usable. `types[]` helps, but a
+   package could need capabilities the host lacks. **Ask:** include the manifest's required
+   `capabilities` (and a simple `assetOnly: true/false`) in the search summary so a host can filter out
+   unusable packages up front instead of downloading then rejecting.
+
+## Adoption / ecosystem
+
+7. **Ship a public reference registry + conformance fixtures.** `spec/repository-api.md` is clear, but
+   there's no public endpoint or sample responses to build against. **Ask:** publish a reference
+   registry instance (or static sample JSON for each endpoint) and a fixture set of signed `.azp`
+   packages, so hosts can integrate and pass `@azphalt/conformance` before a production registry exists.
+
+8. **Clarify mixed-package asset independence.** For `kind: "mixed"`, the asset-host guide says ignore
+   `entry`/`runtime` and use `manifest.assets`. **Ask:** state whether a mixed package's assets may
+   depend on its code (e.g., a LUT generated at runtime). If they can, an asset-only host can't safely
+   use them; a manifest flag marking each asset `standalone: true` would let asset hosts pick only the
+   assets they can honor.

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Sun Jul 12 09:57:31 UTC 2026
-versionMinorLast=35
-versionPatch=35
-versionBuild=14169
+#Mon Jul 13 21:54:08 UTC 2026
+versionBuild=14170
 versionMajor=1
 versionMinor=35
+versionMinorLast=35
+versionPatch=36

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Mon Jul 13 21:54:08 UTC 2026
-versionBuild=14170
+#Tue Jul 14 00:40:56 UTC 2026
+versionBuild=14172
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=36
+versionPatch=38

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Tue Jul 14 00:40:56 UTC 2026
-versionBuild=14172
+#Tue Jul 14 00:56:52 UTC 2026
+versionBuild=14176
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=38
+versionPatch=42


### PR DESCRIPTION
Three changes on this branch.

## 1. AzNavRail 11.0 `noMenu` app-icon fold-up (Design mode)

`azConfig(noMenu = true)` in 11.0 folds the stationary rail up into the app icon when the icon is tapped (`isFoldedUp`) — the long-requested Design-mode behaviour, which 10.32 could only approximate. GraffitiXR already passes `noMenu = true` in Design mode, so it's now live. Refreshed the stale `MainActivity` comment and documented it in `docs/AZNAVRAIL_COMPLETE_GUIDE.md`. No functional change.

## 2. azphalt 0.1 spec conformance (asset host)

Brought the asset-only host up to the current `spec/package-format.md` + `docs/ADOPTION_ASSET_HOST.md`:
- `AssetType` gains `shader` + `transition` (unknown enum values otherwise fail to parse).
- `AssetContribution` models the new `params` + `ui` fields.
- `AZPHALT_SPEC_VERSION = "0.1"` + `isCompatibleSpec()`; installer validates `compat`.
- `AzpInstaller` rejects `kind: "code"` and requires the now-mandatory `LICENSE`.
- `MarketplaceEntry.installable` = `kind != code` (mixed installs, assets-only used).
- Tests for code-reject / incompatible-compat / missing-LICENSE / shader+transition+params/ui / compat validator.

## 3. azphalt registry-API client (spec/repository-api.md)

The registry HTTP API is new since the last pass. Implemented a typed, transport-agnostic client so GraffitiXR can browse a live registry instead of only the bundled seed:
- `RepositoryApi.kt` — models + `RepositoryClient` (discover / paginated search / detail / download URL); `priceStatus: "paid"` surfaced for the Bearer/401/402 flow; `toMarketplaceEntry()` maps a package to a catalog card (kind inferred from `types[]`).
- `ExtensionRepository.catalogFromRegistry()` — optional live browse; the bundled seed stays the offline default so a registry outage never breaks browsing.
- Added the kotlinx.serialization plugin to `core:data` (the new `@Serializable` models need it).
- `RepositoryApiTest` — search parse + URL building, download-URL encoding, kind/price/installable mapping.

### Deferred (with rationale)
- **Ed25519 signature verification** — the manifest canonicalization for the signature bytes is underspecified; a half-right verifier that rejects valid packages is worse than none. Digest gate still enforces integrity.
- **Native UI-panel rendering** (`spec/ui-schema.md`) — GraffitiXR's LUT apply is parameterless today, so there's nothing to bind controls to yet.

Both are captured, with our other asks, in **`docs/azphalt-host-requests.md`** — GraffitiXR's feedback to the marketplace as its first conforming host.

## Verification
`:core:common` + `:core:data` azphalt tests pass; `:app:compileDebugKotlin` clean. version.properties auto-incremented by the builds (single source of truth, not reverted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)