### PR TITLE
azphalt conformance: Ed25519 signature verification + compat grammar fix

### DIFF
--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -66,6 +66,12 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.kotlinx.serialization.cbor)
 
+    // Crypto: Ed25519 signature + trust verification for azphalt `.azp` packages
+    // (spec/package-format.md § Signing). Android's built-in Ed25519 (java.security) is only API 33+,
+    // but this app's minSdk is 26, so Bouncy Castle provides it everywhere. Version pinned to match
+    // the root build's forced 1.85 (already on the app classpath transitively).
+    implementation("org.bouncycastle:bcprov-jdk18on:1.85")
+
     // Networking (Crash Reporting)
     implementation(libs.retrofit)
     implementation(libs.retrofit.converter.gson)

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/azphalt/AzpSignature.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/azphalt/AzpSignature.kt
@@ -1,0 +1,117 @@
+package com.hereliesaz.graffitixr.common.azphalt
+
+import kotlinx.serialization.Serializable
+import org.bouncycastle.crypto.params.Ed25519PublicKeyParameters
+import org.bouncycastle.crypto.signers.Ed25519Signer
+import org.bouncycastle.crypto.util.PublicKeyFactory
+import java.util.Base64
+
+/**
+ * The detached `signature.json` carried by a signed `.azp` (azphalt spec/package-format.md § Signing).
+ *
+ * A signature is an **Ed25519** signature over the **exact `manifest.json` byte sequence stored in the
+ * archive** — verbatim, with **no re-canonicalization** (no JCS/RFC 8785, no whitespace normalization,
+ * no key reordering). `publicKey` is base64 **SPKI** (DER `SubjectPublicKeyInfo`). Signing the manifest
+ * transitively signs the payload through the `files` digests. This mirrors `@azphalt/azp`'s
+ * `AzpSignature`, so a package signed by the reference `signAzp` verifies here byte-for-byte — proven
+ * against the published test vector (`packages/azp/test/vectors/signature-vector.json`) in the tests.
+ */
+@Serializable
+data class AzpSignature(
+    val alg: String,
+    /** Base64 SPKI public key the signature verifies against. */
+    val publicKey: String,
+    /** Base64 Ed25519 signature over the `manifest.json` bytes. */
+    val signature: String,
+    /** Optional signer-chosen key identifier (informational; trust matches on [publicKey]). */
+    val keyId: String? = null,
+    /** Optional registry counter-signature vouching for [publicKey] — see [AzpCountersignature]. */
+    val countersignature: AzpCountersignature? = null,
+)
+
+/**
+ * A counter-signature: an Ed25519 signature over the **SPKI bytes of the key below it** in the chain
+ * (the author at the base, or the previous counter-signer). Counter-signatures nest, forming a
+ * web-of-trust chain a host walks in [evaluateTrust].
+ */
+@Serializable
+data class AzpCountersignature(
+    /** Base64 SPKI public key of the registry/authority making this vouch. */
+    val publicKey: String,
+    /** Base64 Ed25519 signature over the vouched-for key's SPKI DER bytes. */
+    val signature: String,
+    val keyId: String? = null,
+    /** A further counter-signature vouching for [publicKey] — the next hop up the chain. */
+    val countersignature: AzpCountersignature? = null,
+)
+
+/**
+ * A package's provenance, mirroring the spec's integrity-vs-identity split: a valid signature is
+ * tamper-evidence; *trust* is a separate decision against a [TrustStore].
+ */
+enum class SignatureStatus {
+    /** No `signature.json` — integrity only, no established provenance. */
+    UNSIGNED,
+
+    /** Valid Ed25519 signature, but the signer is not in the trust store. */
+    SIGNED_UNTRUSTED,
+
+    /** Valid signature AND the signer is trusted (directly, or via a registry counter-signature). */
+    SIGNED_TRUSTED,
+
+    /** A `signature.json` is present but does not verify — tampered/corrupt; a host MUST refuse it. */
+    INVALID,
+}
+
+/**
+ * Ed25519 signature + trust checks for `.azp` packages. Pure/JVM — BouncyCastle (Android's built-in
+ * Ed25519 is API 33+, but this app's minSdk is 26) and `java.util.Base64` (API 26+) — so parse and
+ * verify are unit-testable off-device, like [CubeLut].
+ */
+object AzpSignatures {
+
+    /** Parse a `signature.json` body, or `null` if it's absent/blank/malformed. */
+    fun parse(signatureJson: String?): AzpSignature? {
+        if (signatureJson.isNullOrBlank()) return null
+        // Explicit serializer (not the reified extension) so parsing needs no extra import.
+        return runCatching { AzphaltJson.decodeFromString(AzpSignature.serializer(), signatureJson) }.getOrNull()
+    }
+
+    /**
+     * Verify an Ed25519 [signatureB64] over [message] against a base64 SPKI [publicKeyB64]. Returns
+     * `false` on any malformation (bad base64, non-Ed25519 key, wrong signature length) rather than
+     * throwing — mirroring the reference's "return false, don't crash" posture.
+     */
+    fun ed25519Verify(publicKeyB64: String, message: ByteArray, signatureB64: String): Boolean =
+        runCatching {
+            val spki = Base64.getDecoder().decode(publicKeyB64)
+            val sig = Base64.getDecoder().decode(signatureB64)
+            val key = PublicKeyFactory.createKey(spki)
+            if (key !is Ed25519PublicKeyParameters) return@runCatching false
+            val verifier = Ed25519Signer()
+            verifier.init(false, key)
+            verifier.update(message, 0, message.size)
+            verifier.verifySignature(sig)
+        }.getOrDefault(false)
+
+    /**
+     * Is [sig] a valid Ed25519 signature over the exact [manifestBytes]? Tamper-evidence only — the
+     * identity question ("is the signer trusted?") is [evaluateTrust].
+     */
+    fun isManifestSignatureValid(manifestBytes: ByteArray, sig: AzpSignature): Boolean {
+        if (!sig.alg.equals("ed25519", ignoreCase = true)) return false
+        return ed25519Verify(sig.publicKey, manifestBytes, sig.signature)
+    }
+
+    /**
+     * Evaluate a package's provenance from its verbatim `manifest.json` [manifestBytes] and optional
+     * `signature.json` body against a [store]. A host MUST refuse a package whose result is
+     * [SignatureStatus.INVALID]; the others are installable but carry differing provenance.
+     */
+    fun evaluate(manifestBytes: ByteArray, signatureJson: String?, store: TrustStore): SignatureStatus {
+        val sig = parse(signatureJson) ?: return SignatureStatus.UNSIGNED
+        if (!isManifestSignatureValid(manifestBytes, sig)) return SignatureStatus.INVALID
+        return if (evaluateTrust(sig, store).trusted) SignatureStatus.SIGNED_TRUSTED
+        else SignatureStatus.SIGNED_UNTRUSTED
+    }
+}

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/azphalt/AzphaltManifest.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/azphalt/AzphaltManifest.kt
@@ -162,20 +162,73 @@ val AzphaltJson: Json = Json {
 fun parseManifest(json: String): AzphaltManifest = AzphaltJson.decodeFromString(json)
 
 /**
+ * The `compat` comparator (azphalt spec/extension-manifest.md § compat).
+ * `0.1` allows exactly one, optional, defaulting to `>=`.
+ */
+enum class CompatOp(val token: String) { GE(">="), LE("<="), GT(">"), LT("<"), EQ("=") }
+
+/** A parsed `compat` (or bare host version): one [CompatOp] over a `MAJOR.MINOR.PATCH` triple. */
+data class Compat(val op: CompatOp, val major: Int, val minor: Int, val patch: Int)
+
+// One comparator (optional, two-char forms first), then MAJOR[.MINOR[.PATCH]]. No ranges, unions,
+// hyphen ranges, ^/~, or prerelease tags — the deliberately small 0.1 subset.
+private val COMPAT_RE = Regex("""^\s*(>=|<=|>|<|=)?\s*(\d+)(?:\.(\d+))?(?:\.(\d+))?\s*$""")
+
+/**
+ * Parse a `compat` string (or a bare `MAJOR[.MINOR[.PATCH]]` host version) into its comparator and
+ * version, or `null` if it doesn't match the `0.1` grammar. Mirrors `@azphalt/azp`'s `parseCompat`,
+ * so this host parses exactly what the reference implementation does — including rejecting `^`/`~`,
+ * ranges, unions (`||`), and prerelease tags, which are **not** part of `0.1`.
+ */
+fun parseCompat(compat: String): Compat? {
+    val m = COMPAT_RE.matchEntire(compat) ?: return null
+    val op = when (m.groupValues[1]) {
+        "<=" -> CompatOp.LE
+        ">" -> CompatOp.GT
+        "<" -> CompatOp.LT
+        "=" -> CompatOp.EQ
+        else -> CompatOp.GE // ">=" or absent (defaults to >=)
+    }
+    return Compat(
+        op = op,
+        major = m.groupValues[2].toInt(),
+        minor = m.groupValues[3].ifEmpty { "0" }.toInt(),
+        patch = m.groupValues[4].ifEmpty { "0" }.toInt(),
+    )
+}
+
+private fun compareVersions(a: Compat, b: Compat): Int {
+    if (a.major != b.major) return a.major.compareTo(b.major)
+    if (a.minor != b.minor) return a.minor.compareTo(b.minor)
+    return a.patch.compareTo(b.patch)
+}
+
+/**
+ * Does a host advertising azphalt-API version [hostVersion] satisfy a package's [compat]? Mirrors
+ * `@azphalt/azp`'s `compatSatisfies`: `false` if either input is unparseable (fail closed), otherwise
+ * the host version, by semver precedence, must satisfy the single comparator.
+ */
+fun compatSatisfies(hostVersion: String, compat: String): Boolean {
+    val c = parseCompat(compat) ?: return false
+    val h = parseCompat(hostVersion) ?: return false
+    val d = compareVersions(h, c)
+    return when (c.op) {
+        CompatOp.GE -> d >= 0
+        CompatOp.GT -> d > 0
+        CompatOp.LE -> d <= 0
+        CompatOp.LT -> d < 0
+        CompatOp.EQ -> d == 0
+    }
+}
+
+/**
  * Whether a package declaring [compat] is compatible with the spec version this host implements
  * ([AZPHALT_SPEC_VERSION]). The asset-host conformance suite requires validating `compat`.
  *
- * We enforce only a lower bound written as `">=x.y"`, `"^x.y"`, `"~x.y"`, or a bare `"x.y"`: the
- * package is accepted when that minimum is ≤ our spec version. Anything we can't parse as a minimum
- * (e.g. a lone upper bound `"<0.2"`) is accepted — the payload digest check is the real integrity
- * gate, so `compat` errs toward leniency rather than rejecting a package we could actually use.
+ * This applies the normative `0.1` grammar (`spec/extension-manifest.md § compat`) via
+ * [compatSatisfies] rather than the earlier lenient lower-bound heuristic: a `compat` outside the
+ * grammar (e.g. `^0.1`, `~0.1`, a union) no longer slips through as "compatible" — it fails closed,
+ * exactly as the reference `compatSatisfies` does, so this host accepts precisely what other
+ * conforming hosts accept.
  */
-fun isCompatibleSpec(compat: String): Boolean {
-    val m = Regex("""^\s*(?:>=|\^|~)?\s*(\d+)\.(\d+)""").find(compat) ?: return true
-    val reqMajor = m.groupValues[1].toInt()
-    val reqMinor = m.groupValues[2].toInt()
-    val specParts = AZPHALT_SPEC_VERSION.split(".")
-    val specMajor = specParts[0].toInt()
-    val specMinor = specParts.getOrElse(1) { "0" }.toInt()
-    return reqMajor < specMajor || (reqMajor == specMajor && reqMinor <= specMinor)
-}
+fun isCompatibleSpec(compat: String): Boolean = compatSatisfies(AZPHALT_SPEC_VERSION, compat)

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/azphalt/TrustStore.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/azphalt/TrustStore.kt
@@ -1,0 +1,86 @@
+package com.hereliesaz.graffitixr.common.azphalt
+
+import java.util.Base64
+
+/**
+ * The azphalt trust model (spec/package-format.md § Signing). A valid signature is *tamper-evidence*;
+ * this is the *identity* decision. A host holds a [TrustStore] of trusted Ed25519 public keys; a
+ * package is **trusted** when either its signer key is directly in the store, or its signer key was
+ * counter-signed by a **registry** key in the store — transitive trust, so a host can trust one
+ * registry instead of every author. Key distribution is out-of-band by design; this only enforces the
+ * cryptography. Mirrors `@azphalt/azp`'s `verifyTrust`.
+ */
+
+/** A public key a host trusts (base64 SPKI), as a direct author key or a registry key. */
+data class TrustedKey(val publicKey: String, val keyId: String? = null, val label: String? = null)
+
+/** The set of Ed25519 public keys a host trusts. [EMPTY] establishes no provenance (signed-untrusted). */
+data class TrustStore(val keys: List<TrustedKey> = emptyList()) {
+    companion object {
+        val EMPTY = TrustStore(emptyList())
+    }
+}
+
+/** The outcome of a trust evaluation. */
+data class TrustResult(
+    val trusted: Boolean,
+    val reason: String,
+    val signerPublicKey: String? = null,
+    /** When trust came transitively, the registry key that vouched for the signer. */
+    val viaRegistryPublicKey: String? = null,
+)
+
+/** Ceiling on counter-signature chain length — a DoS guard against attacker-crafted deep chains. */
+private const val MAX_CHAIN_DEPTH = 10
+
+/**
+ * Decide whether the signer of [sig] is trusted per [store]: directly (signer key in the store), or
+ * transitively by walking the counter-signature chain — each hop's key vouches (signs) for the key
+ * below it (the author at the base, then each previous counter-signer). Trusted as soon as a hop's key
+ * is in the store, provided every hop's signature down to it verifies. Assumes [sig] has already been
+ * confirmed internally valid (see [AzpSignatures.isManifestSignatureValid]).
+ */
+fun evaluateTrust(sig: AzpSignature, store: TrustStore): TrustResult {
+    val trusted = store.keys.map { it.publicKey }.toHashSet()
+    val signer = sig.publicKey
+
+    // (a) Direct trust.
+    if (trusted.contains(signer)) {
+        return TrustResult(true, "signer key is directly trusted", signerPublicKey = signer)
+    }
+
+    // (b) Transitive trust: walk the counter-signature chain from the author up. Each link signs the
+    // SPKI bytes of the key below it (`vouchedKey`), so the message to verify is that key's DER bytes.
+    var vouchedKey = signer
+    var cs = sig.countersignature
+    var hop = 0
+    while (cs != null) {
+        hop++
+        if (hop > MAX_CHAIN_DEPTH) {
+            return TrustResult(false, "counter-signature chain exceeds the $MAX_CHAIN_DEPTH-hop limit", signerPublicKey = signer)
+        }
+        val message = runCatching { Base64.getDecoder().decode(vouchedKey) }.getOrNull()
+            ?: return TrustResult(false, "counter-signature is malformed at hop $hop", signerPublicKey = signer)
+        if (!AzpSignatures.ed25519Verify(cs.publicKey, message, cs.signature)) {
+            return TrustResult(false, "counter-signature invalid at hop $hop", signerPublicKey = signer)
+        }
+        if (trusted.contains(cs.publicKey)) {
+            return TrustResult(
+                trusted = true,
+                reason = if (hop == 1) "signer counter-signed by a trusted registry"
+                else "signer trusted via a $hop-hop counter-signature chain",
+                signerPublicKey = signer,
+                viaRegistryPublicKey = cs.publicKey,
+            )
+        }
+        vouchedKey = cs.publicKey
+        cs = cs.countersignature
+    }
+
+    return TrustResult(
+        trusted = false,
+        reason = if (sig.countersignature != null) "counter-signature chain reaches no trusted key"
+        else "signer key is not in the trust store",
+        signerPublicKey = signer,
+    )
+}

--- a/core/common/src/test/java/com/hereliesaz/graffitixr/common/azphalt/AzpSignaturesTest.kt
+++ b/core/common/src/test/java/com/hereliesaz/graffitixr/common/azphalt/AzpSignaturesTest.kt
@@ -1,0 +1,194 @@
+package com.hereliesaz.graffitixr.common.azphalt
+
+import org.bouncycastle.crypto.generators.Ed25519KeyPairGenerator
+import org.bouncycastle.crypto.params.Ed25519KeyGenerationParameters
+import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters
+import org.bouncycastle.crypto.params.Ed25519PublicKeyParameters
+import org.bouncycastle.crypto.signers.Ed25519Signer
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.security.MessageDigest
+import java.security.SecureRandom
+import java.util.Base64
+
+/**
+ * Ed25519 signature + trust verification, checked against azphalt's **published cross-implementation
+ * test vector** (`packages/azp/test/vectors/signature-vector.json`) so this host verifies a package
+ * signed by the reference `@azphalt/azp` byte-for-byte, plus sign/verify round-trips and a
+ * counter-signature (registry) trust chain built in-test.
+ */
+class AzpSignaturesTest {
+
+    // ── azphalt signature-vector.json (verbatim) ───────────────────────────────────────────────
+    private val vectorManifest: ByteArray = (
+        "{\n" +
+            "  \"azphalt\": \"0.1\",\n" +
+            "  \"id\": \"com.azphalt.example.vector\",\n" +
+            "  \"name\": \"Signature Vector\",\n" +
+            "  \"version\": \"1.0.0\",\n" +
+            "  \"kind\": \"asset\",\n" +
+            "  \"license\": \"MIT\",\n" +
+            "  \"compat\": \">=0.1\",\n" +
+            "  \"files\": {\n" +
+            "    \"assets/x.txt\": \"sha256-2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae\"\n" +
+            "  }\n" +
+            "}\n"
+        ).toByteArray(Charsets.UTF_8)
+    private val vectorPublicKey = "MCowBQYDK2VwAyEAWlUm8cHGqCDVs3Uzn9x7UeErLOyDdCTr0n+HvKjDZ4M="
+    private val vectorSignature =
+        "VzdxDliOyWWAJA8KZjoFHfdizyb36IdZnRVhtJbFS0ZLccQIJOLAHfTNODbh1CNKTDerZZhCCZrPh+BsZ95WAQ=="
+
+    @Test
+    fun `test-vector manifest bytes reproduce the published SHA-256`() {
+        val hex = MessageDigest.getInstance("SHA-256").digest(vectorManifest)
+            .joinToString("") { "%02x".format(it) }
+        assertEquals("699b003ee9f44e8e6ed41ffc8fcb941010cc788d30df7f5d8cb7c36731e3d037", hex)
+    }
+
+    @Test
+    fun `verifies the published azphalt signature vector`() {
+        assertTrue(AzpSignatures.ed25519Verify(vectorPublicKey, vectorManifest, vectorSignature))
+    }
+
+    @Test
+    fun `rejects the vector signature over tampered manifest bytes`() {
+        val tampered = vectorManifest.copyOf().also { it[10] = (it[10] + 1).toByte() }
+        assertFalse(AzpSignatures.ed25519Verify(vectorPublicKey, tampered, vectorSignature))
+    }
+
+    @Test
+    fun `malformed inputs verify false instead of throwing`() {
+        assertFalse(AzpSignatures.ed25519Verify("not-base64!!", vectorManifest, vectorSignature))
+        assertFalse(AzpSignatures.ed25519Verify(vectorPublicKey, vectorManifest, "AAAA"))
+        assertNull(AzpSignatures.parse(null))
+        assertNull(AzpSignatures.parse("   "))
+        assertNull(AzpSignatures.parse("{not json"))
+    }
+
+    @Test
+    fun `evaluate maps the vector to a valid, untrusted-then-trusted signature`() {
+        val sigJson = sigJson(vectorPublicKey, vectorSignature)
+        assertEquals(SignatureStatus.UNSIGNED, AzpSignatures.evaluate(vectorManifest, null, TrustStore.EMPTY))
+        assertEquals(
+            SignatureStatus.SIGNED_UNTRUSTED,
+            AzpSignatures.evaluate(vectorManifest, sigJson, TrustStore.EMPTY),
+        )
+        assertEquals(
+            SignatureStatus.SIGNED_TRUSTED,
+            AzpSignatures.evaluate(vectorManifest, sigJson, TrustStore(listOf(TrustedKey(vectorPublicKey)))),
+        )
+    }
+
+    @Test
+    fun `evaluate flags a present-but-invalid signature as INVALID`() {
+        val tampered = vectorManifest.copyOf().also { it[3] = (it[3] + 1).toByte() }
+        assertEquals(
+            SignatureStatus.INVALID,
+            AzpSignatures.evaluate(tampered, sigJson(vectorPublicKey, vectorSignature), TrustStore.EMPTY),
+        )
+    }
+
+    @Test
+    fun `sign-then-verify round-trips with a freshly generated key`() {
+        val (priv, pub) = genKeyPair()
+        val msg = "manifest-bytes".toByteArray()
+        val pubB64 = spkiB64(pub)
+        val sigB64 = Base64.getEncoder().encodeToString(sign(priv, msg))
+
+        assertTrue(AzpSignatures.ed25519Verify(pubB64, msg, sigB64))
+        assertEquals(
+            SignatureStatus.SIGNED_UNTRUSTED,
+            AzpSignatures.evaluate(msg, sigJson(pubB64, sigB64), TrustStore.EMPTY),
+        )
+        assertEquals(
+            SignatureStatus.SIGNED_TRUSTED,
+            AzpSignatures.evaluate(msg, sigJson(pubB64, sigB64), TrustStore(listOf(TrustedKey(pubB64)))),
+        )
+    }
+
+    @Test
+    fun `trust is established via a one-hop registry counter-signature`() {
+        val (authorPriv, authorPub) = genKeyPair()
+        val (registryPriv, registryPub) = genKeyPair()
+        val msg = "the-manifest".toByteArray()
+
+        val authorPubB64 = spkiB64(authorPub)
+        val registryPubB64 = spkiB64(registryPub)
+        val authorSig = Base64.getEncoder().encodeToString(sign(authorPriv, msg))
+        // The registry vouches for the author by signing the author's SPKI DER bytes.
+        val authorSpkiDer = spkiDer(authorPub)
+        val counterSig = Base64.getEncoder().encodeToString(sign(registryPriv, authorSpkiDer))
+
+        val sigJson = sigJson(
+            authorPubB64,
+            authorSig,
+            countersig = """{"publicKey":"$registryPubB64","signature":"$counterSig"}""",
+        )
+
+        // Registry trusted → transitive trust for the author.
+        val viaRegistry = AzpSignatures.evaluate(msg, sigJson, TrustStore(listOf(TrustedKey(registryPubB64))))
+        assertEquals(SignatureStatus.SIGNED_TRUSTED, viaRegistry)
+
+        val sig = AzpSignatures.parse(sigJson)!!
+        val result = evaluateTrust(sig, TrustStore(listOf(TrustedKey(registryPubB64))))
+        assertTrue(result.trusted)
+        assertEquals(registryPubB64, result.viaRegistryPublicKey)
+
+        // Neither the author nor the registry trusted → untrusted, but still a valid signature.
+        assertEquals(SignatureStatus.SIGNED_UNTRUSTED, AzpSignatures.evaluate(msg, sigJson, TrustStore.EMPTY))
+        assertFalse(evaluateTrust(sig, TrustStore.EMPTY).trusted)
+    }
+
+    @Test
+    fun `a broken counter-signature severs the chain`() {
+        val (authorPriv, authorPub) = genKeyPair()
+        val (_, registryPub) = genKeyPair()
+        val msg = "m".toByteArray()
+
+        val authorSig = Base64.getEncoder().encodeToString(sign(authorPriv, msg))
+        // A counter-signature whose bytes are not a valid signature over the author's key.
+        val bogus = Base64.getEncoder().encodeToString(ByteArray(64) { 7 })
+        val sigJson = sigJson(
+            spkiB64(authorPub),
+            authorSig,
+            countersig = """{"publicKey":"${spkiB64(registryPub)}","signature":"$bogus"}""",
+        )
+
+        val result = evaluateTrust(AzpSignatures.parse(sigJson)!!, TrustStore(listOf(TrustedKey(spkiB64(registryPub)))))
+        assertFalse(result.trusted)
+        assertTrue(result.reason.contains("invalid at hop 1"))
+    }
+
+    // ── helpers ────────────────────────────────────────────────────────────────────────────────
+
+    /** Fixed 12-byte Ed25519 SPKI DER header; the raw 32-byte key follows (RFC 8410). */
+    private val ed25519SpkiPrefix =
+        intArrayOf(0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x03, 0x21, 0x00)
+            .map { it.toByte() }.toByteArray()
+
+    private fun spkiDer(pub: Ed25519PublicKeyParameters): ByteArray = ed25519SpkiPrefix + pub.encoded
+    private fun spkiB64(pub: Ed25519PublicKeyParameters): String =
+        Base64.getEncoder().encodeToString(spkiDer(pub))
+
+    private fun genKeyPair(): Pair<Ed25519PrivateKeyParameters, Ed25519PublicKeyParameters> {
+        val gen = Ed25519KeyPairGenerator()
+        gen.init(Ed25519KeyGenerationParameters(SecureRandom()))
+        val kp = gen.generateKeyPair()
+        return (kp.private as Ed25519PrivateKeyParameters) to (kp.public as Ed25519PublicKeyParameters)
+    }
+
+    private fun sign(priv: Ed25519PrivateKeyParameters, msg: ByteArray): ByteArray {
+        val signer = Ed25519Signer()
+        signer.init(true, priv)
+        signer.update(msg, 0, msg.size)
+        return signer.generateSignature()
+    }
+
+    private fun sigJson(publicKey: String, signature: String, countersig: String? = null): String {
+        val cs = countersig?.let { ""","countersignature":$it""" } ?: ""
+        return """{"alg":"ed25519","publicKey":"$publicKey","signature":"$signature"$cs}"""
+    }
+}

--- a/core/common/src/test/java/com/hereliesaz/graffitixr/common/azphalt/AzphaltManifestTest.kt
+++ b/core/common/src/test/java/com/hereliesaz/graffitixr/common/azphalt/AzphaltManifestTest.kt
@@ -129,14 +129,51 @@ class AzphaltManifestTest {
     }
 
     @Test
-    fun `compat is validated against the implemented spec version`() {
+    fun `compat is validated per the single-comparator 0_1 grammar`() {
+        // Host implements 0.1; comparator defaults to >=.
         assertTrue(isCompatibleSpec(">=0.1"))
-        assertTrue(isCompatibleSpec("0.1"))
-        assertTrue(isCompatibleSpec("^0.1"))
-        assertTrue(isCompatibleSpec("<0.2")) // lone upper bound → accepted (lenient)
-        assertEquals(false, isCompatibleSpec(">=0.2"))
-        assertEquals(false, isCompatibleSpec(">=1.0"))
+        assertTrue(isCompatibleSpec("0.1"))    // bare == ">="
+        assertTrue(isCompatibleSpec("0.0"))    // >=0.0
+        assertTrue(isCompatibleSpec("=0.1"))
+        assertTrue(isCompatibleSpec("<=0.1"))
+        assertTrue(isCompatibleSpec("<0.2"))   // host 0.1 is < 0.2
+        assertFalse(isCompatibleSpec(">=0.2"))
+        assertFalse(isCompatibleSpec(">=1.0"))
+        assertFalse(isCompatibleSpec(">0.1"))  // host is not strictly greater than 0.1
+        assertFalse(isCompatibleSpec("=0.2"))
+        assertFalse(isCompatibleSpec("<0.1"))  // host is not < 0.1
+        // Outside the 0.1 grammar → unparseable → fails closed (matches @azphalt/azp's compatSatisfies).
+        assertFalse(isCompatibleSpec("^0.1"))
+        assertFalse(isCompatibleSpec("~0.1"))
+        assertFalse(isCompatibleSpec(">=0.1 || <0.3"))
+        assertFalse(isCompatibleSpec("0.1.0-beta"))
+        assertFalse(isCompatibleSpec("latest"))
         assertEquals("0.1", AZPHALT_SPEC_VERSION)
+    }
+
+    @Test
+    fun `compatSatisfies mirrors the reference across host versions`() {
+        assertTrue(compatSatisfies("1.2.3", ">=1.0"))
+        assertTrue(compatSatisfies("1.0.0", ">=1"))       // omitted parts are 0
+        assertFalse(compatSatisfies("0.9.9", ">=1.0"))
+        assertTrue(compatSatisfies("2.0.0", ">1.9"))
+        assertTrue(compatSatisfies("1.4.0", "<=1.4"))
+        assertTrue(compatSatisfies("1.4.0", "=1.4"))
+        assertFalse(compatSatisfies("1.4.1", "=1.4"))     // 1.4 ≡ 1.4.0 ≠ 1.4.1
+        assertFalse(compatSatisfies("bogus", ">=0.1"))    // unparseable host → false
+        assertFalse(compatSatisfies("1.0.0", "not-a-compat"))
+    }
+
+    @Test
+    fun `parseCompat rejects grammar outside 0_1 and defaults the comparator`() {
+        assertNull(parseCompat("^1.0"))
+        assertNull(parseCompat("~1.0"))
+        assertNull(parseCompat("1.x"))
+        assertNull(parseCompat(">=1.0 <2.0"))
+        assertEquals(CompatOp.GE, parseCompat("1.2.3")?.op)   // default comparator
+        assertEquals(CompatOp.LT, parseCompat("<0.2")?.op)
+        val c = parseCompat(">=0.1")
+        assertEquals(0, c?.major); assertEquals(1, c?.minor); assertEquals(0, c?.patch)
     }
 
     @Test

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -54,4 +54,6 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.mockk)
     testImplementation(libs.kotlinx.coroutines.test)
+    // Ed25519 signing in AzpInstallerTest, to build signed `.azp` fixtures the installer verifies.
+    testImplementation("org.bouncycastle:bcprov-jdk18on:1.85")
 }

