### PR TITLE
feat: bigger, spread-out onboarding scribble; draw-then-detect flow

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -152,6 +152,12 @@ import kotlin.math.abs
 
 private const val LIBRARY_ROUTE = "library"
 
+/**
+ * Stages of the first-run "drawing in 60 seconds" flow. Split because the two halves need different
+ * things from the device: DRAW is a plain screen (no camera), DETECT needs AR.
+ */
+private enum class FirstRunStage { NONE, DRAW, DETECT }
+
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
 
@@ -529,16 +535,25 @@ class MainActivity : ComponentActivity() {
                     }
                 }
 
-                // --- First-run AR doodle onboarding coordinator ---
-                // Strictly contained: the whole flow is gated behind the tutorial key + ARCore
-                // availability + camera permission. If any condition fails it's a complete no-op and
-                // normal library startup is byte-for-byte unchanged. The tutorial key is marked
-                // complete only once the demo reaches its lock/swap.
+                // --- First-run "drawing in 60 seconds" onboarding coordinator ---
+                // Two explicit stages, because they need different things from the device:
+                //
+                //   DRAW    show the scribble full-screen and wait. No camera, no plane, no anchor —
+                //           the user is looking at the phone and marking a wall. Trying to do this in
+                //           AR meant fighting for screen space with a live feed and depending on a
+                //           pose being established before there was anything drawn to anchor to.
+                //   DETECT  now that marks exist, point the camera at them and let the fingerprint
+                //           builder latch on. Completion means "detected", not "held still long
+                //           enough".
+                //
+                // Strictly contained: gated behind the tutorial key + ARCore availability + camera
+                // permission. If any condition fails it's a complete no-op and normal library startup
+                // is byte-for-byte unchanged. The key is marked complete only once detection lands.
                 val firstRunDoodleKey = "first_run_ar_doodle"
                 val firstRunCompletedTutorials by mainViewModel.completedTutorials.collectAsState()
-                // rememberSaveable so a process/config event mid-flow doesn't reset the flags and
+                // rememberSaveable so a process/config event mid-flow doesn't reset the stage and
                 // re-trigger the gate.
-                var firstRunDoodleActive by rememberSaveable { mutableStateOf(false) }
+                var firstRunStage by rememberSaveable { mutableStateOf(FirstRunStage.NONE) }
                 // Latches true once the gate has fired this session (whether the user picks or cancels),
                 // so a later key change can't re-fire it and spawn a duplicate project. Not persisted —
                 // a fresh launch re-offers onboarding until it's actually completed.
