### PR TITLE
Grant read permission via ClipData on the Graffux hand-off

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -731,6 +731,11 @@ class MainActivity : ComponentActivity() {
                                         setPackage("com.hereliesaz.graffux")
                                         type = "image/png"
                                         putExtra(Intent.EXTRA_STREAM, uri)
+                                        // Carry the URI in ClipData too: FLAG_GRANT_READ_URI_PERMISSION
+                                        // grants against the intent's data/ClipData, not EXTRA_STREAM, so
+                                        // an explicit (setPackage) hand-off can otherwise reach Graffux
+                                        // without read access. The chooser fallback reuses this intent.
+                                        clipData = android.content.ClipData.newRawUri(null, uri)
                                         addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
                                     }
                                     try {

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -735,7 +735,7 @@ class MainActivity : ComponentActivity() {
                                         // grants against the intent's data/ClipData, not EXTRA_STREAM, so
                                         // an explicit (setPackage) hand-off can otherwise reach Graffux
                                         // without read access. The chooser fallback reuses this intent.
-                                        clipData = android.content.ClipData.newRawUri(null, uri)
+                                        clipData = ClipData.newRawUri(null, uri)
                                         addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
                                     }
                                     try {


### PR DESCRIPTION
Follow-up to the interop rename (#1765), which merged before this landed.

## Why
`FLAG_GRANT_READ_URI_PERMISSION` grants read access against the intent's `data`/`ClipData`, **not** the `EXTRA_STREAM` extra. Because the "Edit in Graffux" hand-off is an **explicit** (`setPackage`) `ACTION_SEND`, Graffux could receive a `content://` Uri it has no permission to read — an intermittent `SecurityException`/blank-image failure depending on OEM.

## Change
Carry the Uri in `ClipData.newRawUri(null, uri)` on the send intent so the grant reliably applies. The chooser fallback reuses the same intent, so it benefits too.

Gemini flagged this as HIGH priority on #1765; the PR merged before the fix could be added.

## Notes
- Not built locally (OpenCV SDK / Android toolchain unavailable here); CI verifies compile + tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015TwWZK1SULzHAGUy1tcfPZ

---
_Generated by [Claude Code](https://claude.ai/code/session_015TwWZK1SULzHAGUy1tcfPZ)_