--- a/core/data/src/main/java/com/hereliesaz/graffitixr/data/azphalt/AzpInstaller.kt
+++ b/core/data/src/main/java/com/hereliesaz/graffitixr/data/azphalt/AzpInstaller.kt
@@ -2,7 +2,10 @@ package com.hereliesaz.graffitixr.data.azphalt
 
 import com.hereliesaz.graffitixr.common.azphalt.AZPHALT_SPEC_VERSION
 import com.hereliesaz.graffitixr.common.azphalt.AzphaltManifest
+import com.hereliesaz.graffitixr.common.azphalt.AzpSignatures
 import com.hereliesaz.graffitixr.common.azphalt.ExtensionKind
+import com.hereliesaz.graffitixr.common.azphalt.SignatureStatus
+import com.hereliesaz.graffitixr.common.azphalt.TrustStore
 import com.hereliesaz.graffitixr.common.azphalt.isCompatibleSpec
 import com.hereliesaz.graffitixr.common.azphalt.parseManifest
 import java.io.File
@@ -17,10 +20,15 @@ import java.util.zip.ZipInputStream
  *  - verify every payload file listed in the manifest's `files` map against its SHA-256 digest,
  *  - require a manifest.json.
  *
- * Signature (Ed25519) is treated as tamper-evidence, not identity — the trust model is explicitly
- * open in the spec — so the integrity digests are the enforced gate here.
+ * Signature (Ed25519 over the verbatim `manifest.json`) is verified when present: a package carrying
+ * an invalid signature is refused (tamper-evidence), while an unsigned or signed-but-untrusted package
+ * installs with its provenance recorded on [InstalledExtension.signature]. Trust (identity) is decided
+ * against [trustStore] — directly, or via a registry counter-signature (spec/package-format.md § Signing).
  */