@@ -546,9 +561,6 @@ class MainActivity : ComponentActivity() {
                 // Set on a successful pick; the effect below adds the layer once the project id exists.
                 var firstRunPendingUri by rememberSaveable { mutableStateOf<Uri?>(null) }
                 val firstRunScribble = remember { com.hereliesaz.graffitixr.onboarding.ScribbleGenerator.generate() }
-                val firstRunScribbleBitmap = remember(firstRunScribble) {
-                    com.hereliesaz.graffitixr.onboarding.renderScribbleBitmap(firstRunScribble, 512)
-                }
 
                 val firstRunImagePicker = rememberLauncherForActivityResult(ActivityResultContracts.PickVisualMedia()) { uri ->
                     if (uri != null) {
@@ -557,11 +569,8 @@ class MainActivity : ComponentActivity() {
                         // has propagated — onAddLayer no-ops on a null projectId, so we can't add here.
                         dashboardViewModel.createAndOpenProject()
                         firstRunPendingUri = uri
-                        firstRunDoodleActive = true
-                        navController.navigate(EditorMode.AR.name) {
-                            popUpTo(LIBRARY_ROUTE) { inclusive = true }
-                            launchSingleTop = true
-                        }
+                        // Straight to DRAW; AR is not entered until the marks exist.
+                        firstRunStage = FirstRunStage.DRAW
                     }
                     // Cancel: firstRunTriggered stays true, so the gate won't re-fire this session; the
                     // user lands on the library. No project was created.
@@ -590,17 +599,17 @@ class MainActivity : ComponentActivity() {
                     }
                 }
 
-                // Drive the headless fingerprint-build orchestration in the AR VM with the phase.
-                LaunchedEffect(firstRunDoodleActive) {
-                    arViewModel.setDoodlePhase(firstRunDoodleActive)
+                // Detection only runs in DETECT: the AR VM's capture/fingerprint loop needs the camera,
+                // so it must not start while the user is still drawing.
+                LaunchedEffect(firstRunStage) {
+                    arViewModel.setDoodlePhase(firstRunStage == FirstRunStage.DETECT)
                 }
 
-                // Lock reached: clear the doodle phase (normal composite resumes, swapping the scribble
-                // for the user's artwork) and never show onboarding again.
+                // Detected: the fingerprint latched onto the drawn marks, so the artwork is ready to
+                // place. Tune it to the wall we just measured and never show onboarding again.
                 LaunchedEffect(arUiState.doodleLocked) {
-                    if (firstRunDoodleActive && arUiState.doodleLocked) {
-                        firstRunDoodleActive = false
-                        // Pre-set the adjustment knobs to read well against the wall we captured.
+                    if (firstRunStage == FirstRunStage.DETECT && arUiState.doodleLocked) {
+                        firstRunStage = FirstRunStage.NONE
                         editorViewModel.autoTuneActiveLayer(arUiState.doodleWallStats)
                         mainViewModel.markTutorialCompletePersistent(firstRunDoodleKey)
                     }
@@ -758,8 +767,9 @@ class MainActivity : ComponentActivity() {
                             // layers is handled inside ArViewModel.requestExport, which doesn't have
                             // to wait for a recomposition to reach the GL thread.)
                             isExporting = isExporting,
-                            doodlePhaseActive = firstRunDoodleActive,
-                            doodleScribbleBitmap = firstRunScribbleBitmap
+                            // The detect stage still needs the renderer's tap-free auto-anchor, but the
+                            // scribble is no longer projected onto the wall — it was drawn there.
+                            doodleDetectActive = firstRunStage == FirstRunStage.DETECT,
                         )
 
                     }
@@ -805,16 +815,36 @@ class MainActivity : ComponentActivity() {
                             )
                         }
 
-                        // First-run doodle coaching layer — over the AR camera feed while the demo runs.
-                        if (firstRunDoodleActive &&
+                        // First-run DRAW stage: the scribble owns the whole screen while the user
+                        // copies it. Mounted before the AR coaching below and returns early, so
+                        // nothing else in this layer can draw over it.
+                        if (firstRunStage == FirstRunStage.DRAW && !showSettings) {
+                            com.hereliesaz.graffitixr.onboarding.ScribbleDrawScreen(
+                                scribble = firstRunScribble,
+                                title = "Draw this on your wall",
+                                hint = "Make it big — roughly the size of your artwork. It only has to be recognisable, not neat.",
+                                doneLabel = "I've drawn it",
+                                onDrawn = {
+                                    firstRunStage = FirstRunStage.DETECT
+                                    navController.navigate(EditorMode.AR.name) {
+                                        popUpTo(LIBRARY_ROUTE) { inclusive = true }
+                                        launchSingleTop = true
+                                    }
+                                },
+                            )
+                            return@onscreen
+                        }
+
+                        // First-run DETECT coaching — over the AR camera feed while we look for the
+                        // marks the user just drew.
+                        if (firstRunStage == FirstRunStage.DETECT &&
                             !showSettings &&
                             editorUiState.editorMode == EditorMode.AR
                         ) {
                             com.hereliesaz.graffitixr.onboarding.FirstRunOnboardingOverlay(
-                                scribble = firstRunScribble,
                                 isArReady = arUiState.isArReady,
                                 planeDetected = arUiState.planeDetected,
-                                title = "Doodle this on your wall or canvas",
+                                title = "Now point your camera at what you drew",
                                 movementHint = arUiState.scanHint ?: "Slowly move your device in a circle",
                             )
                         }

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
@@ -69,12 +69,11 @@ fun MainScreen(
     cameraController: androidx.camera.view.LifecycleCameraController,
     onRendererCreated: (ArRenderer) -> Unit,
     isExporting: Boolean = false,
-    // First-run doodle demo: while active, the AR overlay shows this scribble bitmap (the thing the
-    // user copies onto the wall) instead of the layer composite, and the renderer runs the
-    // auto-anchor + hold-lock. On lock the host clears the flag and the normal composite resumes,
-    // swapping the scribble for the user's artwork. Defaulted off — no effect on the normal path.
-    doodlePhaseActive: Boolean = false,
-    doodleScribbleBitmap: android.graphics.Bitmap? = null
+    // First-run DETECT stage: enables the renderer's tap-free auto-anchor so the fingerprint builder
+    // has a pose to work against while it looks for the marks the user drew. The scribble itself is
+    // NOT projected — it was drawn on the wall in the preceding step, so the overlay shows the user's
+    // artwork throughout. Defaulted off — no effect on the normal path.
+    doodleDetectActive: Boolean = false
 ) {
     val activeLayer = uiState.layers.find { it.id == uiState.activeLayerId }
     val isImageLocked = activeLayer?.isImageLocked ?: false
@@ -261,17 +260,7 @@ fun MainScreen(
                             listOf(it.brightness, it.contrast, it.saturation, it.opacity, it.isInverted)
                         }
                     }
-                    LaunchedEffect(visibleLayers, arUiState.isAnchorEstablished, arToneKey, doodlePhaseActive, doodleScribbleBitmap) {
-                        // Doodle phase: the wall shows the scribble the user is copying, not their
-                        // artwork. Once the anchor exists, push the scribble and hold — the host swaps
-                        // to the artwork by clearing doodlePhaseActive (this effect then re-runs and
-                        // falls through to the normal composite below).
-                        if (doodlePhaseActive && doodleScribbleBitmap != null) {
-                            if (arUiState.isAnchorEstablished) {
-                                rendererRef.value?.updateOverlayBitmap(doodleScribbleBitmap)
-                            }
-                            return@LaunchedEffect
-                        }
+                    LaunchedEffect(visibleLayers, arUiState.isAnchorEstablished, arToneKey) {
                         if (!arUiState.isAnchorEstablished || visibleLayers.isEmpty()) {
                             rendererRef.value?.updateOverlayBitmap(null)
                             return@LaunchedEffect
@@ -347,7 +336,7 @@ fun MainScreen(
                                 r.hideVisualization = isExporting
                                 r.visitedSectorsMask = arUiState.visitedSectorsMask
                                 r.scanPhase = arUiState.scanPhase
-                                r.doodleLockActive = doodlePhaseActive
+                                r.doodleLockActive = doodleDetectActive
                                 // Independent in-world perception layers (Settings, default on).
                                 r.showFeaturePoints = uiState.showFeaturePoints
                                 r.showPlaneGrids = uiState.showPlaneGrids

--- a/app/src/main/java/com/hereliesaz/graffitixr/onboarding/FirstRunOnboardingOverlay.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/onboarding/FirstRunOnboardingOverlay.kt
@@ -38,22 +38,24 @@ import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
 
 /**
- * First-run AR coaching layer, drawn as a full-screen sibling over the GL camera surface. Staged:
+ * First-run step two: coaching for the **detect** pass, drawn as a full-screen sibling over the GL
+ * camera surface.
  *
- *  1. "Doodle this on your wall or canvas" appears centred, alone, for [TITLE_HOLD_MS].
- *  2. The title animates up to the top and the generated [scribble] fades in below it — this is the
- *     reference the user copies onto their real wall.
- *  3. Once ARCore is ready ([isArReady]) but no surface has been found yet ([planeDetected] false),
- *     movement guidance ([movementHint]) + a rotating hint icon appear below the scribble. They
- *     disappear the moment a surface is found, so the user isn't nagged once tracking is working.
+ * By the time this is up the user has already copied the scribble onto their wall from
+ * [ScribbleDrawScreen], so there is no reference to show here — the reference is on the wall. The
+ * job is just to get the camera pointed at it and moving enough for a surface to be found, after
+ * which the fingerprint builder latches onto the drawn marks.
  *
- * This layer shows the scribble + coaching only; latching the overlay onto the drawn marks and the
- * swap to the user's artwork are the next phase. The caller is responsible for only composing this
- * during the first-run flow (no other modal open).
+ *  1. [title] ("point your camera at what you drew") appears centred for [TITLE_HOLD_MS].
+ *  2. It rises to the top, leaving the camera view unobstructed while detection runs.
+ *  3. While ARCore is ready ([isArReady]) but no surface has been found ([planeDetected] false),
+ *     movement guidance ([movementHint]) + a rotating hint icon show. They disappear the moment a
+ *     surface is found, so the user isn't nagged once tracking is working.
+ *
+ * The caller only composes this during the first-run detect stage (no other modal open).
  */
 @Composable
 fun FirstRunOnboardingOverlay(
-    scribble: Scribble,
     isArReady: Boolean,
     planeDetected: Boolean,
     title: String,
@@ -66,7 +68,7 @@ fun FirstRunOnboardingOverlay(
         titleAtTop = true
     }
 
-    // -1 = top, 0 = centre. The title starts centred, then rises to make room for the scribble.
+    // -1 = top, 0 = centre. The title starts centred, then rises to clear the camera view.
     val titleBias by animateFloatAsState(
         targetValue = if (titleAtTop) -0.86f else 0f,
         animationSpec = tween(durationMillis = 600),
@@ -86,25 +88,12 @@ fun FirstRunOnboardingOverlay(
                 .padding(horizontal = 32.dp, vertical = 24.dp),
         )
 
-        // The scribble reference occupies the centre once the title has cleared out.
-        AnimatedVisibility(
-            visible = titleAtTop,
-            enter = fadeIn(tween(500)),
-            exit = fadeOut(),
-            modifier = Modifier.align(Alignment.Center),
-        ) {
-            ScribbleView(
-                scribble = scribble,
-                modifier = Modifier.size(240.dp),
-            )
-        }
-
         // Movement guidance: only while ARCore is up but hasn't found a surface yet.
         AnimatedVisibility(
             visible = titleAtTop && isArReady && !planeDetected,
             enter = fadeIn(tween(400)),
             exit = fadeOut(tween(300)),
-            modifier = Modifier.align(BiasAlignment(0f, 0.72f)),
+            modifier = Modifier.align(BiasAlignment(0f, 0.35f)),
         ) {
             MovementGuidance(movementHint)
         }

--- a/app/src/main/java/com/hereliesaz/graffitixr/onboarding/ScribbleDrawScreen.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/onboarding/ScribbleDrawScreen.kt
@@ -1,0 +1,90 @@
+package com.hereliesaz.graffitixr.onboarding
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.hereliesaz.aznavrail.AzButton
+import com.hereliesaz.aznavrail.model.AzButtonShape
+
+/**
+ * First-run step one: show the scribble and wait while the user copies it onto their wall.
+ *
+ * Deliberately **not** an AR view. Nothing here needs the camera, a tracked plane or an anchor —
+ * the user is looking at their phone and drawing on a wall, so the scribble gets the whole screen
+ * at maximum legibility instead of competing with a live camera feed and a pose that isn't
+ * established yet. Detection happens afterwards, as its own step, once there is actually something
+ * drawn to detect.
+ *
+ * The scribble fills a square that tracks the screen width, which is what makes it big enough to
+ * copy at arm's length.
+ */
+@Composable
+fun ScribbleDrawScreen(
+    scribble: Scribble,
+    title: String,
+    hint: String,
+    doneLabel: String,
+    onDrawn: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier
+            .fillMaxSize()
+            // Opaque: this is a step in its own right, not a translucent coaching layer, and a solid
+            // ground keeps the marks maximally readable.
+            .background(Color.Black)
+    ) {
+        Column(
+            modifier = Modifier.fillMaxSize().padding(horizontal = 20.dp, vertical = 28.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text(
+                text = title,
+                color = Color.White,
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.SemiBold,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            ScribbleView(
+                scribble = scribble,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    // Square, so the generator's normalized [0,1]x[0,1] layout is drawn without
+                    // distorting the glyph spread.
+                    .aspectRatio(1f)
+                    .weight(1f, fill = false),
+            )
+
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                Text(
+                    text = hint,
+                    color = Color.White.copy(alpha = 0.75f),
+                    style = MaterialTheme.typography.bodyLarge,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                AzButton(text = doneLabel, onClick = onDrawn, shape = AzButtonShape.RECTANGLE)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/hereliesaz/graffitixr/onboarding/ScribbleGenerator.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/onboarding/ScribbleGenerator.kt
@@ -1,14 +1,14 @@
 package com.hereliesaz.graffitixr.onboarding
 
-import kotlin.math.cos
+import kotlin.math.ceil
 import kotlin.math.hypot
-import kotlin.math.sin
+import kotlin.math.sqrt
 import kotlin.random.Random
 
 /**
  * A single character placed in the onboarding scribble, expressed in a normalized [0,1] x [0,1]
  * canvas so the renderer can scale it to any size. [sizeFrac] is the glyph box edge as a fraction
- * of the canvas' smaller dimension; the glyph's circular footprint (used for the overlap rule) has
+ * of the canvas' smaller dimension; the glyph's circular footprint (used for the spacing rule) has
  * radius `sizeFrac / 2` around ([cx], [cy]).
  */
 data class ScribbleGlyph(
@@ -19,40 +19,47 @@ data class ScribbleGlyph(
     val sizeFrac: Float,
 )
 
-/** An ordered set of overlapping glyphs forming one connected scribble. */
+/** A set of glyphs forming one scribble for the user to copy. */
 data class Scribble(val glyphs: List<ScribbleGlyph>)
 
 /**
- * Generates the random "doodle this" scribble shown at first run: a small cluster of characters
- * (letters, digits, symbols) at random positions and rotations, with the rule that **every glyph
- * overlaps at least one other** so the result reads as a single connected mark rather than scattered
- * confetti. A complexity cap ([MAX_GLYPHS]) keeps it drawable in a few seconds regardless of the
- * user's utensil.
+ * Generates the random "draw this" scribble shown at first run: a handful of large characters
+ * (letters, digits, symbols) spread across the canvas at random rotations.
+ *
+ * Glyphs are placed on a **jittered grid** rather than chained onto each other, so the marks cover
+ * the whole area instead of clustering in the middle. That serves both halves of the job: the
+ * scribble is easier to copy onto a wall at a useful size, and — because detection solves a pose
+ * from the drawn marks — features spread across a wide baseline condition that solve far better
+ * than a tight knot of overlapping glyphs in one spot.
  *
  * Pure and deterministic given a seeded [Random], so the placement logic is unit-testable without
  * Android. Rendering (rotation, stroke) is the caller's job.
  */
 object ScribbleGenerator {
 
-    /** Complexity cap — more than this becomes an unreadable tangle nobody wants to copy. */
-    const val MAX_GLYPHS = 7
-    const val MIN_GLYPHS = 3
+    /** Complexity cap — the marks want to be big, so fewer of them fit before it turns to mush. */
+    const val MAX_GLYPHS = 6
+    const val MIN_GLYPHS = 4
 
     private val ALPHABET: List<Char> =
         (('A'..'Z') + ('a'..'z') + ('2'..'9') + listOf('#', '@', '&', '%', '*', '?', '!', '+', '=')).toList()
 
-    // Glyph footprint size range, as a fraction of the canvas' smaller edge.
-    private const val MIN_SIZE = 0.14f
-    private const val MAX_SIZE = 0.24f
+    /**
+     * Glyph footprint size range, as a fraction of the canvas' smaller edge. Deliberately large —
+     * these get copied onto a wall by hand, and a small mark is both fiddly to draw and poor to
+     * detect. Capped per-layout against the grid cell so a dense layout doesn't collapse into a blob.
+     */
+    private const val MIN_SIZE = 0.20f
+    private const val MAX_SIZE = 0.34f
 
-    // Keep centres inside a margin so rotated glyphs don't clip the canvas edge.
-    private const val MARGIN = 0.16f
+    /** Keep centres inside a margin so rotated glyphs don't clip the canvas edge. */
+    private const val MARGIN = 0.12f
 
-    // A new glyph is dropped this fraction of (r_self + r_neighbor) from a chosen neighbour's
-    // centre. < 1.0 forces the footprints to overlap (two circles overlap iff centre distance is
-    // below the radius sum); the range keeps the overlap visible but not fully concentric.
-    private const val MIN_OVERLAP_SPACING = 0.45f
-    private const val MAX_OVERLAP_SPACING = 0.80f
+    /**
+     * How far a glyph may wander from its grid cell centre, as a fraction of the cell. Enough to
+     * break up the grid so it doesn't read as a table, not enough to re-cluster.
+     */
+    private const val JITTER = 0.45f
 
     /**
      * @param random seeded for determinism/testability.
@@ -63,43 +70,35 @@ object ScribbleGenerator {
         glyphCount: Int = random.nextInt(MIN_GLYPHS, MAX_GLYPHS + 1),
     ): Scribble {
         val n = glyphCount.coerceIn(MIN_GLYPHS, MAX_GLYPHS)
-        val glyphs = ArrayList<ScribbleGlyph>(n)
 
-        // Seed glyph near centre with a little jitter.
-        glyphs += ScribbleGlyph(
-            char = ALPHABET.random(random),
-            cx = 0.5f + random.nextFloat() * 0.1f - 0.05f,
-            cy = 0.5f + random.nextFloat() * 0.1f - 0.05f,
-            rotationDeg = randomRotation(random),
-            sizeFrac = randomSize(random),
-        )
+        // Near-square grid big enough to hold n cells; shuffle which cells get used so a count that
+        // doesn't fill the grid leaves its gaps in a random place rather than always the last row.
+        val cols = ceil(sqrt(n.toFloat())).toInt().coerceAtLeast(1)
+        val rows = ceil(n / cols.toFloat()).toInt().coerceAtLeast(1)
+        val usable = 1f - 2f * MARGIN
+        val cellW = usable / cols
+        val cellH = usable / rows
 
-        while (glyphs.size < n) {
-            val neighbor = glyphs[random.nextInt(glyphs.size)]
-            val size = randomSize(random)
-            val rSelf = size / 2f
-            val rNeighbor = neighbor.sizeFrac / 2f
-            val spacing = MIN_OVERLAP_SPACING + random.nextFloat() * (MAX_OVERLAP_SPACING - MIN_OVERLAP_SPACING)
-            val dist = (rSelf + rNeighbor) * spacing
-            val angle = random.nextFloat() * (2f * Math.PI.toFloat())
+        // A glyph may exceed its cell a little (marks touching still reads as one scribble, which is
+        // fine) but not so much that neighbours bury each other.
+        val maxSize = minOf(MAX_SIZE, minOf(cellW, cellH) * 1.15f)
+        val minSize = minOf(MIN_SIZE, maxSize * 0.75f)
 
-            // Offset from the neighbour. `dist < rSelf + rNeighbor` (spacing < 1) guarantees the
-            // footprints overlap. To keep the glyph on-canvas WITHOUT shrinking that distance (which
-            // could break the overlap), mirror the offset on any axis that would leave the margin —
-            // reflection preserves |offset|, so overlap with the neighbour is retained exactly. With
-            // dist <= MAX_SIZE (0.24) and a [MARGIN, 1-MARGIN] band of width 0.68 > 2*0.24, at least
-            // one direction per axis always lands in-bounds.
-            var dx = cos(angle) * dist
-            var dy = sin(angle) * dist
-            if (neighbor.cx + dx !in MARGIN..(1f - MARGIN)) dx = -dx
-            if (neighbor.cy + dy !in MARGIN..(1f - MARGIN)) dy = -dy
+        val cells = ArrayList<Pair<Int, Int>>(rows * cols)
+        for (r in 0 until rows) for (c in 0 until cols) cells += r to c
+        cells.shuffle(random)
 
-            glyphs += ScribbleGlyph(
+        val glyphs = cells.take(n).map { (r, c) ->
+            val jx = (random.nextFloat() - 0.5f) * cellW * JITTER
+            val jy = (random.nextFloat() - 0.5f) * cellH * JITTER
+            ScribbleGlyph(
                 char = ALPHABET.random(random),
-                cx = neighbor.cx + dx,
-                cy = neighbor.cy + dy,
+                // Clamped into the margin band: jitter is at most half a cell, so the clamp is a
+                // safety net rather than something the common case relies on.
+                cx = (MARGIN + cellW * (c + 0.5f) + jx).coerceIn(MARGIN, 1f - MARGIN),
+                cy = (MARGIN + cellH * (r + 0.5f) + jy).coerceIn(MARGIN, 1f - MARGIN),
                 rotationDeg = randomRotation(random),
-                sizeFrac = size,
+                sizeFrac = minSize + random.nextFloat() * (maxSize - minSize),
             )
         }
 
@@ -107,12 +106,11 @@ object ScribbleGenerator {
     }
 
     /** True iff glyph [a]'s circular footprint overlaps glyph [b]'s (centre distance < radius sum). */
-    fun overlaps(a: ScribbleGlyph, b: ScribbleGlyph): Boolean {
-        val centreDist = hypot(a.cx - b.cx, a.cy - b.cy)
-        return centreDist < (a.sizeFrac / 2f + b.sizeFrac / 2f)
-    }
+    fun overlaps(a: ScribbleGlyph, b: ScribbleGlyph): Boolean =
+        centreDistance(a, b) < (a.sizeFrac / 2f + b.sizeFrac / 2f)
+
+    /** Centre-to-centre distance between two glyphs, in normalized canvas units. */
+    fun centreDistance(a: ScribbleGlyph, b: ScribbleGlyph): Float = hypot(a.cx - b.cx, a.cy - b.cy)
 
     private fun randomRotation(random: Random): Float = random.nextFloat() * 360f
-
-    private fun randomSize(random: Random): Float = MIN_SIZE + random.nextFloat() * (MAX_SIZE - MIN_SIZE)
 }

--- a/app/src/main/java/com/hereliesaz/graffitixr/onboarding/ScribbleView.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/onboarding/ScribbleView.kt
@@ -1,6 +1,5 @@
 package com.hereliesaz.graffitixr.onboarding
 
-import android.graphics.Bitmap
 import android.graphics.Canvas as AndroidCanvas
 import android.graphics.Paint
 import androidx.compose.foundation.Canvas
@@ -17,7 +16,7 @@ import kotlin.math.min
  * Renders a [Scribble] — the glyphs are laid out in a normalized [0,1] square, so this scales the
  * generator's output to whatever box the caller gives it. Each glyph is drawn centred on its
  * ([ScribbleGlyph.cx], [ScribbleGlyph.cy]) and rotated by [ScribbleGlyph.rotationDeg]. A soft shadow
- * keeps it legible over the live camera feed behind the overlay.
+ * keeps it legible whether it is drawn on the dark draw-step ground or over a camera feed.
  */
 @Composable
 fun ScribbleView(
@@ -46,23 +45,6 @@ fun ScribbleView(
             drawScribble(canvas.nativeCanvas, scribble, w, h, edge, paint, fontMetrics)
         }
     }
-}
-
-/**
- * Rasterizes a [Scribble] into a transparent square [Bitmap] of [sizePx] — used as the AR overlay
- * texture during the first-run doodle demo. Same glyph layout/rotation as [ScribbleView]; drawn
- * as filled white so it reads on the wall (the overlay renderer applies it as a texture).
- */
-fun renderScribbleBitmap(scribble: Scribble, sizePx: Int, color: Color = Color.White): Bitmap {
-    val bmp = Bitmap.createBitmap(sizePx, sizePx, Bitmap.Config.ARGB_8888)
-    val paint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
-        this.color = color.toArgb()
-        textAlign = Paint.Align.CENTER
-        style = Paint.Style.FILL
-        isFakeBoldText = true
-    }
-    drawScribble(AndroidCanvas(bmp), scribble, sizePx.toFloat(), sizePx.toFloat(), sizePx.toFloat(), paint, Paint.FontMetrics())
-    return bmp
 }
 
 private fun drawScribble(

--- a/app/src/test/java/com/hereliesaz/graffitixr/onboarding/ScribbleGeneratorTest.kt
+++ b/app/src/test/java/com/hereliesaz/graffitixr/onboarding/ScribbleGeneratorTest.kt
@@ -38,15 +38,44 @@ class ScribbleGeneratorTest {
         }
     }
 
+    // Bounds below are derived from the generator's grid, not guessed. For n in 4..6 the layout is
+    // 2x2 (n=4) or 2x3 (n=5,6); with at most one cell dropped every row and column stays occupied,
+    // so worst case (all jitter pulling inward) the bounding box spans cellDim*(1 - JITTER) = 0.209
+    // on the tighter axis, adjacent centres sit at least 0.139 apart, and sizeFrac is at least 0.20.
+    // The assertions sit safely under those figures.
+
     @Test
-    fun `every glyph overlaps at least one other glyph`() {
+    fun `glyphs are spread across the canvas, not clustered in the middle`() {
+        // The scribble gets copied onto a wall and then detected from the drawn marks, so the marks
+        // must cover area: a tight central knot is both awkward to draw big and a badly-conditioned
+        // pose solve.
         seeds.forEach { seed ->
             val glyphs = ScribbleGenerator.generate(Random(seed)).glyphs
-            glyphs.forEachIndexed { i, g ->
-                val hasOverlap = glyphs.withIndex().any { (j, other) ->
-                    j != i && ScribbleGenerator.overlaps(g, other)
-                }
-                assertTrue("seed=$seed glyph[$i]='${g.char}' has no overlapping neighbour", hasOverlap)
+            val spanX = glyphs.maxOf { it.cx } - glyphs.minOf { it.cx }
+            val spanY = glyphs.maxOf { it.cy } - glyphs.minOf { it.cy }
+            assertTrue("seed=$seed spanX=$spanX", spanX >= 0.15f)
+            assertTrue("seed=$seed spanY=$spanY", spanY >= 0.15f)
+        }
+    }
+
+    @Test
+    fun `no two glyphs sit on top of each other`() {
+        // Marks touching is fine and still reads as one scribble; near-concentric is not, because
+        // then there is nothing legible to copy.
+        seeds.forEach { seed ->
+            val glyphs = ScribbleGenerator.generate(Random(seed)).glyphs
+            for (i in glyphs.indices) for (j in i + 1 until glyphs.size) {
+                val d = ScribbleGenerator.centreDistance(glyphs[i], glyphs[j])
+                assertTrue("seed=$seed glyphs[$i]/[$j] centres only $d apart", d > 0.10f)
+            }
+        }
+    }
+
+    @Test
+    fun `glyphs are large enough to be worth drawing`() {
+        seeds.forEach { seed ->
+            ScribbleGenerator.generate(Random(seed)).glyphs.forEach { g ->
+                assertTrue("seed=$seed size=${g.sizeFrac}", g.sizeFrac >= 0.15f)
             }
         }
     }

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -2002,11 +2002,15 @@ class ArViewModel @Inject constructor(
     private var doodleCaptureJob: Job? = null
 
     /**
-     * Host tells us when the first-run doodle overlay is up. While active we periodically capture the
-     * live frame (no tap) and try to build a wall fingerprint from whatever the user has drawn; the
-     * builder returns null until there's enough texture, so this self-times to "they've drawn enough".
-     * Once a fingerprint is set, native relocalization + self-grow run automatically and the renderer's
-     * inlier-gated lock can fire. Purist teleological path — the fingerprint IS the demo.
+     * Host tells us the first-run DETECT stage is running — the user has already drawn the scribble on
+     * their wall and is now pointing the camera at it. While active we periodically capture the live
+     * frame (no tap) and try to build a wall fingerprint from the marks; the builder returns null
+     * until there is enough texture, so this self-times to "the drawing is visible enough".
+     *
+     * Completion is the fingerprint landing, not the user holding still: a built fingerprint means
+     * the marks were genuinely recognised and relocalization has something to track, which is exactly
+     * what "detected, ready to go" should mean. The renderer's stability lock remains as a second
+     * trigger, and the timeout below as a last resort.
      */
     fun setDoodlePhase(active: Boolean) {
         if (doodlePhaseActive == active) return
@@ -2021,9 +2025,13 @@ class ArViewModel @Inject constructor(
                     delay(DOODLE_CAPTURE_INTERVAL_MS)
                     if (!_uiState.value.isAnchorEstablished || renderer?.doodleWallPlane == null) continue
                     if (deadlineMs == 0L) deadlineMs = System.currentTimeMillis() + DOODLE_LOCK_TIMEOUT_MS
-                    if (!doodleFingerprintBuilt) {
-                        requestCapture() // no onScreenTap → no tap; onTargetCaptured builds headlessly
+                    if (doodleFingerprintBuilt) {
+                        // Detected: the drawing was recognised. Done — don't make the user hold the
+                        // phone still to satisfy a separate stability gate.
+                        onDoodleLocked()
+                        continue
                     }
+                    requestCapture() // no onScreenTap → no tap; onTargetCaptured builds headlessly
                     // Graceful fallback: on a featureless wall relocalization may never converge. Rather
                     // than hang forever, after the timeout place the artwork on the plain anchor so the
                     // user still ends up with art stuck to the wall.


### PR DESCRIPTION
Two changes to the first-run "drawing in 60 seconds" onboarding.

## 1. The scribble is bigger and spread out

It was a tight central cluster: up to 7 glyphs at 0.14–0.24 of the canvas edge, each chained onto a neighbour at *sub-radius* spacing so every glyph was guaranteed to overlap another. That produced a knot in the middle of the canvas — awkward to copy onto a wall at any useful size.

Now 4–6 glyphs at **0.20–0.34** of the canvas edge, placed on a **jittered grid** covering the canvas rather than chained off each other. Per-layout the size is capped against the grid cell so a denser layout doesn't collapse into a blob.

Spreading them out also helps the part that comes after: detection recovers a pose from the drawn marks, and features spread over a wide baseline condition that solve far better than a cluster in one spot. So "bigger and more spread out" is the same direction for both drawing it and finding it.

## 2. The drawing step is no longer done in AR

It used to project the scribble onto the wall as an AR overlay texture. That needed a tracked plane and an established anchor *before the user had drawn anything*, and left the reference competing for screen space with a live camera feed.

Split into two stages, because they want different things from the device:

| Stage | What it needs | What it shows |
|---|---|---|
| **DRAW** | nothing — no camera, plane or anchor | `ScribbleDrawScreen`: the scribble full-screen on a solid ground, sized to the screen width, with an "I've drawn it" CTA |
| **DETECT** | AR | point the camera at the marks; the existing headless fingerprint builder latches onto them |

`FirstRunOnboardingOverlay` becomes the DETECT coaching layer only — no scribble param, since the reference is on the wall now, and the title changes to "Now point your camera at what you drew".

**Completion is now the fingerprint landing, not the user holding still.** A built fingerprint means the marks were genuinely recognised and relocalization has something to track — that's what "detected, ready to go" should mean. Previously the swap fired on an anchor-stability tracker. That tracker stays as a second trigger and the 30 s timeout as a last resort, so a featureless wall still ends with art stuck to it.

The renderer's tap-free auto-anchor is still enabled during DETECT (the builder needs a pose to work against), which is why `doodlePhaseActive` became `doodleDetectActive` rather than disappearing. `renderScribbleBitmap` went with the projection it existed for.

## Tests

The old "every glyph overlaps at least one other" invariant no longer holds by design; replaced with spread and non-concentricity.

Bounds are **derived from the grid, not guessed** — worth noting because my first pass at them would have failed CI. For n in 4..6 the layout is 2×2 or 2×3, and with at most one cell dropped every row and column stays occupied, so worst case (all jitter pulling inward):

- bounding box spans `cellDim * (1 - JITTER)` = **0.209** on the tighter axis → assert ≥ 0.15
- adjacent centres sit **0.139** apart → assert > 0.10
- `sizeFrac` ≥ **0.20** → assert ≥ 0.15

I'd initially written `span >= 0.25` and `distance > minRadius`; both are violable (0.209 < 0.25, and 0.139 < 0.146 for the largest glyph pair). Simulated the generator over 2000 layouts to confirm the corrected bounds hold with headroom.

## Verification

No Android SDK here, so CI is the compiler. Checked structurally rather than by grepping for names: both composables' declared parameters cross-checked against their call sites (no unknown args, no missing required args), and `MainScreen`'s renamed parameter confirmed declared-and-passed with no stale references.

Not covered by tests: the stage transitions and the AR detection path need a device. Worth walking first-run end to end — picker → draw screen → "I've drawn it" → AR detect → artwork appears tuned to the wall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FNdRBgp5zMj9rZVHffb5rK

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNdRBgp5zMj9rZVHffb5rK)_

## Summary by Sourcery

Split first-run onboarding into separate draw and detect phases, update the scribble layout to be larger and more spread out, and align AR detection and rendering behavior with the new flow.

New Features:
- Introduce a non-AR first-run DRAW screen that shows a fullscreen scribble and guides users to copy it before AR detection starts

Enhancements:
- Redesign scribble generation to use larger glyphs spread across a jittered grid for better wall copying and pose detection
- Refine the first-run onboarding flow into distinct DRAW and DETECT stages, with detection completion keyed to fingerprint creation instead of anchor stability
- Simplify AR overlay rendering by removing the projected scribble bitmap and reusing the normal artwork overlay during onboarding

Tests:
- Update and expand scribble generator tests to validate spread-out layouts, minimum inter-glyph spacing, and minimum glyph size constraints