### PR TITLE
fix: six defects found by tracing the user flow end to end

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -58,6 +58,7 @@ import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
+import android.widget.Toast
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontFamily
@@ -317,12 +318,48 @@ class MainActivity : ComponentActivity() {
 
                 // Interop: an image shared in via ACTION_SEND (e.g. an edited overlay returning from
                 // GraffiXR) becomes a new overlay layer, consumed once.
+                //
+                // Gated on a loaded project: onAddLayer requires a projectId to save the artifact
+                // under, and on a cold start via ACTION_SEND there is none yet (the library screen is
+                // still up). Firing regardless dropped the shared image with a misleading "Invalid
+                // image format or missing project" toast — the whole advertised share-in flow failed
+                // on exactly the launch path it exists for. Hold the Uri until the user opens or
+                // creates a project, then add it.
                 val sharedImage = incomingSharedImage
-                LaunchedEffect(sharedImage) {
-                    if (sharedImage != null) {
+                val projectIdForShare = editorUiState.projectId
+                LaunchedEffect(sharedImage, projectIdForShare) {
+                    if (sharedImage != null && projectIdForShare != null) {
                         editorViewModel.onAddLayer(sharedImage)
                         incomingSharedImage = null
                     }
+                }
+                // Tell the user why the shared image hasn't appeared yet, once, rather than leaving
+                // them on the library screen wondering whether the share worked. (`context` proper is
+                // declared further down this composable, so capture the local here.)
+                val shareToastContext = LocalContext.current
+                val sharePending = sharedImage != null && projectIdForShare == null
+                LaunchedEffect(sharePending) {
+                    if (sharePending) {
+                        Toast.makeText(
+                            shareToastContext,
+                            shareToastContext.getString(DesignR.string.shared_image_pick_project),
+                            Toast.LENGTH_LONG
+                        ).show()
+                    }
+                }
+
+                // Flush the editor's debounced layer writes when the app leaves the foreground. The
+                // 1.5 s save debounce means the last stroke exists only in memory until it elapses,
+                // so a process kill while backgrounded silently lost it.
+                val lifecycleOwner = androidx.lifecycle.compose.LocalLifecycleOwner.current
+                DisposableEffect(lifecycleOwner) {
+                    val observer = androidx.lifecycle.LifecycleEventObserver { _, event ->
+                        if (event == androidx.lifecycle.Lifecycle.Event.ON_STOP) {
+                            editorViewModel.flushPendingSaves()
+                        }
+                    }
+                    lifecycleOwner.lifecycle.addObserver(observer)
+                    onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
                 }
 
                 var isProcessing by remember { mutableStateOf(false) }
@@ -683,8 +720,17 @@ class MainActivity : ComponentActivity() {
                                 //     against per-mode background (backgroundBitmap / transparent).
                                 when (editorUiState.editorMode) {
                                     EditorMode.AR -> {
-                                        arViewModel.requestExport { bmp ->
+                                        isExporting = true
+                                        val requested = arViewModel.requestExport { bmp ->
+                                            isExporting = false
                                             editorViewModel.exportImage(backgroundBitmap = bmp, skipLayerComposite = true)
+                                        }
+                                        if (!requested) {
+                                            // No renderer attached (e.g. AR mode without camera
+                                            // permission), so there is no framebuffer to read back.
+                                            // Export the layers alone rather than doing nothing.
+                                            isExporting = false
+                                            editorViewModel.exportImage()
                                         }
                                     }
                                     EditorMode.OVERLAY -> {
@@ -721,6 +767,13 @@ class MainActivity : ComponentActivity() {
                             hasCameraPermission = hasCameraPermission,
                             cameraController = cameraController,
                             onRendererCreated = { _ -> },
+                            // Was omitted, so MainScreen always saw the parameter default (false) and
+                            // the flag was inert everywhere it is read. Wiring it makes the rail and
+                            // the loading/segmentation overlays actually step aside for an export, as
+                            // the export contract describes. (Suppressing the renderer's perception
+                            // layers is handled inside ArViewModel.requestExport, which doesn't have
+                            // to wait for a recomposition to reach the GL thread.)
+                            isExporting = isExporting,
                             doodlePhaseActive = firstRunDoodleActive,
                             doodleScribbleBitmap = firstRunScribbleBitmap
                         )

--- a/core/design/src/main/res/values/strings.xml
+++ b/core/design/src/main/res/values/strings.xml
@@ -312,6 +312,8 @@
     <!-- Action to delete a layer. -->
     <string name="delete">Delete</string>
     <string name="new_project_name">New Project</string>
+    <!-- Shown when an image was shared into the app before a project is open, so it can't be added yet. -->
+    <string name="shared_image_pick_project">Open or create a project to add the shared image</string>
     <!-- Label for the lock button. -->
     <string name="lock_button">Lock</string>
     <!-- Label for the freeze button. -->

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -200,9 +200,20 @@ class ArViewModel @Inject constructor(
                 }
                 _hostQrPayload.value = qrString
             } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
                 _uiState.update {
                     it.copy(coopSessionState = com.hereliesaz.graffitixr.common.model.CoopSessionState.Ended(com.hereliesaz.graffitixr.common.model.CoopSessionState.EndReason.NetworkLost))
                 }
+                // Ended(NetworkLost) is the only state this can express, but the real cause is often
+                // not the network at all — HostSession fails fast on an oversized project precisely so
+                // the reason is attributable, and collapsing everything to "network lost" threw that
+                // away. Surface the actual message through the feedback channel the UI already toasts.
+                android.util.Log.e("ArViewModel", "Failed to start hosting", e)
+                _feedback.tryEmit(
+                    com.hereliesaz.graffitixr.common.model.FeedbackEvent.Error(
+                        "Couldn't start sharing: ${e.message ?: "unknown error"}", e
+                    )
+                )
                 return@launch
             }
             // Observe collaborationManager.state and propagate (single tracked collector).
@@ -225,9 +236,18 @@ class ArViewModel @Inject constructor(
                 _uiState.update { it.copy(coopRole = com.hereliesaz.graffitixr.common.model.CoopRole.GUEST) }
                 observeCoopState()
             } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
                 _uiState.update {
                     it.copy(coopSessionState = com.hereliesaz.graffitixr.common.model.CoopSessionState.Ended(com.hereliesaz.graffitixr.common.model.CoopSessionState.EndReason.NetworkLost))
                 }
+                // Same attribution problem as startHosting: a malformed QR payload or an unreachable
+                // host both read as "network lost" without this.
+                android.util.Log.e("ArViewModel", "Failed to join session", e)
+                _feedback.tryEmit(
+                    com.hereliesaz.graffitixr.common.model.FeedbackEvent.Error(
+                        "Couldn't join: ${e.message ?: "unknown error"}", e
+                    )
+                )
             }
         }
     }
@@ -1861,13 +1881,29 @@ class ArViewModel @Inject constructor(
         _uiState.update { it.copy(isCaptureRequested = true) }
     }
 
-    fun requestExport(callback: (Bitmap) -> Unit) {
-        renderer?.onExportCaptured = { bmp ->
+    /**
+     * Asks the renderer to read back its composited framebuffer, delivering it to [callback] on the
+     * main thread. Returns false when no renderer is attached — AR mode without camera permission,
+     * or before/after the GLSurfaceView's lifetime — in which case nothing was requested and the
+     * caller must fall back. Previously both statements were null-safe no-ops, so Export in AR mode
+     * with no renderer did nothing at all and reported nothing.
+     */
+    fun requestExport(callback: (Bitmap) -> Unit): Boolean {
+        val r = renderer ?: return false
+        // Suppress the perception layers for the readback here rather than relying on the
+        // `hideVisualization = isExporting` push in MainScreen's AndroidView update block: that only
+        // runs on recomposition, so the GL thread could reach the readback first. Restore whatever the
+        // flag was (anchorEstablished drives it independently) once the frame is captured.
+        val previousHide = r.hideVisualization
+        r.hideVisualization = true
+        r.onExportCaptured = { bmp ->
+            r.hideVisualization = previousHide
             viewModelScope.launch(Dispatchers.Main) {
                 callback(bmp)
             }
         }
-        renderer?.exportRequested = true
+        r.exportRequested = true
+        return true
     }
 
     fun onCaptureRequestHandled() {

--- a/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/DrawingCanvas.kt
+++ b/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/DrawingCanvas.kt
@@ -2,6 +2,7 @@ package com.hereliesaz.graffitixr.feature.editor
 
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -67,6 +68,25 @@ fun DrawingCanvas(
                             liquifyPending = liquifyPoints
                             liquifyPoints = emptyList()
                         }
+                        onStrokeEnd()
+                    }
+                )
+            }
+            // detectDragGestures only fires once the touch slop is exceeded, so a plain tap produced
+            // no stroke at all — tapping with the brush selected silently did nothing, and the
+            // single-point paths that already exist downstream (ImageProcessor.drawStroke's
+            // `size == 1` drawPoint, and onStrokeEnd's whole-stroke fallback) were unreachable. A tap
+            // is a legitimate dab, so report it as a one-point stroke.
+            //
+            // Safe to combine with the drag detector above: detectDragGestures awaits its down with
+            // requireUnconsumed = false, so tap consuming the down doesn't hide it; and once slop is
+            // crossed the drag detector consumes the moves, which makes waitForUpOrCancellation
+            // return null here so onTap cannot also fire for the same gesture.
+            .pointerInput(activeTool) {
+                if (activeTool == Tool.NONE) return@pointerInput
+                detectTapGestures(
+                    onTap = { offset ->
+                        onStrokeStart(offset, canvasSize)
                         onStrokeEnd()
                     }
                 )

--- a/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/EditorViewModel.kt
+++ b/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/EditorViewModel.kt
@@ -129,6 +129,9 @@ class EditorViewModel @Inject constructor(
     // scheduled for layer B cancel a still-pending save for layer A, silently dropping
     // A's strokes; per-layer jobs cancel only the same layer's superseded save.
     private val pendingSaveJobs = java.util.concurrent.ConcurrentHashMap<String, kotlinx.coroutines.Job>()
+    // What each pending debounce still owes the disk, so flushPendingSaves() can write it out when
+    // the app leaves the foreground rather than losing it to a process kill mid-delay.
+    private val pendingSaveTargets = java.util.concurrent.ConcurrentHashMap<String, PendingSave>()
 
     // Per-layer rebuild jobs: cancels stale compositing coroutines on rapid undo/redo so
     // only the most recent rebuild's result lands in the UI state.
@@ -427,28 +430,67 @@ class EditorViewModel @Inject constructor(
         val path = uri?.path ?: return
         // Cancel only this layer's previous pending save, never another layer's.
         pendingSaveJobs.remove(layerId)?.cancel()
+        // Record what this debounce owes the disk, so [flushPendingSaves] can honour it immediately
+        // if the app is backgrounded before the delay elapses.
+        val pending = PendingSave(bitmap, path)
+        pendingSaveTargets[layerId] = pending
         val job = viewModelScope.launch(dispatchers.io) {
             kotlinx.coroutines.delay(1500)
-            try {
-                val file = java.io.File(path)
-                java.io.FileOutputStream(file).use { out ->
-                    bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)
-                }
-            } catch (e: kotlinx.coroutines.CancellationException) {
-                // Normal: a newer stroke superseded this debounced save. Not a failure.
-                throw e
-            } catch (e: Exception) {
-                // A swallowed failure here means the user's edits are silently lost.
-                android.util.Log.e("EditorViewModel", "Failed to save layer bitmap to $path", e)
-                withContext(dispatchers.main) {
-                    Toast.makeText(context, "Couldn't save your changes — storage may be full", Toast.LENGTH_LONG).show()
-                }
-            } finally {
-                // Don't leak completed jobs in the map.
-                pendingSaveJobs.remove(layerId, coroutineContext[kotlinx.coroutines.Job])
-            }
+            writeLayerBitmap(layerId, pending)
+            // Don't leak completed jobs in the map.
+            pendingSaveJobs.remove(layerId, coroutineContext[kotlinx.coroutines.Job])
         }
         pendingSaveJobs[layerId] = job
+    }
+
+    /** A debounced layer write that hasn't landed on disk yet. */
+    private class PendingSave(val bitmap: Bitmap, val path: String)
+
+    private suspend fun writeLayerBitmap(layerId: String, pending: PendingSave) {
+        val bitmap = pending.bitmap
+        val path = pending.path
+        try {
+            if (bitmap.isRecycled) return
+            val file = java.io.File(path)
+            java.io.FileOutputStream(file).use { out ->
+                bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)
+            }
+            // Value-matched removal: a newer scheduleDiskSave may have replaced the entry while this
+            // write was in flight, and that newer write still owes the disk its own bitmap.
+            pendingSaveTargets.remove(layerId, pending)
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            // Normal: a newer stroke superseded this debounced save. Not a failure.
+            throw e
+        } catch (e: Exception) {
+            // A swallowed failure here means the user's edits are silently lost.
+            android.util.Log.e("EditorViewModel", "Failed to save layer bitmap to $path", e)
+            withContext(dispatchers.main) {
+                Toast.makeText(context, "Couldn't save your changes — storage may be full", Toast.LENGTH_LONG).show()
+            }
+        }
+    }
+
+    /**
+     * Writes every debounced layer save immediately instead of waiting out its 1.5 s delay.
+     *
+     * Call this when the app leaves the foreground. Without it, the last stroke before backgrounding
+     * lived only in [layerStore] and [EditHistory] — neither of which is persisted — so if Android
+     * killed the process during those 1.5 s the stroke was gone from disk and the layer reloaded from
+     * its pre-stroke file. The debounce is what makes stroke-heavy editing cheap; flushing on the way
+     * out is what makes it safe.
+     */
+    fun flushPendingSaves() {
+        val targets = pendingSaveTargets.keys.mapNotNull { id ->
+            pendingSaveTargets[id]?.let { id to it }
+        }
+        if (targets.isEmpty()) return
+        // Cancel the outstanding debounces first so they can't re-run the same write behind us.
+        targets.forEach { (id, _) -> pendingSaveJobs.remove(id)?.cancel() }
+        // NonCancellable: this runs as the app is going away, and a viewModelScope cancellation
+        // mid-write is exactly the case being defended against.
+        viewModelScope.launch(dispatchers.io + kotlinx.coroutines.NonCancellable) {
+            targets.forEach { (id, pending) -> writeLayerBitmap(id, pending) }
+        }
     }
 
     override fun onAddLayer(uri: Uri) {

--- a/feature/editor/src/test/java/com/hereliesaz/graffitixr/feature/editor/EditorViewModelTest.kt
+++ b/feature/editor/src/test/java/com/hereliesaz/graffitixr/feature/editor/EditorViewModelTest.kt
@@ -399,6 +399,41 @@ class EditorViewModelTest {
         assertTrue("Expected liveStrokeVersion >= 1, got ${state.liveStrokeVersion}", state.liveStrokeVersion >= 1)
     }
 
+    /**
+     * The tap path DrawingCanvas now emits: start immediately followed by end, with no drag points.
+     * Covers both halves of that gesture — the dab must actually commit (detectDragGestures never
+     * fired for a tap, so tapping with a brush selected used to do nothing at all), and the
+     * background bitmap-copy coroutine that is still queued when the stroke ends must abandon
+     * cleanly rather than indexing an emptied point list or stranding the live-stroke overlay.
+     */
+    @Test
+    fun `a tap-length stroke commits a dab and leaves no live-stroke state`() = runTest {
+        val uri = Uri.parse("content://test/image.png")
+        viewModel.onAddLayer(uri)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val layerId = viewModel.uiState.value.layers.first().id
+        viewModel.onLayerActivated(layerId)
+        viewModel.setActiveTool(Tool.BRUSH)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val undoBefore = viewModel.uiState.value.undoCount
+
+        // No advance between the two calls: the copy coroutine is still queued, which is exactly the
+        // ordering a tap produces.
+        viewModel.onStrokeStart(Offset(10f, 10f), IntSize(100, 100))
+        viewModel.onStrokeEnd()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertTrue(
+            "Expected the tap to commit a dab to history, undoCount went $undoBefore -> ${state.undoCount}",
+            state.undoCount > undoBefore
+        )
+        assertNull("Live-stroke layer id should be cleared after the stroke ends", state.liveStrokeLayerId)
+        assertNull("Live-stroke bitmap should be cleared after the stroke ends", state.liveStrokeBitmap)
+    }
+
     @Test
     fun `setSegmentationInfluence updates state and does not crash when no confidence stored`() = runTest {
         viewModel.setSegmentationInfluence(0.3f)


### PR DESCRIPTION
A second audit pass. Instead of reading file by file, this one follows the app from launch through project open, editing, drawing, export and co-op. Everything here lives in the seams *between* components — which is why the per-file pass (#1774) didn't surface any of it.

No Android SDK in this environment, so these were found by reading. One new unit test covers the drawing change; the rest are verified by compile + CI.

## Fixed

### 1. Sharing an image into the app dropped it on cold start
The manifest advertises an `ACTION_SEND` `image/*` filter, and `MainActivity` consumes it in a `LaunchedEffect` on first composition. But `EditorViewModel.onAddLayer` needs a `projectId` to save the artifact under, and on a cold start there isn't one — `ProjectRepositoryImpl._currentProject` starts null and is only set by open/create/import, while the library screen is still up.

So the effect fired, hit the `else` branch, showed *"Invalid image format or missing project"*, and cleared `incomingSharedImage` — the image was gone with no retry. The advertised interop failed on exactly the launch path it exists for.

Now keyed on `projectId` as well, so the Uri is held until a project is open, with a one-time toast explaining why.

### 2. Tapping the canvas with a brush selected painted nothing
`DrawingCanvas` wires only `detectDragGestures`, which fires only once the touch slop is exceeded. A plain tap produced no `onStrokeStart`/`onStrokeEnd` at all.

The giveaway that this was unintended: the single-point case is implemented twice downstream and was unreachable from the UI — `ImageProcessor.drawStroke`'s `stroke.size == 1 → canvas.drawPoint`, and `onStrokeEnd`'s whole-stroke fallback. Added a tap detector that reports a one-point stroke.

Combining the two detectors is safe: `detectDragGestures` awaits its down with `requireUnconsumed = false` so tap consuming the down doesn't hide it, and once slop is crossed the drag detector consumes the moves, so `waitForUpOrCancellation` returns null and `onTap` cannot double-fire.

### 3. The last stroke before backgrounding could be lost
Layer writes are debounced 1.5 s (`scheduleDiskSave`) and nothing flushed them. In that window the stroke exists only in `layerStore` and `EditHistory` — neither is persisted, and `Layer.bitmap` is `@Transient`. Android killing the backgrounded process inside those 1.5 s reverted the layer to its pre-stroke file, silently.

Added `flushPendingSaves()`, which cancels the outstanding debounces and writes immediately under `NonCancellable`, driven from an `ON_STOP` observer. Pending writes are tracked in a map with value-matched removal so a newer scheduled write isn't dropped by an older one completing.

### 4. Export in AR mode did nothing, silently
`ArViewModel.requestExport` was two null-safe statements on `renderer`. With no renderer attached — AR entered without camera permission, or outside the `GLSurfaceView`'s lifetime — both no-op'd: no image, no error, no feedback. It now returns whether it took the request, and `MainActivity` falls back to a layers-only export, matching what the OVERLAY branch already does on capture failure.

### 5. `isExporting` was inert
Declared in `MainActivity`, read in six places, **never assigned**, and never passed to `MainScreen` (which fell back to its `false` default). Wired both ends.

Suppressing the renderer's perception layers now happens inside `requestExport` rather than via the `hideVisualization = isExporting` push in the `AndroidView` update block — that only runs on recomposition, so the GL thread could reach the readback first. Note this narrows but does not fully close a one-frame window: `exportRequested` is honoured at the end of the same frame it's observed, so a flag set mid-frame can still miss that frame's perception draw. In practice the `!anchorEstablished || isInPlaneRealignment` gate already covers the common case; plane realignment is the state where it mattered.

### 6. Co-op failures all read as "network lost"
`startHosting` and `joinFromQr` mapped every exception to `Ended(NetworkLost)`. That discarded the reason — including the oversized-project `require` that `HostSession.init` raises *specifically* so the cause would be attributable ("failing fast here turns an oversized project into an immediate, attributable hosting error"). A malformed QR and an unreachable host were likewise indistinguishable. Both now log and surface the real message through the `feedback` channel the UI already toasts, and stop swallowing `CancellationException`.

## Not fixed — noted for triage

- Hosting is gated on `isAnchorEstablished && splatCount > 0`, not on a project being open. `serializeCurrentProject()` returns an empty array with no project, and the guest's `loadAsSpectator` returns early on empty — so the guest joins to nothing, silently. Tapping the greyed-out Host button also gives no explanation.
- Drawing tools remain selectable in AR mode, where `mapScreenToBitmap` undoes the layer's *Compose* transform — but in AR the layer is rendered on the wall quad, not at that transform, so strokes would land in the wrong place. Unclear whether drawing in AR is meant to be reachable.
- `DashboardViewModel.parseRelease` regex-scrapes `tag_name`/`html_url` from the releases JSON, relying on the release's `html_url` preceding the author object's. Works today; fragile.
- `isNewerVersion` parses version segments with `toIntOrNull() ?: 0`, so a suffixed build (`1.2.3-beta`) compares as `1.2.0`.

## Verified as correct

Recording these so a future pass can skip them: the project create/open/delete lifecycle and its `currentProject` propagation into the editor, the atomic read-modify-write in `ProjectRepositoryImpl.updateProject`, the AR session lifecycle (CameraX unbind before ARCore opens, `exitArMode` on dispose, dead-camera watchdog), `compositeLayersForAr`'s rotated-bounds sizing and recycled-bitmap guard, and the spectator-op buffering handoff in `setSpectatorOpHandler`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FNdRBgp5zMj9rZVHffb5rK

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNdRBgp5zMj9rZVHffb5rK)_