-class AzpInstaller(private val extensionsRoot: File) {
+class AzpInstaller(
+    private val extensionsRoot: File,
+    private val trustStore: TrustStore = TrustStore.EMPTY,
+) {
 
     class InstallException(message: String) : Exception(message)
 
@@ -83,14 +91,24 @@ class AzpInstaller(private val extensionsRoot: File) {
             }
         }
 
+        // Provenance: verify the detached Ed25519 signature (if any) over the *verbatim* manifest.json
+        // bytes. A present-but-invalid signature is tamper-evidence — refuse it. An unsigned or
+        // signed-but-untrusted package installs, with its status recorded for the UI to warn on.
+        val signatureJson = entries["signature.json"]?.decodeToString()
+        val signatureStatus = AzpSignatures.evaluate(manifestBytes, signatureJson, trustStore)
+        if (signatureStatus == SignatureStatus.INVALID) {
+            throw InstallException("Package '${manifest.id}' has an invalid signature (tampered or corrupt)")
+        }
+
         // Unpack into <root>/<safe id>/, replacing any prior install.
         val dir = File(extensionsRoot, safeId(manifest.id))
         if (dir.exists()) dir.deleteRecursively()
         dir.mkdirs()
         for ((path, bytes) in entries) {
-            // Only unpack manifest.json and files the manifest declares (and which therefore passed
+            // Only unpack manifest.json, the detached signature.json (exempt from the files map, so
+            // provenance can be re-derived on rescan), and files the manifest declares (which passed
             // the digest check above). An unlisted entry is an unverified payload — never write it.
-            if (path != "manifest.json" && !manifest.files.containsKey(path)) continue
+            if (path != "manifest.json" && path != "signature.json" && !manifest.files.containsKey(path)) continue
             val target = File(dir, path)
             // Second-line defence: the resolved target must stay inside dir.
             if (!target.canonicalPath.startsWith(dir.canonicalPath + File.separator)) {
@@ -101,7 +119,12 @@ class AzpInstaller(private val extensionsRoot: File) {
             target.writeBytes(bytes)
         }
 
-        return InstalledExtension(manifest = manifest, dir = dir.absolutePath, installedAt = nowMs)
+        return InstalledExtension(
+            manifest = manifest,
+            dir = dir.absolutePath,
+            installedAt = nowMs,
+            signature = signatureStatus,
+        )
     }
 
     private fun isUnsafePath(name: String): Boolean {

--- a/core/data/src/main/java/com/hereliesaz/graffitixr/data/azphalt/ExtensionRepository.kt
+++ b/core/data/src/main/java/com/hereliesaz/graffitixr/data/azphalt/ExtensionRepository.kt
@@ -2,7 +2,9 @@ package com.hereliesaz.graffitixr.data.azphalt
 
 import android.content.Context
 import com.hereliesaz.graffitixr.common.azphalt.AssetType
+import com.hereliesaz.graffitixr.common.azphalt.AzpSignatures
 import com.hereliesaz.graffitixr.common.azphalt.CubeLut
+import com.hereliesaz.graffitixr.common.azphalt.TrustStore
 import com.hereliesaz.graffitixr.common.azphalt.parseCubeLut
 import com.hereliesaz.graffitixr.common.azphalt.parseManifest
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -25,7 +27,12 @@ class ExtensionRepository @Inject constructor(
     @ApplicationContext private val context: Context,
 ) {
     private val extensionsRoot = File(context.filesDir, "extensions")
-    private val installer = AzpInstaller(extensionsRoot)
+
+    // The keys this host trusts. Empty for now — signed packages install as SIGNED_UNTRUSTED (valid
+    // signature, no established identity) until a trust store is seeded (e.g. a registry's key from
+    // .well-known). Wiring that source in is a follow-up; the verification path is already live.
+    private val trustStore = TrustStore.EMPTY
+    private val installer = AzpInstaller(extensionsRoot, trustStore)
 
     /** Serializes filesystem-mutating operations so concurrent install/uninstall can't interleave. */
     private val lock = Any()
@@ -99,10 +106,16 @@ class ExtensionRepository @Inject constructor(
             val manifestFile = File(dir, "manifest.json")
             if (!manifestFile.exists()) return@mapNotNull null
             runCatching {
+                // Re-derive provenance from the unpacked tree so it survives process death, using the
+                // verbatim manifest bytes and the detached signature.json (if the package carried one).
+                val manifestBytes = manifestFile.readBytes()
+                val sigFile = File(dir, "signature.json")
+                val signatureJson = if (sigFile.exists()) sigFile.readText() else null
                 InstalledExtension(
-                    manifest = parseManifest(manifestFile.readText()),
+                    manifest = parseManifest(manifestBytes.decodeToString()),
                     dir = dir.absolutePath,
                     installedAt = manifestFile.lastModified(),
+                    signature = AzpSignatures.evaluate(manifestBytes, signatureJson, trustStore),
                 )
             }.getOrNull()
         }.sortedBy { it.manifest.name }

--- a/core/data/src/main/java/com/hereliesaz/graffitixr/data/azphalt/InstalledExtension.kt
+++ b/core/data/src/main/java/com/hereliesaz/graffitixr/data/azphalt/InstalledExtension.kt
@@ -1,16 +1,19 @@
 package com.hereliesaz.graffitixr.data.azphalt
 
 import com.hereliesaz.graffitixr.common.azphalt.AzphaltManifest
+import com.hereliesaz.graffitixr.common.azphalt.SignatureStatus
 
 /**
  * An azphalt extension that has been verified and unpacked into app storage under
  * `filesDir/extensions/<id>/`. [manifest] is the parsed manifest.json; [dir] is the absolute path to
- * the unpacked tree; [installedAt] is epoch millis.
+ * the unpacked tree; [installedAt] is epoch millis; [signature] is the provenance established at
+ * install (and re-derived on rescan) — a valid signature is tamper-evidence, trust is separate.
  */
 data class InstalledExtension(
     val manifest: AzphaltManifest,
     val dir: String,
     val installedAt: Long,
+    val signature: SignatureStatus = SignatureStatus.UNSIGNED,
 ) {
     val id: String get() = manifest.id
 

--- a/core/data/src/test/java/com/hereliesaz/graffitixr/data/azphalt/AzpInstallerTest.kt
+++ b/core/data/src/test/java/com/hereliesaz/graffitixr/data/azphalt/AzpInstallerTest.kt
@@ -1,5 +1,13 @@
 package com.hereliesaz.graffitixr.data.azphalt
 
+import com.hereliesaz.graffitixr.common.azphalt.SignatureStatus
+import com.hereliesaz.graffitixr.common.azphalt.TrustStore
+import com.hereliesaz.graffitixr.common.azphalt.TrustedKey
+import org.bouncycastle.crypto.generators.Ed25519KeyPairGenerator
+import org.bouncycastle.crypto.params.Ed25519KeyGenerationParameters
+import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters
+import org.bouncycastle.crypto.params.Ed25519PublicKeyParameters
+import org.bouncycastle.crypto.signers.Ed25519Signer
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -10,6 +18,8 @@ import org.junit.rules.TemporaryFolder
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.security.MessageDigest
+import java.security.SecureRandom
+import java.util.Base64
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 
@@ -219,5 +229,100 @@ class AzpInstallerTest {
         } catch (e: AzpInstaller.InstallException) {
             assertTrue(e.message!!.contains("LICENSE"))
         }
+    }
+
+    // ── signature / provenance ───────────────────────────────────────────────────────────────────
+
+    private val lutBytes = "TITLE \"x\"\nLUT_3D_SIZE 2\n".toByteArray() +
+        "0 0 0\n1 0 0\n0 1 0\n1 1 0\n0 0 1\n1 0 1\n0 1 1\n1 1 1\n".toByteArray()
+
+    /** Build a `.azp` whose `signature.json` signs [manifestBytes] with [signedBytes] (default: the
+     *  manifest itself → a valid signature; pass different bytes to forge an invalid one). */
+    private fun signedPackage(
+        pub: Ed25519PublicKeyParameters,
+        priv: Ed25519PrivateKeyParameters,
+        id: String = "com.test.signed",
+        signedBytes: ByteArray? = null,
+    ): ByteArray {
+        val payload = mapOf("assets/grade.cube" to lutBytes, "LICENSE" to license)
+        val manifestBytes = manifest(id, payload)
+        val sig = Base64.getEncoder().encodeToString(sign(priv, signedBytes ?: manifestBytes))
+        val sigJson = """{"alg":"ed25519","publicKey":"${spkiB64(pub)}","signature":"$sig"}""".toByteArray()
+        return zip(payload + mapOf("manifest.json" to manifestBytes, "signature.json" to sigJson))
+    }
+
+    @Test
+    fun `valid signature installs as SIGNED_UNTRUSTED with an empty trust store`() {
+        val (priv, pub) = keyPair()
+        val bytes = signedPackage(pub, priv)
+
+        val installer = AzpInstaller(tmp.newFolder("extensions"))
+        val installed = installer.install(ByteArrayInputStream(bytes), nowMs = 0L)
+
+        assertEquals(SignatureStatus.SIGNED_UNTRUSTED, installed.signature)
+        // signature.json is preserved so provenance survives a rescan.
+        assertTrue(java.io.File(installed.filePath("signature.json")).exists())
+    }
+
+    @Test
+    fun `valid signature from a trusted key installs as SIGNED_TRUSTED`() {
+        val (priv, pub) = keyPair()
+        val bytes = signedPackage(pub, priv)
+
+        val store = TrustStore(listOf(TrustedKey(spkiB64(pub))))
+        val installer = AzpInstaller(tmp.newFolder("extensions"), store)
+        val installed = installer.install(ByteArrayInputStream(bytes), nowMs = 0L)
+
+        assertEquals(SignatureStatus.SIGNED_TRUSTED, installed.signature)
+    }
+
+    @Test
+    fun `invalid signature is rejected`() {
+        val (priv, pub) = keyPair()
+        // Sign bytes that are not the manifest → the signature won't verify over manifest.json.
+        val bytes = signedPackage(pub, priv, signedBytes = "not the manifest".toByteArray())
+
+        val installer = AzpInstaller(tmp.newFolder("extensions"))
+        try {
+            installer.install(ByteArrayInputStream(bytes), nowMs = 0L)
+            fail("Expected InstallException for an invalid signature")
+        } catch (e: AzpInstaller.InstallException) {
+            assertTrue(e.message!!.contains("invalid signature"))
+        }
+    }
+
+    @Test
+    fun `unsigned package installs as UNSIGNED`() {
+        val payload = mapOf("assets/grade.cube" to lutBytes, "LICENSE" to license)
+        val bytes = zip(payload + ("manifest.json" to manifest("com.test.unsigned", payload)))
+
+        val installer = AzpInstaller(tmp.newFolder("extensions"))
+        val installed = installer.install(ByteArrayInputStream(bytes), nowMs = 0L)
+
+        assertEquals(SignatureStatus.UNSIGNED, installed.signature)
+    }
+
+    // ── Ed25519 signing helpers (BouncyCastle) ───────────────────────────────────────────────────
+
+    /** Fixed 12-byte Ed25519 SPKI DER header; the raw 32-byte key follows (RFC 8410). */
+    private val ed25519SpkiPrefix =
+        intArrayOf(0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x03, 0x21, 0x00)
+            .map { it.toByte() }.toByteArray()
+
+    private fun spkiB64(pub: Ed25519PublicKeyParameters): String =
+        Base64.getEncoder().encodeToString(ed25519SpkiPrefix + pub.encoded)
+
+    private fun keyPair(): Pair<Ed25519PrivateKeyParameters, Ed25519PublicKeyParameters> {
+        val gen = Ed25519KeyPairGenerator()
+        gen.init(Ed25519KeyGenerationParameters(SecureRandom()))
+        val kp = gen.generateKeyPair()
+        return (kp.private as Ed25519PrivateKeyParameters) to (kp.public as Ed25519PublicKeyParameters)
+    }
+
+    private fun sign(priv: Ed25519PrivateKeyParameters, msg: ByteArray): ByteArray {
+        val signer = Ed25519Signer()
+        signer.init(true, priv)
+        signer.update(msg, 0, msg.size)
+        return signer.generateSignature()
     }
 }


### PR DESCRIPTION
Two azphalt host-conformance fixes, now that the spec has resolved the underlying gaps. GraffitiXR is the azphalt standard's first conforming host; both changes bring its `.azp` handling in line with the reference `@azphalt/azp`.

## 1. `compat` grammar (`fix(azphalt): parse compat per the normative single-comparator 0.1 grammar`)
`isCompatibleSpec` previously extracted only a lower bound and was lenient about the rest — it accepted `^`/`~` (not in the spec) and blanket-accepted anything it couldn't parse (e.g. a lone `<0.2`). The spec now pins `compat` to a **single optional comparator** (`>= > <= < =`, default `>=`) over `MAJOR[.MINOR[.PATCH]]`, with no ranges/unions/`^`/`~`/prerelease.

- Reimplemented `parseCompat` + `compatSatisfies` to mirror `@azphalt/azp` exactly — **fail closed** on anything outside the grammar — and routed `isCompatibleSpec` through them.
- This host now accepts precisely what other conforming hosts accept.
- Tests updated to the conformant behavior (the old test asserted the lenient results).

## 2. Ed25519 signature + trust verification (`feat(azphalt): verify Ed25519 package signatures and evaluate signer trust`)
The spec now pins signature canonicalization (Ed25519 over the **verbatim** `manifest.json` bytes) and ships a cross-implementation test vector, so the host can move from "integrity digests only" to real signature + trust verification.

- **`AzpSignatures`** — parse `signature.json`, verify the Ed25519 signature over the exact manifest bytes, classify provenance as `UNSIGNED` / `SIGNED_UNTRUSTED` / `SIGNED_TRUSTED` / `INVALID`. Uses **BouncyCastle** because Android's built-in Ed25519 (`java.security`) is API 33+ while `minSdk` here is 26; BC 1.85 is already on the app classpath (root build pins it), so no new APK weight.
- **`TrustStore` + `evaluateTrust`** — direct trust plus the registry **counter-signature chain** (each hop signs the vouched key's SPKI bytes), with the 10-hop DoS cap — mirroring `verifyTrust`.
- **`AzpInstaller`** — refuses a present-but-**invalid** signature (tamper-evidence); installs unsigned/untrusted packages with provenance recorded on `InstalledExtension.signature`; preserves `signature.json` so status survives a rescan.
- **`ExtensionRepository`** re-derives provenance on scan against its trust store (empty for now — seeding a trusted-key source, e.g. a registry's `.well-known` key, is a follow-up; the verification path itself is live).

## Tests
- Verifies the **published azphalt signature vector** (`packages/azp/test/vectors/signature-vector.json`) byte-for-byte — proving cross-implementation agreement with the reference — including a SHA-256 check that the embedded manifest bytes are exact.
- Sign/verify round-trips with a freshly generated key, a one-hop registry counter-signature trust chain, a broken-counter-signature negative, and installer-level tests (signed→`SIGNED_UNTRUSTED`, trusted key→`SIGNED_TRUSTED`, invalid signature→refused, unsigned→`UNSIGNED`).

## Verification note
This environment has no Android SDK, so I could not run the Gradle build/tests locally — CI on this PR is the validation gate. The changes are pure-JVM (BouncyCastle + `java.util.Base64`, both available on `minSdk` 26 and in unit tests), and the new logic lives in `core:common`/`core:data` unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AcdJmnK51oQKxR8CdLZDH

---
_Generated by [Claude Code](https://claude.ai/code/session_015AcdJmnK51oQKxR8CdLZDH)_