### PR TITLE
fix: stop app state emptying the rail, and mode-gate the mode tools

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -442,12 +442,6 @@ class MainActivity : ComponentActivity() {
                     mainViewModel.setTouchLocked(false)
                 }
 
-                val isRailVisible = !editorUiState.hideUiForCapture &&
-                        !mainUiState.isTouchLocked &&
-                        !mainUiState.isCapturingTarget &&
-                        !showSettings &&
-                        !isExporting
-
                 // noMenu (AzNavRail 11.0) removes the side drawer entirely — all entries become rail
                 // items — and makes the app-icon tap FOLD THE RAIL UP INTO THE ICON (the scope tracks
                 // this as `isFoldedUp`).
@@ -459,7 +453,11 @@ class MainActivity : ComponentActivity() {
                 // everywhere also means the app-icon fold and AzNavRail's isExpanded=false
                 // initialisation — which keeps its outer fillMaxSize Box from attaching
                 // tapOutsideToCollapse over the screen — apply in AR, Overlay, Mockup and Trace too,
-                // not only Design/library/hidden-rail.
+                // not only Design.
+                //
+                // Folding is the ONLY thing that hides rail items. App state must never withhold
+                // them: the icon stays on screen either way, so an empty rail turns a tap on it into
+                // a dead input with no way back. See the unconditional ConfigureRailItems below.
                 val railMenuDisabled = true
 
                 var permissionRequestedAtLeastOnce by remember { mutableStateOf(hasCameraPermission) }
@@ -680,70 +678,83 @@ class MainActivity : ComponentActivity() {
                     // onboarding text, and per-mode goals that self-activate on mode entry.
                     ConfigureGuidance(editorUiState, arUiState, context, strings)
 
-                    if (isRailVisible) {
-                        ConfigureRailItems(
-                            mainViewModel, editorViewModel, arViewModel, dashboardViewModel, context,
-                            overlayImagePicker, backgroundImagePicker, editorUiState, railExpansion, arUiState, strings,
-                            navItemColor = navItemColor,
-                            showLibrary = showLibrary,
-                            coopState = coopState,
-                            isTouchLocked = mainUiState.isTouchLocked,
-                            isWaitingForTap = mainUiState.isWaitingForTap,
-                            onShowJoinScanner = { showJoinScanner = true },
-                            onWallPhoto = {
-                                if (hasCameraPermission) {
-                                    val tmpFile = File(context.cacheDir, "wall_camera_${System.currentTimeMillis()}.jpg")
-                                    val uri = FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", tmpFile)
-                                    cameraUri = uri.toString()
-                                    takePictureLauncher.launch(uri)
-                                } else {
-                                    permissionLauncher.launch(arrayOf(Manifest.permission.CAMERA, Manifest.permission.ACCESS_FINE_LOCATION))
+                    // Registered UNCONDITIONALLY. This used to be gated on an isRailVisible built from
+                    // hideUiForCapture / isTouchLocked / isCapturingTarget / showSettings /
+                    // isExporting, which emptied the rail outright in those states. The app icon stays
+                    // on screen regardless, so tapping it to bring the rail back did nothing — and
+                    // some of those states are reached FROM the rail (Trace ▸ Freeze locks touch;
+                    // Target starts a capture), so the button that got you in was the same button that
+                    // vanished. Whether items are on screen is AzNavRail's fold state, driven by the
+                    // user tapping the icon; it is not app state's call.
+                    //
+                    // Nothing needed those gates for correctness. hideUiForCapture is dead state (no
+                    // code ever sets it). Export never screenshots the Compose window — AR reads its GL
+                    // framebuffer, Overlay uses ImageCapture, the rest composite in the editor — so the
+                    // rail cannot leak into a capture. showLibrary is still honoured inside
+                    // ConfigureRailItems: that is a different navigation destination with its own UI,
+                    // not a state the user is stuck in.
+                    ConfigureRailItems(
+                        mainViewModel, editorViewModel, arViewModel, dashboardViewModel, context,
+                        overlayImagePicker, backgroundImagePicker, editorUiState, railExpansion, arUiState, strings,
+                        navItemColor = navItemColor,
+                        showLibrary = showLibrary,
+                        coopState = coopState,
+                        isTouchLocked = mainUiState.isTouchLocked,
+                        isWaitingForTap = mainUiState.isWaitingForTap,
+                        onShowJoinScanner = { showJoinScanner = true },
+                        onWallPhoto = {
+                            if (hasCameraPermission) {
+                                val tmpFile = File(context.cacheDir, "wall_camera_${System.currentTimeMillis()}.jpg")
+                                val uri = FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", tmpFile)
+                                cameraUri = uri.toString()
+                                takePictureLauncher.launch(uri)
+                            } else {
+                                permissionLauncher.launch(arrayOf(Manifest.permission.CAMERA, Manifest.permission.ACCESS_FINE_LOCATION))
+                            }
+                        },
+                        onExportRequested = {
+                            // Mode-aware dispatch of the Export rail button. The spec is
+                            // "screenshot of the mode's content minus the rail/settings" — nothing
+                            // here touches the Compose window, so no UI overlays leak in:
+                            //   - AR: ArRenderer already reads its GL framebuffer (camera + wall
+                            //     overlay quad). skipLayerComposite=true because the layers are
+                            //     already baked into the readback as the wall quad.
+                            //   - Overlay: CameraX ImageCapture yields the sensor still; the
+                            //     editor composites layers on top at screen positions.
+                            //   - Mockup / Trace / Design: no camera capture, editor composites
+                            //     against per-mode background (backgroundBitmap / transparent).
+                            when (editorUiState.editorMode) {
+                                EditorMode.AR -> {
+                                    isExporting = true
+                                    val requested = arViewModel.requestExport { bmp ->
+                                        isExporting = false
+                                        editorViewModel.exportImage(backgroundBitmap = bmp, skipLayerComposite = true)
+                                    }
+                                    if (!requested) {
+                                        // No renderer attached (e.g. AR mode without camera
+                                        // permission), so there is no framebuffer to read back.
+                                        // Export the layers alone rather than doing nothing.
+                                        isExporting = false
+                                        editorViewModel.exportImage()
+                                    }
                                 }
-                            },
-                            onExportRequested = {
-                                // Mode-aware dispatch of the Export rail button. The spec is
-                                // "screenshot of the mode's content minus the rail/settings" — nothing
-                                // here touches the Compose window, so no UI overlays leak in:
-                                //   - AR: ArRenderer already reads its GL framebuffer (camera + wall
-                                //     overlay quad). skipLayerComposite=true because the layers are
-                                //     already baked into the readback as the wall quad.
-                                //   - Overlay: CameraX ImageCapture yields the sensor still; the
-                                //     editor composites layers on top at screen positions.
-                                //   - Mockup / Trace / Design: no camera capture, editor composites
-                                //     against per-mode background (backgroundBitmap / transparent).
-                                when (editorUiState.editorMode) {
-                                    EditorMode.AR -> {
-                                        isExporting = true
-                                        val requested = arViewModel.requestExport { bmp ->
-                                            isExporting = false
-                                            editorViewModel.exportImage(backgroundBitmap = bmp, skipLayerComposite = true)
-                                        }
-                                        if (!requested) {
-                                            // No renderer attached (e.g. AR mode without camera
-                                            // permission), so there is no framebuffer to read back.
-                                            // Export the layers alone rather than doing nothing.
-                                            isExporting = false
+                                EditorMode.OVERLAY -> {
+                                    exportDispatchScope.launch {
+                                        try {
+                                            val bmp = cameraController.takePictureAsBitmap(context)
+                                            editorViewModel.exportImage(backgroundBitmap = bmp)
+                                        } catch (t: Throwable) {
+                                            // Fall back to a layers-only export so the user
+                                            // still gets something rather than a silent failure.
+                                            android.util.Log.w("MainActivity", "Overlay capture failed; exporting layers only", t)
                                             editorViewModel.exportImage()
                                         }
                                     }
-                                    EditorMode.OVERLAY -> {
-                                        exportDispatchScope.launch {
-                                            try {
-                                                val bmp = cameraController.takePictureAsBitmap(context)
-                                                editorViewModel.exportImage(backgroundBitmap = bmp)
-                                            } catch (t: Throwable) {
-                                                // Fall back to a layers-only export so the user
-                                                // still gets something rather than a silent failure.
-                                                android.util.Log.w("MainActivity", "Overlay capture failed; exporting layers only", t)
-                                                editorViewModel.exportImage()
-                                            }
-                                        }
-                                    }
-                                    else -> editorViewModel.exportImage()
                                 }
-                            },
-                        )
-                    }
+                                else -> editorViewModel.exportImage()
+                            }
+                        },
+                    )
 
                     background(weight = 0) {
                         MainScreen(
@@ -1631,33 +1642,42 @@ class MainActivity : ComponentActivity() {
             }
 
             // Mockup ▸ Wall ▸ { Photo (take a photo), File (pick an image) }
+            // Its tools are registered only while Mockup is the active mode, matching AR and Overlay
+            // above. They used to be registered unconditionally, so an artist lining up a wall in AR
+            // was carrying a Wall ▸ Photo/File/Clear folder and a Mockup Lock that could not act on
+            // anything they were looking at. Tapping Mockup routes into the mode, so the tools are one
+            // tap away rather than gone.
             azRailSubHostItem(id = "mode.mockup", hostId = "host.modes", text = navStrings.mockup, route = EditorMode.MOCKUP.name, color = navItemColor, shape = AzButtonShape.RECTANGLE)
-            azRailSubHostItem(id = "mockup.wall", hostId = "mode.mockup", text = navStrings.wall, color = navItemColor, shape = AzButtonShape.NONE)
-            azRailSubItem(id = "wall.photo", hostId = "mockup.wall", text = navStrings.photo, color = navItemColor, shape = AzButtonShape.NONE) {
-                onWallPhoto()
-            }
-            azRailSubItem(id = "wall.file", hostId = "mockup.wall", text = navStrings.file, color = navItemColor, shape = AzButtonShape.NONE) {
-                backgroundPicker.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
-            }
-            // Clear — only offered once a wall photo is set, so there is something to remove.
-            if (editorUiState.backgroundBitmap != null) {
-                azRailSubItem(id = "wall.clear", hostId = "mockup.wall", text = navStrings.wallClear, color = navItemColor, shape = AzButtonShape.NONE) {
-                    editorViewModel.clearBackgroundImage()
+            if (editorUiState.editorMode == EditorMode.MOCKUP) {
+                azRailSubHostItem(id = "mockup.wall", hostId = "mode.mockup", text = navStrings.wall, color = navItemColor, shape = AzButtonShape.NONE)
+                azRailSubItem(id = "wall.photo", hostId = "mockup.wall", text = navStrings.photo, color = navItemColor, shape = AzButtonShape.NONE) {
+                    onWallPhoto()
+                }
+                azRailSubItem(id = "wall.file", hostId = "mockup.wall", text = navStrings.file, color = navItemColor, shape = AzButtonShape.NONE) {
+                    backgroundPicker.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
+                }
+                // Clear — only offered once a wall photo is set, so there is something to remove.
+                if (editorUiState.backgroundBitmap != null) {
+                    azRailSubItem(id = "wall.clear", hostId = "mockup.wall", text = navStrings.wallClear, color = navItemColor, shape = AzButtonShape.NONE) {
+                        editorViewModel.clearBackgroundImage()
+                    }
+                }
+                val mockupLocked = editorUiState.modeAdjustments[EditorMode.MOCKUP]?.isTransformLocked == true
+                azRailSubItem(id = "mode.mockup.lock", hostId = "mode.mockup", text = "Lock", color = if (mockupLocked) Cyan else navItemColor, shape = AzButtonShape.NONE) {
+                    editorViewModel.onToggleModeTransformLocked(EditorMode.MOCKUP)
                 }
             }
-            val mockupLocked = editorUiState.modeAdjustments[EditorMode.MOCKUP]?.isTransformLocked == true
-            azRailSubItem(id = "mode.mockup.lock", hostId = "mode.mockup", text = "Lock", color = if (mockupLocked) Cyan else navItemColor, shape = AzButtonShape.NONE) {
-                editorViewModel.onToggleModeTransformLocked(EditorMode.MOCKUP)
-            }
 
-            // Trace ▸ Freeze
+            // Trace ▸ { Freeze, Lock } — same mode gating as the others.
             azRailSubHostItem(id = "mode.trace", hostId = "host.modes", text = navStrings.trace, route = EditorMode.TRACE.name, color = navItemColor, shape = AzButtonShape.RECTANGLE)
-            azRailSubItem(id = "mode.trace.freeze", hostId = "mode.trace", text = "Freeze", color = navItemColor, shape = AzButtonShape.NONE) {
-                mainViewModel.setTouchLocked(!isTouchLocked)
-            }
-            val traceLocked = editorUiState.modeAdjustments[EditorMode.TRACE]?.isTransformLocked == true
-            azRailSubItem(id = "mode.trace.lock", hostId = "mode.trace", text = "Lock", color = if (traceLocked) Cyan else navItemColor, shape = AzButtonShape.NONE) {
-                editorViewModel.onToggleModeTransformLocked(EditorMode.TRACE)
+            if (editorUiState.editorMode == EditorMode.TRACE) {
+                azRailSubItem(id = "mode.trace.freeze", hostId = "mode.trace", text = "Freeze", color = if (isTouchLocked) Cyan else navItemColor, shape = AzButtonShape.NONE) {
+                    mainViewModel.setTouchLocked(!isTouchLocked)
+                }
+                val traceLocked = editorUiState.modeAdjustments[EditorMode.TRACE]?.isTransformLocked == true
+                azRailSubItem(id = "mode.trace.lock", hostId = "mode.trace", text = "Lock", color = if (traceLocked) Cyan else navItemColor, shape = AzButtonShape.NONE) {
+                    editorViewModel.onToggleModeTransformLocked(EditorMode.TRACE)
+                }
             }
 
             // Help — opens AzNavRail's built-in help overlay (populated by azAdvanced(helpList=...)).

--- a/app/src/main/java/com/hereliesaz/graffitixr/RailIdEnumerator.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/RailIdEnumerator.kt
@@ -8,11 +8,14 @@ import com.hereliesaz.graffitixr.common.model.Layer
  * Pure function; no Compose. Used by tests (RailIdUniquenessTest) and the debug-only
  * RailIntegrityCheck.
  *
- * Conditional registration in ConfigureRailItems is mirrored here:
- *   - target.host / target.create only registered in AR mode
- *   - design.wall only registered in MOCKUP mode
- *   - coop / coop.host / coop.join only registered in AR mode (coop.leave is
- *     additionally gated on an active session, so it is omitted here)
+ * Conditional registration in ConfigureRailItems is mirrored here. Each mode's sub-host is always
+ * registered (it is the navigation entry); that mode's tools are registered only while it is active:
+ *   - target.create / mode.ar.light / mode.ar.lock / coop / coop.host / coop.join in AR mode
+ *     (coop.leave is additionally gated on an active session, so it is omitted here)
+ *   - mode.overlay.light / mode.overlay.lock in OVERLAY mode
+ *   - mockup.wall / wall.photo / wall.file / mode.mockup.lock in MOCKUP mode
+ *     (wall.clear is additionally gated on a wall photo existing, so it is omitted here)
+ *   - mode.trace.freeze / mode.trace.lock in TRACE mode
  *
  * CAVEAT: the per-layer block below emits the UNION of every layer-menu suffix, whereas
  * ConfigureRailItems registers a different suffix subset per layer type (text vs sketch vs
@@ -36,17 +39,26 @@ internal fun enumerateRailItemIds(layers: List<Layer>, mode: EditorMode): Set<St
 internal fun enumerateRailItemIdRegistrations(layers: List<Layer>, mode: EditorMode): List<String> {
     val ids = mutableListOf<String>()
 
-    // Modes menu
-    ids += listOf(
-        "host.modes", "mode.ar", "mode.overlay", "mode.mockup", "mode.trace", "mockup.wall", "mode.trace.freeze"
-    )
+    // Modes menu. Every mode's sub-host is always registered (they are the navigation entries); each
+    // mode's TOOLS are registered only while that mode is active.
+    ids += listOf("host.modes", "mode.ar", "mode.overlay", "mode.mockup", "mode.trace")
     if (mode == EditorMode.AR) {
         ids += "target.create"
         ids += "mode.ar.light"
+        ids += "mode.ar.lock"
         ids += listOf("coop", "coop.host", "coop.join")
     }
     if (mode == EditorMode.OVERLAY) {
         ids += "mode.overlay.light"
+        ids += "mode.overlay.lock"
+    }
+    if (mode == EditorMode.MOCKUP) {
+        // wall.clear is additionally gated on a wall photo existing, so it is omitted here for the
+        // same reason as coop.leave.
+        ids += listOf("mockup.wall", "wall.photo", "wall.file", "mode.mockup.lock")
+    }
+    if (mode == EditorMode.TRACE) {
+        ids += listOf("mode.trace.freeze", "mode.trace.lock")
     }
 
     // Open (top-level, replaces the old Design folder — no sub-items)


### PR DESCRIPTION
## 1. Tapping the app icon could not bring the rail back

`ConfigureRailItems` was gated on an `isRailVisible` built from `hideUiForCapture`, `isTouchLocked`, `isCapturingTarget`, `showSettings` and `isExporting`. In any of those states the rail was registered with **zero items**, so the app icon — which stays on screen regardless — became a dead tap with no way back.

Worse, two of those states are entered *from the rail*: `Trace ▸ Freeze` locks touch, and `Target` starts a capture. The button that got you in was the same button that vanished.

Whether items are on screen is AzNavRail's fold state, driven by the user tapping the icon. It isn't app state's call, so the registration is now unconditional.

None of those gates were load-bearing:

- **`hideUiForCapture` is dead state** — nothing in the codebase ever sets it. `EditorModels.kt` declares it, `AdjustmentsPanel` and this gate read it, no writer exists.
- **Export never screenshots the Compose window.** AR reads its own GL framebuffer, Overlay uses CameraX `ImageCapture`, and Mockup/Trace/Design composite in the editor — as the existing comment at the export dispatch already documents. The rail cannot leak into a capture.
- **`showLibrary` is still honoured** inside `ConfigureRailItems`. That's a separate navigation destination with its own UI, not a state the user is stuck in.

## 2. Mode tools no longer follow you into other modes

AR and Overlay already registered their tools only while their mode was active. Mockup and Trace did not, so an artist lining up a wall in AR was carrying a `Wall ▸ Photo/File/Clear` folder, a Mockup `Lock` and a Trace `Freeze`/`Lock` that could not act on anything in front of them.

They're now gated the same way. Tapping the mode routes into it, so the tools are one tap away rather than gone.

The rail now reads, per mode:

```
Open
—
Project ▸ New, Save, Export, Load, Settings
—
Modes ▸ AR ▸ Target, Light, Lock, Co-op ▸ Host, Join, Leave   (in AR)
        Overlay ▸ Light, Lock                                  (in Overlay)
        Mockup ▸ Wall ▸ Photo, File, Clear · Lock              (in Mockup)
        Trace ▸ Freeze, Lock                                   (in Trace)
—
Help
```

`Trace ▸ Freeze` also goes cyan while engaged, matching `Lock` and `Light` — and now that the rail survives touch lock, it's reachable to switch back off.

## Notes

`RailIdEnumerator` mirrors the new gating so `RailIdUniquenessTest` keeps modelling the real rail; the per-mode `Lock` ids it had never covered are included too.

`RailIntegrityCheck` will now log its existing debug-only "no matching rail item" warning for `mockup.wall` and `mode.trace.freeze` when you're not in those modes. That's the same benign pattern `target.create` (AR-only) already produces — the help list and guidance graph legitimately name items that only exist in their own mode.

## Testing

Unit tests only (`RailIdUniquenessTest` still passes over the updated enumerator). No Android SDK in this environment, so CI is the first compile check and the rail behaviour itself is unverified on device. Worth confirming:

- Tapping the app icon folds and unfolds the rail in every mode, including while touch is locked and during a target capture.
- `Trace ▸ Freeze` can now be switched back off from the rail rather than only by the four-tap unlock.

**Scope check:** for "remove the unnecessary stuff" I read *unnecessary* as items that can't act on the current mode, and removed those. I did not delete any feature — Co-op, the per-mode Locks, Project ▸ Settings and so on are all still there. If you meant specific buttons should go entirely, name them and I'll pull them.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E3E6oVmJoHRHoUpwatsVwv)_

## Summary by Sourcery

Keep the navigation rail permanently registered and gate mode-specific tools so they only appear in their active mode.

Bug Fixes:
- Ensure the app icon can always fold/unfold the navigation rail by preventing app state from unregistering rail items in capture, touch-lock, or export states.
- Allow Trace ▸ Freeze to be toggled off from the rail even while touch is locked.

Enhancements:
- Restrict Mockup and Trace tools to their respective active modes, aligning behaviour with AR and Overlay and reducing irrelevant tools in other modes.
- Highlight Trace ▸ Freeze in cyan while engaged, matching the visual feedback of other lock/light controls.
- Update rail ID enumeration to mirror new mode-based tool registration so integrity checks and uniqueness tests match runtime behaviour.