### PR TITLE
fix: confine the onboarding scribble to the sixty-second walkthrough

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -824,8 +824,22 @@ class MainActivity : ComponentActivity() {
                                 title = "Draw this on your wall",
                                 hint = "Make it big — roughly the size of your artwork. It only has to be recognisable, not neat.",
                                 doneLabel = "I've drawn it",
+                                skipLabel = "Skip — I'll place it myself",
                                 onDrawn = {
                                     firstRunStage = FirstRunStage.DETECT
+                                    navController.navigate(EditorMode.AR.name) {
+                                        popUpTo(LIBRARY_ROUTE) { inclusive = true }
+                                        launchSingleTop = true
+                                    }
+                                },
+                                // Out of the walkthrough entirely: no detect stage, no marks needed. Still
+                                // lands in AR with the picked project open — the user chose an image to
+                                // trace, they only declined the guided marks — so the pick isn't orphaned
+                                // on the library behind a stray project. Marked done so it doesn't
+                                // re-offer on every launch.
+                                onSkip = {
+                                    firstRunStage = FirstRunStage.NONE
+                                    mainViewModel.markTutorialCompletePersistent(firstRunDoodleKey)
                                     navController.navigate(EditorMode.AR.name) {
                                         popUpTo(LIBRARY_ROUTE) { inclusive = true }
                                         launchSingleTop = true

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
@@ -305,9 +305,6 @@ fun MainScreen(
                                 onPlaneDetected = {
                                     arViewModel.onFirstPlaneDetected()
                                 },
-                                onDoodleLockProgress = { stability ->
-                                    arViewModel.onDoodleLockProgress(stability)
-                                },
                                 onDoodleLocked = {
                                     arViewModel.onDoodleLocked()
                                 }

--- a/app/src/main/java/com/hereliesaz/graffitixr/onboarding/ScribbleDrawScreen.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/onboarding/ScribbleDrawScreen.kt
@@ -1,6 +1,7 @@
 package com.hereliesaz.graffitixr.onboarding
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -31,6 +32,10 @@ import com.hereliesaz.aznavrail.model.AzButtonShape
  *
  * The scribble fills a square that tracks the screen width, which is what makes it big enough to
  * copy at arm's length.
+ *
+ * [onSkip] is not optional garnish. This screen is opaque and mounted ahead of everything else in its
+ * layer, so without a way out the marks would be a toll gate on reaching the app at all — and they are
+ * only ever a teaching aid for the sixty-second walkthrough.
  */
 @Composable
 fun ScribbleDrawScreen(
@@ -38,7 +43,9 @@ fun ScribbleDrawScreen(
     title: String,
     hint: String,
     doneLabel: String,
+    skipLabel: String,
     onDrawn: () -> Unit,
+    onSkip: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Box(
@@ -84,6 +91,16 @@ fun ScribbleDrawScreen(
                     modifier = Modifier.fillMaxWidth(),
                 )
                 AzButton(text = doneLabel, onClick = onDrawn, shape = AzButtonShape.RECTANGLE)
+                Text(
+                    text = skipLabel,
+                    color = Color.White.copy(alpha = 0.6f),
+                    style = MaterialTheme.typography.bodyMedium,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable(onClick = onSkip)
+                        .padding(vertical = 8.dp),
+                )
             }
         }
     }

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/UiState.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/UiState.kt
@@ -37,9 +37,8 @@ data class ArUiState(
     // stage transitions (show movement guidance until a surface appears, etc.).
     val isArReady: Boolean = false,
     val planeDetected: Boolean = false,
-    // First-run doodle demo: 0..1 "how steadily is the scribble overlay holding" (drives a hold-steady
-    // indicator), and a latching flag set once it has held long enough to swap in the user's artwork.
-    val doodleLockStability: Float = 0f,
+    // First-run walkthrough only: latches true once the marks the user drew have been detected (or the
+    // phase timed out), which is what ends the walkthrough and places the artwork.
     val doodleLocked: Boolean = false,
     // Wall stats from the doodle capture, used to auto-tune the artwork's adjustments on the swap.
     val doodleWallStats: com.hereliesaz.graffitixr.common.util.ImageStats? = null,

--- a/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
+++ b/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
@@ -951,6 +951,11 @@ Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeClearWallFeatureMa
     if (gSlamEngine) gSlamEngine->clearWallFeatureMap();
 }
 
+JNIEXPORT void JNICALL
+Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeClearWallFingerprint(JNIEnv*, jobject) {
+    if (gSlamEngine) gSlamEngine->clearWallFingerprint();
+}
+
 JNIEXPORT jint JNICALL
 Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeGetMapPointCount(JNIEnv*, jobject) {
     return gSlamEngine ? gSlamEngine->getMapPointCount() : 0;

--- a/core/nativebridge/src/main/cpp/MobileGS.cpp
+++ b/core/nativebridge/src/main/cpp/MobileGS.cpp
@@ -828,6 +828,16 @@ void MobileGS::restoreWallFingerprintMetric(const cv::Mat& d, const std::vector<
     if (intrinsics4)    memcpy(mFingerprintIntrinsics, intrinsics4, 4 * sizeof(float));
 }
 
+void MobileGS::clearWallFingerprint() {
+    std::lock_guard<std::mutex> lock(mMutex);
+    mWallDescriptors.release();
+    mWallKeypoints3D.clear();
+    // Back to the constructed defaults, so a later project can't inherit this one's co-registration.
+    static const float kIdentity16[16] = {1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1};
+    memcpy(mFingerprintAnchorMatrix, kIdentity16, 16 * sizeof(float));
+    memset(mFingerprintIntrinsics, 0, 4 * sizeof(float));
+}
+
 void MobileGS::restoreWallFeatureMap(const cv::Mat& d, const std::vector<cv::Point3f>& p,
                                      const std::vector<float>& conf, const std::vector<int>& obs,
                                      const float* anchorMatrix16, const float* intrinsics4) {

--- a/core/nativebridge/src/main/cpp/include/MobileGS.h
+++ b/core/nativebridge/src/main/cpp/include/MobileGS.h
@@ -46,6 +46,11 @@ public:
     // fingerprint anchor pose and the intrinsics the reloc PnP should use.
     void restoreWallFingerprintMetric(const cv::Mat& descriptors, const std::vector<cv::Point3f>& points3d,
                                       const float* anchorMatrix16, const float* intrinsics4);
+    // Drop the stored wall fingerprint (marks + co-registration). Needed because a fingerprint is
+    // otherwise process-lifetime state: the restore calls above only ever REPLACE it, so a project
+    // with no fingerprint of its own would keep relocalizing against whatever wall was fingerprinted
+    // earlier in the session. Reloc already treats an empty fingerprint as "nothing to match".
+    void clearWallFingerprint();
     // Persistent wall *feature* map (lean reloc backbone; docs/RELOC_MAP_DESIGN.md), co-registered to
     // the fingerprint anchor. Restore replaces the stored map (confidence/obs optional). Phase 2a stores
     // it only; reloc matching against it (Phase 2b) is gated separately.

--- a/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
+++ b/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
@@ -111,6 +111,15 @@ class SlamManager @Inject constructor(
         nativeRestoreWallFingerprintMetric(descriptorsData, rows, cols, type, points3d, anchorMatrix, intrinsics)
     }
 
+    /**
+     * Drop the in-native wall fingerprint. The restore calls above only ever REPLACE the stored
+     * fingerprint, so without this it is process-lifetime state: a project that has no fingerprint of
+     * its own would keep relocalizing against whatever wall was fingerprinted earlier in the session
+     * (notably the marks built during first-run onboarding). Call it when loading a project that has
+     * no saved fingerprint, alongside [clearWallFeatureMap].
+     */
+    fun clearWallFingerprint() = nativeClearWallFingerprint()
+
     /** Restore the persistent wall feature map into native (Phase 2a: stored; matched in Phase 2b). */
     fun restoreWallFeatureMap(map: WallFeatureMap) {
         nativeRestoreWallFeatureMap(
@@ -551,6 +560,7 @@ class SlamManager @Inject constructor(
         anchor: FloatArray, intrinsics: FloatArray
     )
     private external fun nativeClearWallFeatureMap()
+    private external fun nativeClearWallFingerprint()
     private external fun nativeGetMapPointCount(): Int
     private external fun nativeSetMapRelocEnabled(enabled: Boolean)
     private external fun nativeSetMapBuildEnabled(enabled: Boolean)

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -1340,6 +1340,14 @@ class ArViewModel @Inject constructor(
                 // after reload, even though the builder doesn't run on a restored fingerprint.
                 slamManager.overlayMarkCenterLocal =
                     if (fp.markCenterLocal.size >= 3) fp.markCenterLocal.toFloatArray() else null
+            } else {
+                // No fingerprint on this project: drop whatever is left in native from earlier in the
+                // session. The restore calls only ever REPLACE the stored fingerprint, so without this
+                // an un-fingerprinted project silently relocalizes against a previous target — most
+                // visibly the marks built during first-run onboarding, which are a throwaway teaching
+                // aid and must not register anything beyond that flow.
+                slamManager.clearWallFingerprint()
+                slamManager.overlayMarkCenterLocal = null
             }
             // Restore the persistent wall feature map (Phase 2a: stored in native; matched in Phase 2b).
             // Independent of the marks fingerprint above and co-registered to the same anchor. Null on
@@ -1977,21 +1985,20 @@ class ArViewModel @Inject constructor(
         _uiState.update { if (it.planeDetected) it else it.copy(planeDetected = true) }
     }
 
-    /** Doodle demo (GL thread): report anchor-hold stability for the hold-steady indicator. */
-    fun onDoodleLockProgress(stability: Float) {
-        _uiState.update { it.copy(doodleLockStability = stability) }
-    }
-
     /** Doodle demo (GL thread): the overlay has held one spot long enough — trigger the artwork swap. */
     fun onDoodleLocked() {
         _uiState.update { if (it.doodleLocked) it else it.copy(doodleLocked = true) }
     }
 
     // --- Doodle demo: headless fingerprint build ---
-    private companion object {
+    internal companion object {
         const val DOODLE_CAPTURE_INTERVAL_MS = 2500L
         // After this long without a relocalization lock (featureless wall), place on the plain anchor.
+        // Measured from the point an anchor + wall plane exist, i.e. from when detection can start.
         const val DOODLE_LOCK_TIMEOUT_MS = 30_000L
+        // Hard cap on the whole detect phase, measured from when it starts. Guarantees the phase ends
+        // even if ARCore never finds a surface, so onboarding can't run indefinitely.
+        const val DOODLE_PHASE_TIMEOUT_MS = 60_000L
     }
     // @Volatile: written on main (setDoodlePhase) / IO (build result) and read on the GL thread
     // (onTargetCaptured), so the GL thread must observe the latest value.
@@ -2019,24 +2026,43 @@ class ArViewModel @Inject constructor(
             doodleFingerprintBuilt = false
             slamManager.overlayMarkCenterLocal = null
             doodleCaptureJob = viewModelScope.launch {
-                // Deadline starts once we actually have an anchor to build against.
-                var deadlineMs = 0L
+                // Two budgets, because they bound different failures:
+                //
+                //  - phaseTicks caps the WHOLE phase from the moment it starts. Without it, a room where
+                //    ARCore never finds a surface never arms the detect budget below, so onboarding runs
+                //    forever: the tutorial is never marked complete and doodleLockActive stays latched.
+                //    The drawn marks are a throwaway teaching aid — they must never be able to hold the
+                //    rest of the app hostage.
+                //  - detectTicks caps detection once there is actually something to build against, so a
+                //    slow-to-track room doesn't eat the detection budget.
+                //
+                // Counted in loop ticks rather than System.currentTimeMillis(): delay() is the only thing
+                // in this loop that consumes time (the native build runs off-loop on IO), so ticks are an
+                // honest elapsed-time proxy that can't be skewed by a device clock adjustment mid-flow.
+                val maxPhaseTicks = (DOODLE_PHASE_TIMEOUT_MS / DOODLE_CAPTURE_INTERVAL_MS).toInt()
+                val maxDetectTicks = (DOODLE_LOCK_TIMEOUT_MS / DOODLE_CAPTURE_INTERVAL_MS).toInt()
+                var phaseTicks = 0
+                var detectTicks = 0
                 while (isActive && doodlePhaseActive && !_uiState.value.doodleLocked) {
                     delay(DOODLE_CAPTURE_INTERVAL_MS)
+                    if (++phaseTicks >= maxPhaseTicks) {
+                        onDoodleLocked()
+                        break
+                    }
                     if (!_uiState.value.isAnchorEstablished || renderer?.doodleWallPlane == null) continue
-                    if (deadlineMs == 0L) deadlineMs = System.currentTimeMillis() + DOODLE_LOCK_TIMEOUT_MS
                     if (doodleFingerprintBuilt) {
                         // Detected: the drawing was recognised. Done — don't make the user hold the
                         // phone still to satisfy a separate stability gate.
                         onDoodleLocked()
-                        continue
+                        break
                     }
                     requestCapture() // no onScreenTap → no tap; onTargetCaptured builds headlessly
                     // Graceful fallback: on a featureless wall relocalization may never converge. Rather
-                    // than hang forever, after the timeout place the artwork on the plain anchor so the
-                    // user still ends up with art stuck to the wall.
-                    if (System.currentTimeMillis() >= deadlineMs && !_uiState.value.doodleLocked) {
+                    // than hang forever, after the budget is spent place the artwork on the plain anchor
+                    // so the user still ends up with art stuck to the wall.
+                    if (++detectTicks >= maxDetectTicks) {
                         onDoodleLocked()
+                        break
                     }
                 }
             }

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -49,10 +49,9 @@ class ArRenderer(
     // ViewModel flips ArUiState.planeDetected so first-run onboarding can drop
     // the "move your device" guidance once a surface exists.
     private val onPlaneDetected: () -> Unit = {},
-    // First-run doodle demo: reports the anchor-hold stability (0..1) as the user
-    // draws, and fires once when the overlay has held one spot long enough to swap
-    // the scribble for the user's artwork. Both no-op outside the doodle phase.
-    private val onDoodleLockProgress: (Float) -> Unit = {},
+    // First-run walkthrough: fires once when the fused pose has held one spot long
+    // enough to place the user's artwork. No-op outside the walkthrough's detect
+    // phase (doodleLockActive false).
     private val onDoodleLocked: () -> Unit = {},
     // Fired from the GL thread when ARCore has been stuck not-tracking for a
     // sustained run of frames (true) or recovers (false). MainScreen uses this
@@ -1097,7 +1096,6 @@ class ArRenderer(
                 // fires when the teleological SLAM has genuinely latched onto the drawn marks. On a
                 // blank wall relocalization stays weak until the user draws, so this self-times.
                 anchorLockTracker.update(anchorMatrix[12], anchorMatrix[13], anchorMatrix[14])
-                if (frameCount % 4 == 0) onDoodleLockProgress(anchorLockTracker.stability)
                 val relocInliers = slamManager.getRelocResult()[16].toInt()
                 if (anchorLockTracker.locked && relocInliers >= DOODLE_MIN_RELOC_INLIERS) {
                     doodleLockReported = true

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/ArViewModelTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/ArViewModelTest.kt
@@ -411,6 +411,50 @@ class ArViewModelTest {
         assertEquals(4, state.unwarpPoints.size)
     }
 
+    // ==================== First-run walkthrough (doodle) tests ====================
+
+    @Test
+    fun `doodle detect phase ends itself when ARCore never establishes an anchor`() = runTest {
+        // The room never yields a trackable surface, so isAnchorEstablished stays false and the detect
+        // budget is never armed. The phase must still terminate: the marks the user drew are only a
+        // teaching aid for the sixty-second walkthrough, and an unbounded phase would leave onboarding
+        // running forever — the tutorial never marked complete, doodleLockActive latched on.
+        assertFalse(viewModel.uiState.value.isAnchorEstablished)
+
+        viewModel.setDoodlePhase(true)
+        testDispatcher.scheduler.advanceTimeBy(ArViewModel.DOODLE_PHASE_TIMEOUT_MS + 1_000L)
+        testDispatcher.scheduler.runCurrent()
+
+        assertTrue(
+            "detect phase must self-terminate without an anchor",
+            viewModel.uiState.value.doodleLocked,
+        )
+    }
+
+    @Test
+    fun `doodle detect phase does not end early while it still has budget`() = runTest {
+        viewModel.setDoodlePhase(true)
+        // Well past a couple of capture intervals but far short of the phase cap.
+        testDispatcher.scheduler.advanceTimeBy(ArViewModel.DOODLE_CAPTURE_INTERVAL_MS * 3)
+        testDispatcher.scheduler.runCurrent()
+
+        assertFalse(viewModel.uiState.value.doodleLocked)
+    }
+
+    @Test
+    fun `setDoodlePhase false cancels the capture loop`() = runTest {
+        viewModel.setDoodlePhase(true)
+        testDispatcher.scheduler.advanceTimeBy(ArViewModel.DOODLE_CAPTURE_INTERVAL_MS * 2)
+        testDispatcher.scheduler.runCurrent()
+
+        viewModel.setDoodlePhase(false)
+        // Past the cap: a cancelled loop must not fire the completion signal afterwards.
+        testDispatcher.scheduler.advanceTimeBy(ArViewModel.DOODLE_PHASE_TIMEOUT_MS * 2)
+        testDispatcher.scheduler.runCurrent()
+
+        assertFalse(viewModel.uiState.value.doodleLocked)
+    }
+
     @Suppress("UNCHECKED_CAST")
     private fun enableArCore() {
         // setArMode(true) early-returns unless ARCore is reported available; flip the flag on the


### PR DESCRIPTION
The generated glyphs are a teaching aid for the first-run "drawing in 60 seconds" flow, and nothing else should depend on them.

Their **code** was already scoped correctly. `ScribbleGenerator`, `Scribble`, `ScribbleGlyph`, `ScribbleView` and `ScribbleDrawScreen` have no callers outside the first-run coordinator in `MainActivity`; no `feature:` or `core:` module references them. `setDoodlePhase`, `doodleDetectActive` and `ArRenderer.doodleLockActive` are each driven solely by `firstRunStage == DETECT`, and normal target creation reaches `MetricFingerprintBuilder` with no scribble involvement.

What was **not** scoped was the consequence of drawing them. Three ways the marks became a requirement beyond the walkthrough:

### 1. The scribble's fingerprint outlived onboarding

`MetricFingerprintBuilder` commits every build to the native engine, and the restore entry points only ever *replace* the stored fingerprint — there was no way to clear one, so it was effectively process-lifetime state.

The doodle fingerprint is deliberately never persisted (persisting it would make the symbols a permanent registration requirement for that project). So `loadFingerprintIfExists` took its no-fingerprint path both on the onboarding project itself and on every other project opened later in the session, leaving native still relocalizing against marks on a wall and the overlay still centred on their centroid.

Adds `MobileGS::clearWallFingerprint` (+ JNI + `SlamManager`) and calls it, along with `overlayMarkCenterLocal`, on the no-fingerprint load path — mirroring what the wall feature map already did one block below. Reloc already treats an empty fingerprint as "nothing to match", so a cleared fingerprint is inert rather than a new failure mode.

### 2. The detect phase could never end

Its deadline was armed only once an anchor *and* a wall plane existed, so a room where ARCore never finds a surface spun the capture loop forever: `doodleLocked` never fired, the tutorial was never marked complete, and `doodleLockActive` stayed latched.

Adds `DOODLE_PHASE_TIMEOUT_MS` as a hard cap on the whole phase, keeping the existing detection budget for the case where detection can actually run. Both are now counted in loop ticks rather than `System.currentTimeMillis()`: `delay()` is the only thing in the loop that consumes time (the native build runs off-loop on IO), so ticks are an honest elapsed-time proxy that a device clock adjustment can't skew — and it makes the phase testable, which the wall-clock version was not.

### 3. The draw step had no exit

`ScribbleDrawScreen` is opaque and mounted ahead of everything else in its layer with an early return, so its single "I've drawn it" button made copying the marks a toll gate on reaching the app at all. Adds a skip that ends the walkthrough and lands in AR with the picked project open, so the pick isn't orphaned behind a stray project on the library.

### Also

Drops `doodleLockStability` — written every fourth frame from the GL thread into the shared `core:common` `ArUiState` and read by nothing since the AR-projected scribble was removed. Takes `onDoodleLockProgress` out of `ArRenderer` with it. `AnchorLockTracker.stability` stays and is still covered by its own test; the renderer's stability lock still fires `onDoodleLocked` as a secondary trigger.

## Testing

Three new `ArViewModelTest` cases, using the existing mockk + `StandardTestDispatcher` harness: the detect phase self-terminates with no anchor ever established, does not fire early while it still has budget, and stops firing once `setDoodlePhase(false)` cancels it. These are only possible because the deadlines moved to virtual-time ticks.

No Android SDK in this environment, so nothing was compiled locally — CI is the first compile. Verified structurally instead: zero remaining references to `onDoodleLockProgress` and `doodleLockStability`; the single `ArRenderer(` construction site updated; the new JNI function sits inside the file's `extern "C"` block (unmangled symbol, so the runtime lookup resolves); the `clearWallFingerprint` chain is complete from `ArViewModel` through `SlamManager`, the JNI shim, `MobileGS.h` and `MobileGS.cpp`.

Not covered by unit tests, needs a device: picker → draw screen → skip lands in AR with the image; picker → draw → "I've drawn it" → detect → artwork placed and tuned; and opening a second project after onboarding no longer chases the first wall's marks.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNdRBgp5zMj9rZVHffb5rK)_

## Summary by Sourcery

Scope the onboarding scribble flow so its AR fingerprint and detect/draw phases do not affect normal projects or block access to the app.

New Features:
- Add a skip action to the scribble draw screen that exits the walkthrough and opens the chosen project directly in AR.

Bug Fixes:
- Clear the in-native wall fingerprint and overlay mark center when loading projects without a saved fingerprint so subsequent sessions do not relocalize against onboarding marks.
- Ensure the doodle detect phase always terminates by adding a hard timeout on the whole phase and using tick-based budgets rather than wall-clock time.
- Prevent the doodle capture loop from firing completion after the phase has been cancelled.

Enhancements:
- Simplify the doodle lock handling by removing the unused stability field and related renderer callback.
- Expose doodle timing constants from ArViewModel for use in tests and document the walkthrough-related AR state more clearly.

Tests:
- Add ArViewModel tests covering detect phase self-termination without an anchor, non-termination while still within budget, and cancellation via setDoodlePhase(false).