### PR TITLE
Fix interop hand-off after companion rename (GraffiXR → Graffux)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -42,10 +42,10 @@
     <uses-feature android:name="android.hardware.location.gps" android:required="false" />
     <uses-feature android:name="android.hardware.location.network" android:required="false" />
 
-    <!-- Interop: Android 11+ package visibility so we can detect GraffiXR (the companion rich editor)
+    <!-- Interop: Android 11+ package visibility so we can detect Graffux (the companion rich editor)
          and hand off an overlay to it via an explicit ACTION_SEND. -->
     <queries>
-        <package android:name="com.hereliesaz.graffixr" />
+        <package android:name="com.hereliesaz.graffux" />
     </queries>
 
     <application
@@ -94,7 +94,7 @@
                 <data android:scheme="graffitixr" />
             </intent-filter>
 
-            <!-- Interop: receive an image shared from GraffiXR (e.g. an edited overlay returning from
+            <!-- Interop: receive an image shared from Graffux (e.g. an edited overlay returning from
                  the rich editor) and open it as an AR overlay layer. -->
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -594,11 +594,11 @@ class MainActivity : ComponentActivity() {
                 val navStrings = strings.nav
 
                 val context = LocalContext.current
-                // Interop: is the GraffiXR companion editor installed? Gates the "Edit in GraffiXR"
+                // Interop: is the Graffux companion editor installed? Gates the "Edit in Graffux"
                 // hand-off rail item. Visibility works because the manifest <queries> declares the pkg.
                 val isGraffiXrInstalled = remember {
                     runCatching {
-                        context.packageManager.getLaunchIntentForPackage("com.hereliesaz.graffixr") != null
+                        context.packageManager.getLaunchIntentForPackage("com.hereliesaz.graffux") != null
                     }.getOrDefault(false)
                 }
                 val canvasBg = editorUiState.canvasBackground
@@ -723,12 +723,12 @@ class MainActivity : ComponentActivity() {
                             },
                             isGraffiXrInstalled = isGraffiXrInstalled,
                             onEditInGraffiXr = {
-                                // Hand off the current overlay to GraffiXR for rich editing: composite to
-                                // a content:// Uri and fire an explicit ACTION_SEND at the GraffiXR package.
+                                // Hand off the current overlay to Graffux for rich editing: composite to
+                                // a content:// Uri and fire an explicit ACTION_SEND at the Graffux package.
                                 exportDispatchScope.launch {
                                     val uri = editorViewModel.exportForShare() ?: return@launch
                                     val send = Intent(Intent.ACTION_SEND).apply {
-                                        setPackage("com.hereliesaz.graffixr")
+                                        setPackage("com.hereliesaz.graffux")
                                         type = "image/png"
                                         putExtra(Intent.EXTRA_STREAM, uri)
                                         addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
@@ -736,7 +736,7 @@ class MainActivity : ComponentActivity() {
                                     try {
                                         context.startActivity(send)
                                     } catch (t: Throwable) {
-                                        // GraffiXR became unresolvable between the check and the tap —
+                                        // Graffux became unresolvable between the check and the tap —
                                         // fall back to a generic chooser so the image still goes somewhere.
                                         context.startActivity(
                                             Intent.createChooser(send.apply { setPackage(null) }, null)
@@ -1511,15 +1511,15 @@ class MainActivity : ComponentActivity() {
                 azRailSubItem(id = "design.addImg", hostId = "host.design", text = "Open", color = navItemColor, shape = AzButtonShape.NONE) {
                     overlayPicker.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
                 }
-                // Interop hand-off: only when the GraffiXR companion editor is installed. Sends the
-                // current overlay to GraffiXR for rich editing; the edited result can be shared back.
+                // Interop hand-off: only when the Graffux companion editor is installed. Sends the
+                // current overlay to Graffux for rich editing; the edited result can be shared back.
                 if (isGraffiXrInstalled) {
-                    azRailSubItem(id = "design.editInGraffixr", hostId = "host.design", text = "GraffiXR", color = navItemColor, shape = AzButtonShape.NONE) {
+                    azRailSubItem(id = "design.editInGraffixr", hostId = "host.design", text = "Graffux", color = navItemColor, shape = AzButtonShape.NONE) {
                         onEditInGraffiXr()
                     }
                 }
                 // Core tracing prep (GraffitiXR is core-only; rich multi-layer / paint / text /
-                // effects editing is GraffiXR's job, reached via the "GraffiXR" hand-off above).
+                // effects editing is Graffux's job, reached via the "Graffux" hand-off above).
                 // These act on the active overlay layer.
                 val overlay = editorUiState.layers.find { it.id == editorUiState.activeLayerId }
                 if (overlay != null) {


### PR DESCRIPTION
## What & why

The standalone editor was rebranded **GraffiXR → Graffux** and its `applicationId` changed `com.hereliesaz.graffixr` → `com.hereliesaz.graffux` (see GraffiXR PR #15). GraffitiXR's hand-off to the companion editor still targeted the old package, so the "Edit in Graffux" flow would silently miss on the renamed app.

## Changes
- **`<queries>` package visibility** → `com.hereliesaz.graffux`. Without this, `getLaunchIntentForPackage` never sees the companion on Android 11+, so the hand-off button never even appears.
- **Install probe** (`getLaunchIntentForPackage`) and the explicit **`ACTION_SEND` `setPackage(...)`** → `com.hereliesaz.graffux`.
- **Hand-off rail button label** `"GraffiXR"` → `"Graffux"`; surrounding comments updated.

## Notes
- Internal identifiers (`isGraffiXrInstalled`, `onEditInGraffiXr`, the rail id `"design.editInGraffixr"`) are intentionally left unchanged to avoid churn in the rail-id uniqueness/enumerator tests — only the package target and the user-facing label affect behaviour.
- Receiving a share *from* Graffux already worked (the inbound `image/*` intent-filter is package-agnostic); this only fixes the *outbound* explicit hand-off.
- Not built locally (OpenCV SDK / full Android toolchain unavailable in this environment); the change is a package-string + label swap with no API surface change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015TwWZK1SULzHAGUy1tcfPZ

---
_Generated by [Claude Code](https://claude.ai/code/session_015TwWZK1SULzHAGUy1tcfPZ)_