### PR TITLE
fix: render latency, low-light surfaces, plane merging, surface dissolve; disable the rail menu

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -450,17 +450,17 @@ class MainActivity : ComponentActivity() {
 
                 // noMenu (AzNavRail 11.0) removes the side drawer entirely — all entries become rail
                 // items — and makes the app-icon tap FOLD THE RAIL UP INTO THE ICON (the scope tracks
-                // this as `isFoldedUp`). That is exactly the Design-mode behaviour we want: the user
-                // asked for the rail to fold up when the app icon is pressed in Design mode with the
-                // menu disabled, and 11.0's noMenu delivers it natively (10.32 could not — it had no
-                // app-icon/expansion hook, so this used to be only an approximation).
+                // this as `isFoldedUp`).
                 //
-                // We also assert noMenu while the rail is hidden or the library screen is up: forcing
-                // it there re-initialises AzNavRail's saved isExpanded to false so its outer
-                // fillMaxSize Box never attaches tapOutsideToCollapse over those screens.
-                val railMenuDisabled = !isRailVisible ||
-                        showLibrary ||
-                        editorUiState.editorMode == EditorMode.DESIGN
+                // The menu is disabled in EVERY mode, not just Design. Nothing is lost by doing so:
+                // this app declares no drawer-only entries at all (no azMenuItem / azMenuToggle /
+                // azMenuCycler / azMenu*Host anywhere — every entry is an azRailItem, azRailHostItem
+                // or azRailSubItem), so the side drawer only ever duplicated the rail. Disabling it
+                // everywhere also means the app-icon fold and AzNavRail's isExpanded=false
+                // initialisation — which keeps its outer fillMaxSize Box from attaching
+                // tapOutsideToCollapse over the screen — apply in AR, Overlay, Mockup and Trace too,
+                // not only Design/library/hidden-rail.
+                val railMenuDisabled = true
 
                 var permissionRequestedAtLeastOnce by remember { mutableStateOf(hasCameraPermission) }
 

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
@@ -307,6 +307,9 @@ fun MainScreen(
                                 },
                                 onDoodleLocked = {
                                     arViewModel.onDoodleLocked()
+                                },
+                                onFlashlightUnavailable = {
+                                    arViewModel.onFlashlightUnavailable()
                                 }
                             )
                             renderer.hideVisualization = isExporting

--- a/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
+++ b/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
@@ -504,10 +504,11 @@ Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeFeedYuvFrame(
 
     cv::Mat yMat(height, width, CV_8UC1, yData, yStride);
 
-    if (gLastColorFrame.empty() || gLastColorFrame.cols != width || gLastColorFrame.rows != height) {
-        gLastColorFrame = cv::Mat(height, width, CV_8UC3);
-    }
-
+    // This runs on the GL render thread, so every allocation here costs frame time directly.
+    // An eagerly allocated CV_8UC3 height x width Mat used to be assigned to gLastColorFrame here
+    // and then immediately overwritten below by the YUV frame — a full RGB-sized allocation (~6 MB
+    // at 1080p) thrown away on every single call. Its size guard could never match either, because
+    // gLastColorFrame ends up height*1.5 rows tall, so it re-allocated every frame forever.
     cv::Mat yuv(height + height / 2, width, CV_8UC1);
     yMat.copyTo(yuv(cv::Rect(0, 0, width, height)));
 
@@ -528,35 +529,51 @@ Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeFeedYuvFrame(
                 dst[2 * c + 1] = (uCap <= 0 || (jlong)idx < uCap) ? uData[idx] : 0; // U
             }
         }
-        // No conversion on GL thread; pass raw YUV to map thread
-        gLastColorFrame = yuv.clone();
+        // No conversion on GL thread; pass raw YUV to map thread. Plain assignment, not clone():
+        // `yuv` is a local whose buffer nothing else writes, so cv::Mat's refcount hands ownership
+        // over for free. The clone() this replaces copied the whole frame a second time, on the GL
+        // thread, every call.
+        gLastColorFrame = yuv;
     } else if (uvPixelStride == 2) {
+        // Semi-planar (NV12/NV21): the interleaved chroma can be memcpy'd straight into the YUV
+        // block's rows. The previous version built a separate zero-filled full-chroma Mat and then
+        // copyTo'd it across — an extra allocation, an extra zero-fill and an extra copy per frame.
         jlong vCap = env->GetDirectBufferCapacity(vBuffer);
-        cv::Mat uvInterleaved = cv::Mat::zeros(height / 2, width, CV_8UC1);
+        cv::Mat chroma = yuv(cv::Rect(0, height, width, height / 2));
         size_t limit = (vCap > 0) ? (size_t)vCap : (size_t)((height / 2 - 1) * uvStride + width);
         for (int r = 0; r < height / 2; ++r) {
-            size_t rowStart = r * uvStride;
+            uint8_t* dst = chroma.ptr(r);
+            size_t rowStart = (size_t)r * uvStride;
             size_t rowLen = std::min((size_t)width, (size_t)(limit > rowStart ? limit - rowStart : 0));
-            if (rowLen > 0) {
-                std::memcpy(uvInterleaved.ptr(r), vData + rowStart, rowLen);
-            }
+            if (rowLen > 0) std::memcpy(dst, vData + rowStart, rowLen);
+            // Rows the source can't fill must still be cleared: a fresh cv::Mat is uninitialised,
+            // whereas the scratch Mat this replaces was zero-filled.
+            if (rowLen < (size_t)width) std::memset(dst + rowLen, 0, (size_t)width - rowLen);
         }
-        uvInterleaved.copyTo(yuv(cv::Rect(0, height, width, height / 2)));
-        // No conversion on GL thread; pass raw YUV to map thread
-        gLastColorFrame = yuv.clone();
+        gLastColorFrame = yuv;
     } else {
         cv::cvtColor(yMat, gLastColorFrame, cv::COLOR_GRAY2RGB);
     }
 
