### PR TITLE
fix: close the export race and the remaining triage items

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -1588,8 +1588,10 @@ class MainActivity : ComponentActivity() {
                         color = if (isHosting) Cyan else if (canHost) navItemColor else Color.Gray,
                         shape = AzButtonShape.NONE
                     ) {
-                        // Hosting requires an established anchor with mapped splats to share.
-                        if (canHost && !isHosting) arViewModel.startHosting()
+                        // canHost still drives the colour, but the tap is no longer swallowed when it
+                        // is false: startHosting() re-checks the anchor (and that a project is open)
+                        // and explains which one is missing, rather than the button doing nothing.
+                        if (!isHosting) arViewModel.startHosting()
                     }
                     azRailSubItem(
                         id = "coop.join", hostId = "coop", text = navStrings.joinCoop,

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -183,8 +183,42 @@ class ArViewModel @Inject constructor(
     fun startHosting() {
         viewModelScope.launch {
             try {
+                // Both preconditions are checked here rather than only in the rail's enablement
+                // colour, so tapping Host always yields either a session or an explanation of what
+                // is missing — previously a tap with the button greyed out simply did nothing.
+                val st = _uiState.value
+                if (!st.isAnchorEstablished || st.splatCount <= 0) {
+                    _feedback.tryEmit(
+                        com.hereliesaz.graffitixr.common.model.FeedbackEvent.Error(
+                            "Scan and lock onto the wall first — a guest needs the mapped surface to line up with yours"
+                        )
+                    )
+                    return@launch
+                }
+                // The anchor and an open project are independent: hosting without the latter produced
+                // a session that looked healthy on the host (QR shown, WaitingForGuest) but shipped a
+                // zero-byte bulk payload, which the guest's loadAsSpectator discards on its
+                // `bytes.isEmpty()` guard — the guest joined to nothing, with no error on either end.
+                if (projectRepository.currentProject.value == null) {
+                    _feedback.tryEmit(
+                        com.hereliesaz.graffitixr.common.model.FeedbackEvent.Error(
+                            "Open a project before sharing — there's nothing to send to a guest yet"
+                        )
+                    )
+                    return@launch
+                }
                 val fingerprint = slamManager.exportFingerprint() ?: ByteArray(0)
                 val projectBytes = projectManager.serializeCurrentProject()
+                if (projectBytes.isEmpty()) {
+                    // A project is open but its folder didn't serialize (never saved to disk, or the
+                    // directory is missing). Same silent-empty-session outcome, different cause.
+                    _feedback.tryEmit(
+                        com.hereliesaz.graffitixr.common.model.FeedbackEvent.Error(
+                            "Couldn't package this project to share — try saving it first"
+                        )
+                    )
+                    return@launch
+                }
                 val qrString = collaborationManager.startHosting(
                     projectId = projectManager.currentProjectId(),
                     layerCount = projectRepository.currentProject.value?.layers?.size ?: 0,

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -736,6 +736,15 @@ class ArRenderer(
         // instantaneous and we never touch a session that is being closed.
         if (isDestroying) return
         frameCount++
+        // Latch the export request HERE, at the top of the frame, not at the readback site near the
+        // end. ArViewModel.requestExport sets hideVisualization before exportRequested, so observing
+        // the request at frame start guarantees the suppression is already in effect for everything
+        // this frame draws. Reading the flag at the end instead meant a request landing mid-frame —
+        // after the perception layers had already been drawn with suppression off — was still served
+        // by that same frame's readback, baking feature points / plane grids into the exported image.
+        // Only latched here; consumed at the export block below, so a frame that bails early (no
+        // session yet) still leaves the request pending for the next one, as before.
+        val exportThisFrame = exportRequested
         lastTickMs = android.os.SystemClock.elapsedRealtime()
         lastStep = "lock"
 
@@ -1312,7 +1321,7 @@ class ArRenderer(
             }
 
             lastStep = "export"
-            if (exportRequested) {
+            if (exportThisFrame) {
                 exportRequested = false
                 try {
                     // Read the composited GL framebuffer instead of the raw camera image. By this

--- a/feature/dashboard/src/main/java/com/hereliesaz/graffitixr/feature/dashboard/DashboardViewModel.kt
+++ b/feature/dashboard/src/main/java/com/hereliesaz/graffitixr/feature/dashboard/DashboardViewModel.kt
@@ -179,16 +179,32 @@ class DashboardViewModel @Inject constructor(
         }
     }
 
-    private fun parseRelease(json: String): GitHubRelease? {
+    internal fun parseRelease(json: String): GitHubRelease? {
         return try {
             val tagName = Regex("\"tag_name\"\\s*:\\s*\"([^\"]+)\"").find(json)?.groupValues?.get(1) ?: return null
-            val htmlUrl = Regex("\"html_url\"\\s*:\\s*\"([^\"]+)\"").find(json)?.groupValues?.get(1) ?: "https://github.com/hereliesaz/GraffitiXR/releases"
+            // Match the RELEASE's html_url specifically (it contains /releases/), not merely the first
+            // one in the document. The release payload also carries the author object's html_url
+            // (https://github.com/<user>), so a positional match only worked because GitHub happens to
+            // order the release's own field first — reorder the response and this would have started
+            // opening the author's profile page instead of the release.
+            val htmlUrl = Regex("\"html_url\"\\s*:\\s*\"([^\"]*/releases/[^\"]*)\"").find(json)?.groupValues?.get(1)
+                ?: "https://github.com/hereliesaz/GraffitiXR/releases"
             GitHubRelease(tagName, htmlUrl)
         } catch (e: Exception) { null }
     }
 
-    private fun isNewerVersion(latest: String, current: String): Boolean {
-        fun parse(v: String) = v.split(".").map { it.toIntOrNull() ?: 0 }
+    /**
+     * Compares dotted version strings numerically, segment by segment.
+     *
+     * Segments are read up to the first non-digit, so a qualifier travels with its segment
+     * ("1.2.3-beta" -> [1, 2, 3]) instead of collapsing it to zero. `toIntOrNull()` on the whole
+     * segment returned null for "3-beta" and fell back to 0, making 1.2.3-beta compare as 1.2.0 —
+     * which reported a *newer* release as older and silently suppressed the update prompt.
+     */
+    internal fun isNewerVersion(latest: String, current: String): Boolean {
+        fun parse(v: String) = v.trim().removePrefix("v").split(".").map { segment ->
+            segment.takeWhile { it.isDigit() }.toIntOrNull() ?: 0
+        }
         val l = parse(latest)
         val c = parse(current)
         for (i in 0 until maxOf(l.size, c.size)) {
@@ -199,5 +215,5 @@ class DashboardViewModel @Inject constructor(
         return false
     }
 
-    private data class GitHubRelease(val tagName: String, val htmlUrl: String)
+    internal data class GitHubRelease(val tagName: String, val htmlUrl: String)
 }

--- a/feature/dashboard/src/test/java/com/hereliesaz/graffitixr/feature/dashboard/DashboardViewModelTest.kt
+++ b/feature/dashboard/src/test/java/com/hereliesaz/graffitixr/feature/dashboard/DashboardViewModelTest.kt
@@ -14,6 +14,9 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
@@ -89,5 +92,50 @@ class DashboardViewModelTest {
         
         coVerify { repository.deleteProject(projectId) }
         coVerify { repository.getProjects() } // loadAvailableProjects is called
+    }
+
+    // ── Update check: pure helpers ────────────────────────────────────────────
+
+    @Test
+    fun `isNewerVersion compares segments numerically`() {
+        assertTrue(viewModel.isNewerVersion("1.2.4", "1.2.3"))
+        assertTrue(viewModel.isNewerVersion("1.3.0", "1.2.9"))
+        assertTrue(viewModel.isNewerVersion("2.0.0", "1.99.99"))
+        assertFalse(viewModel.isNewerVersion("1.2.3", "1.2.3"))
+        assertFalse(viewModel.isNewerVersion("1.2.3", "1.2.4"))
+    }
+
+    @Test
+    fun `isNewerVersion does not collapse a qualified segment to zero`() {
+        // "3-beta" used to parse as 0, so 1.2.3-beta read as 1.2.0 and a genuinely newer release
+        // was reported as older — the update prompt never appeared.
+        assertTrue(viewModel.isNewerVersion("1.2.3-beta", "1.2.2"))
+        assertFalse(viewModel.isNewerVersion("1.2.3-beta", "1.2.4"))
+    }
+
+    @Test
+    fun `isNewerVersion tolerates a v prefix and differing segment counts`() {
+        assertTrue(viewModel.isNewerVersion("v1.3", "1.2.9"))
+        assertFalse(viewModel.isNewerVersion("1.2", "1.2.0"))
+    }
+
+    @Test
+    fun `parseRelease picks the release url, not the author's`() {
+        // GitHub's payload carries the author object's html_url too. Matching the first html_url in
+        // the document only worked because of field ordering; assert on a payload that puts the
+        // author first.
+        val json = """
+            {"tag_name":"v2.1.0",
+             "author":{"login":"someone","html_url":"https://github.com/someone"},
+             "html_url":"https://github.com/hereliesaz/GraffitiXR/releases/tag/v2.1.0"}
+        """.trimIndent()
+        val release = viewModel.parseRelease(json)
+        assertEquals("v2.1.0", release?.tagName)
+        assertEquals("https://github.com/hereliesaz/GraffitiXR/releases/tag/v2.1.0", release?.htmlUrl)
+    }
+
+    @Test
+    fun `parseRelease returns null without a tag name`() {
+        assertNull(viewModel.parseRelease("""{"html_url":"https://github.com/x/y/releases/tag/v1"}"""))
     }
 }


### PR DESCRIPTION
Clears the deferred list from #1775, including the one-frame race I explicitly left open there.

## Fixed

### 1. The export race, closed properly
`ArRenderer` read `exportRequested` at the **end** of `onDrawFrame`. A request arriving mid-frame — after the perception layers had already been drawn with suppression off — was still served by that same frame's readback, baking feature points and plane grids into the exported image.

The flag is now latched at the **top** of the frame. `ArViewModel.requestExport` sets `hideVisualization` before `exportRequested`, so observing the request at frame start guarantees suppression is already in effect for everything that frame draws — no extra frame of latency needed, which is why this turned out cheaper than the two-phase handshake I'd assumed.

It's still *consumed* at the original site, deliberately: a frame that bails early (no session yet) leaves the request pending for the next one, preserving the old retry behaviour. Clearing at the latch point would have dropped those requests.

### 2. Hosting with no project open
`startHosting` required an established anchor but not an open project, and those are independent. Hosting without one produced a session that looked healthy on the host (QR shown, `WaitingForGuest`) but shipped a **zero-byte bulk payload**, which the guest's `loadAsSpectator` discards on its `bytes.isEmpty()` guard. The guest joined to nothing, with no error on either end.

Both preconditions now live in the ViewModel and name what's missing. That also fixes the dead tap: the rail called `startHosting()` only `if (canHost)`, so tapping the greyed-out button did nothing at all. It now always reports the reason.

### 3. `parseRelease` picked the wrong URL
It matched the first `"html_url"` in the payload. That's the release's own **only because** GitHub happens to order it before the `author` object's — reorder the response and the update button would have opened the author's profile. Now requires the URL to contain `/releases/`.

### 4. `isNewerVersion` collapsed qualified segments
Each dotted segment was parsed with `toIntOrNull()`, so `"3-beta"` → `0` and `1.2.3-beta` compared as `1.2.0`. A genuinely newer release read as older and the update prompt never appeared. Segments are now read up to the first non-digit, with a leading `v` tolerated.

`parseRelease` / `isNewerVersion` widened to `internal` so the tests can reach them; both are pure. Five new tests.

## Deliberately not fixed

**The per-layer rail does not exist.** `ConfigureRailItems` builds only Open, the Project folder, and the Modes folder. There is no `layers.forEach` loop and no tool items — nothing in the app calls `EditorViewModel.setActiveTool`.

So `uiState.activeTool` is always `Tool.NONE`, `DrawingCanvas` never renders, and the whole layer-editing surface has no entry point: brush/eraser/blur/liquify/dodge/burn, adjustments, colour balance, blend mode, invert, stencil generation, background removal, edge detect, and the text tools.

`RailIdEnumerator` still enumerates all of it (`layerId(layer, "size.brush")`, `"eraser"`, `"blur"`, `"liquify"`, `"stencil"`, …) and `HelpItemsBuilder` still maps help text for those ids. `RailIntegrityCheck` only `Log.w`s on orphans, and only in debug, so nothing surfaced the gap.

I've left this alone: restoring a rail of that size is feature work with real design decisions in it (grouping, per-layer-type visibility, mode gating), not a bug fix, and I'd be inventing the UI. Worth confirming whether it was removed intentionally.

This also supersedes the "drawing tools are reachable in AR mode" item from #1775 — I'd flagged that strokes would land in the wrong place there, but no tool is selectable in any mode, so the concern is moot until the rail returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FNdRBgp5zMj9rZVHffb5rK

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNdRBgp5zMj9rZVHffb5rK)_