### PR TITLE
feat(azphalt): full current asset-type set incl. AI models + host requests

### DIFF
--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/azphalt/AzphaltManifest.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/azphalt/AzphaltManifest.kt
@@ -26,6 +26,8 @@ data class AzphaltManifest(
     val author: String? = null,
     val description: String? = null,
     val homepage: String? = null,
+    /** Apps this extension targets (spec/extension-manifest.md), by host app id. Empty = universal. */
+    val targetApps: List<String> = emptyList(),
     val entry: String? = null,
     val runtime: Runtime? = null,
     val capabilities: List<Capability> = emptyList(),
@@ -74,15 +76,59 @@ data class Contribution(
     val ui: String? = null,
 )
 
-@Serializable
-enum class AssetType {
-    @SerialName("brush") BRUSH,
-    @SerialName("lut") LUT,
-    @SerialName("pattern") PATTERN,
-    @SerialName("stamp") STAMP,
-    // Added in spec 0.1's asset-host guide: GLSL/ISF shaders and gl-transition transitions.
-    @SerialName("shader") SHADER,
-    @SerialName("transition") TRANSITION,
+/**
+ * Asset contribution types (spec 0.1: brush/lut/pattern/stamp/shader/transition). Deserialized through
+ * a custom serializer that maps any value this build doesn't recognise to [UNKNOWN] instead of
+ * throwing — so a package using a newer asset type (e.g. azphalt's normalized ML `model` assets, not
+ * yet in the asset-host spec) still parses, and a host simply ignores the contributions it can't apply.
+ */
+@Serializable(with = AssetType.Serializer::class)
+enum class AssetType(val wire: String) {
+    // Traditional assets (spec/extension-manifest.md).
+    BRUSH("brush"),
+    LUT("lut"),
+    PATTERN("pattern"),
+    STAMP("stamp"),
+    SHADER("shader"),
+    TRANSITION("transition"),
+    MESH("mesh"),
+    MATERIAL("material"),
+    HDRI("hdri"),
+    MOTION("motion"),
+    PALETTE("palette"),
+    IMAGE("image"),
+    VIDEO("video"),
+    FONT("font"),
+    AUDIO("audio"),
+    VECTOR("vector"),
+
+    // AI model assets. Paired with AssetContribution.role (e.g. "depth", "segmentation") so a host
+    // routes the model graph to the right on-device engine.
+    TFLITE("tflite"),
+    LITERT("litert"),
+    ONNX("onnx"),
+    SHERPA_BUNDLE("sherpa-bundle"),
+
+    /** A type this host build does not recognise; the contribution is retained but not applied. */
+    UNKNOWN("");
+
+    /** True for the AI-model asset types (spec/extension-manifest.md "AI Models"). */
+    val isModel: Boolean get() = this == TFLITE || this == LITERT || this == ONNX || this == SHERPA_BUNDLE;
+
+    internal object Serializer : kotlinx.serialization.KSerializer<AssetType> {
+        override val descriptor = kotlinx.serialization.descriptors.PrimitiveSerialDescriptor(
+            "com.hereliesaz.graffitixr.common.azphalt.AssetType",
+            kotlinx.serialization.descriptors.PrimitiveKind.STRING,
+        )
+
+        override fun serialize(encoder: kotlinx.serialization.encoding.Encoder, value: AssetType) =
+            encoder.encodeString(value.wire)
+
+        override fun deserialize(decoder: kotlinx.serialization.encoding.Decoder): AssetType {
+            val raw = decoder.decodeString()
+            return entries.firstOrNull { it.wire == raw } ?: UNKNOWN
+        }
+    }
 }
 
 @Serializable
@@ -97,6 +143,13 @@ data class AssetContribution(
     val params: JsonObject? = null,
     /** Optional path to a native UI panel schema (spec/ui-schema.md), e.g. `"ui/grade.json"`. */
     val ui: String? = null,
+    /**
+     * Optional semantic role, chiefly for model assets — e.g. `type: "tflite", role: "depth"`. Lets a
+     * host route a generic model graph to the correct engine (depth, segmentation, feature-descriptor…).
+     */
+    val role: String? = null,
+    /** Optional payload size in bytes; helps a host allocate/report before downloading a large asset. */
+    val byteSize: Long? = null,
 )
 
 /** Shared lenient JSON — tolerates unknown/future manifest fields rather than failing to parse. */

--- a/core/common/src/test/java/com/hereliesaz/graffitixr/common/azphalt/AzphaltManifestTest.kt
+++ b/core/common/src/test/java/com/hereliesaz/graffitixr/common/azphalt/AzphaltManifestTest.kt
@@ -1,6 +1,7 @@
 package com.hereliesaz.graffitixr.common.azphalt
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -85,6 +86,46 @@ class AzphaltManifestTest {
         assertEquals("isf", m.assets[0].params?.get("format")?.let { it.toString().trim('"') })
         assertEquals(AssetType.TRANSITION, m.assets[1].type)
         assertNull(m.assets[1].ui)
+    }
+
+    @Test
+    fun `parses AI model assets with role and byteSize`() {
+        val m = parseManifest(
+            """
+            {
+              "azphalt": "0.1", "id": "com.ai.seg", "name": "Segmenter", "version": "1.0.0",
+              "kind": "asset", "license": "MIT", "compat": ">=0.1",
+              "targetApps": ["com.hereliesaz.graffitixr"],
+              "assets": [
+                { "type": "tflite", "path": "models/seg.tflite", "role": "segmentation", "byteSize": 4194304 },
+                { "type": "lut", "path": "assets/grade.cube" }
+              ],
+              "files": {}
+            }
+            """.trimIndent(),
+        )
+        assertEquals(AssetType.TFLITE, m.assets[0].type)
+        assertTrue(m.assets[0].type.isModel)
+        assertEquals("segmentation", m.assets[0].role)
+        assertEquals(4194304L, m.assets[0].byteSize)
+        assertEquals(listOf("com.hereliesaz.graffitixr"), m.targetApps)
+        assertFalse(m.assets[1].type.isModel)
+    }
+
+    @Test
+    fun `unrecognized asset type parses as UNKNOWN instead of throwing`() {
+        // A type newer than this build knows about must not break the parse.
+        val m = parseManifest(
+            """
+            {
+              "azphalt": "0.1", "id": "com.x.y", "name": "N", "version": "1.0.0",
+              "kind": "asset", "license": "MIT", "compat": ">=0.1",
+              "assets": [{ "type": "quantum-brush", "path": "assets/q.bin" }],
+              "files": {}
+            }
+            """.trimIndent(),
+        )
+        assertEquals(AssetType.UNKNOWN, m.assets[0].type)
     }
 
     @Test

--- a/docs/azphalt-host-requests.md
+++ b/docs/azphalt-host-requests.md
@@ -58,3 +58,52 @@ list to relay.
    depend on its code (e.g., a LUT generated at runtime). If they can, an asset-only host can't safely
    use them; a manifest flag marking each asset `standalone: true` would let asset hosts pick only the
    assets they can honor.
+
+## Security / lifecycle
+
+9. **A revocation / kill-switch list.** If a signing key is compromised or a package turns out to be
+   malicious, a host that already installed it has no way to learn it should be disabled. **Ask:** a
+   well-known revocations feed (e.g. `GET /.well-known/azphalt-revocations.json`) listing revoked
+   package ids / versions / key ids, so a host can honor a takedown for already-installed extensions.
+
+10. **Update semantics in the registry.** `GET /packages/{id}` returns `versions[]` but no "latest"
+    pointer and no batch update-check. A host that has N extensions installed wants to show "update
+    available" without N round-trips. **Ask:** a `latest` field on the package plus a batch endpoint
+    (e.g. `POST /updates` with `[{id, version}]` → the ids with a newer version).
+
+## Registry metadata (round out the summary)
+
+11. **Download size.** Add `size` (bytes) to version metadata so a mobile host can show it and warn on
+    metered connections before downloading.
+
+12. **Localized `name` / `description`.** They're single-language today. GraffitiXR ships ~14 UI
+    locales; the catalog card should localize. **Ask:** an optional localized-strings map
+    (`{ "en": "...", "es": "..." }`) the host picks from.
+
+13. **A normative error response body.** The API defines status codes (401/402/404) but no error
+    payload. **Ask:** a standard `{ "error": { "code": "...", "message": "..." } }` shape so hosts can
+    show meaningful messages instead of a bare status.
+
+## ML model delivery (high interest for GraffitiXR)
+
+Model assets are already first-class in `spec/extension-manifest.md` — types `tflite` / `litert` /
+`onnx` / `sherpa-bundle`, an asset `role` (e.g. `"depth"`) for routing, and `byteSize`. GraffitiXR now
+parses all of these. Delivering updated segmentation / SuperPoint-descriptor / depth models over the
+marketplace **without an app release** is exactly what we want. The remaining asks are about closing
+gaps so a host can actually *run* a delivered model:
+
+14. **Sync the asset-host adoption guide with the manifest spec.** `docs/ADOPTION_ASSET_HOST.md` still
+    lists only `brush/lut/pattern/stamp/shader/transition` — it omits the model types (and `mesh`,
+    `material`, `hdri`, `motion`, `palette`, `image`, `video`, `font`, `audio`, `vector`) plus `role` /
+    `byteSize`. A host implementer reading the adoption guide alone would miss model support entirely.
+
+15. **Standardize the `role` vocabulary.** `role` is what lets a host route a generic model graph to
+    the right engine, but the identifiers are freeform. **Ask:** a normative (or registry-maintained)
+    role list — e.g. `depth`, `segmentation`, `feature-descriptor`, `style`, `upscale`, `matting` — so
+    a model tagged `role: "depth"` deterministically lands in GraffitiXR's depth engine.
+
+16. **Model runtime / compat metadata.** A `.tflite` may need a specific LiteRT/TFLite version, a
+    delegate (GPU/NNAPI), or an input resolution the on-device runtime must support. `compat` covers the
+    azphalt spec version, not the model runtime. **Ask:** per-model runtime requirements (e.g.
+    `params.runtimeVersion`, `params.delegates`, input/output tensor shapes + dtypes + quantization) so
+    a host refuses a model it cannot execute *before* downloading `byteSize` bytes onto a phone.

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Tue Jul 14 03:02:35 UTC 2026
-versionBuild=14179
+#Tue Jul 14 03:05:57 UTC 2026
+versionBuild=14180
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=45
+versionPatch=46

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Tue Jul 14 01:52:05 UTC 2026
-versionMinorLast=35
-versionPatch=44
-versionBuild=14178
+#Tue Jul 14 03:02:35 UTC 2026
+versionBuild=14179
 versionMajor=1
 versionMinor=35
+versionMinorLast=35
+versionPatch=45


### PR DESCRIPTION
## What

Caught up to the **authoritative `spec/extension-manifest.md`**. My earlier azphalt work modeled only the asset types listed in `docs/ADOPTION_ASSET_HOST.md`, which is a subset — the real manifest spec carries a much larger, current list, **including first-class AI model types**. Directly enables delivering AI models to GraffitiXR over the marketplace (updated segmentation / SuperPoint-descriptor / depth models without an app release).

## Changes

- **`AssetType`** — full current set: `mesh, material, hdri, motion, palette, image, video, font, audio, vector` and the AI-model types **`tflite, litert, onnx, sherpa-bundle`** (`isModel` marks them). The custom serializer's `UNKNOWN` fallback stays for anything newer, so the parser never throws on an unrecognized type.
- **`AssetContribution`** — added **`role`** (routes a model to the right host engine, e.g. `role: "depth"`) and **`byteSize`** (allocate/report before downloading a large model).
- **`AzphaltManifest`** — added top-level **`targetApps`**.
- **Tests** — parse a `tflite` model asset (role + byteSize + targetApps); confirm an unrecognized type degrades to `UNKNOWN` rather than throwing.
- **`docs/azphalt-host-requests.md`** — models are already in-spec, so the ML asks are reframed to the real gaps, plus the other new requests:
  - sync `ADOPTION_ASSET_HOST.md` with the manifest spec (it omits models + `role`/`byteSize`);
  - standardize the `role` vocabulary (depth / segmentation / feature-descriptor / …) for deterministic routing;
  - per-model runtime/compat metadata (LiteRT/TFLite version, delegates, tensor shapes) so a host refuses a model it can't run *before* downloading it;
  - a revocation/kill-switch feed; registry update/`latest` semantics; download `size`; localized name/description; a normative error-response body.

## Verification
`:core:common` + `:core:data` azphalt tests pass; `:app:compileDebugKotlin` clean. Rebased onto latest `main` (which had advanced on unrelated files); version.properties kept moving forward (14178 → 14179, never reverted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBwsyyWbkuTH9QV27ZnmVU)_

## Summary by Sourcery

Align azphalt manifest support with the latest extension spec, including AI model assets and targeted apps, while keeping parsing forward-compatible with new asset types.

New Features:
- Support the full set of manifest asset types including traditional media assets and first-class AI model types.
- Add target app identifiers to azphalt manifests so extensions can declare which host applications they target.
- Allow asset contributions to carry a semantic role and payload byte size for better routing and download handling.

Enhancements:
- Introduce a lenient asset-type serializer that maps unknown types to an UNKNOWN enum value instead of failing deserialization.
- Expose a convenience flag on asset types to distinguish AI model assets from other asset kinds.

Build:
- Increment project version metadata for the new changes.

Documentation:
- Expand azphalt host request documentation with registry lifecycle, metadata, error handling, and ML model delivery requirements.

Tests:
- Add tests covering AI model asset parsing with role/byteSize/targetApps and verifying unknown asset types deserialize as UNKNOWN rather than throwing.