-    // Relocalization MATCHING still uses the Display-Aligned frame for best user feedback
-    if (!gLastColorFrame.empty() && gLastColorFrame.rows == height + height/2) {
+    // Relocalization MATCHING still uses the Display-Aligned frame for best user feedback.
+    //
+    // Ask FIRST whether the reloc worker will take a frame. scheduleRelocCheck drops the frame
+    // outright when relocalization is off, when there is no wall fingerprint to match against yet,
+    // or when the worker is still busy with the previous one — and building its argument costs a
+    // full-frame YUV->RGB conversion plus a full-frame rotate, both on the GL render thread. That
+    // work used to be done unconditionally, so during the entire scanning phase (no fingerprint
+    // exists yet, by definition) every single conversion was built and immediately thrown away,
+    // several times a second, stalling the render loop for nothing.
+    if (gLastColorFrame.empty() || !gSlamEngine->relocWantsFrame()) return;
+
+    if (gLastColorFrame.rows == height + height/2) {
         cv::Mat relocFrame;
         cv::cvtColor(gLastColorFrame, relocFrame, cv::COLOR_YUV2RGB_NV21);
         if (cvRotateCode >= 0) {
             cv::rotate(relocFrame, relocFrame, cvRotateCode);
         }
         gSlamEngine->scheduleRelocCheck(relocFrame);
-    } else if (!gLastColorFrame.empty()) {
+    } else {
         cv::Mat relocFrame = gLastColorFrame.clone();
         if (cvRotateCode >= 0) {
             cv::rotate(relocFrame, relocFrame, cvRotateCode);

--- a/core/nativebridge/src/main/cpp/MobileGS.cpp
+++ b/core/nativebridge/src/main/cpp/MobileGS.cpp
@@ -944,6 +944,13 @@ void MobileGS::alignToFingerprint(const uint8_t* data, size_t size) {
     }
     LOGI("Co-op: Received fingerprint with %u points. Relocalization triggered.", numPoints);
 }
+bool MobileGS::relocWantsFrame() {
+    if (!mRelocEnabled) return false;
+    if (mRelocRequested) return false; // worker still holds the previous frame
+    std::lock_guard<std::mutex> lock(mMutex);
+    return !mWallDescriptors.empty();
+}
+
 void MobileGS::scheduleRelocCheck(const cv::Mat& f) {
     // Feed the latest camera frame to the background relocalization thread. Previously a no-op, which
     // meant mRelocColorFrame was never populated and the reloc thread always saw an empty frame —

--- a/core/nativebridge/src/main/cpp/include/MobileGS.h
+++ b/core/nativebridge/src/main/cpp/include/MobileGS.h
@@ -68,6 +68,17 @@ public:
     // the match flag (accumulate without matching, or match a persisted map without growing).
     void setMapBuildEnabled(bool e) { mMapBuildEnabled.store(e, std::memory_order_relaxed); }
     void scheduleRelocCheck(const cv::Mat& colorFrame);
+    /**
+     * Cheap pre-check for the three conditions under which scheduleRelocCheck() drops the frame:
+     * relocalization disabled, no wall fingerprint to match against yet, or the reloc worker still
+     * busy with the previous request.
+     *
+     * Callers convert a raw camera frame to RGB (and rotate it) before they can schedule it, which
+     * is the single most expensive thing on the GL render thread. Ask this first so that work is
+     * only paid for on frames the worker will actually take — during scanning there is no
+     * fingerprint yet, so every one of those conversions used to be built and thrown away.
+     */
+    bool relocWantsFrame();
     void getAnchorTransform(float* outMat16) const;
     void getRelocResult(float* out19) const;       // [0..15]=pnpMat,16=inliers,17=matches,18=seq
     void getFingerprintAnchor(float* out16) const;

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -933,13 +933,22 @@ class ArViewModel @Inject constructor(
         try {
             val s = Session(context)
             val config = Config(s)
-            // FIXED, not AUTO: autofocus sweeps shift the effective focal length mid-stream, and on
-            // devices with sloppy OEM intrinsics that destabilizes ARCore's feature triangulation —
-            // this device's perception threads (MTC_vio, MTC_triangulati) have segfaulted inside
-            // libarcore_c during live tracking. FIXED keeps the optics constant, which is also
-            // ARCore's documented recommendation for tracking-priority apps. Revisit if nearby
-            // surfaces render too blurred for mark detection.
-            config.focusMode = Config.FocusMode.FIXED
+            // AUTO, except in safe mode. FIXED parks the lens at infinity, which is right for a
+            // room-scale tracking app but wrong for this one: an artist works a wall at arm's length,
+            // often at night with a torch, and at that range a fixed-infinity lens delivers a blurred
+            // frame with no usable texture. ARCore then finds no features, so no plane ever forms —
+            // "impossible to get a surface to read in low light, even with a flashlight" — and the
+            // fragments it does form are too noisy to merge into one wall. The blur cost was called
+            // out when FIXED was chosen ("Revisit if nearby surfaces render too blurred for mark
+            // detection"); close-range low light is exactly that case, so AUTO is the default now.
+            //
+            // The stability reason for FIXED is preserved: autofocus sweeps shift the effective focal
+            // length mid-stream and on devices with sloppy OEM intrinsics that destabilized ARCore's
+            // triangulation badly enough to segfault its perception threads (MTC_vio,
+            // MTC_triangulati) inside libarcore_c. forceSafeCameraConfig is the flag those devices
+            // already set after a camera stall, so safe mode keeps the old constant-optics behaviour.
+            config.focusMode =
+                if (forceSafeCameraConfig) Config.FocusMode.FIXED else Config.FocusMode.AUTO
             // LATEST_CAMERA_IMAGE so session.update() never blocks the GL render thread. On this
             // device the BLOCKING mode left the renderer stuck "Waiting for first frame" (the render
             // heartbeat never fired) — update() hung waiting for a frame that never arrived, so the
@@ -1959,6 +1968,16 @@ class ArViewModel @Inject constructor(
 
     fun toggleFlashlight() {
         _uiState.update { it.copy(isFlashlightOn = !it.isFlashlightOn) }
+    }
+
+    /**
+     * ARCore refused a torch request (no flash unit, or a camera config that can't drive one).
+     * Called from the GL thread. Drop the toggle back off so the rail button reflects the real
+     * state instead of latching on over a light that never came on.
+     */
+    fun onFlashlightUnavailable() {
+        _uiState.update { it.copy(isFlashlightOn = false) }
+        appendDiag("flashlight: unavailable on this device/camera config")
     }
 
     fun updateLightLevel(level: Float) {

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -57,7 +57,11 @@ class ArRenderer(
     // sustained run of frames (true) or recovers (false). MainScreen uses this
     // to drop the GLSurfaceView render mode to WHEN_DIRTY so the saturated
     // main thread can serve input again.
-    private val onTrackingLoopStuck: (Boolean) -> Unit = {}
+    private val onTrackingLoopStuck: (Boolean) -> Unit = {},
+    // Fired from the GL thread when a torch request was rejected by ARCore (no flash unit, or a
+    // camera config that can't drive one), so the UI can drop the toggle instead of latching a
+    // light that never came on.
+    private val onFlashlightUnavailable: () -> Unit = {}
 ) : GLSurfaceView.Renderer {
 
     /**
@@ -245,6 +249,8 @@ class ArRenderer(
     // Set by updateFlashlight (any thread); consumed at the top of onDrawFrame so the ARCore
     // configure() runs on the GL thread under sessionLock, never concurrently with update().
     @Volatile private var flashDirty: Boolean = false
+    // Guards onFlashlightUnavailable so a rejected torch reports once per request, not once a frame.
+    private var flashUnsupportedReported: Boolean = false
 
     fun saveCloudPoints(path: String) {
         pointCloudRenderer.saveToFile(path)
@@ -375,6 +381,15 @@ class ArRenderer(
     // drift and survives anchor re-establishment and project reload.
     private var markOffsetX: Float = 0f
     private var markOffsetY: Float = 0f
+    // Per-frame pose scratch. These were allocated fresh inside onDrawFrame, so at 60 fps they made
+    // five 16-float arrays a frame purely to be filled and dropped — allocation churn on the GL
+    // thread, which is the one thread whose pauses the artist sees as the overlay stuttering
+    // against the wall. Owned by onDrawFrame; not safe to read from another thread.
+    private val viewMatrixScratch = FloatArray(16)
+    private val projMatrixScratch = FloatArray(16)
+    private val mappingViewMatrixScratch = FloatArray(16)
+    private val mappingProjMatrixScratch = FloatArray(16)
+    private val backboneScratch = FloatArray(16)
     // Scratch for composing the overlay matrix (anchor frame * in-plane transform).
     private val overlayBaseScratch = FloatArray(16)
     private val overlayLocalScratch = FloatArray(16)
@@ -498,15 +513,25 @@ class ArRenderer(
      * held (GL frame body or [attachSession]) so configure() is serialized against update().
      */
     private fun applyFlashlightStateLocked(activeSession: Session) {
+        val wanted = if (isFlashlightRequested) Config.FlashMode.TORCH else Config.FlashMode.OFF
         try {
             val config = activeSession.config
-            val newMode = if (isFlashlightRequested) Config.FlashMode.TORCH else Config.FlashMode.OFF
-            if (config.flashMode != newMode) {
-                config.flashMode = newMode
+            if (config.flashMode != wanted) {
+                config.flashMode = wanted
                 activeSession.configure(config)
             }
+            flashUnsupportedReported = false
         } catch (e: Exception) {
+            // ARCore rejects TORCH when the device has no flash unit or the selected camera config
+            // can't drive it. This used to be logged and dropped, so the rail's torch button latched
+            // on while the light stayed off and the artist had no way to know the camera — not their
+            // technique — was why a dark wall wouldn't read. Surface it once per request instead.
             Timber.e(e, "Failed to set flash mode via ARCore Config")
+            if (isFlashlightRequested && !flashUnsupportedReported) {
+                flashUnsupportedReported = true
+                onDiag("flashlight: not available on this camera config (${e.javaClass.simpleName})")
+                onFlashlightUnavailable()
+            }
         }
     }
 
@@ -990,13 +1015,16 @@ class ArRenderer(
             val isDualLensHardware = activeSession.cameraConfig.stereoCameraUsage == com.google.ar.core.CameraConfig.StereoCameraUsage.REQUIRE_AND_USE
             val isDualLens = isDualLensHardware || (stereoProvider?.isDualLensActive == true)
 
-            val viewMatrix = FloatArray(16)
-            val projMatrix = FloatArray(16)
+            val viewMatrix = viewMatrixScratch
+            val projMatrix = projMatrixScratch
             camera.getViewMatrix(viewMatrix, 0)
             camera.getProjectionMatrix(projMatrix, 0, 0.1f, 100.0f)
 
-            val mappingViewMatrix = FloatArray(16)
-            val mappingProjMatrix = FloatArray(16)
+            val mappingViewMatrix = mappingViewMatrixScratch
+            val mappingProjMatrix = mappingProjMatrixScratch
+            // mappingProjMatrix is only partially overwritten below (cells 0/5/8/9/10/11/14/15), so
+            // a reused buffer has to be cleared or it would carry the previous frame's stray cells.
+            java.util.Arrays.fill(mappingProjMatrix, 0f)
             camera.pose.inverse().toMatrix(mappingViewMatrix, 0)
 
             val intrinsics = camera.imageIntrinsics
@@ -1077,7 +1105,7 @@ class ArRenderer(
             // --- Democratic Consensus Transformation + smoothed reloc fusion ---
             // Backbone: ARCore consensus once anchored, else the native cached pose (as before).
             lastStep = "consensus"
-            val backbone = FloatArray(16)
+            val backbone = backboneScratch
             if (anchorEstablished) {
                 anchorOrchestrator.getConsensusMatrix(backbone)
             } else {
@@ -1155,6 +1183,9 @@ class ArRenderer(
                 } catch (e: Exception) { /* ignore */ }
                 // Snapshot the smoothed value (kept across invalid/dropped frames) for the readout.
                 val centerDepth = smoothedCenterDepth
+                // The view matrix is GL-thread scratch that the next frame overwrites in place, so
+                // the coroutine below gets its own copy rather than a live reference.
+                val viewMatrixSnapshot = viewMatrix.copyOf()
 
                 backgroundScope.launch {
                     val (count, immutableCount) = if (currentScanMode == ArScanMode.CLOUD_POINTS) {
@@ -1170,7 +1201,7 @@ class ArRenderer(
                     val distanceMeters = run {
                         if (!anchorEstablished) return@run -1f
                         val camPose = FloatArray(16)
-                        android.opengl.Matrix.invertM(camPose, 0, viewMatrix, 0)
+                        android.opengl.Matrix.invertM(camPose, 0, viewMatrixSnapshot, 0)
                         val dx = anchorMatrix[12] - camPose[12]
                         val dy = anchorMatrix[13] - camPose[13]
                         val dz = anchorMatrix[14] - camPose[14]
@@ -1780,22 +1811,43 @@ class ArRenderer(
         // Find the plane most directly ahead of the camera (unbiased search)
         val planes = session.getAllTrackables(com.google.ar.core.Plane::class.java)
         var bestPlane: com.google.ar.core.Plane? = null
-        var maxDot = 0.4f
+        var bestDot = 0f
+        var bestArea = 0f
 
         for (plane in planes) {
             if (plane.trackingState != TrackingState.TRACKING) continue
-            
+            // A subsumed plane is a stale fragment ARCore has already merged into a larger one. It
+            // keeps its own centerPose, so leaving it in the search let the anchor snap onto a
+            // leftover shard of the wall and jump between shards as the artist moved.
+            if (plane.subsumedBy != null) continue
+
             val pose = plane.centerPose
             val dx = pose.tx() - camX
             val dy = pose.ty() - camY
             val dz = pose.tz() - camZ
             val len = kotlin.math.sqrt((dx * dx + dy * dy + dz * dz).toDouble()).toFloat()
             if (len < 0.3f || len > 15f) continue
-            
+
             val dot = (dx * fwdX + dy * fwdY + dz * fwdZ) / len
-            if (dot > maxDot) { 
-                maxDot = dot
-                bestPlane = plane 
+            if (dot < PLANE_PICK_MIN_DOT) continue
+            val area = plane.extentX * plane.extentZ
+            // Within a tie band of "most directly ahead", prefer the LARGER plane. ARCore leaves
+            // co-planar fragments of one wall un-subsumed, and they all point roughly the same way,
+            // so a raw argmax on the dot product picked whichever shard happened to be centred
+            // nearest the view axis — the anchor then hopped between fragments of the same surface
+            // from frame to frame, which reads as the overlay refusing to settle.
+            val better = when {
+                bestPlane == null -> true
+                dot > bestDot + PLANE_PICK_DOT_TIE -> true   // clearly more centred
+                dot < bestDot - PLANE_PICK_DOT_TIE -> false  // clearly less centred
+                else -> area > bestArea                      // as centred as each other → bigger wins
+            }
+            if (better) {
+                // max(), so the tie band stays anchored to the best centring seen rather than
+                // sliding every time a larger-but-less-centred plane wins.
+                bestDot = kotlin.math.max(bestDot, dot)
+                bestArea = area
+                bestPlane = plane
             }
         }
 
@@ -1927,6 +1979,13 @@ class ArRenderer(
         // Higher values → subtler perspective; lower → more dramatic. 3.0 gives a moderate
         // effect visible at 20-30° and dramatic at 45°+.
         const val CONTENT_PERSPECTIVE_FACTOR = 3.0f
+
+        // Anchor plane pick: minimum cos(angle) between the camera forward axis and the direction to
+        // a plane's centre for that plane to be considered "ahead" at all (the previous inline 0.4f).
+        const val PLANE_PICK_MIN_DOT = 0.4f
+        // Planes whose centring differs by less than this count as equally centred, and the larger
+        // one wins — so the anchor settles on the whole wall instead of the nearest-centred fragment.
+        const val PLANE_PICK_DOT_TIE = 0.05f
 
         const val PERCEPTION_FULL_FPS = 60
         const val PERCEPTION_FLOOR_FPS = 30

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -1762,7 +1762,11 @@ class ArRenderer(
                 val moved = perceptionPoseChanged(viewMatrix)
                 val splatCount = slamManager.getSplatCount()
                 val mapGrew = splatCount != lastPerceptionSplatCount
-                val refresh = !havePerceptionCache || (due && (moved || mapGrew))
+                // A plane mid-dissolve changes every frame with nothing else moving, so it has to
+                // count as a reason to redraw. Otherwise holding the phone still — exactly when the
+                // artist is watching the surfaces settle — would freeze the dissolve part-way.
+                val dissolving = nowMs < planeRenderer.dissolveCompletesAtMs
+                val refresh = !havePerceptionCache || (due && (moved || mapGrew || dissolving))
                 if (refresh) {
                     val t0 = android.os.SystemClock.elapsedRealtime()
                     perceptionFbo.bindForRender()

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/PlaneRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/PlaneRenderer.kt
@@ -25,7 +25,29 @@ class PlaneRenderer : GlReleasable {
     private var isOutlineUniform = 0
     private var gridModeUniform = 0
     private var developUniform = 0
+    private var fadeUniform = 0
     private var firstDrawNs = -1L // for the ink-spread develop ramp
+
+    /**
+     * When each still-drawn plane was first classified as non-green (elapsedRealtime ms). A plane
+     * that classifies as MATCH is removed, so going green stops the dissolve outright and turning
+     * non-green again restarts the full hold + dissolve from zero.
+     *
+     * Keyed on [Plane]: ARCore's trackables define equals/hashCode over the underlying native
+     * object, so the wrapper instances handed back by successive getAllTrackables calls hash to the
+     * same entry. Pruned every pass to whatever is still being drawn, so it can't grow unbounded.
+     */
+    private val nonGreenSinceMs = HashMap<Plane, Long>()
+    private val seenThisPass = HashSet<Plane>()
+
+    /**
+     * elapsedRealtime (ms) at which the last in-progress dissolve finishes, or 0 when nothing is
+     * dissolving. ArRenderer caches the perception layers in an FBO and only redraws them when the
+     * pose moves or the map grows — without this a dissolve would freeze the moment the artist held
+     * the phone still, which is exactly when they are looking at it.
+     */
+    var dissolveCompletesAtMs: Long = 0L
+        private set
 
     private var vertexBuffer = ByteBuffer.allocateDirect(1000 * 4) // Reusable buffer (Float = 4 bytes), grown on demand
         .order(ByteOrder.nativeOrder())
@@ -59,6 +81,11 @@ class PlaneRenderer : GlReleasable {
             uniform int u_IsOutline;
             uniform int u_GridMode;
             uniform float u_Develop;
+            // 1 = fully present, 0 = gone. Drives the timed dissolve of surfaces that aren't a good
+            // match for the artwork, so the scan view declutters down to the usable walls. It erodes
+            // through the same value noise the ink fill develops through, so a surface breaks up in
+            // patches instead of just dimming uniformly.
+            uniform float u_Fade;
             varying vec2 v_PosXZ;
             float hash(vec2 p) { return fract(sin(dot(p, vec2(12.9898, 78.233))) * 43758.5453); }
             float vnoise(vec2 p) {
@@ -69,7 +96,8 @@ class PlaneRenderer : GlReleasable {
             }
             void main() {
                 if (u_IsOutline == 1) {
-                    gl_FragColor = vec4(u_Color.rgb, 0.9);
+                    // A line loop is too thin to read as patchy, so the outline just fades out.
+                    gl_FragColor = vec4(u_Color.rgb, 0.9 * u_Fade);
                 } else if (u_GridMode == 1) {
                     vec2 f = fract(v_PosXZ * 4.0);
                     vec2 d = min(f, 1.0 - f);
@@ -78,11 +106,17 @@ class PlaneRenderer : GlReleasable {
                     // Lines lifted toward white so the grid reads over the camera and any hue.
                     vec3 lineCol = mix(u_Color.rgb, vec3(1.0), 0.55);
                     float a = max(line * 0.85, axis);
-                    gl_FragColor = vec4(lineCol, max(a, 0.03));
+                    // Erode the grid through the same plane-local noise, so it breaks up in patches
+                    // on the surface as it goes rather than dimming as one flat sheet.
+                    float n = vnoise(v_PosXZ * 18.0);
+                    a *= smoothstep(n - 0.18, n + 0.18, u_Fade);
+                    gl_FragColor = vec4(lineCol, max(a, 0.03) * u_Fade);
                 } else {
                     float n = vnoise(v_PosXZ * 18.0);
-                    float ink = smoothstep(n - 0.18, n + 0.18, u_Develop);
-                    gl_FragColor = vec4(u_Color.rgb, ink * 0.5);
+                    // Running the develop threshold back down is the ink un-soaking from the wall:
+                    // the same patches that spread in are the ones that recede.
+                    float ink = smoothstep(n - 0.18, n + 0.18, u_Develop * u_Fade);
+                    gl_FragColor = vec4(u_Color.rgb, ink * 0.5 * u_Fade);
                 }
             }
         """.trimIndent()
@@ -102,6 +136,7 @@ class PlaneRenderer : GlReleasable {
         isOutlineUniform = GLES20.glGetUniformLocation(planeProgram, "u_IsOutline")
         gridModeUniform = GLES20.glGetUniformLocation(planeProgram, "u_GridMode")
         developUniform = GLES20.glGetUniformLocation(planeProgram, "u_Develop")
+        fadeUniform = GLES20.glGetUniformLocation(planeProgram, "u_Fade")
     }
 
     /**
@@ -125,20 +160,58 @@ class PlaneRenderer : GlReleasable {
         val develop = ((System.nanoTime() - firstDrawNs) / 1_500_000_000.0f).coerceIn(0f, 1f)
         GLES20.glUniform1f(developUniform, develop)
 
+        val nowMs = android.os.SystemClock.elapsedRealtime()
+        var lastDissolveEndMs = 0L
+        seenThisPass.clear()
+
         for (plane in planes) {
             if (plane.trackingState != TrackingState.TRACKING || plane.subsumedBy != null) {
                 continue
             }
+            seenThisPass.add(plane)
 
-            val color = calculatePlaneColor(plane, cameraPose)
-            GLES20.glUniform4fv(planeColorUniform, 1, color, 0)
+            val match = classifyPlane(plane, cameraPose)
+            val fade = fadeFor(plane, match, nowMs)
+            if (fade <= 0f) continue // fully dissolved — stays gone until it goes green again
+            if (fade < 1f) {
+                lastDissolveEndMs = maxOf(lastDissolveEndMs, dissolveEndMs(plane))
+            }
+
+            GLES20.glUniform4fv(planeColorUniform, 1, colorFor(match), 0)
+            GLES20.glUniform1f(fadeUniform, fade)
 
             drawPlane(plane, viewMatrix, projectionMatrix)
         }
 
+        // Forget planes that are no longer drawn, so a long session can't accumulate entries for
+        // trackables ARCore has since dropped or subsumed.
+        nonGreenSinceMs.keys.retainAll(seenThisPass)
+        dissolveCompletesAtMs = lastDissolveEndMs
+
         GLES20.glDisable(GLES20.GL_BLEND)
         GLES20.glDepthMask(true)
     }
+
+    /**
+     * Dissolve weight for [plane] this frame: 1 while it is green or still inside the hold, ramping
+     * to 0 across [DISSOLVE_MS] once the hold expires.
+     *
+     * A green (MATCH) classification clears the plane's timer entirely, so a surface that goes green
+     * stops dissolving immediately and — if it later stops matching — starts a fresh
+     * [HOLD_MS] + [DISSOLVE_MS] rather than resuming where it left off.
+     */
+    private fun fadeFor(plane: Plane, match: PlaneMatchResult, nowMs: Long): Float {
+        if (match == PlaneMatchResult.MATCH) {
+            nonGreenSinceMs.remove(plane)
+            return 1f
+        }
+        val since = nonGreenSinceMs.getOrPut(plane) { nowMs }
+        return dissolveFade(nowMs - since)
+    }
+
+    /** When [plane]'s in-progress dissolve finishes, or 0 if it isn't dissolving. */
+    private fun dissolveEndMs(plane: Plane): Long =
+        nonGreenSinceMs[plane]?.let { it + HOLD_MS + DISSOLVE_MS } ?: 0L
 
     /**
      * Collapses co-planar detections down to one plane per real surface.
@@ -271,12 +344,13 @@ class PlaneRenderer : GlReleasable {
         }
     }
 
-    fun calculatePlaneColor(plane: Plane, cameraPose: Pose): FloatArray {
-        return when (classifyPlane(plane, cameraPose)) {
-            PlaneMatchResult.MATCH -> floatArrayOf(0.0f, 1.0f, 0.0f, 0.3f)
-            PlaneMatchResult.NO_MATCH -> floatArrayOf(1.0f, 0.4f, 0.7f, 0.3f)
-            PlaneMatchResult.SUBOPTIMAL -> floatArrayOf(0.0f, 1.0f, 1.0f, 0.3f)
-        }
+    fun calculatePlaneColor(plane: Plane, cameraPose: Pose): FloatArray =
+        colorFor(classifyPlane(plane, cameraPose))
+
+    private fun colorFor(match: PlaneMatchResult): FloatArray = when (match) {
+        PlaneMatchResult.MATCH -> floatArrayOf(0.0f, 1.0f, 0.0f, 0.3f)
+        PlaneMatchResult.NO_MATCH -> floatArrayOf(1.0f, 0.4f, 0.7f, 0.3f)
+        PlaneMatchResult.SUBOPTIMAL -> floatArrayOf(0.0f, 1.0f, 1.0f, 0.3f)
     }
 
     private fun calculateDistance(p1: Pose, p2: Pose): Float {
@@ -288,6 +362,24 @@ class PlaneRenderer : GlReleasable {
 
     companion object {
         private const val TAG = "PlaneRenderer"
+
+        /** How long a surface stays fully drawn after it stops classifying as a green match. */
+        const val HOLD_MS = 5_000L
+
+        /** How long the dissolve itself takes once the hold expires. */
+        const val DISSOLVE_MS = 10_000L
+
+        /**
+         * Dissolve weight from how long a surface has been continuously non-green: 1 through the
+         * hold, then a linear ramp to 0 across the dissolve. Split out from the ARCore types so it
+         * can be unit-tested. The caller clears the elapsed time whenever the surface goes green, so
+         * this only ever sees an unbroken non-green run.
+         */
+        fun dissolveFade(elapsedSinceNonGreenMs: Long): Float = when {
+            elapsedSinceNonGreenMs <= HOLD_MS -> 1f
+            elapsedSinceNonGreenMs >= HOLD_MS + DISSOLVE_MS -> 0f
+            else -> 1f - (elapsedSinceNonGreenMs - HOLD_MS).toFloat() / DISSOLVE_MS
+        }
 
         /**
          * |dot| of two plane normals above which they count as the same orientation (~14°). Loose

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/PlaneRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/PlaneRenderer.kt
@@ -109,7 +109,7 @@ class PlaneRenderer : GlReleasable {
      * emphasised local axes instead of the ink-develop fill, so their orientation is visible.
      */
     fun drawPlanes(session: Session, viewMatrix: FloatArray, projectionMatrix: FloatArray, cameraPose: Pose, gridMode: Boolean = false) {
-        val planes = session.getAllTrackables(Plane::class.java)
+        val planes = mergeCoplanar(session.getAllTrackables(Plane::class.java))
 
         GLES20.glUseProgram(planeProgram)
         GLES20.glDepthMask(false)
@@ -139,6 +139,60 @@ class PlaneRenderer : GlReleasable {
         GLES20.glDisable(GLES20.GL_BLEND)
         GLES20.glDepthMask(true)
     }
+
+    /**
+     * Collapses co-planar detections down to one plane per real surface.
+     *
+     * ARCore only sets [Plane.getSubsumedBy] when it actually merges two detections. A single wall
+     * scanned from a few angles routinely ends up as several separate TRACKING planes that share a
+     * normal and lie on the same infinite plane but are never subsumed — and drawing all of them
+     * stacks overlapping, differently-coloured, differently-sized quads on one surface, which is the
+     * "surfaces don't combine, they overlap into a mess" the artist sees.
+     *
+     * Planes are grouped by (normal direction, signed distance along that normal from the origin);
+     * within a group only the largest is drawn, so a wall reads as one surface. Groups stay separate
+     * when normals differ past [NORMAL_DOT_EPS] or the planes sit on parallel-but-offset surfaces
+     * more than [COPLANAR_DIST_M] apart, so genuinely distinct walls are never fused.
+     *
+     * This is a rendering/selection filter only — no ARCore state is modified, and the discarded
+     * planes stay available to hit tests.
+     */
+    private fun mergeCoplanar(planes: Collection<Plane>): List<Plane> {
+        val kept = ArrayList<Plane>(planes.size)
+        for (plane in planes) {
+            if (plane.trackingState != TrackingState.TRACKING || plane.subsumedBy != null) continue
+            val pose = plane.centerPose
+            val normal = FloatArray(3)
+            pose.getTransformedAxis(1, 1f, normal, 0) // plane local +Y is the surface normal
+            var merged = false
+            for (i in kept.indices) {
+                if (coplanar(kept[i], plane, normal)) {
+                    // Keep the bigger detection: it is the one that actually covers the surface, and
+                    // the smaller fragments are what produce the overlapping stack.
+                    if (area(plane) > area(kept[i])) kept[i] = plane
+                    merged = true
+                    break
+                }
+            }
+            if (!merged) kept.add(plane)
+        }
+        return kept
+    }
+
+    /** True when [b] (whose world-space normal is [bNormal]) lies on the same infinite plane as [a]. */
+    private fun coplanar(a: Plane, b: Plane, bNormal: FloatArray): Boolean {
+        val aPose = a.centerPose
+        val aNormal = FloatArray(3)
+        aPose.getTransformedAxis(1, 1f, aNormal, 0)
+        val bPose = b.centerPose
+        return isCoplanar(
+            aNormal, aPose.tx(), aPose.ty(), aPose.tz(),
+            bNormal, bPose.tx(), bPose.ty(), bPose.tz(),
+        )
+    }
+
+    /** Extent-based area proxy; ARCore reports the plane's extent, not its polygon area. */
+    private fun area(plane: Plane): Float = plane.extentX * plane.extentZ
 
     private fun drawPlane(plane: Plane, viewMatrix: FloatArray, projectionMatrix: FloatArray) {
         val polygon = plane.polygon
@@ -234,5 +288,41 @@ class PlaneRenderer : GlReleasable {
 
     companion object {
         private const val TAG = "PlaneRenderer"
+
+        /**
+         * |dot| of two plane normals above which they count as the same orientation (~14°). Loose
+         * enough to absorb the normal jitter between separate detections of one wall, tight enough
+         * that a wall and an adjoining floor/ceiling never merge.
+         */
+        private const val NORMAL_DOT_EPS = 0.97f
+
+        /**
+         * Max separation (m) along the shared normal for two same-orientation planes to count as the
+         * same surface. Covers ARCore's depth error on a wall without fusing, say, two parallel walls
+         * of a corridor.
+         */
+        private const val COPLANAR_DIST_M = 0.10f
+
+        /**
+         * Pure geometry behind [mergeCoplanar]: do two oriented surface patches lie on the same
+         * infinite plane? Split out from the ARCore types so it can be unit-tested.
+         *
+         * @param aNormal unit surface normal of the first patch (world space)
+         * @param bNormal unit surface normal of the second patch (world space)
+         */
+        fun isCoplanar(
+            aNormal: FloatArray, aX: Float, aY: Float, aZ: Float,
+            bNormal: FloatArray, bX: Float, bY: Float, bZ: Float,
+        ): Boolean {
+            val dot = aNormal[0] * bNormal[0] + aNormal[1] * bNormal[1] + aNormal[2] * bNormal[2]
+            // abs(): one wall seen from opposite sides yields anti-parallel normals.
+            if (abs(dot) < NORMAL_DOT_EPS) return false
+            val dx = bX - aX
+            val dy = bY - aY
+            val dz = bZ - aZ
+            // Only the offset ALONG the shared normal matters — two patches far apart across the
+            // face of the same wall are still the same surface.
+            return abs(dx * aNormal[0] + dy * aNormal[1] + dz * aNormal[2]) <= COPLANAR_DIST_M
+        }
     }
 }

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/rendering/PlaneCoplanarityTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/rendering/PlaneCoplanarityTest.kt
@@ -1,12 +1,13 @@
 package com.hereliesaz.graffitixr.feature.ar.rendering
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
  * Geometry behind the co-planar plane merge that stops one wall from rendering as a stack of
- * overlapping ARCore detections.
+ * overlapping ARCore detections, and the timing of the non-green surface dissolve.
  */
 class PlaneCoplanarityTest {
 
@@ -76,6 +77,27 @@ class PlaneCoplanarityTest {
                 jittered, 0.5f, 0f, 0f,
             )
         )
+    }
+
+    @Test
+    fun `surface is fully drawn through the five second hold`() {
+        assertEquals(1f, PlaneRenderer.dissolveFade(0L), 1e-4f)
+        assertEquals(1f, PlaneRenderer.dissolveFade(4_999L), 1e-4f)
+        assertEquals(1f, PlaneRenderer.dissolveFade(PlaneRenderer.HOLD_MS), 1e-4f)
+    }
+
+    @Test
+    fun `dissolve ramps linearly over ten seconds after the hold`() {
+        assertEquals(1f, PlaneRenderer.dissolveFade(5_001L), 1e-3f)
+        assertEquals(0.75f, PlaneRenderer.dissolveFade(7_500L), 1e-4f)
+        assertEquals(0.5f, PlaneRenderer.dissolveFade(10_000L), 1e-4f)
+        assertEquals(0.25f, PlaneRenderer.dissolveFade(12_500L), 1e-4f)
+    }
+
+    @Test
+    fun `surface is gone at fifteen seconds and stays gone`() {
+        assertEquals(0f, PlaneRenderer.dissolveFade(PlaneRenderer.HOLD_MS + PlaneRenderer.DISSOLVE_MS), 1e-4f)
+        assertEquals(0f, PlaneRenderer.dissolveFade(60_000L), 1e-4f)
     }
 
     @Test

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/rendering/PlaneCoplanarityTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/rendering/PlaneCoplanarityTest.kt
@@ -1,0 +1,91 @@
+package com.hereliesaz.graffitixr.feature.ar.rendering
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Geometry behind the co-planar plane merge that stops one wall from rendering as a stack of
+ * overlapping ARCore detections.
+ */
+class PlaneCoplanarityTest {
+
+    private val wallNormal = floatArrayOf(0f, 0f, 1f)   // wall facing +Z
+    private val floorNormal = floatArrayOf(0f, 1f, 0f)  // floor facing +Y
+
+    @Test
+    fun `two patches across the same wall merge`() {
+        // Far apart horizontally and vertically, but on the same plane: still one surface.
+        assertTrue(
+            PlaneRenderer.isCoplanar(
+                wallNormal, 0f, 0f, 0f,
+                wallNormal, 3f, 2f, 0f,
+            )
+        )
+    }
+
+    @Test
+    fun `patch offset along the normal past the tolerance stays separate`() {
+        // 0.5 m in front of the wall — a different surface, e.g. a pillar face.
+        assertFalse(
+            PlaneRenderer.isCoplanar(
+                wallNormal, 0f, 0f, 0f,
+                wallNormal, 0f, 0f, 0.5f,
+            )
+        )
+    }
+
+    @Test
+    fun `depth jitter within the tolerance still merges`() {
+        assertTrue(
+            PlaneRenderer.isCoplanar(
+                wallNormal, 0f, 0f, 0f,
+                wallNormal, 1f, 1f, 0.05f,
+            )
+        )
+    }
+
+    @Test
+    fun `perpendicular surfaces never merge`() {
+        assertFalse(
+            PlaneRenderer.isCoplanar(
+                wallNormal, 0f, 0f, 0f,
+                floorNormal, 0f, 0f, 0f,
+            )
+        )
+    }
+
+    @Test
+    fun `anti-parallel normals on the same plane merge`() {
+        // ARCore can report one wall's normal flipped depending on the approach direction.
+        assertTrue(
+            PlaneRenderer.isCoplanar(
+                wallNormal, 0f, 0f, 0f,
+                floatArrayOf(0f, 0f, -1f), 1f, 1f, 0f,
+            )
+        )
+    }
+
+    @Test
+    fun `small normal jitter within the angular tolerance merges`() {
+        // ~8 degrees off — inside the 0.97 dot tolerance.
+        val jittered = floatArrayOf(0f, 0.139f, 0.990f)
+        assertTrue(
+            PlaneRenderer.isCoplanar(
+                wallNormal, 0f, 0f, 0f,
+                jittered, 0.5f, 0f, 0f,
+            )
+        )
+    }
+
+    @Test
+    fun `distinct walls of a corridor stay separate`() {
+        // Parallel, facing each other, 2 m apart.
+        assertFalse(
+            PlaneRenderer.isCoplanar(
+                wallNormal, 0f, 0f, 0f,
+                floatArrayOf(0f, 0f, -1f), 0f, 0f, 2f,
+            )
+        )
+    }
+}


### PR DESCRIPTION
Five items from live use.

## 1. Frame rate — "lag in the lineup" reads as drift

The overlay pose is already recomputed from the current frame's camera pose on every draw (`PoseFusion` only updates its correction on a new PnP snap, then re-applies it to a fresh backbone), so the perceived drift is **render latency**, not pose smoothing. The GL render thread was doing avoidable work every frame:

- **`nativeFeedYuvFrame` built the relocalization frame before checking whether anything wanted it.** Producing that argument costs a full-frame `cvtColor(YUV2RGB_NV21)` plus a full-frame `cv::rotate`. `scheduleRelocCheck` then drops the frame outright when relocalization is off, when there is no wall fingerprint to match against yet, or when the worker is still busy. During the entire scanning phase there is no fingerprint *by definition* — so every one of those conversions was built and immediately thrown away, several times a second, stalling the render loop for nothing. Added `MobileGS::relocWantsFrame()` and gate on it first.
- **A dead ~6 MB allocation per call.** The same function allocated a `CV_8UC3` height×width Mat into `gLastColorFrame` and then immediately overwrote it with the YUV frame. Its size guard could never match either, because `gLastColorFrame` ends up `height*1.5` rows tall, so it re-allocated every call forever.
- **A redundant full-frame copy.** `gLastColorFrame = yuv.clone()` → plain assignment; `yuv` is a local whose buffer nothing else writes, so cv::Mat's refcount hands ownership over for free.
- **An extra allocation + zero-fill + copy** in the semi-planar (NV12/NV21) branch, which built a separate zeroed chroma Mat and then `copyTo`'d it into the YUV block. Now memcpy'd straight into the block's rows (with an explicit clear for short rows, since a fresh Mat is uninitialised where the scratch was zeroed).
- **Five `FloatArray(16)` allocated per frame** in `onDrawFrame` are now reusable scratch. The one that escaped into a coroutine (`viewMatrix`, for the distance readout) is snapshotted explicitly so it can't be read while the next frame overwrites it in place.

## 2. Low light — surfaces won't read even with a torch

`config.focusMode` was `FIXED`, which parks the lens at infinity. That's right for a room-scale tracking app and wrong for this one: an artist works a wall at arm's length, often at night with a torch, and at that range a fixed-infinity lens delivers a blurred frame with no usable texture. ARCore then finds no features, so no plane ever forms — and the fragments it does form are too noisy to merge into one wall (which feeds issue 3 below). The blur cost was explicitly flagged when `FIXED` was chosen — *"Revisit if nearby surfaces render too blurred for mark detection"* — and close-range low light is that case.

`AUTO` is now the default. The stability reason for `FIXED` is preserved: autofocus sweeps shift the effective focal length mid-stream and on devices with sloppy OEM intrinsics that destabilized ARCore's triangulation badly enough to segfault its perception threads. `forceSafeCameraConfig` is the flag those devices already set after a camera stall, and safe mode keeps the old constant-optics behaviour.

Separately, a rejected torch request was logged and swallowed, so the rail button latched on over a light that never came on and the artist had no way to know the camera — not their technique — was why a dark wall wouldn't read. It now reports once per request via the diag channel and drops the toggle.

## 3. Surfaces don't combine — they overlap into a mess

ARCore only sets `subsumedBy` when it actually merges two detections. One wall scanned from several angles routinely ends up as several separate TRACKING planes that share a normal and lie on the same infinite plane but are never subsumed. Both consumers treated them as distinct surfaces:

- **`PlaneRenderer` drew all of them**, stacking overlapping, differently-coloured, differently-sized quads on a single wall. It now collapses co-planar detections — shared normal within ~14°, offset along that normal within 10 cm — and draws the largest of each group. This is a render/selection filter only; no ARCore state is modified and the discarded planes stay available to hit tests.
- **`refineAnchorFromBestPlane` did not skip subsumed planes at all**, and picked by a raw argmax on "most directly ahead", so the anchor latched onto whichever fragment happened to be centred nearest the view axis and hopped between fragments of the same wall from frame to frame. It now skips subsumed planes and prefers the larger plane within a centring tie band.

## 4. Non-green surfaces dissolve away

A surface that isn't a green (`MATCH`) plane now holds fully drawn for 5 s, then dissolves out over the next 10 s, so the scan view declutters down to the walls actually worth painting instead of accumulating pink/cyan clutter.

Going green stops the process outright: a `MATCH` classification drops the plane's timer, so a surface that turns green stays, and if it later stops matching it starts a fresh 5 s hold + 10 s dissolve rather than resuming where it left off.

Two implementation notes:

- **It needed a new uniform, not an alpha tweak.** The plane shader hardcodes alpha per branch (outline `0.9`, grid floor `0.03`, `ink*0.5`), so `u_Color.a` was doing nothing. `u_Fade` drives a real dissolve rather than a dip in opacity: the ink fill runs its develop threshold *back down* through the same plane-local value noise it soaked in through, so the same patches that spread in are the ones that recede, and the grid erodes through that noise too. Only the outline plain-fades — a line loop is too thin to read as patchy.
- **The FBO cache would have frozen it.** Perception layers are cached and only redrawn when the pose moves or the map grows, so a dissolve would have stalled part-way the moment the artist held the phone still — exactly when they are watching it. `PlaneRenderer` publishes when its last in-progress dissolve completes and `ArRenderer` counts that as a reason to refresh.

Per-plane timers are keyed on the ARCore trackable (equals/hashCode cover the underlying native object) and pruned every pass to the planes still being drawn, so a long session can't accumulate entries for trackables ARCore has dropped.

## 5. Rail menu disabled

Per `docs/AZNAVRAIL_COMPLETE_GUIDE.md`, `noMenu` (11.0) removes the side drawer entirely, makes every entry a rail item, and makes the app-icon tap fold the rail up into the icon. It was only asserted in Design mode / library / hidden-rail; it is now asserted in every mode.

Nothing is lost by doing so: the app declares **no drawer-only entries at all** — no `azMenuItem`, `azMenuToggle`, `azMenuCycler` or `azMenu*Host` anywhere; every entry is an `azRailItem`, `azRailHostItem` or `azRailSubItem` — so the side drawer only ever duplicated the rail. Disabling it everywhere also extends the app-icon fold and AzNavRail's `isExpanded=false` initialisation (which keeps its outer `fillMaxSize` Box from attaching `tapOutsideToCollapse` over the screen) to AR, Overlay, Mockup and Trace.

## Testing

CI is green on this head: both `unit-tests` and both `build-and-release` jobs pass, so the Kotlin and the C++ compile and the tests pass. `Analyze (c-cpp)` is also green.

`PlaneCoplanarityTest` covers the two pieces of new logic that are testable off-device:
- Co-planarity geometry — patches across one wall merge, depth jitter within tolerance merges, anti-parallel normals on one plane merge; perpendicular surfaces, an offset pillar face and opposite corridor walls stay separate.
- Dissolve timing — full through the 5 s hold, linear ramp across the 10 s dissolve, gone at 15 s and staying gone.

Everything else is **unverified on device** — this environment has no Android SDK, so the rendering, camera and native-path behaviour is reviewed by reading only. Worth checking on hardware:

- Frame rate during scanning specifically (that's where the discarded reloc conversions were worst).
- That `FocusMode.AUTO` doesn't reintroduce the tracking instability on the devices that motivated `FIXED` — the safe-mode fallback only kicks in after a camera stall has already been observed once. **This is the highest-risk change in the PR.**
- That the co-planar tolerances (~14°, 10 cm) merge a real wall without fusing surfaces that should stay distinct.
- That the dissolve keeps running smoothly while the phone is held still.