### PR TITLE
fix: stop the AR camera preview magnifying a single pixel

### DIFF
--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/DisplayRotationHelper.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/DisplayRotationHelper.kt
@@ -52,14 +52,32 @@ class DisplayRotationHelper(context: Context) : DisplayListener {
     }
 
     /**
-     * Updates the session display geometry if a change was registered in [onSurfaceChanged] or in
-     * [onDisplayChanged]. Should be called from [android.opengl.GLSurfaceView.Renderer.onDrawFrame].
+     * Forces the next [updateSessionIfNeeded] to re-push the display geometry even though neither the
+     * surface nor the display rotation changed.
+     *
+     * Display geometry is per-[Session] state, not per-surface state. When a NEW session is attached to
+     * a renderer whose surface already exists (AR re-entry, resume, or a session rebuilt onto a
+     * fallback camera config), [onSurfaceChanged] does not fire again — so without this the fresh
+     * session would never be told the real viewport and would keep ARCore's default geometry. The
+     * camera-background texture transform derived from that default collapses the whole quad onto a
+     * sliver of the camera image, which renders as a hugely magnified preview.
+     */
+    fun markGeometryDirty() {
+        lock.withLock { viewportChanged = true }
+    }
+
+    /**
+     * Updates the session display geometry if a change was registered in [onSurfaceChanged],
+     * [onDisplayChanged], or [markGeometryDirty]. Should be called from
+     * [android.opengl.GLSurfaceView.Renderer.onDrawFrame].
      *
      * @param session The session to update.
      */
     fun updateSessionIfNeeded(session: Session) {
         lock.withLock {
-            if (viewportChanged) {
+            // A zero-size viewport means onSurfaceChanged hasn't run yet. Pushing it would hand ARCore
+            // a degenerate geometry; keep the dirty flag set so the real size lands as soon as it's known.
+            if (viewportChanged && viewportWidth > 0 && viewportHeight > 0) {
                 val displayRotation = display.rotation
                 session.setDisplayGeometry(displayRotation, viewportWidth, viewportHeight)
                 viewportChanged = false

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -431,6 +431,15 @@ class ArRenderer(
                 frameCount = 0
                 resetCameraStreamWatchdog()
                 displayRotationHelper.onResume()
+                // Display geometry is per-session state. This session is new, so it has never been told
+                // the viewport — and onSurfaceChanged won't fire again for a surface that already
+                // exists (AR re-entry, resume, or a rebuild onto a fallback camera config). Force the
+                // geometry to be re-pushed on the next frame and drop the cached camera UV transform,
+                // which belongs to the previous session. Without both, the background quad gets a
+                // transform derived from ARCore's default geometry and the camera renders magnified to
+                // the point of showing a single pixel across the whole screen.
+                displayRotationHelper.markGeometryDirty()
+                backgroundRenderer.invalidateDisplayGeometry()
                 if (isSurfaceCreated) {
                     session.setCameraTextureName(backgroundRenderer.textureId)
                 }
@@ -505,6 +514,9 @@ class ArRenderer(
         onDiag("surface: onSurfaceCreated start")
         GLES30.glClearColor(0.0f, 0.0f, 0.0f, 1.0f)
         backgroundRenderer.createOnGlThread(context)
+        // The GL surface is (re)born here, so recompute the camera UV transform once the follow-up
+        // onSurfaceChanged has pushed the viewport, rather than reusing UVs cached before the pause.
+        backgroundRenderer.invalidateDisplayGeometry()
         onDiag("surface: bg prog=${backgroundRenderer.isProgramReady} shader=${backgroundRenderer.shaderLog} tex=${backgroundRenderer.textureId}")
 
         // SLAM GL init is isolated: if it throws it must NOT kill the GL thread (that would leave the

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/BackgroundRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/BackgroundRenderer.kt
@@ -38,8 +38,14 @@ class BackgroundRenderer : GlReleasable {
     private var uMask: Int = 0
     private var uDotSize: Int = 0
     private var uGrayscale: Int = 0
-    private var hasTransformed = false
+    /** @Volatile: cleared off the GL thread by [invalidateDisplayGeometry] when a new session is
+     *  attached; read and written on the GL thread by [draw]. */
+    @Volatile private var hasTransformed = false
     private var diagFrame = 0
+    private var badTransformFrame = 0
+    /** Last UV set that passed [transformedTexCoordsAreSane], restored whenever a fresh transform is
+     *  rejected. Starts as the identity mapping so the very first rejection still shows the frame. */
+    private val lastGoodTexCoords = QUAD_TEXCOORDS.copyOf()
 
     // 36-sector scan-coverage mask (for the world-mapping "ink develop" reveal).
     private var maskTextureId = 0
@@ -83,8 +89,13 @@ class BackgroundRenderer : GlReleasable {
                 .order(ByteOrder.nativeOrder()).asFloatBuffer().apply { put(QUAD_TEXCOORDS); position(0) }
         }
         if (!::quadTexCoordTransformed.isInitialized) {
+            // Seeded with the identity UVs, NOT left zero-filled. A zero-filled buffer makes all four
+            // vertices sample texel (0,0), so the camera renders as one texel stretched over the whole
+            // screen — indistinguishable from a broken camera. The identity mapping is the wrong
+            // orientation on most devices but still shows the whole frame, so any window where the
+            // ARCore transform is missing or rejected degrades to a readable preview.
             quadTexCoordTransformed = ByteBuffer.allocateDirect(numVertices * 2 * 4)
-                .order(ByteOrder.nativeOrder()).asFloatBuffer()
+                .order(ByteOrder.nativeOrder()).asFloatBuffer().apply { put(QUAD_TEXCOORDS); position(0) }
         }
 
         // Try ESSL3 (matches the rest of the pipeline). If this driver lacks the
@@ -108,6 +119,41 @@ class BackgroundRenderer : GlReleasable {
         uMask = GLES30.glGetUniformLocation(backgroundProgram, "u_MaskTex")
         uDotSize = GLES30.glGetUniformLocation(backgroundProgram, "u_DotSizePx")
         uGrayscale = GLES30.glGetUniformLocation(backgroundProgram, "u_Grayscale")
+    }
+
+    /**
+     * Drops the cached camera UV transform so [draw] recomputes it on the next frame.
+     *
+     * Must be called whenever a different [com.google.ar.core.Frame] source takes over — i.e. when a
+     * new ARCore session is attached — because the cached UVs describe the previous session's camera
+     * image and display geometry. Safe to call off the GL thread.
+     */
+    fun invalidateDisplayGeometry() {
+        hasTransformed = false
+    }
+
+    /**
+     * True when the transformed UVs still cover a meaningful span of the camera image in both axes.
+     *
+     * A correct full-screen transform always spans most of the texture (ARCore centre-crops the camera
+     * image to the viewport, so the smaller axis never drops far below half). Anything near-degenerate
+     * — or non-finite — means the transform was taken against geometry ARCore hasn't been given yet,
+     * and drawing with it magnifies a few texels across the whole screen.
+     */
+    private fun transformedTexCoordsAreSane(): Boolean {
+        var minU = Float.MAX_VALUE; var maxU = -Float.MAX_VALUE
+        var minV = Float.MAX_VALUE; var maxV = -Float.MAX_VALUE
+        for (i in 0 until 4) {
+            // Absolute gets: transformCoordinates2d may leave the buffer's position anywhere.
+            val u = quadTexCoordTransformed.get(i * 2)
+            val v = quadTexCoordTransformed.get(i * 2 + 1)
+            if (!u.isFinite() || !v.isFinite()) return false
+            if (u < minU) minU = u
+            if (u > maxU) maxU = u
+            if (v < minV) minV = v
+            if (v > maxV) maxV = v
+        }
+        return (maxU - minU) >= MIN_UV_SPAN && (maxV - minV) >= MIN_UV_SPAN
     }
 
     /** Push the 36-sector visited bitmask that drives the ink-develop reveal. */
@@ -138,13 +184,41 @@ class BackgroundRenderer : GlReleasable {
         if (diagFrame % 120 == 0) Log.i("ARDIAG", "BackgroundRenderer.draw: drawing camera quad (scanActive=$scanActive)")
 
         if (frame.hasDisplayGeometryChanged() || !hasTransformed) {
-            frame.transformCoordinates2d(
-                Coordinates2d.OPENGL_NORMALIZED_DEVICE_COORDINATES,
-                quadVertices,
-                Coordinates2d.TEXTURE_NORMALIZED,
-                quadTexCoordTransformed
-            )
-            hasTransformed = true
+            // Rewind both buffers first: transformCoordinates2d reads/writes from the current position,
+            // and the transform can now run on more than the first frame.
+            quadVertices.position(0)
+            quadTexCoordTransformed.position(0)
+            val transformed = try {
+                frame.transformCoordinates2d(
+                    Coordinates2d.OPENGL_NORMALIZED_DEVICE_COORDINATES,
+                    quadVertices,
+                    Coordinates2d.TEXTURE_NORMALIZED,
+                    quadTexCoordTransformed
+                )
+                // Only accept a result that actually maps the quad across the camera image. A transform
+                // taken against a session that hasn't been given the real display geometry collapses the
+                // full-screen quad onto a sliver (or a single point) of the texture, which draws as the
+                // camera magnified to the point of showing one pixel.
+                transformedTexCoordsAreSane()
+            } catch (t: Throwable) {
+                // This now runs on more than just the first frame, so a throw here must not take the GL
+                // thread (and with it the whole camera passthrough) down.
+                Log.w("ARDIAG", "BackgroundRenderer: camera UV transform threw", t)
+                false
+            }
+            quadTexCoordTransformed.position(0)
+            if (transformed) {
+                quadTexCoordTransformed.get(lastGoodTexCoords)
+                hasTransformed = true
+            } else {
+                // Fall back to the last accepted UVs (identity until one is accepted) and retry next
+                // frame, by which time DisplayRotationHelper will have pushed the viewport.
+                quadTexCoordTransformed.put(lastGoodTexCoords)
+                if (badTransformFrame++ % 120 == 0) {
+                    Log.w("ARDIAG", "BackgroundRenderer: camera UV transform rejected -> last good UVs")
+                }
+            }
+            quadTexCoordTransformed.position(0)
         }
 
         GLES30.glBindVertexArray(0)
@@ -260,6 +334,10 @@ class BackgroundRenderer : GlReleasable {
     companion object {
         private const val SECTOR_COUNT = 36
         private const val DOT_SIZE_PX = 6.0f // halftone cell size in screen pixels (newspaper grain)
+
+        /** Minimum span, per axis, a valid camera UV transform must cover. A real one covers ~0.5–1.0;
+         *  this floor only catches collapsed transforms, never a legitimate crop. */
+        private const val MIN_UV_SPAN = 0.1f
 
         private val QUAD_COORDS = floatArrayOf(
             -1.0f, -1.0f,


### PR DESCRIPTION
## Symptom

The AR camera passthrough renders a few texels of the camera image stretched across the whole screen — it reads as "the centre pixel blown up to fill the display".

## Root cause

Display geometry is per-`Session` state in ARCore, but nothing re-pushed it when a new session was attached to a renderer whose GL surface already existed.

`DisplayRotationHelper` only sets `viewportChanged` from `onSurfaceChanged` / `onDisplayChanged`. Neither fires on AR re-entry, resume, or a session rebuilt onto a fallback camera config (safe-mode after a camera stall, stereo→mono downgrade, fps swap) — the surface is unchanged, only the session is new. So `updateSessionIfNeeded` did nothing and the fresh session kept ARCore's default geometry.

That session's first frame still reports `hasDisplayGeometryChanged()`, so `BackgroundRenderer` recomputed its camera UV transform — against the unset geometry. The resulting UVs collapse the full-screen NDC quad onto a sliver of the camera texture, so every fragment samples nearly the same texel.

The failure was also unrecoverable and silent: `hasTransformed` latched the bad result permanently, and `quadTexCoordTransformed` was zero-initialised, so any path that skipped the transform sampled texel (0,0) with the same visual outcome.

## Changes

`feature/ar/.../DisplayRotationHelper.kt`
- `markGeometryDirty()` forces the viewport to be re-pushed on the next frame.
- `updateSessionIfNeeded` refuses to push a zero-size viewport and keeps the dirty flag set until a real size is known.

`feature/ar/.../rendering/BackgroundRenderer.kt`
- `invalidateDisplayGeometry()` drops the cached UV transform.
- The transform result is validated before being latched: all components finite, and spanning at least 10% of the texture on both axes (a real transform spans ~0.5–1.0, so this only catches collapsed ones).
- A rejected or throwing transform falls back to the last accepted UVs and retries on the next frame rather than drawing a collapsed quad; the transform is also wrapped so a throw can't take down the GL thread now that it can run on more than the first frame.
- `quadTexCoordTransformed` is seeded with the identity UVs instead of zeros, so a failure before any good transform shows the whole frame (wrong orientation) rather than one texel.

`feature/ar/.../rendering/ArRenderer.kt`
- `attachSession()` marks the geometry dirty and invalidates the cached UVs, so the new session is given the viewport and the transform is recomputed against it.
- `onSurfaceCreated()` invalidates the cached UVs too, since the surface is (re)born there.

## Testing

Not compiled or run on device — this environment has no Android SDK (`./gradlew` fails at `SDK location not found`), so the change is reviewed by reading only. Worth confirming on device that AR entry → leave → re-enter and background/foreground cycles all come back with a correctly scaled preview.

Overlay mode (CameraX `PreviewView`) is untouched; it does not use this code path.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E3E6oVmJoHRHoUpwatsVwv)_

## Summary by Sourcery

Ensure AR camera passthrough renders a correctly scaled preview when sessions are reattached or rebuilt, avoiding single-pixel magnification and unrecoverable UV state.

Bug Fixes:
- Prevent AR background from collapsing to a single magnified texel when a new ARCore session is attached to an existing GL surface.
- Avoid latching and reusing invalid or degenerate camera UV transforms that were computed against missing or incorrect display geometry.

Enhancements:
- Add validation and fallback logic for camera UV transforms in the background renderer to keep previews readable even when transforms fail.
- Track and reuse the last known good UV coordinates and seed transformed buffers with identity UVs to provide a safe default mapping.
- Allow display geometry to be explicitly marked dirty and re-pushed per ARCore session while guarding against zero-size viewports.
- Invalidate cached display geometry and UV transforms whenever a new ARCore session is attached or the GL surface is created to keep rendering state in sync.