### PR TITLE
fix(docs): correct rellax SRI hash (was silently blocking the parallax script)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -4,6 +4,7 @@
 
 ### Done
 
+- **CodeQL #3/#4/#5 — Inclusion of functionality from untrusted source** (`docs/index.html`). Added Subresource Integrity to the three cdnjs `<script>` tags (rellax 1.12.0, gsap 3.12.2, ScrollTrigger 3.12.2): `integrity="sha512-…"` + `crossorigin="anonymous"` (Action A). **Correction:** the rellax hash was wrong — the SRI mismatch silently blocked `rellax.min.js`, breaking the parallax effects. Recomputed the sha512 from the file the CDN actually serves and fixed it; gsap/ScrollTrigger hashes verified as already correct. The tailwind play-CDN (line 7) intentionally has no stable SRI and is not one of the flagged alerts, so it is left as-is.
 - **CodeQL #6 — Multiplication result converted to larger type** (`core/nativebridge/src/main/cpp/SurfaceUnroller.cpp:100`). `mCount * mCount` was computed as `int` and then widened to `size_t` for the `std::vector` ctor; overflows for `mCount ≥ 46341`. Fixed by casting both operands to `std::size_t` before multiplying.
 - **Dependabot #27 — Netty HTTP header injection in HttpProxyHandler** (`io.netty:netty-handler-proxy`). Fixed by forcing the netty family (incl. `netty-handler-proxy`) to `4.2.15.Final` in `build.gradle.kts` `commonForcedDependencies`. **Verified:** 4.2.15.Final addresses CVE-2025-67735 and subsequent regressions.
 
@@ -38,11 +39,6 @@ Still open, not touched this pass:
 
 ### Todo
 
-- **CodeQL #3/#4/#5 — Inclusion of functionality from untrusted source** (`docs/index.html:8–10`). Three `<script src="https://cdnjs.cloudflare.com/...">` tags (rellax 1.12.0, gsap 3.12.2, ScrollTrigger 3.12.2) load without integrity checks.
-  - **Action A (preferred):** add `integrity="sha384-…"` + `crossorigin="anonymous"` to each tag. Hashes are published on the cdnjs page for each library version.
-  - **Action B:** vendor the three files under `docs/vendor/` and reference local paths. Eliminates the alert and removes a runtime CDN dependency.
-  - **Note:** line 7 (`https://cdn.tailwindcss.com`) is the tailwind play-CDN, which intentionally has no stable SRI hash. If it shows up as an alert, prefer Action B (vendor a built Tailwind CSS) since SRI is impractical here.
-
-  (The Bouncy Castle advisories #23/#24/#25 previously listed here are resolved — see the `1.84` force in the Done section above.)
+- _No open security alerts._ (CodeQL #3/#4/#5 SRI and the Bouncy Castle advisories #23/#24/#25 are resolved — see the Done section above.)
 
 (Dead-features and export/YUV items cleared — see the notes under **Done** above. Remaining open items: Glasses AR session, AR freeze-preview.)

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>GraffitiXR - The AR Toolkit for Street Artists</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/rellax/1.12.0/rellax.min.js" integrity="sha512-Ym0tV8pUqOAXo165G4vNq7Y/G85Bv8M95+C6A6y4Yp855U004mNU8BFp3WKatWanAFKU2SQbdk4PdjXg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/rellax/1.12.0/rellax.min.js" integrity="sha512-LBHxA/ZHne1xMD9sA+/pihMJNdxV89sq5I44iB8lY7Rrzd7s58N+nBzVZXOreIc7+3bFQ4IrTUQLWKtwnUweLw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js" integrity="sha512-16esztaSRplJROstbIIdwX3N97V1+pZvV33ABoG1H2OyTttBxEGkTsoIVsiP1iaTtM8b3+hu2kB6pQ4Clr5yug==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/ScrollTrigger.min.js" integrity="sha512-Ic9xkERjyZ1xgJ5svx3y0u3xrvfT/uPkV99LBwe68xjy/mGtO+4eURHZBW2xW4SZbFrF1Tf090XqB+EVgXnVjw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <style>


### PR DESCRIPTION
## Problem

The landing page (`docs/index.html`) loads three cdnjs scripts with Subresource Integrity. Two are correct, but **rellax's `integrity` hash was wrong**:

| script | in-file hash | actual served file |
|---|---|---|
| rellax 1.12.0 | `sha512-Ym0t…dXg==` ❌ | `sha512-LBHxA…weLw==` |
| gsap 3.12.2 | `sha512-16es…yug==` ✓ | matches |
| ScrollTrigger 3.12.2 | `sha512-Ic9x…nVjw==` ✓ | matches |

A browser blocks any `<script>` whose SRI doesn't match, so `rellax.min.js` was **silently blocked** and the parallax effects on the page never ran.

## Fix

Recomputed the sha512 from the file cdnjs actually serves (`curl … | openssl dgst -sha512 -binary | openssl base64`) and corrected the rellax `integrity`. gsap/ScrollTrigger were verified as already correct and left unchanged.

This also resolves the backlog's **CodeQL #3/#4/#5** (inclusion of functionality from untrusted source) item — all three cdnjs scripts now carry valid `integrity` + `crossorigin`. The tailwind play-CDN intentionally has no stable SRI and is not one of the flagged alerts, so it's left as-is.

## Changes

- `docs/index.html` — corrected the rellax `integrity` hash.
- `BACKLOG.md` — moved the CodeQL #3/#4/#5 item to **Done** with a note about the mismatch correction.


---
_Generated by [Claude Code](https://claude.ai/code/session_015AcdJmnK51oQKxR8CdLZDH)_