### PR TITLE
fix: make relocalization reachable, and its failures legible

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -2084,6 +2084,13 @@ private fun DiagnosticOverlay(
 private val EVAL_OVERLAY_ENABLED = com.hereliesaz.graffitixr.BuildConfig.DEBUG
 
 /**
+ * Live-frame feature count below which a match shortfall is blamed on the capture (dark, blurred,
+ * blank wall) rather than on aim. The detector is configured for 1500, and a fingerprint needs 20 to
+ * exist at all, so a frame yielding under 100 is starved regardless of where it's pointed.
+ */
+private const val FEW_FEATURES_IN_FRAME = 100
+
+/**
  * Live relocalization state: whether the wall fingerprint exists, whether PnP is locking, and if not,
  * which gate the last attempt missed and by how much.
  *
@@ -2107,7 +2114,13 @@ private fun RelocDiagnosticsOverlay(
         RelocReject.NO_FEATURES ->
             "NO FEATURES" to "frame has no texture — light, focus or blur"
         RelocReject.FEW_MATCHES ->
-            "${d.matches}/8 MATCHES" to "aim at the registered marks, closer and squarer"
+            // Same shortfall, opposite causes. Few features in frame at all is a capture problem;
+            // plenty of features that don't match is an aiming problem.
+            "${d.matches}/8 MATCHES" to if (d.detected < FEW_FEATURES_IN_FRAME) {
+                "only ${d.detected} features in frame — more light, or a more detailed patch"
+            } else {
+                "${d.detected} features but few match — aim at the registered marks, closer and squarer"
+            }
         RelocReject.PNP_FAILED ->
             "NO POSE" to "${d.matches} matches, none geometrically consistent"
         RelocReject.FEW_INLIERS ->
@@ -2133,6 +2146,7 @@ private fun RelocDiagnosticsOverlay(
             "Inliers", "${d.inliers}/${d.matches} (${(d.inlierRatio * 100).toInt()}%)",
             androidx.compose.ui.graphics.Color.White,
         )
+        DiagnosticRow("In frame", "${d.detected} features", androidx.compose.ui.graphics.Color.White)
         DiagnosticRow("FP pts", fingerprintPoints.toString(), androidx.compose.ui.graphics.Color.Cyan)
         DiagnosticRow("Corroborated", "${(paintingProgress * 100).toInt()}%", androidx.compose.ui.graphics.Color.White)
     }

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -119,6 +119,8 @@ import com.hereliesaz.graffitixr.feature.dashboard.SettingsViewModel
 import com.hereliesaz.graffitixr.feature.editor.EditorUi
 import com.hereliesaz.graffitixr.feature.editor.EditorViewModel
 import com.hereliesaz.graffitixr.nativebridge.SlamManager
+import com.hereliesaz.graffitixr.common.model.RelocDiagnostics
+import com.hereliesaz.graffitixr.common.model.RelocReject
 import com.hereliesaz.graffitixr.common.model.RelocState
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Dispatchers
@@ -361,14 +363,15 @@ class MainActivity : ComponentActivity() {
                 LaunchedEffect(currentTempCapture, currentCaptureStep, isWaitingForTap) {
                     if (currentTempCapture != null) {
                         val tapPath = currentCaptureStep == CaptureStep.NONE && isWaitingForTap
-                        // Depth-off (single-capture) target creation back-projects onto the green
-                        // ARCore wall plane, so it needs one. Gate BEFORE the review step: if the tap
-                        // wasn't on a green wall, discard the frame and let the artist re-aim/re-tap,
-                        // rather than letting them erase marks on a capture we'd reject at confirm.
+                        // Depth-off (single-capture) target creation back-projects onto an ARCore wall
+                        // plane, so it needs one. Gate BEFORE the review step: if the tap landed on no
+                        // tracked surface, discard the frame and let the artist re-aim/re-tap, rather
+                        // than letting them erase marks on a capture we'd reject at confirm.
+                        // (The plane no longer has to be green — see the hit-test in ArRenderer.)
                         val depthOff = arUiState.targetDepthBuffer == null
                         val plane = arUiState.targetWallPlane
-                        val onGreenWall = plane != null && plane.size >= 6
-                        if (tapPath && depthOff && !onGreenWall) {
+                        val onWall = plane != null && plane.size >= 6
+                        if (tapPath && depthOff && !onWall) {
                             arViewModel.clearCaptureForRetry()
                             mainViewModel.notifyTargetNotOnWall()
                         } else if (tapPath) {
@@ -1083,6 +1086,20 @@ class MainActivity : ComponentActivity() {
 
                             if (editorUiState.editorMode == EditorMode.AR && !showLibrary && !showSettings) {
                                 AnchorLockFlash(isAnchorEstablished = arUiState.isAnchorEstablished, strings = strings)
+                            }
+
+                            // Relocalization state — available in RELEASE too, behind the same opt-in
+                            // Diagnostic Overlay setting. The eval panel below is a dev instrument and
+                            // stays debug-only, but "is relocalization working, and if not which gate
+                            // is it missing" is the question an artist in the field needs answered,
+                            // and it was only reachable through logcat on a debug build.
+                            if (editorUiState.showDiagOverlay && editorUiState.editorMode == EditorMode.AR &&
+                                !showLibrary && !showSettings && !mainUiState.isCapturingTarget) {
+                                RelocDiagnosticsOverlay(
+                                    diagnostics = arUiState.relocDiagnostics,
+                                    fingerprintPoints = arUiState.evalLiveMetrics.wallCount,
+                                    paintingProgress = arUiState.paintingProgress,
+                                )
                             }
 
                             // Dev/eval overlay: debug builds only, and off unless the user opts in
@@ -2065,6 +2082,61 @@ private fun DiagnosticOverlay(
 
 // Eval overlay only renders in debug builds; production users never see it.
 private val EVAL_OVERLAY_ENABLED = com.hereliesaz.graffitixr.BuildConfig.DEBUG
+
+/**
+ * Live relocalization state: whether the wall fingerprint exists, whether PnP is locking, and if not,
+ * which gate the last attempt missed and by how much.
+ *
+ * This is deliberately shipped in release (behind the Diagnostic Overlay setting) because the failure
+ * modes are all silent otherwise — a relocalizer that has never locked once looks exactly like one
+ * that is idle, and the counters that did exist only updated on success.
+ */
+@Composable
+private fun RelocDiagnosticsOverlay(
+    diagnostics: RelocDiagnostics,
+    fingerprintPoints: Int,
+    paintingProgress: Float,
+) {
+    val d = diagnostics
+    // What to DO about it, not just what happened.
+    val (label, hint) = when (d.reject) {
+        RelocReject.OK -> "LOCKED" to "matching the wall"
+        RelocReject.NO_FINGERPRINT ->
+            "NO TARGET" to "create a target — nothing to match against"
+        RelocReject.DISABLED -> "OFF" to "relocalization disabled"
+        RelocReject.NO_FEATURES ->
+            "NO FEATURES" to "frame has no texture — light, focus or blur"
+        RelocReject.FEW_MATCHES ->
+            "${d.matches}/8 MATCHES" to "aim at the registered marks, closer and squarer"
+        RelocReject.PNP_FAILED ->
+            "NO POSE" to "${d.matches} matches, none geometrically consistent"
+        RelocReject.FEW_INLIERS ->
+            "${d.inliers}/6 INLIERS" to "close — hold steadier, or get square to the wall"
+        RelocReject.UNKNOWN -> "—" to "waiting for the first attempt"
+    }
+    val locked = d.reject == RelocReject.OK
+    androidx.compose.foundation.layout.Column(
+        androidx.compose.ui.Modifier
+            .background(androidx.compose.ui.graphics.Color(0xAA000000))
+            .padding(8.dp)
+    ) {
+        DiagnosticRow(
+            "Reloc", label,
+            if (locked) androidx.compose.ui.graphics.Color.Green else androidx.compose.ui.graphics.Color.Yellow,
+        )
+        if (hint.isNotEmpty()) {
+            DiagnosticRow("", hint, androidx.compose.ui.graphics.Color.LightGray)
+        }
+        // The ratio is what PoseFusion actually gates on (>= 0.5 to correct at all, >= 0.7 with 20+
+        // inliers to hard-snap), so show it rather than making the artist divide two numbers.
+        DiagnosticRow(
+            "Inliers", "${d.inliers}/${d.matches} (${(d.inlierRatio * 100).toInt()}%)",
+            androidx.compose.ui.graphics.Color.White,
+        )
+        DiagnosticRow("FP pts", fingerprintPoints.toString(), androidx.compose.ui.graphics.Color.Cyan)
+        DiagnosticRow("Corroborated", "${(paintingProgress * 100).toInt()}%", androidx.compose.ui.graphics.Color.White)
+    }
+}
 
 @Composable
 private fun EvalOverlay(

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -2147,6 +2147,14 @@ private fun RelocDiagnosticsOverlay(
             androidx.compose.ui.graphics.Color.White,
         )
         DiagnosticRow("In frame", "${d.detected} features", androidx.compose.ui.graphics.Color.White)
+        // Whether the plane-guided rectification pass is firing. It was dead in practice until the
+        // capture view started being stored, so seeing a real angle here is the confirmation that it
+        // now runs; "off" means it wasn't eligible (no capture view, not tracking, too few points).
+        DiagnosticRow(
+            "Oblique",
+            if (d.obliquityDeg < 0) "off" else "${d.obliquityDeg}° +${d.rectifiedCorrespondences} corr",
+            androidx.compose.ui.graphics.Color.White,
+        )
         DiagnosticRow("FP pts", fingerprintPoints.toString(), androidx.compose.ui.graphics.Color.Cyan)
         DiagnosticRow("Corroborated", "${(paintingProgress * 100).toInt()}%", androidx.compose.ui.graphics.Color.White)
     }

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainViewModel.kt
@@ -329,10 +329,12 @@ class MainViewModel @Inject constructor(
                 context = context,
                 projectData = currentProject.copy(
                     fingerprint = fp.copy(patchData = patch),
-                    // Persist the capture's intrinsics + anchor — the exact values just fed to
-                    // restoreWallFingerprintMetric — so reload relocalizes with the true intrinsics.
+                    // Persist the capture's intrinsics + anchor + view — the exact values just fed to
+                    // restoreWallFingerprintMetric — so reload relocalizes with the true intrinsics
+                    // and keeps the plane-guided rectification that the capture session had.
                     fingerprintIntrinsics = intr.toList(),
                     fingerprintAnchor = anchor.toList(),
+                    fingerprintViewMatrix = view.toList(),
                 ),
                 targetImages = listOf(bitmap)
             )

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainViewModel.kt
@@ -276,10 +276,22 @@ class MainViewModel @Inject constructor(
                 slamManager, bitmap, view, intr, planePoint, planeNormal, anchor
             )
             if (fp == null) {
+                // Say WHICH way it fell short. "Not enough texture" was the same message whether the
+                // frame was blank, out of focus, or full of features that simply missed the plane —
+                // three problems with three different fixes, and no way to tell them apart.
+                val detected = MetricFingerprintBuilder.lastDetected
+                val placed = MetricFingerprintBuilder.lastPlaced
+                val need = MetricFingerprintBuilder.lastRequired
+                val message = when {
+                    detected < need ->
+                        "Only $detected features on this wall (need $need). Too dark, too smooth, " +
+                            "or out of focus — try a more detailed patch or more light."
+                    else ->
+                        "Found $detected features but only $placed landed on the wall surface " +
+                            "(need $need). Aim at the middle of the detected wall, square on."
+                }
                 withContext(Dispatchers.Main) {
-                    Toast.makeText(context,
-                        "Not enough texture on the wall to lock a target. Try a more detailed area.",
-                        Toast.LENGTH_LONG).show()
+                    Toast.makeText(context, message, Toast.LENGTH_LONG).show()
                 }
                 return@launch
             }
@@ -307,11 +319,14 @@ class MainViewModel @Inject constructor(
         }
     }
 
-    // Shared guidance shown when single-capture target creation isn't aimed at a green wall plane
+    // Shared guidance shown when single-capture target creation lands on no tracked wall plane at all
     // (used by both the pre-review gate and the handleSingleCapture backstop). Toast-in-VM matches the
     // existing capture toasts here; a full AppStrings/event-channel i18n pass is a separate cleanup.
+    //
+    // No longer says "green": any tracked plane under the tap is accepted now (see the wall-plane
+    // hit-test in ArRenderer), so the only real failure is aiming where no surface has been detected.
     private val notOnGreenWallMessage =
-        "Aim at a wall shown in green (face it straight-on, within ~3 m), then tap your marks."
+        "No wall detected there yet. Sweep the phone across the surface until it's outlined, then tap."
 
     /**
      * The single-capture tap wasn't on a green (parallel, in-range) wall plane. Guide the artist;

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainViewModel.kt
@@ -152,13 +152,25 @@ class MainViewModel @Inject constructor(
         viewMatrix: FloatArray? = null,
         wallPlane: FloatArray? = null
     ) {
-        if (bitmap == null || intrinsics == null || viewMatrix == null) { resetCaptureUi(); return }
+        if (bitmap == null || intrinsics == null || viewMatrix == null) {
+            // Was a bare reset: the artist confirmed a target and the capture simply vanished with no
+            // message, indistinguishable from the app ignoring the tap. Name it — these are ARCore
+            // frame values that should always be present by confirm time, so if this fires it is a
+            // real bug worth reporting rather than something to re-aim around.
+            resetCaptureUi()
+            Toast.makeText(
+                context,
+                "Capture incomplete (missing camera pose). Try creating the target again.",
+                Toast.LENGTH_LONG,
+            ).show()
+            return
+        }
         val safeIntr = intrinsics
         val safeView = viewMatrix
 
         if (depthBuffer == null) {
             // No depth source: build the wall fingerprint from a SINGLE capture by back-projecting
-            // features onto the green ARCore wall plane (whose metric pose ARCore already solved).
+            // features onto the ARCore wall plane (whose metric pose ARCore already solved).
             handleSingleCapture(bitmap, safeIntr, safeView, wallPlane)
             return
         }
@@ -271,7 +283,20 @@ class MainViewModel @Inject constructor(
         // Clear any prior marks-centering override; the builder re-publishes it on a successful build.
         slamManager.overlayMarkCenterLocal = null
         viewModelScope.launch(Dispatchers.IO) {
-            val currentProject = projectRepository.currentProject.value ?: return@launch
+            // A fingerprint is persisted INTO a project, so without one there is nowhere to put it.
+            // This was a bare `?: return@launch`: the artist aimed, tapped, confirmed, and nothing
+            // happened — no target, no error, no clue that the missing piece was a project.
+            val currentProject = projectRepository.currentProject.value
+            if (currentProject == null) {
+                withContext(Dispatchers.Main) {
+                    Toast.makeText(
+                        context,
+                        "No project open — a target is saved into a project. Open or create one first.",
+                        Toast.LENGTH_LONG,
+                    ).show()
+                }
+                return@launch
+            }
             val fp = MetricFingerprintBuilder.buildSingle(
                 slamManager, bitmap, view, intr, planePoint, planeNormal, anchor
             )

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/GraffitiProject.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/GraffitiProject.kt
@@ -138,6 +138,16 @@ data class GraffitiProject(
     val fingerprintIntrinsics: List<Float> = emptyList(),
     val fingerprintAnchor: List<Float> = emptyList(),
 
+    // The camera view (column-major 4x4, GL convention world→camera) at fingerprint capture. This is
+    // what lets the reloc thread pre-cancel oblique-vs-frontal distortion: the marks lie on a known
+    // plane, so with the capture view and the live view it can warp the live frame into the
+    // fingerprint's frontal frame, match there, and map the correspondences back.
+    // Without it MobileGS::computeRectifyHomography returns false and that whole pass is skipped —
+    // which is what happened to every metric fingerprint, since only the (dead, depth-API) capture
+    // path ever set it. An artist working a wall at arm's length is oblique most of the time, so this
+    // is exactly the case it exists for. Empty on projects saved before this field.
+    val fingerprintViewMatrix: List<Float> = emptyList(),
+
     // Persistent confidence-weighted feature map of the wall around the marks fingerprint — the
     // lean spatial backbone for wide-area relocalization (see docs/RELOC_MAP_DESIGN.md). Null on
     // projects without one; built passively during normal use. Defaulted for back-compat.

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/RelocDiagnostics.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/RelocDiagnostics.kt
@@ -17,6 +17,12 @@ data class RelocDiagnostics(
     val matches: Int = 0,
     /** RANSAC inliers the last attempt found. Publishing needs 6; PoseFusion trusts a ratio ≥ 0.5. */
     val inliers: Int = 0,
+    /**
+     * Features detected in the live frame before any matching. Separates "this frame has no texture
+     * to work with" (dark, blurred, blank wall) from "plenty of texture, none of it the registered
+     * wall" (aimed somewhere else) — a low match count means opposite things in those two cases.
+     */
+    val detected: Int = 0,
 ) {
     /** Inlier ratio of the last attempt, or 0 when it produced no correspondences. */
     val inlierRatio: Float get() = if (matches > 0) inliers.toFloat() / matches else 0f

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/RelocDiagnostics.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/RelocDiagnostics.kt
@@ -23,6 +23,14 @@ data class RelocDiagnostics(
      * wall" (aimed somewhere else) — a low match count means opposite things in those two cases.
      */
     val detected: Int = 0,
+    /**
+     * Obliquity (degrees between the wall normal and the optical axis) measured by the plane-guided
+     * rectification pass, or -1 when that pass wasn't eligible — no capture view stored, ARCore not
+     * tracking, or too few fingerprint points. The pass only warps above 25°.
+     */
+    val obliquityDeg: Int = -1,
+    /** Correspondences the rectification pass contributed on top of the plain and scaled passes. */
+    val rectifiedCorrespondences: Int = 0,
 ) {
     /** Inlier ratio of the last attempt, or 0 when it produced no correspondences. */
     val inlierRatio: Float get() = if (matches > 0) inliers.toFloat() / matches else 0f

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/RelocDiagnostics.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/RelocDiagnostics.kt
@@ -1,0 +1,46 @@
+package com.hereliesaz.graffitixr.common.model
+
+/**
+ * Why the last relocalization attempt did not publish a pose, and how far it got.
+ *
+ * Every one of these failures used to be silent. The only published counters updated on SUCCESS, so a
+ * relocalizer that had never locked once was indistinguishable from an idle one — all zeros, forever,
+ * with no way to tell whether the fingerprint was missing, the frame had no texture, or PnP was
+ * solving and falling one inlier short.
+ *
+ * Lives in `core:common` rather than next to `SlamManager` so both the AR UI state and the native
+ * bridge can name the same type.
+ */
+data class RelocDiagnostics(
+    val reject: RelocReject = RelocReject.UNKNOWN,
+    /** Correspondences the last attempt built. PnP needs 8. */
+    val matches: Int = 0,
+    /** RANSAC inliers the last attempt found. Publishing needs 6; PoseFusion trusts a ratio ≥ 0.5. */
+    val inliers: Int = 0,
+) {
+    /** Inlier ratio of the last attempt, or 0 when it produced no correspondences. */
+    val inlierRatio: Float get() = if (matches > 0) inliers.toFloat() / matches else 0f
+}
+
+/**
+ * Mirrors `MobileGS::RelocReject`, ordinal for ordinal — the native side reports an int. Ordered by
+ * how early the gate sits in the pipeline, so a larger value means the attempt got further.
+ */
+enum class RelocReject {
+    /** Published a pose. */
+    OK,
+    /** No wall fingerprint yet, or one carrying descriptors but no 3D points. */
+    NO_FINGERPRINT,
+    /** Relocalization switched off. */
+    DISABLED,
+    /** Nothing detected in the live frame, or a descriptor type that can't compare. */
+    NO_FEATURES,
+    /** Fewer than 8 correspondences survived the Lowe ratio test. */
+    FEW_MATCHES,
+    /** solvePnPRansac found no consistent pose. */
+    PNP_FAILED,
+    /** PnP solved but fewer than 6 inliers agreed. */
+    FEW_INLIERS,
+    /** The native side reported a code this build doesn't know. */
+    UNKNOWN,
+}

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/UiState.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/UiState.kt
@@ -211,6 +211,11 @@ data class ArUiState(
     val trackingFailed: Boolean = false,
 
     val evalLiveMetrics: EvalLiveMetrics = EvalLiveMetrics(),
+
+    // Live relocalization state: locked, or which gate the last attempt missed. Surfaced by the
+    // Diagnostic Overlay in release as well as debug — every one of these failures is otherwise
+    // silent, which is why "it never works" was so hard to pin down.
+    val relocDiagnostics: RelocDiagnostics = RelocDiagnostics(),
 )
 
 enum class CoopRole { NONE, HOST, GUEST }

--- a/core/common/src/test/java/com/hereliesaz/graffitixr/common/model/RelocDiagnosticsTest.kt
+++ b/core/common/src/test/java/com/hereliesaz/graffitixr/common/model/RelocDiagnosticsTest.kt
@@ -38,6 +38,10 @@ class RelocDiagnosticsTest {
         assertEquals(RelocReject.UNKNOWN, RelocDiagnostics().reject)
         assertEquals(0, RelocDiagnostics().matches)
         assertEquals(0, RelocDiagnostics().detected)
+        // -1, not 0: zero degrees is a legitimate measurement (dead-on square to the wall), so the
+        // "rectification wasn't eligible" state needs its own value.
+        assertEquals(-1, RelocDiagnostics().obliquityDeg)
+        assertEquals(0, RelocDiagnostics().rectifiedCorrespondences)
     }
 
     /**

--- a/core/common/src/test/java/com/hereliesaz/graffitixr/common/model/RelocDiagnosticsTest.kt
+++ b/core/common/src/test/java/com/hereliesaz/graffitixr/common/model/RelocDiagnosticsTest.kt
@@ -1,0 +1,41 @@
+package com.hereliesaz.graffitixr.common.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class RelocDiagnosticsTest {
+
+    /**
+     * The native side reports the reject as a raw int and the Kotlin side reads it by ordinal, so the
+     * two enums have to stay ordinal-for-ordinal. These are the values in MobileGS::RelocReject.
+     */
+    @Test
+    fun `reject ordinals match the native contract`() {
+        assertEquals(0, RelocReject.OK.ordinal)
+        assertEquals(1, RelocReject.NO_FINGERPRINT.ordinal)
+        assertEquals(2, RelocReject.DISABLED.ordinal)
+        assertEquals(3, RelocReject.NO_FEATURES.ordinal)
+        assertEquals(4, RelocReject.FEW_MATCHES.ordinal)
+        assertEquals(5, RelocReject.PNP_FAILED.ordinal)
+        assertEquals(6, RelocReject.FEW_INLIERS.ordinal)
+        // UNKNOWN is Kotlin-only: it absorbs any code a future native build reports.
+        assertEquals(7, RelocReject.UNKNOWN.ordinal)
+    }
+
+    @Test
+    fun `inlier ratio is inliers over matches`() {
+        assertEquals(0.5f, RelocDiagnostics(RelocReject.OK, matches = 40, inliers = 20).inlierRatio, 1e-4f)
+        assertEquals(1f, RelocDiagnostics(RelocReject.OK, matches = 12, inliers = 12).inlierRatio, 1e-4f)
+    }
+
+    @Test
+    fun `inlier ratio is zero rather than NaN when nothing matched`() {
+        assertEquals(0f, RelocDiagnostics(RelocReject.NO_FEATURES).inlierRatio, 1e-4f)
+    }
+
+    @Test
+    fun `default is the never-attempted state, not a fake success`() {
+        assertEquals(RelocReject.UNKNOWN, RelocDiagnostics().reject)
+        assertEquals(0, RelocDiagnostics().matches)
+    }
+}

--- a/core/common/src/test/java/com/hereliesaz/graffitixr/common/model/RelocDiagnosticsTest.kt
+++ b/core/common/src/test/java/com/hereliesaz/graffitixr/common/model/RelocDiagnosticsTest.kt
@@ -37,5 +37,19 @@ class RelocDiagnosticsTest {
     fun `default is the never-attempted state, not a fake success`() {
         assertEquals(RelocReject.UNKNOWN, RelocDiagnostics().reject)
         assertEquals(0, RelocDiagnostics().matches)
+        assertEquals(0, RelocDiagnostics().detected)
+    }
+
+    /**
+     * The same match shortfall means opposite things depending on how much texture the frame had, so
+     * the two have to be independently readable.
+     */
+    @Test
+    fun `detected count is independent of the match count`() {
+        val starved = RelocDiagnostics(RelocReject.FEW_MATCHES, matches = 3, inliers = 0, detected = 12)
+        val misaimed = RelocDiagnostics(RelocReject.FEW_MATCHES, matches = 3, inliers = 0, detected = 1400)
+        assertEquals(starved.matches, misaimed.matches)
+        assertEquals(12, starved.detected)
+        assertEquals(1400, misaimed.detected)
     }
 }

--- a/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
+++ b/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
@@ -881,7 +881,7 @@ Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeRestoreWallFingerp
 JNIEXPORT void JNICALL
 Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeRestoreWallFingerprintMetric(
         JNIEnv* env, jobject thiz, jbyteArray descArray, jint rows, jint cols, jint type,
-        jfloatArray ptsArray, jfloatArray anchorArray, jfloatArray intrArray) {
+        jfloatArray ptsArray, jfloatArray anchorArray, jfloatArray intrArray, jfloatArray viewArray) {
     // Same defensive validation as the plain restore: reject a malformed/old .gxr before cv::Mat
     // wraps the descriptor blob (valid OpenCV type + 64-bit overflow-safe size check), and only pass
     // anchor/intrinsics when correctly sized (native copies a fixed 16 / 4 floats and tolerates null),
@@ -903,11 +903,13 @@ Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeRestoreWallFingerp
     }
     jfloat* anchor = (anchorArray && env->GetArrayLength(anchorArray) == 16) ? env->GetFloatArrayElements(anchorArray, nullptr) : nullptr;
     jfloat* intr   = (intrArray && env->GetArrayLength(intrArray) == 4)    ? env->GetFloatArrayElements(intrArray, nullptr)   : nullptr;
-    gSlamEngine->restoreWallFingerprintMetric(descriptors, points3d, anchor, intr);
+    jfloat* view   = (viewArray && env->GetArrayLength(viewArray) == 16)   ? env->GetFloatArrayElements(viewArray, nullptr)   : nullptr;
+    gSlamEngine->restoreWallFingerprintMetric(descriptors, points3d, anchor, intr, view);
     env->ReleaseByteArrayElements(descArray, descData, JNI_ABORT);
     env->ReleaseFloatArrayElements(ptsArray, ptsData, JNI_ABORT);
     if (anchor) env->ReleaseFloatArrayElements(anchorArray, anchor, JNI_ABORT);
     if (intr)   env->ReleaseFloatArrayElements(intrArray, intr, JNI_ABORT);
+    if (view)   env->ReleaseFloatArrayElements(viewArray, view, JNI_ABORT);
 }
 
 // Persistent wall feature map (Phase 2a: store only). Mirrors the metric-fingerprint restore but

--- a/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
+++ b/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
@@ -1277,19 +1277,20 @@ Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeGetPaintingProgres
 }
 
 // Relocalization diagnostics: why the last attempt did not publish, and the counts it reached.
-// Packed into one int[] so the UI reads a consistent snapshot instead of three racing getters.
-// [0] = RelocReject code, [1] = correspondences, [2] = RANSAC inliers.
+// Packed into one int[] so the UI reads a consistent snapshot instead of four racing getters.
+// [0] = RelocReject code, [1] = correspondences, [2] = RANSAC inliers, [3] = features detected.
 extern "C" JNIEXPORT jintArray JNICALL
 Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeGetRelocDiagnostics(JNIEnv* env, jobject) {
-    jint vals[3] = {0, 0, 0};
+    jint vals[4] = {0, 0, 0, 0};
     if (gSlamEngine) {
         vals[0] = gSlamEngine->lastRelocReject();
         vals[1] = gSlamEngine->lastRelocMatches();
         vals[2] = gSlamEngine->lastRelocInliers();
+        vals[3] = gSlamEngine->lastRelocDetected();
     }
-    jintArray out = env->NewIntArray(3);
+    jintArray out = env->NewIntArray(4);
     if (!out) return nullptr;
-    env->SetIntArrayRegion(out, 0, 3, vals);
+    env->SetIntArrayRegion(out, 0, 4, vals);
     return out;
 }
 

--- a/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
+++ b/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
@@ -1280,19 +1280,23 @@ Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeGetPaintingProgres
 
 // Relocalization diagnostics: why the last attempt did not publish, and the counts it reached.
 // Packed into one int[] so the UI reads a consistent snapshot instead of four racing getters.
-// [0] = RelocReject code, [1] = correspondences, [2] = RANSAC inliers, [3] = features detected.
+// [0] = RelocReject code, [1] = correspondences, [2] = RANSAC inliers, [3] = features detected,
+// [4] = obliquity in degrees (-1 when the rectification pass wasn't eligible), [5] = correspondences
+// the rectification pass contributed.
 extern "C" JNIEXPORT jintArray JNICALL
 Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeGetRelocDiagnostics(JNIEnv* env, jobject) {
-    jint vals[4] = {0, 0, 0, 0};
+    jint vals[6] = {0, 0, 0, 0, -1, 0};
     if (gSlamEngine) {
         vals[0] = gSlamEngine->lastRelocReject();
         vals[1] = gSlamEngine->lastRelocMatches();
         vals[2] = gSlamEngine->lastRelocInliers();
         vals[3] = gSlamEngine->lastRelocDetected();
+        vals[4] = gSlamEngine->lastRelocObliquityDeg();
+        vals[5] = gSlamEngine->lastRelocRectifiedCorr();
     }
-    jintArray out = env->NewIntArray(4);
+    jintArray out = env->NewIntArray(6);
     if (!out) return nullptr;
-    env->SetIntArrayRegion(out, 0, 4, vals);
+    env->SetIntArrayRegion(out, 0, 6, vals);
     return out;
 }
 

--- a/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
+++ b/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
@@ -1276,6 +1276,23 @@ Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeGetPaintingProgres
     return 0.0f;
 }
 
+// Relocalization diagnostics: why the last attempt did not publish, and the counts it reached.
+// Packed into one int[] so the UI reads a consistent snapshot instead of three racing getters.
+// [0] = RelocReject code, [1] = correspondences, [2] = RANSAC inliers.
+extern "C" JNIEXPORT jintArray JNICALL
+Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeGetRelocDiagnostics(JNIEnv* env, jobject) {
+    jint vals[3] = {0, 0, 0};
+    if (gSlamEngine) {
+        vals[0] = gSlamEngine->lastRelocReject();
+        vals[1] = gSlamEngine->lastRelocMatches();
+        vals[2] = gSlamEngine->lastRelocInliers();
+    }
+    jintArray out = env->NewIntArray(3);
+    if (!out) return nullptr;
+    env->SetIntArrayRegion(out, 0, 3, vals);
+    return out;
+}
+
 extern "C" JNIEXPORT void JNICALL
 Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeSetArScanMode(JNIEnv* env, jobject, jint mode) {
     if (gSlamEngine) gSlamEngine->setArScanMode(mode);

--- a/core/nativebridge/src/main/cpp/MobileGS.cpp
+++ b/core/nativebridge/src/main/cpp/MobileGS.cpp
@@ -77,7 +77,13 @@ void MobileGS::initialize(int width, int height) {
     std::lock_guard<std::mutex> lock(mMutex);
     mScreenWidth = width;
     mScreenHeight = height;
-    mFeatureDetector = cv::ORB::create(500);
+    // 1500, not 500. This is the QUERY side: the live frame matched against a fingerprint built with
+    // ORB(1500) (MetricFingerprintBuilder) or ORB(1000) (generateFingerprint). Detecting a third as
+    // many features on the query as exist in the reference throws away matches before the ratio test
+    // even runs — and PnP needs 8 survivors from a frame that may show the marks small, partial or
+    // off-centre. ORB is cheap next to the SuperPoint path this falls back from, and it runs on the
+    // background reloc thread, so the symmetric budget is the right default.
+    mFeatureDetector = cv::ORB::create(1500);
     mMatcher = cv::DescriptorMatcher::create("BruteForce-Hamming");
     mL2Matcher = cv::DescriptorMatcher::create("BruteForce");
 
@@ -280,6 +286,7 @@ void MobileGS::relocThreadFunc() {
             if (sp && !mSuperPoint.detect(gray, baseKps, baseDescs)) sp = false;
             if (!sp) mFeatureDetector->detectAndCompute(gray, cv::noArray(), baseKps, baseDescs);
         }
+        mLastRelocDetected.store((int)baseKps.size(), std::memory_order_relaxed);
 
         auto buildCorr = [&](const cv::Mat& g, const cv::Mat& Hback,
                              std::vector<cv::Point2f>& outImg, std::vector<cv::Point3f>& outObj,
@@ -520,9 +527,15 @@ void MobileGS::relocThreadFunc() {
 
         // Teleological gatekeeper: update painting-progress from how much of the artwork base the clean
         // frame now corroborates. No-op until an artwork is registered; read-only on the reloc set.
-        tryUpdateFingerprint(gray);
+        // Hands over this frame's detection so it isn't recomputed (see tryUpdateFingerprint).
+        tryUpdateFingerprint(gray, &baseKps, &baseDescs);
 
-        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+        // Back off only once locked. A flat 200 ms capped every state at 5 Hz, including the one that
+        // matters most — hunting for the first lock, or re-acquiring after the artist looks away —
+        // where the cost of an extra attempt is far smaller than the cost of the overlay staying
+        // adrift. Locked and stable, 200 ms is plenty and keeps the thermal/battery profile.
+        const bool locked = mLastRelocReject.load(std::memory_order_relaxed) == kRelocOk;
+        std::this_thread::sleep_for(std::chrono::milliseconds(locked ? 200 : 60));
     }
 }
 bool MobileGS::computeRectifyHomography(const float* viewCur16, cv::Mat& Hcur_fp,
@@ -711,7 +724,9 @@ void MobileGS::growMapFromReloc(const glm::mat4& camFromFp, const std::vector<cv
     if (added > 0) LOGI("Map build: +%d pts (map now %zu)", added, mMapPoints3D.size());
 }
 
-void MobileGS::tryUpdateFingerprint(const cv::Mat& grayClean) {
+void MobileGS::tryUpdateFingerprint(const cv::Mat& grayClean,
+                                    const std::vector<cv::KeyPoint>* preKps,
+                                    const cv::Mat* preDescs) {
     cv::Mat artDescs;
     {
         std::lock_guard<std::mutex> lock(mMutex);
@@ -723,10 +738,19 @@ void MobileGS::tryUpdateFingerprint(const cv::Mat& grayClean) {
     // Detect on the CLEAN frame (the real wall incl. any new paint — overlays are GL-only, never in
     // this CV frame) and match against the ARTWORK base: a clean feature corroborates the target only
     // if it matches what the artwork expects. This is the validator for the upcoming self-grow.
-    std::vector<cv::KeyPoint> kps; cv::Mat descs;
-    bool sp = mSuperPoint.isLoaded() && (artDescs.type() == CV_32F);
-    if (sp && !mSuperPoint.detect(grayClean, kps, descs)) sp = false;
-    if (!sp) mFeatureDetector->detectAndCompute(grayClean, cv::noArray(), kps, descs);
+    //
+    // Reuse the caller's detection when it is usable: the reloc thread has already run the detector
+    // over this identical frame, and with SuperPoint that is a whole ONNX forward pass. A descriptor
+    // type mismatch can't knnMatch against the artwork anyway, so that case re-detects.
+    std::vector<cv::KeyPoint> localKps; cv::Mat localDescs;
+    const bool reuse = preKps && preDescs && !preDescs->empty() && preDescs->type() == artDescs.type();
+    if (!reuse) {
+        bool sp = mSuperPoint.isLoaded() && (artDescs.type() == CV_32F);
+        if (sp && !mSuperPoint.detect(grayClean, localKps, localDescs)) sp = false;
+        if (!sp) mFeatureDetector->detectAndCompute(grayClean, cv::noArray(), localKps, localDescs);
+    }
+    const std::vector<cv::KeyPoint>& kps = reuse ? *preKps : localKps;
+    const cv::Mat& descs = reuse ? *preDescs : localDescs;
     if (descs.empty() || descs.type() != artDescs.type()) return;
 
     cv::Ptr<cv::DescriptorMatcher>& matcher = (descs.type() == CV_32F) ? mL2Matcher : mMatcher;

--- a/core/nativebridge/src/main/cpp/MobileGS.cpp
+++ b/core/nativebridge/src/main/cpp/MobileGS.cpp
@@ -240,7 +240,18 @@ void MobileGS::relocThreadFunc() {
             mapPriorSeq = mPnpResultSeq.load(std::memory_order_relaxed);
         }
 
-        if (frame.empty() || wallDescs.empty() || wallKps3d.empty() || !mRelocEnabled) continue;
+        if (!mRelocEnabled) {
+            mLastRelocReject.store(kRelocDisabled, std::memory_order_relaxed);
+            continue;
+        }
+        if (wallDescs.empty() || wallKps3d.empty()) {
+            // No fingerprint, or one carrying descriptors but no 3D points (the depth-path result when
+            // the depth API is off). Either way PnP has nothing to solve against, so the whole thread
+            // idles here — silently, before this reject code existed.
+            mLastRelocReject.store(kRelocNoFingerprint, std::memory_order_relaxed);
+            continue;
+        }
+        if (frame.empty()) continue;
 
         // Optionally enhance the RGB frame under low light before grayscale conversion
         cv::Mat workFrame = frame;
@@ -423,6 +434,15 @@ void MobileGS::relocThreadFunc() {
         // Lowered floors so a close-up PARTIAL view (only a corner of the marks visible) can still
         // localize: PnP needs only a handful of correspondences. The inlier RATIO (published below) is
         // the quality gate PoseFusion actually trusts, so being permissive here is safe.
+        mLastRelocMatches.store((int)imgPts.size(), std::memory_order_relaxed);
+        mLastRelocInliers.store(0, std::memory_order_relaxed);
+        if (imgPts.size() < 8) {
+            // Distinguish "the detector found nothing / the descriptors don't even compare" from
+            // "features were found but too few agreed with the fingerprint" — they call for opposite
+            // fixes (light/focus/texture vs. aim at the registered area).
+            mLastRelocReject.store(baseDescs.empty() ? kRelocNoFeatures : kRelocFewMatches,
+                                   std::memory_order_relaxed);
+        }
         if (imgPts.size() >= 8) {
             cv::Mat rvec, tvec;
             std::vector<int> inliers;
@@ -437,7 +457,13 @@ void MobileGS::relocThreadFunc() {
             double idata[] = {fx, 0.0, cx, 0.0, fy, cy, 0.0, 0.0, 1.0};
             cv::Mat intr = cv::Mat(3, 3, CV_64F, idata).clone();
             StageTimer _pnpTimer(&mStageAccumMs[4], &mStageSamples[4]);
-            if (cv::solvePnPRansac(objPts, imgPts, intr, cv::Mat(), rvec, tvec, false, 100, 8.0, 0.99, inliers)) {
+            if (!cv::solvePnPRansac(objPts, imgPts, intr, cv::Mat(), rvec, tvec, false, 100, 8.0, 0.99, inliers)) {
+                mLastRelocReject.store(kRelocPnpFailed, std::memory_order_relaxed);
+            } else {
+                mLastRelocInliers.store((int)inliers.size(), std::memory_order_relaxed);
+                if (inliers.size() < 6) {
+                    mLastRelocReject.store(kRelocFewInliers, std::memory_order_relaxed);
+                }
                 if (inliers.size() >= 6) {
                     // Refine on the RANSAC inliers. The marks lie on the wall plane, so resolve the
                     // planar two-fold (flip) ambiguity with IPPE and keep whichever pose reprojects
@@ -483,6 +509,7 @@ void MobileGS::relocThreadFunc() {
                     mPnpInlierCount.store((int)inliers.size(), std::memory_order_relaxed);
                     mPnpMatchCount.store((int)imgPts.size(), std::memory_order_relaxed);
                     mPnpResultSeq.fetch_add(1, std::memory_order_relaxed);
+                    mLastRelocReject.store(kRelocOk, std::memory_order_relaxed);
                     LOGI("Relocalization: PnP match published (%zu/%zu inliers)", inliers.size(), imgPts.size());
                     // Phase 3 passive build: grow the feature map from this locked frame (default OFF).
                     if (mMapBuildEnabled.load(std::memory_order_relaxed))
@@ -730,22 +757,23 @@ void MobileGS::tryUpdateFingerprint(const cv::Mat& grayClean) {
     // backstop, but it still mutates the authoritative set, so it stays OFF unless explicitly enabled.
     if (!mSelfGrowEnabled.load(std::memory_order_relaxed) || validQuery.empty()) return;
 
-    cv::Matx33d R; cv::Vec3d t; double fx, fy, cx, cy; int inliers; long seq;
+    cv::Matx33d R; cv::Vec3d t; double fx, fy, cx, cy; int inliers; int matches; long seq;
     std::vector<cv::Point3f> wall;
     {
         std::lock_guard<std::mutex> lock(mMutex);
         seq = mPnpResultSeq.load(std::memory_order_relaxed);
         if (seq == mLastGrowSeq) return;          // no fresh relock this tick — pose would be stale
         inliers = mPnpInlierCount.load(std::memory_order_relaxed);
+        matches = mPnpMatchCount.load(std::memory_order_relaxed);
         const float* M = mPnpCamFromFpWorld;      // camera_from_fpWorld, column-major (OpenCV frame)
         R = cv::Matx33d(M[0], M[4], M[8], M[1], M[5], M[9], M[2], M[6], M[10]);
         t = cv::Vec3d(M[12], M[13], M[14]);
         fx = mFingerprintIntrinsics[0]; fy = mFingerprintIntrinsics[1];
         cx = mFingerprintIntrinsics[2]; cy = mFingerprintIntrinsics[3];
         wall = mWallKeypoints3D;
-        if (inliers >= 20) mLastGrowSeq = seq;    // claim this relock (whether or not it yields points)
+        if (growTrusted(inliers, matches)) mLastGrowSeq = seq; // claim it (yield or not)
     }
-    if (inliers < 20 || fx <= 0 || fy <= 0 || wall.size() < 12 || wall.size() > 5000) return;
+    if (!growTrusted(inliers, matches) || fx <= 0 || fy <= 0 || wall.size() < 12 || wall.size() > 5000) return;
 
     // Wall plane (n·X = pdist, pdist>0) in the fingerprint frame, fit to the existing marks.
     cv::Mat data((int)wall.size(), 3, CV_32F);

--- a/core/nativebridge/src/main/cpp/MobileGS.cpp
+++ b/core/nativebridge/src/main/cpp/MobileGS.cpp
@@ -757,23 +757,24 @@ void MobileGS::tryUpdateFingerprint(const cv::Mat& grayClean) {
     // backstop, but it still mutates the authoritative set, so it stays OFF unless explicitly enabled.
     if (!mSelfGrowEnabled.load(std::memory_order_relaxed) || validQuery.empty()) return;
 
-    cv::Matx33d R; cv::Vec3d t; double fx, fy, cx, cy; int inliers; int matches; long seq;
+    // pnpMatches, not `matches` — that name is already the knnMatch result vector in this scope.
+    cv::Matx33d R; cv::Vec3d t; double fx, fy, cx, cy; int inliers; int pnpMatches; long seq;
     std::vector<cv::Point3f> wall;
     {
         std::lock_guard<std::mutex> lock(mMutex);
         seq = mPnpResultSeq.load(std::memory_order_relaxed);
         if (seq == mLastGrowSeq) return;          // no fresh relock this tick — pose would be stale
         inliers = mPnpInlierCount.load(std::memory_order_relaxed);
-        matches = mPnpMatchCount.load(std::memory_order_relaxed);
+        pnpMatches = mPnpMatchCount.load(std::memory_order_relaxed);
         const float* M = mPnpCamFromFpWorld;      // camera_from_fpWorld, column-major (OpenCV frame)
         R = cv::Matx33d(M[0], M[4], M[8], M[1], M[5], M[9], M[2], M[6], M[10]);
         t = cv::Vec3d(M[12], M[13], M[14]);
         fx = mFingerprintIntrinsics[0]; fy = mFingerprintIntrinsics[1];
         cx = mFingerprintIntrinsics[2]; cy = mFingerprintIntrinsics[3];
         wall = mWallKeypoints3D;
-        if (growTrusted(inliers, matches)) mLastGrowSeq = seq; // claim it (yield or not)
+        if (growTrusted(inliers, pnpMatches)) mLastGrowSeq = seq; // claim it (yield or not)
     }
-    if (!growTrusted(inliers, matches) || fx <= 0 || fy <= 0 || wall.size() < 12 || wall.size() > 5000) return;
+    if (!growTrusted(inliers, pnpMatches) || fx <= 0 || fy <= 0 || wall.size() < 12 || wall.size() > 5000) return;
 
     // Wall plane (n·X = pdist, pdist>0) in the fingerprint frame, fit to the existing marks.
     cv::Mat data((int)wall.size(), 3, CV_32F);

--- a/core/nativebridge/src/main/cpp/MobileGS.cpp
+++ b/core/nativebridge/src/main/cpp/MobileGS.cpp
@@ -873,12 +873,21 @@ void MobileGS::restoreWallFingerprint(const cv::Mat& d, const std::vector<cv::Po
     mWallKeypoints3D = p;
 }
 void MobileGS::restoreWallFingerprintMetric(const cv::Mat& d, const std::vector<cv::Point3f>& p,
-                                            const float* anchorMatrix16, const float* intrinsics4) {
+                                            const float* anchorMatrix16, const float* intrinsics4,
+                                            const float* viewMatrix16) {
     std::lock_guard<std::mutex> lock(mMutex);
     mWallDescriptors = d.clone();
     mWallKeypoints3D = p;
     if (anchorMatrix16) memcpy(mFingerprintAnchorMatrix, anchorMatrix16, 16 * sizeof(float));
     if (intrinsics4)    memcpy(mFingerprintIntrinsics, intrinsics4, 4 * sizeof(float));
+    if (viewMatrix16) {
+        memcpy(mFingerprintViewMatrix, viewMatrix16, 16 * sizeof(float));
+        mHasFingerprintView = true; // enables plane-guided rectification at reloc time
+    } else {
+        // A fingerprint without a capture view must not inherit the previous one's — the rectifying
+        // warp would be computed against the wrong frontal frame and inject bad correspondences.
+        mHasFingerprintView = false;
+    }
 }
 
 void MobileGS::clearWallFingerprint() {

--- a/core/nativebridge/src/main/cpp/MobileGS.cpp
+++ b/core/nativebridge/src/main/cpp/MobileGS.cpp
@@ -342,13 +342,22 @@ void MobileGS::relocThreadFunc() {
         // known plane and VIO gives a pose, so the oblique-vs-frontal distortion is a homography we can
         // pre-cancel: warp the live frame into the fingerprint's frontal frame, match, and ADD the
         // correspondences mapped back to the current image (RANSAC filters any that don't fit).
+        // Published so the diagnostics can show whether this pass is actually running. It was dead in
+        // practice for a long time (nothing set mHasFingerprintView on the live capture path), so
+        // "did rectification fire, and did it help" is worth being able to read off the device rather
+        // than infer. -1 = the pass was not eligible at all this attempt.
+        mLastRelocObliquityDeg.store(-1, std::memory_order_relaxed);
+        mLastRelocRectifiedCorr.store(0, std::memory_order_relaxed);
         if (hasFpView && mIsArCoreTracking.load(std::memory_order_relaxed) && wallKps3d.size() >= 12) {
             cv::Mat Hcur_fp, Hfp_cur; double obliqDeg = 0.0;
-            if (computeRectifyHomography(relocView, Hcur_fp, Hfp_cur, obliqDeg) && obliqDeg > 25.0) {
+            const bool haveH = computeRectifyHomography(relocView, Hcur_fp, Hfp_cur, obliqDeg);
+            if (haveH) mLastRelocObliquityDeg.store((int)(obliqDeg + 0.5), std::memory_order_relaxed);
+            if (haveH && obliqDeg > 25.0) {
                 cv::Mat grayRect;
                 cv::warpPerspective(gray, grayRect, Hfp_cur, gray.size());
                 size_t before = imgPts.size();
                 buildCorr(grayRect, Hcur_fp, imgPts, objPts);
+                mLastRelocRectifiedCorr.store((int)(imgPts.size() - before), std::memory_order_relaxed);
                 if (imgPts.size() > before)
                     LOGI("Reloc: rectified (obliquity %.0f deg) added %zu corr (total %zu)",
                          obliqDeg, imgPts.size() - before, imgPts.size());

--- a/core/nativebridge/src/main/cpp/include/MobileGS.h
+++ b/core/nativebridge/src/main/cpp/include/MobileGS.h
@@ -67,6 +67,45 @@ public:
     // Phase 3: passively grow the feature map from reloc-locked frames. Default OFF, and independent of
     // the match flag (accumulate without matching, or match a persisted map without growing).
     void setMapBuildEnabled(bool e) { mMapBuildEnabled.store(e, std::memory_order_relaxed); }
+    /**
+     * Why the last relocalization attempt failed to publish a pose. Ordered by how early the gate
+     * sits in the pipeline, so the largest value reached is the furthest the attempt got.
+     */
+    enum RelocReject {
+        kRelocOk = 0,            //!< published a pose
+        kRelocNoFingerprint = 1, //!< no wall fingerprint yet (or it carries no 3D points)
+        kRelocDisabled = 2,      //!< relocalization switched off
+        kRelocNoFeatures = 3,    //!< nothing detected in the live frame, or descriptor type mismatch
+        kRelocFewMatches = 4,    //!< fewer than 8 correspondences survived the Lowe ratio test
+        kRelocPnpFailed = 5,     //!< solvePnPRansac found no consistent pose
+        kRelocFewInliers = 6,    //!< PnP solved but fewer than 6 inliers agreed
+    };
+
+    /**
+     * Whether a relock is trusted enough to promote new marks into the authoritative fingerprint.
+     *
+     * This used to be a flat `inliers >= 20`, which could not bootstrap: self-grow is the mechanism
+     * that keeps relocalization alive as the original marks get painted over, but a wall whose marks
+     * are already half-covered rarely reaches 20 raw inliers, so the fingerprint could only grow when
+     * it was already strong — exactly when it needed to least.
+     *
+     * The ratio is the quality signal (it is what PoseFusion trusts), so a strong ratio now qualifies
+     * at a lower absolute count, while a weak ratio still cannot qualify at any count. RANSAC in the
+     * reloc PnP remains the geometric backstop for anything this lets through.
+     */
+    static bool growTrusted(int inliers, int matches) {
+        if (inliers >= 20) return true;                  // unchanged: a big lock always qualifies
+        if (inliers < 10 || matches <= 0) return false;  // absolute floor — PnP noise below this
+        return (float)inliers / (float)matches >= 0.6f;  // above PoseFusion's 0.5 trust bar
+    }
+
+    /** Last [RelocReject]. */
+    int lastRelocReject() const { return mLastRelocReject.load(std::memory_order_relaxed); }
+    /** Correspondences built by the last attempt, successful or not. */
+    int lastRelocMatches() const { return mLastRelocMatches.load(std::memory_order_relaxed); }
+    /** RANSAC inliers from the last attempt, successful or not (0 if PnP never ran). */
+    int lastRelocInliers() const { return mLastRelocInliers.load(std::memory_order_relaxed); }
+
     void scheduleRelocCheck(const cv::Mat& colorFrame);
     /**
      * Cheap pre-check for the three conditions under which scheduleRelocCheck() drops the frame:
@@ -273,5 +312,17 @@ private:
     std::atomic<bool>       mRelocRunning{false};
     std::atomic<bool>       mRelocRequested{false};
     std::atomic<bool>       mRelocEnabled{true};
+
+    /**
+     * Why the most recent relocalization attempt did not publish a pose (a RelocReject value), and
+     * the correspondence/inlier counts from that attempt whether or not it succeeded.
+     *
+     * mPnpMatchCount / mPnpInlierCount only update on SUCCESS, so before the first lock they read
+     * zero and a failing pipeline is indistinguishable from an idle one. These always reflect the
+     * last attempt, so the diagnostics can say which gate is being missed and by how much.
+     */
+    std::atomic<int>        mLastRelocReject{0};
+    std::atomic<int>        mLastRelocMatches{0};
+    std::atomic<int>        mLastRelocInliers{0};
     cv::Mat                 mRelocColorFrame;
 };

--- a/core/nativebridge/src/main/cpp/include/MobileGS.h
+++ b/core/nativebridge/src/main/cpp/include/MobileGS.h
@@ -44,8 +44,14 @@ public:
     void restoreWallFingerprint(const cv::Mat& descriptors, const std::vector<cv::Point3f>& points3d);
     // Ingest a fingerprint built from triangulated metric marks (no depth source): also fixes the
     // fingerprint anchor pose and the intrinsics the reloc PnP should use.
+    //
+    // viewMatrix16 (optional, GL-convention world->camera at capture) enables the plane-guided
+    // rectification pass in relocThreadFunc. Without it computeRectifyHomography bails and oblique
+    // views get no correction — which was the case for EVERY fingerprint built this way, since only
+    // generateFingerprint (the depth path, disabled) ever set it.
     void restoreWallFingerprintMetric(const cv::Mat& descriptors, const std::vector<cv::Point3f>& points3d,
-                                      const float* anchorMatrix16, const float* intrinsics4);
+                                      const float* anchorMatrix16, const float* intrinsics4,
+                                      const float* viewMatrix16 = nullptr);
     // Drop the stored wall fingerprint (marks + co-registration). Needed because a fingerprint is
     // otherwise process-lifetime state: the restore calls above only ever REPLACE it, so a project
     // with no fingerprint of its own would keep relocalizing against whatever wall was fingerprinted
@@ -336,7 +342,10 @@ private:
      * zero and a failing pipeline is indistinguishable from an idle one. These always reflect the
      * last attempt, so the diagnostics can say which gate is being missed and by how much.
      */
-    std::atomic<int>        mLastRelocReject{0};
+    // NOT {0}: zero is kRelocOk, so a default-constructed engine would report a successful lock
+    // before a single attempt had run and the overlay would read LOCKED on a wall it had never seen.
+    // kRelocNoFingerprint is the truthful starting state — there is no fingerprint until one is built.
+    std::atomic<int>        mLastRelocReject{kRelocNoFingerprint};
     std::atomic<int>        mLastRelocMatches{0};
     std::atomic<int>        mLastRelocInliers{0};
     std::atomic<int>        mLastRelocDetected{0};

--- a/core/nativebridge/src/main/cpp/include/MobileGS.h
+++ b/core/nativebridge/src/main/cpp/include/MobileGS.h
@@ -117,6 +117,10 @@ public:
      * count means opposite things in those two cases.
      */
     int lastRelocDetected() const { return mLastRelocDetected.load(std::memory_order_relaxed); }
+    /** Obliquity (deg) measured by the rectification pass, or -1 when it wasn't eligible. */
+    int lastRelocObliquityDeg() const { return mLastRelocObliquityDeg.load(std::memory_order_relaxed); }
+    /** Extra correspondences the rectification pass contributed to the last attempt. */
+    int lastRelocRectifiedCorr() const { return mLastRelocRectifiedCorr.load(std::memory_order_relaxed); }
 
     void scheduleRelocCheck(const cv::Mat& colorFrame);
     /**
@@ -349,5 +353,9 @@ private:
     std::atomic<int>        mLastRelocMatches{0};
     std::atomic<int>        mLastRelocInliers{0};
     std::atomic<int>        mLastRelocDetected{0};
+    // Obliquity (degrees) the rectification pass measured, or -1 when it wasn't eligible; and how many
+    // extra correspondences it contributed.
+    std::atomic<int>        mLastRelocObliquityDeg{-1};
+    std::atomic<int>        mLastRelocRectifiedCorr{0};
     cv::Mat                 mRelocColorFrame;
 };

--- a/core/nativebridge/src/main/cpp/include/MobileGS.h
+++ b/core/nativebridge/src/main/cpp/include/MobileGS.h
@@ -105,6 +105,12 @@ public:
     int lastRelocMatches() const { return mLastRelocMatches.load(std::memory_order_relaxed); }
     /** RANSAC inliers from the last attempt, successful or not (0 if PnP never ran). */
     int lastRelocInliers() const { return mLastRelocInliers.load(std::memory_order_relaxed); }
+    /**
+     * Features detected in the last live frame, before any matching. Separates "this frame has no
+     * texture to work with" from "plenty of texture, none of it the registered wall" — a low match
+     * count means opposite things in those two cases.
+     */
+    int lastRelocDetected() const { return mLastRelocDetected.load(std::memory_order_relaxed); }
 
     void scheduleRelocCheck(const cv::Mat& colorFrame);
     /**
@@ -213,7 +219,16 @@ private:
     // Teleological self-grow (gatekeeper stage): measure how much of the registered artwork base is now
     // corroborated by real wall content in the clean camera frame -> mPaintingProgress. Read-only on the
     // reloc fingerprint; the promotion step (adding validated new marks) is staged separately.
-    void tryUpdateFingerprint(const cv::Mat& grayClean);
+    /**
+     * @param preKps,preDescs features already detected on [grayClean] by the caller. The reloc thread
+     *        has just run the detector over this exact frame, and SuperPoint is an ONNX forward pass —
+     *        detecting it a second time doubled the per-cycle cost for an identical result. Reused
+     *        only when the descriptor type matches the artwork's (a mismatch can't knnMatch anyway,
+     *        so it re-detects with the right detector). Pass nullptr to always detect.
+     */
+    void tryUpdateFingerprint(const cv::Mat& grayClean,
+                              const std::vector<cv::KeyPoint>* preKps = nullptr,
+                              const cv::Mat* preDescs = nullptr);
     // Plane-guided rectification: homography (current-image <-> fingerprint-image) from the wall plane
     // and the VIO baseline between the current and fingerprint-capture views, plus the viewing
     // obliquity in degrees. False if no fingerprint view is stored or the geometry is degenerate.
@@ -324,5 +339,6 @@ private:
     std::atomic<int>        mLastRelocReject{0};
     std::atomic<int>        mLastRelocMatches{0};
     std::atomic<int>        mLastRelocInliers{0};
+    std::atomic<int>        mLastRelocDetected{0};
     cv::Mat                 mRelocColorFrame;
 };

--- a/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
+++ b/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
@@ -5,6 +5,8 @@ import android.content.res.AssetManager
 import android.graphics.Bitmap
 import android.util.Log
 import com.hereliesaz.graffitixr.common.model.Fingerprint
+import com.hereliesaz.graffitixr.common.model.RelocDiagnostics
+import com.hereliesaz.graffitixr.common.model.RelocReject
 import com.hereliesaz.graffitixr.common.model.WallFeatureMap
 import com.hereliesaz.graffitixr.common.sensor.CameraFrame
 import com.hereliesaz.graffitixr.common.sensor.ImuSample
@@ -80,6 +82,21 @@ class SlamManager @Inject constructor(
     }
 
     fun getPaintingProgress(): Float = nativeGetPaintingProgress()
+
+    /**
+     * Why the last relocalization attempt did not publish a pose, and how far it got. See
+     * [RelocDiagnostics]; the native side packs the three values into one int[] so the read is a
+     * consistent snapshot rather than three racing getters.
+     */
+    fun getRelocDiagnostics(): RelocDiagnostics {
+        val v = nativeGetRelocDiagnostics()
+        if (v == null || v.size < 3) return RelocDiagnostics()
+        return RelocDiagnostics(
+            reject = RelocReject.entries.getOrElse(v[0]) { RelocReject.UNKNOWN },
+            matches = v[1],
+            inliers = v[2],
+        )
+    }
 
     fun getAnchorTransform(): FloatArray = nativeGetAnchorTransform()
 
@@ -530,6 +547,7 @@ class SlamManager @Inject constructor(
     private external fun nativeUpdateDeviceMotion(angularVel: FloatArray, linearVel: FloatArray)
     private external fun nativeGetAnchorTransform(): FloatArray
     private external fun nativeGetPaintingProgress(): Float
+    private external fun nativeGetRelocDiagnostics(): IntArray?
     private external fun nativeSetArScanMode(mode: Int)
     private external fun nativeSetMuralMethod(method: Int)
     private external fun nativeGetStageTimings(out: FloatArray)

--- a/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
+++ b/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
@@ -90,12 +90,14 @@ class SlamManager @Inject constructor(
      */
     fun getRelocDiagnostics(): RelocDiagnostics {
         val v = nativeGetRelocDiagnostics()
-        if (v == null || v.size < 4) return RelocDiagnostics()
+        if (v == null || v.size < 6) return RelocDiagnostics()
         return RelocDiagnostics(
             reject = RelocReject.entries.getOrElse(v[0]) { RelocReject.UNKNOWN },
             matches = v[1],
             inliers = v[2],
             detected = v[3],
+            obliquityDeg = v[4],
+            rectifiedCorrespondences = v[5],
         )
     }
 

--- a/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
+++ b/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
@@ -90,11 +90,12 @@ class SlamManager @Inject constructor(
      */
     fun getRelocDiagnostics(): RelocDiagnostics {
         val v = nativeGetRelocDiagnostics()
-        if (v == null || v.size < 3) return RelocDiagnostics()
+        if (v == null || v.size < 4) return RelocDiagnostics()
         return RelocDiagnostics(
             reject = RelocReject.entries.getOrElse(v[0]) { RelocReject.UNKNOWN },
             matches = v[1],
             inliers = v[2],
+            detected = v[3],
         )
     }
 

--- a/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
+++ b/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
@@ -121,12 +121,21 @@ class SlamManager @Inject constructor(
      * Ingest a fingerprint built from triangulated metric marks (no depth source). Also fixes the
      * fingerprint anchor pose (column-major 4x4) and the camera intrinsics (fx,fy,cx,cy) the reloc
      * PnP should use. points3d are in keyframe-0's CV camera frame (see [MetricMarks]).
+     *
+     * [viewMatrix] is the GL-convention world->camera view at capture. Supplying it enables the
+     * reloc thread's plane-guided rectification: the marks lie on a known plane, so the oblique-
+     * vs-frontal distortion is a homography that can be pre-cancelled before matching. Pass an empty
+     * array only when the capture view genuinely isn't known (e.g. a project saved before it was
+     * persisted) — then that pass is skipped rather than run against a stale frontal frame.
      */
     fun restoreWallFingerprintMetric(
         descriptorsData: ByteArray, rows: Int, cols: Int, type: Int,
         points3d: FloatArray, anchorMatrix: FloatArray, intrinsics: FloatArray,
+        viewMatrix: FloatArray = FloatArray(0),
     ) {
-        nativeRestoreWallFingerprintMetric(descriptorsData, rows, cols, type, points3d, anchorMatrix, intrinsics)
+        nativeRestoreWallFingerprintMetric(
+            descriptorsData, rows, cols, type, points3d, anchorMatrix, intrinsics, viewMatrix,
+        )
     }
 
     /**
@@ -571,7 +580,8 @@ class SlamManager @Inject constructor(
     )
     private external fun nativeRestoreWallFingerprintMetric(
         descriptorsData: ByteArray, rows: Int, cols: Int, type: Int,
-        points3d: FloatArray, anchorMatrix: FloatArray, intrinsics: FloatArray
+        points3d: FloatArray, anchorMatrix: FloatArray, intrinsics: FloatArray,
+        viewMatrix: FloatArray
     )
     private external fun nativeRestoreWallFeatureMap(
         descriptorsData: ByteArray, rows: Int, cols: Int, type: Int,

--- a/docs/TELEOLOGICAL_SLAM.md
+++ b/docs/TELEOLOGICAL_SLAM.md
@@ -79,6 +79,15 @@ attempt missed:
 | `FEW_INLIERS` | PnP solved but fewer than 6 inliers agreed |
 | `OK` | pose published; PoseFusion applies it if the inlier ratio ≥ 0.5 |
 
+The overlay also shows how many features the live frame yielded *before* matching.
+That disambiguates `FEW_MATCHES`, which means opposite things depending on it: a
+handful of features in frame is a capture problem (light, focus, a blank wall),
+while a thousand features that don't match is an aiming problem.
+
+The reloc thread runs at 5 Hz once locked and ~16 Hz while hunting, since the
+cost of an extra attempt is far smaller than the cost of the overlay staying
+adrift.
+
 ## Relationship to the rest of the engine
 
 - **Relocalization** (snap-back after tracking loss / screen-off) is the

--- a/docs/TELEOLOGICAL_SLAM.md
+++ b/docs/TELEOLOGICAL_SLAM.md
@@ -88,6 +88,45 @@ The reloc thread runs at 5 Hz once locked and ~16 Hz while hunting, since the
 cost of an extra attempt is far smaller than the cost of the overlay staying
 adrift.
 
+## Open question: the display-rotation convention
+
+**Unresolved, and the leading suspect if relocalization matches but places the
+overlay wrong.** Recorded here so the analysis isn't redone from scratch.
+
+At capture, `ArRenderer` rotates the intrinsics to display orientation (the
+`when (rotationNeeded)` block: swap `fx`/`fy`, remap `cx`/`cy`) and `ArViewModel`
+rotates the bitmap by the same angle. The **view matrix is not rotated** — it is
+`camera.pose.inverse()` in ARCore's own camera frame.
+
+`PlaneMarks.backProject` builds each ray from the rotated pixel and rotated `K`,
+then intersects it with the plane transformed into the camera frame by that
+unrotated view. Working the algebra for a 90° turn: a pixel's ray in the rotated
+frame is `d' = (-d_y, d_x, 1)`, i.e. `d' = R·d` with `R = [[0,-1,0],[1,0,0],[0,0,1]]`.
+So the rays live in a frame rotated about the optical axis relative to the plane
+they are being intersected with, and the resulting depths are skewed — the
+fingerprint's 3D structure is not the real wall, and no consistent PnP pose
+exists over it.
+
+Two details make this fit the observed "never locks" behaviour:
+
+- The error **vanishes for a head-on wall** — a plane normal of `(0,0,±1)` is
+  invariant under rotation about Z — and grows with obliquity. That matches a
+  failure that feels intermittent rather than absolute.
+- The onboarding doodle path (`buildDoodleFingerprint`) uses the identical
+  convention, so it would fail the same way.
+
+Why it was not simply fixed: rotating the capture view is not sufficient on its
+own. The 3D points would then live in the rotated camera frame, while
+`PoseFusion.composeCorrected` composes `inverse(V_current) · pnp · fpAnchor` with
+`V_current` in ARCore's **unrotated** frame — so the composition needs the same
+treatment, and the sign of every rotation has to be right or the overlay lands
+worse than it does now. That is a system-wide convention change and wants device
+evidence first.
+
+**How to tell:** with the Diagnostic Overlay on, a healthy match count and a
+**low inlier ratio** points here. `NO TARGET` / `NO FEATURES` / a low in-frame
+feature count point at capture problems instead, which are covered above.
+
 ## Relationship to the rest of the engine
 
 - **Relocalization** (snap-back after tracking loss / screen-off) is the

--- a/docs/TELEOLOGICAL_SLAM.md
+++ b/docs/TELEOLOGICAL_SLAM.md
@@ -30,8 +30,54 @@ on top of the OpenCV relocalizer:
    becomes more aggressive — the overlay "snaps" more tightly the more of the
    mural exists on the wall.
 
+   Concretely: `ArRenderer` passes the progress as `PoseFusion.currentAnchor`'s
+   `confGlobal`, which scales the smoothing rate as
+   `alpha = BASE_ALPHA * inlierRatio * (CONF_FLOOR + (1 - CONF_FLOOR) * progress)`.
+   The floor means a bare wall still corrects at half strength on the PnP inlier
+   ratio alone; a fully corroborated one earns twice that.
+
+   (Until 2026-07 this stage was **not wired**: `confGlobal` was pinned at `1f`
+   with a comment about the retired voxel map, so progress reached the HUD and
+   nothing else and correction strength was identical at 0% and 100% painted.)
+
+4. **Self-grow.** Live features that pass the same corroboration test are
+   promoted into the reloc fingerprint (`mSelfGrowEnabled`, default on), so
+   relocalization survives the original marks being painted over. The promotion
+   gate is `MobileGS::growTrusted` — a strong inlier ratio qualifies at a lower
+   absolute count, because a half-covered wall rarely reaches a large raw inlier
+   count and the old flat `inliers >= 20` meant the fingerprint could only grow
+   when it was already strong.
+
 This is the inverse of the failure mode other tracing apps hit, where accuracy
 degrades as the original reference marks disappear under paint.
+
+## What "matching the image" does and does not mean
+
+The corroboration test is **descriptor similarity, not geometric accuracy**. A
+live feature corroborates the artwork when its nearest neighbour among the
+design composite's descriptors passes a Lowe ratio of 0.75
+(`MobileGS::tryUpdateFingerprint`). There is no positional tolerance, no scale
+or colour check, and nothing anywhere compares your brushwork to the design
+geometrically. Painting "more accurately" only helps insofar as it makes the
+wall's local appearance descriptor-match the design image.
+
+Tracking itself never consults the artwork at all: relocalization matches the
+live camera against the **photograph of the wall taken at target creation**.
+
+## Diagnosing it
+
+Every failure in this chain used to be silent. `RelocDiagnostics` (surfaced by
+the Diagnostic Overlay, in release as well as debug) reports which gate the last
+attempt missed:
+
+| State | Meaning |
+|---|---|
+| `NO_FINGERPRINT` | no target created, or one with no 3D points — nothing to match |
+| `NO_FEATURES` | live frame had no usable texture (light, focus, blur) |
+| `FEW_MATCHES` | fewer than 8 correspondences survived the ratio test |
+| `PNP_FAILED` | matches found, none geometrically consistent |
+| `FEW_INLIERS` | PnP solved but fewer than 6 inliers agreed |
+| `OK` | pose published; PoseFusion applies it if the inlier ratio ≥ 0.5 |
 
 ## Relationship to the rest of the engine
 

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -1328,6 +1328,10 @@ class ArViewModel @Inject constructor(
                         fp.points3d.toFloatArray(),
                         anchor.toFloatArray(),
                         intr.toFloatArray(),
+                        // Empty on projects saved before the capture view was persisted; native then
+                        // skips the rectification pass rather than warping to a stale frontal frame.
+                        viewMatrix = project.fingerprintViewMatrix
+                            .takeIf { it.size == 16 }?.toFloatArray() ?: FloatArray(0),
                     )
                 } else {
                     // Depth-path or pre-existing project: descriptors-only legacy restore.

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -1239,7 +1239,7 @@ class ArViewModel @Inject constructor(
     /**
      * Drops the large capture bitmaps and the native depth buffer held in [ArUiState], letting
      * GC reclaim them. We deliberately do NOT call recycle(): on AR-mode teardown a background
-     * fingerprint/save coroutine (onConfirmTargetCreation, setArtworkFingerprintFromComposite)
+     * fingerprint/save coroutine (onConfirmTargetCreation, updatePaintingGuide)
      * may still hold these same bitmap instances, and recycling them out from under it would
      * cause a "trying to use a recycled bitmap" crash. Nulling the references is deterministic
      * and safe; the platform reclaims the memory once no coroutine references them.
@@ -1463,6 +1463,9 @@ class ArViewModel @Inject constructor(
         globConf: Float = 0f
     ) {
         val progress = if (isTracking) slamManager.getPaintingProgress() else _uiState.value.paintingProgress
+        // Read every tick (~15 Hz) rather than only on a successful lock — the whole point is to show
+        // the FAILING states, which by definition never reach a success path.
+        val relocDiag = slamManager.getRelocDiagnostics()
 
         val nowMs = System.currentTimeMillis()
         if (isTracking) lastTrackingTimestampMs = nowMs
@@ -1499,6 +1502,7 @@ class ArViewModel @Inject constructor(
                 immutableSplatCount = immutableSplatCount,
                 isDepthApiSupported = isDepthApiSupported,
                 paintingProgress = progress,
+                relocDiagnostics = relocDiag,
                 scanPhase = newPhase,
                 ambientSectorsCovered = sectorsCovered / 3, // Keep backward compatibility for 30 degree UI units if needed
                 worldMappingProgress = mappingProgress,
@@ -2142,27 +2146,11 @@ class ArViewModel @Inject constructor(
         }
     }
 
-    fun setArtworkFingerprintFromComposite(bitmap: Bitmap) {
-        val ui = _uiState.value
-        val depth = ui.targetDepthBuffer ?: return
-        val intr = ui.targetIntrinsics ?: return
-        val view = ui.targetCaptureViewMatrix ?: return
-        
-        viewModelScope.launch(Dispatchers.IO) {
-            slamManager.setArtworkFingerprint(
-                bitmap,
-                depth,
-                ui.targetDepthBufferWidth,
-                ui.targetDepthBufferHeight,
-                ui.targetDepthStride,
-                intr,
-                view
-            )
-            
-            // Progress is reset when new features are added
-            _uiState.update { it.copy(paintingProgress = 0f) }
-        }
-    }
+    // setArtworkFingerprintFromComposite removed: nothing called it, and it bailed on its first line
+    // (`targetDepthBuffer ?: return`) because the ARCore depth API is disabled, so it could not have
+    // registered an artwork base even if something had. [updatePaintingGuide] is the live path — it
+    // re-registers the design composite whenever the design changes, descriptors-only, which is all
+    // the teleological corroboration test needs.
 
     fun computeScanHint(isTracking: Boolean, splatCount: Int, lightLevel: Float, scanPhase: ScanPhase, sectorsCovered: Int): String? {
         if (!isTracking) return appContext.getString(DesignR.string.scan_hint_recover)

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/MetricFingerprintBuilder.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/MetricFingerprintBuilder.kt
@@ -149,6 +149,23 @@ object MetricFingerprintBuilder {
      * @param planeNormalWorld the wall plane normal in world space.
      * @param anchorModel the anchor's world pose (column-major 4x4) at capture time.
      */
+    /**
+     * How a [buildSingle] attempt went, so a failure can say what was actually short instead of a
+     * generic "not enough texture". Reset at the start of each attempt.
+     *
+     * [detected] is how many features the detector found in the frame at all; [placed] is how many of
+     * those back-projected onto the wall plane. detected≈0 means the frame had no texture to work
+     * with (light, focus, blur, a blank wall). detected high but placed low means the features were
+     * there but missed the plane — usually aiming past the plane's extent, or a plane whose polygon
+     * doesn't cover what the camera sees.
+     */
+    @Volatile var lastDetected: Int = 0
+        private set
+    @Volatile var lastPlaced: Int = 0
+        private set
+    @Volatile var lastRequired: Int = 0
+        private set
+
     fun buildSingle(
         slam: SlamManager,
         bitmap: Bitmap, glView: FloatArray, intr: FloatArray,
@@ -156,6 +173,7 @@ object MetricFingerprintBuilder {
         anchorModel: FloatArray,
         minPoints: Int = 20,
     ): Fingerprint? {
+        lastDetected = 0; lastPlaced = 0; lastRequired = minPoints
         val cvView = MetricMarks.glViewToCv(glView)
 
         val sp = unpackSuperPoint(slam.detectSuperPoint(bitmap))
@@ -204,6 +222,10 @@ object MetricFingerprintBuilder {
             pixels, cvView, planePointWorld, planeNormalWorld,
             intr[0], intr[1], intr[2], intr[3],
         )
+        // Record before the bail so a refusal can report how far short it fell. SuperPoint runs first
+        // and ORB is the fallback, so keep whichever pass got furthest rather than the last one.
+        if (pixels.size > lastDetected) lastDetected = pixels.size
+        if (res.count > lastPlaced) lastPlaced = res.count
         if (res.count < minPoints) return null
 
         // Center the AR overlay on the marks (their centroid), not the screen-center anchor.

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/MetricFingerprintBuilder.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/MetricFingerprintBuilder.kt
@@ -184,7 +184,7 @@ object MetricFingerprintBuilder {
                 var i = 0
                 while (i + 1 < pos.size) { pixels.add(PlaneMarks.Pixel(pos[i], pos[i + 1])); i += 2 }
                 val fp = ingestSingle(slam, descs, pixels, cvView, intr,
-                    planePointWorld, planeNormalWorld, anchorModel, minPoints)
+                    planePointWorld, planeNormalWorld, anchorModel, minPoints, glView)
                 if (fp != null) return fp
             } finally {
                 descs.release()
@@ -203,7 +203,7 @@ object MetricFingerprintBuilder {
             if (d.empty()) return null
             val pixels = kp.toArray().map { PlaneMarks.Pixel(it.pt.x.toFloat(), it.pt.y.toFloat()) }
             return ingestSingle(slam, d, pixels, cvView, intr,
-                planePointWorld, planeNormalWorld, anchorModel, minPoints)
+                planePointWorld, planeNormalWorld, anchorModel, minPoints, glView)
         } finally {
             gray.release(); norm.release(); kp.release(); d.release()
         }
@@ -217,6 +217,9 @@ object MetricFingerprintBuilder {
         cvView: FloatArray, intr: FloatArray,
         planePointWorld: FloatArray, planeNormalWorld: FloatArray,
         anchorModel: FloatArray, minPoints: Int,
+        // GL-convention capture view, handed to native so the reloc thread can pre-cancel
+        // oblique-vs-frontal distortion. Null on the two-keyframe path, which has no single view.
+        glView: FloatArray? = null,
     ): Fingerprint? {
         val res = PlaneMarks.backProject(
             pixels, cvView, planePointWorld, planeNormalWorld,
@@ -254,7 +257,10 @@ object MetricFingerprintBuilder {
         }
         keptDesc.release()
 
-        slam.restoreWallFingerprintMetric(bytes, rows, cols, type, res.pointsCam, anchorModel, intr)
+        slam.restoreWallFingerprintMetric(
+            bytes, rows, cols, type, res.pointsCam, anchorModel, intr,
+            viewMatrix = glView ?: FloatArray(0),
+        )
         return Fingerprint(
             keypoints, res.pointsCam.toList(), bytes, rows, cols, type,
             markCenterLocal = markCenterLocal?.toList() ?: emptyList(),

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/PlaneMarks.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/PlaneMarks.kt
@@ -3,10 +3,15 @@ package com.hereliesaz.graffitixr.feature.ar.anchor
 /**
  * Assembles metric 3D marks from a SINGLE camera view by back-projecting detected feature pixels
  * onto a known wall plane — the depth-off, single-capture path. No triangulation and no second view:
- * by the time ARCore renders a wall plane **green** ([rendering.PlaneRenderer.PlaneMatchResult.MATCH])
- * it has already fitted that plane and solved its metric pose and distance, so the depth is already
- * paid for. The single capture only supplies the appearance (descriptors); each feature's 3D position
- * is the intersection of its camera ray with that plane.
+ * once ARCore is tracking a plane it has already fitted it and solved its metric pose and distance,
+ * so the depth is already paid for. The single capture only supplies the appearance (descriptors);
+ * each feature's 3D position is the intersection of its camera ray with that plane.
+ *
+ * The plane does NOT have to be one the UI paints green
+ * ([rendering.PlaneRenderer.PlaneMatchResult.MATCH]) — that classification judges how good the
+ * viewing angle and distance are, not whether ARCore solved the plane, and a SUBOPTIMAL plane's
+ * centerPose is exactly as metric. Requiring green used to make target creation refuse outright on
+ * dim or obliquely-viewed walls.
  *
  * Output points are in the **capture camera's frame, CV convention** (camera looks +Z, depth
  * positive) — exactly the frame [MetricMarks] produces and `MobileGS::generateFingerprint` stores

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/PlaneMarks.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/PlaneMarks.kt
@@ -24,6 +24,14 @@ package com.hereliesaz.graffitixr.feature.ar.anchor
  * looks +Z); ARCore/OpenGL views look −Z, so convert them with [MetricMarks.glViewToCv] first. The
  * plane point and normal are in ARCore **world** space (e.g. `plane.centerPose` translation and its
  * local +Y axis); they are moved into the camera frame here.
+ *
+ * CAUTION — unresolved convention mismatch. Callers pass pixels and intrinsics that have been rotated
+ * to DISPLAY orientation, but a view matrix that has not. The rays built here therefore live in a
+ * frame rotated about the optical axis relative to the plane they are intersected with, which skews
+ * the depths for anything but a head-on wall (a normal of (0,0,±1) is invariant under that rotation,
+ * which is why it is not obvious). Fixing it properly also requires the matching change in
+ * PoseFusion's pose composition — see "Open question: the display-rotation convention" in
+ * docs/TELEOLOGICAL_SLAM.md before changing anything here.
  */
 object PlaneMarks {
 

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/PoseFusion.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/PoseFusion.kt
@@ -37,9 +37,10 @@ class PoseFusion {
         /** Base smoothing rate for a (non-cold) correction update. */
         const val BASE_ALPHA = 0.25f
         /**
-         * Splat-confidence floor. Effective confidence = CONF_FLOOR + (1-CONF_FLOOR)*confGlobal, so
-         * map maturity can *raise* trust toward 1.0 but can never drop it below the floor — depth-off
-         * (confGlobal≈0) still corrects, driven by the inlier ratio.
+         * Corroboration floor. Effective confidence = CONF_FLOOR + (1-CONF_FLOOR)*confGlobal, so
+         * painting progress can *raise* trust toward 1.0 but can never drop it below the floor — an
+         * unpainted wall still corrects, driven by the inlier ratio alone. At 0.5 the floor also sets
+         * the range: a fully corroborated wall pulls exactly twice as hard as a bare one.
          */
         const val CONF_FLOOR = 0.5f
         /** A cold (hard) snap requires at least this inlier ratio … */
@@ -81,8 +82,11 @@ class PoseFusion {
      * @param vCurrent current ARCore view matrix (fresh, GL thread)
      * @param reloc    FloatArray(19): [0..15]=pnpMat, [16]=inlierCount, [17]=matchCount, [18]=seq
      * @param fpAnchor fingerprint-frame anchor model matrix
-     * @param confGlobal global splat confidence in [0,1] — reserved (unused: with the ML depth API off
-     *        the voxel map is empty so this is ~0; correction strength is driven by PnP inlier ratio).
+     * @param confGlobal teleological corroboration in [0,1] — the fraction of the registered artwork's
+     *        features the real wall currently answers for (MobileGS painting progress). Raises smooth
+     *        correction strength from [CONF_FLOOR] at 0% painted to full at 100%, which is the
+     *        "the further along, the tighter it locks" behaviour. Never lowers it below the floor, so
+     *        a bare wall still corrects on the PnP inlier ratio alone.
      */
     fun currentAnchor(
         backbone: FloatArray,

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -330,6 +330,9 @@ class ArRenderer(
     private var lastPoseX = 0f
     private var lastPoseY = 0f
     private var lastPoseZ = 0f
+    // ARCore frame timestamp (ns) of the last motion sample, so velocity uses the real interval
+    // rather than a hardcoded rate that only matched one of the two feed throttles.
+    private var lastMotionSampleNs = 0L
     // Last camera rotation quaternion [x,y,z,w], for delta-based angular velocity.
     private var lastQuat: FloatArray? = null
 
@@ -1119,10 +1122,18 @@ class ArRenderer(
                     vCurrent = viewMatrix,
                     reloc = slamManager.getRelocResult(),
                     fpAnchor = slamManager.getFingerprintAnchor(),
-                    // Map retirement: confGlobal came from the (now-neutralized) voxel map's global
-                    // confidence, which is always 0 once the map stops building. Decouple PoseFusion
-                    // from it — pass full trust so smooth correction keeps working on the inlier ratio.
-                    confGlobal = 1f,
+                    // THE teleological input, finally connected. The claim in TELEOLOGICAL_SLAM.md is
+                    // that the further along the painting is, the more real-world corroboration the
+                    // engine has and the harder the overlay locks. That third stage was never wired:
+                    // this argument was pinned at 1f, so painting progress reached the HUD and nothing
+                    // else, and correction strength was identical at 0% and 100% painted.
+                    //
+                    // It now carries the measured corroboration (fraction of the registered artwork's
+                    // features the real wall currently answers for). PoseFusion floors it at
+                    // CONF_FLOOR, so an unpainted wall still corrects at half strength on the inlier
+                    // ratio alone — the previous behaviour is the floor, not the ceiling — and a
+                    // well-advanced mural earns up to 2x that.
+                    confGlobal = slamManager.getPaintingProgress(),
                 )
             } else backbone
 
@@ -1322,25 +1333,39 @@ class ArRenderer(
                         }
 
                         // Single-capture target creation needs the metric wall plane being aimed at.
-                        // Hit-test the tapped pixel for an ARCore plane that classifies as MATCH (green
-                        // = parallel and within range) and capture its world point + normal. Null when
-                        // the tap isn't on a green plane, which gates target creation downstream.
+                        //
+                        // This used to accept ONLY a plane classifying as MATCH (green: near-parallel
+                        // and within 3 m). But MATCH is a judgement about how good the VIEW is, not
+                        // about whether ARCore has solved the plane — a SUBOPTIMAL plane's centerPose
+                        // is exactly as metric. Requiring green meant that on a dim wall, or one taken
+                        // at an angle, target creation refused outright with "face a wall", and the
+                        // artist had no way to proceed. Now any tracking plane under the tap will do,
+                        // green preferred; the honest quality bar is downstream, where the fingerprint
+                        // needs enough features to actually localize.
                         var wallPlane: FloatArray? = null
                         if (tap != null && surfaceWidth > 0) {
                             try {
                                 val px = tap[0] * surfaceWidth
                                 val py = tap[1] * surfaceHeight
+                                var fallback: com.google.ar.core.Plane? = null
                                 for (h in frame.hitTest(px, py)) {
                                     val tr = h.trackable
-                                    if (tr is com.google.ar.core.Plane && tr.isPoseInPolygon(h.hitPose) &&
-                                        planeRenderer.classifyPlane(tr, camera.pose) ==
+                                    if (tr !is com.google.ar.core.Plane) continue
+                                    if (tr.trackingState != TrackingState.TRACKING) continue
+                                    if (tr.subsumedBy != null) continue
+                                    if (!tr.isPoseInPolygon(h.hitPose)) continue
+                                    if (planeRenderer.classifyPlane(tr, camera.pose) ==
                                             PlaneRenderer.PlaneMatchResult.MATCH) {
-                                        val c = tr.centerPose
-                                        val nrm = FloatArray(3)
-                                        c.getTransformedAxis(1, 1.0f, nrm, 0) // plane local +Y = normal
-                                        wallPlane = floatArrayOf(c.tx(), c.ty(), c.tz(), nrm[0], nrm[1], nrm[2])
-                                        break
+                                        fallback = tr
+                                        break // green wins outright
                                     }
+                                    if (fallback == null) fallback = tr // first non-green hit, kept
+                                }
+                                fallback?.let { tr ->
+                                    val c = tr.centerPose
+                                    val nrm = FloatArray(3)
+                                    c.getTransformedAxis(1, 1.0f, nrm, 0) // plane local +Y = normal
+                                    wallPlane = floatArrayOf(c.tx(), c.ty(), c.tz(), nrm[0], nrm[1], nrm[2])
                                 }
                             } catch (e: Exception) {
                                 Timber.w(e, "Wall-plane hit-test for capture failed")
@@ -1404,18 +1429,32 @@ class ArRenderer(
                 }
             }
 
-            // Throttle frame feeding to 15Hz (every 4 frames at 60Hz) to halve processing-related power draw.
-            // When tracking is stable and the device is stationary, we could throttle even further.
-            // ── Frame Data Pipeline (Throttle to 20Hz or 2Hz for Battery Efficiency) ──
+            // ── Frame Data Pipeline ──
+            // Post-anchor this was every 30th frame — 2 Hz at 60 fps — which is the rate the wall gets
+            // re-checked for relocalization while the artist is actually painting, i.e. the rate the
+            // overlay can recover after drift or a look-away. That was set when every feed did a full
+            // YUV->RGB convert plus rotate on this thread whether or not anything wanted the result;
+            // relocWantsFrame() now rejects that work up front, so a feed the reloc worker isn't ready
+            // for costs only the YUV assembly. The worker itself self-limits (200 ms between attempts),
+            // so feeding at ~6 Hz keeps it saturated without ever queueing.
             lastStep = "slamFeed"
-            val throttleRate = if (anchorEstablished) 30 else 3 // 2Hz vs 20Hz
+            val throttleRate = if (anchorEstablished) 10 else 3 // 6Hz vs 20Hz
             if (isTracking && frameCount % throttleRate == 0) {
                 // Calculate device motion (linear and angular velocity) for deblurring
                 val currentPose = camera.displayOrientedPose
                 if (frameCount > 0) {
-                    // Simple delta-based velocity estimation
-                    // In a production app, we'd use raw IMU high-frequency data.
-                    val dt = 1.0f / 20.0f // Approx 20Hz throttle
+                    // Delta-based velocity estimation, over the MEASURED interval. This was hardcoded
+                    // to 1/20 s "approx 20Hz throttle", which only ever matched the pre-anchor rate —
+                    // post-anchor the same divisor was applied to a 2 Hz sample interval, inflating
+                    // every reported velocity by 10x. The deblur consumer reads these, so the error
+                    // was real, not cosmetic. Clamped so a long first gap can't produce a wild value.
+                    val nowNs = frame.timestamp
+                    val dt = if (lastMotionSampleNs > 0L && nowNs > lastMotionSampleNs) {
+                        ((nowNs - lastMotionSampleNs) / 1_000_000_000.0f).coerceIn(0.005f, 1f)
+                    } else {
+                        throttleRate / 60f // first sample: assume the nominal 60 fps camera
+                    }
+                    lastMotionSampleNs = nowNs
                     val linVel = floatArrayOf(
                         (currentPose.tx() - lastPoseX) / dt,
                         (currentPose.ty() - lastPoseY) / dt,

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/PoseFusionTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/PoseFusionTest.kt
@@ -65,6 +65,33 @@ class PoseFusionTest {
         assertTrue("expected non-zero correction with depth off, got ${out[12]}", out[12] > 0f)
     }
 
+    /**
+     * The teleological claim: the further along the painting, the harder the overlay locks. This is
+     * the behaviour that was inert while ArRenderer pinned confGlobal at 1f — both ends of the range
+     * produced the identical correction.
+     */
+    @Test fun `corroboration scales correction strength`() {
+        // Same relock, same inlier ratio; only the corroboration differs.
+        val bare = PoseFusion().currentAnchor(trans(0f,0f,0f), identity(),
+            reloc(trans(10f,0f,0f), inliers = 60f, matches = 100f, seq = 1f), identity(), confGlobal = 0f)
+        val painted = PoseFusion().currentAnchor(trans(0f,0f,0f), identity(),
+            reloc(trans(10f,0f,0f), inliers = 60f, matches = 100f, seq = 1f), identity(), confGlobal = 1f)
+        assertTrue(
+            "a corroborated wall should pull harder than a bare one: bare=${bare[12]} painted=${painted[12]}",
+            painted[12] > bare[12],
+        )
+        // And the floor bounds how much: CONF_FLOOR=0.5 means full corroboration is exactly 2x.
+        assertEquals(2f, painted[12] / bare[12], 1e-3f)
+    }
+
+    @Test fun `corroboration outside 0-1 is clamped, not extrapolated`() {
+        val full = PoseFusion().currentAnchor(trans(0f,0f,0f), identity(),
+            reloc(trans(10f,0f,0f), inliers = 60f, matches = 100f, seq = 1f), identity(), confGlobal = 1f)
+        val over = PoseFusion().currentAnchor(trans(0f,0f,0f), identity(),
+            reloc(trans(10f,0f,0f), inliers = 60f, matches = 100f, seq = 1f), identity(), confGlobal = 5f)
+        assertEquals(full[12], over[12], 1e-4f)
+    }
+
     @Test fun `correction persists and stays world-locked between snaps`() {
         val f = PoseFusion()
         // Confident cold snap establishes D = +10x at backbone origin.

--- a/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/EditorViewModel.kt
+++ b/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/EditorViewModel.kt
@@ -173,6 +173,10 @@ class EditorViewModel @Inject constructor(
             slamManager.restoreWallFingerprintMetric(
                 fp.descriptorsData, fp.descriptorsRows, fp.descriptorsCols, fp.descriptorsType,
                 fp.points3d.toFloatArray(), anchor.toFloatArray(), intr.toFloatArray(),
+                // Capture view, so reload keeps the plane-guided rectification for oblique views.
+                // Empty on projects saved before it was persisted — native then skips that pass.
+                viewMatrix = project.fingerprintViewMatrix
+                    .takeIf { it.size == 16 }?.toFloatArray() ?: FloatArray(0),
             )
         } else {
             slamManager.restoreWallFingerprint(


### PR DESCRIPTION
Everything found tracing why relocalization has never locked once. Every item here was silent.

## 1. Every failure was invisible

`mPnpMatchCount` / `mPnpInlierCount` only updated on **success**, so a relocalizer that had never locked was indistinguishable from an idle one — zeros forever, with no way to tell whether the fingerprint was missing, the frame had no texture, or PnP was solving and falling one inlier short.

`MobileGS` now records why each attempt stopped and how far it got, published through one packed JNI read and rendered by a new overlay that names the gate **and what to do about it**:

| State | Overlay |
|---|---|
| `NO_FINGERPRINT` | NO TARGET — create a target, nothing to match against |
| `NO_FEATURES` | NO FEATURES — frame has no texture: light, focus or blur |
| `FEW_MATCHES` | `n`/8 MATCHES — with the *right* advice, see §5 |
| `PNP_FAILED` | NO POSE — `n` matches, none geometrically consistent |
| `FEW_INLIERS` | `n`/6 INLIERS — close: hold steadier, or get square to the wall |
| `OK` | LOCKED |

Plus the inlier **ratio** (what PoseFusion actually gates on: ≥0.5 to correct, ≥0.7 with 20+ inliers to hard-snap), features in frame, fingerprint point count, corroboration %, and obliquity.

Shipped in **release**, behind the existing Diagnostic Overlay setting.

## 2. Oblique-view rectification was dead code

`relocThreadFunc` has a plane-guided rectification pass — the marks lie on a known plane, so oblique-vs-frontal distortion is a homography it can pre-cancel before matching. It runs only when `mHasFingerprintView` is set, and that flag is assigned in exactly one place: `generateFingerprint`, the ARCore-depth path, which is **disabled**. Every fingerprint the app actually builds goes through `restoreWallFingerprintMetric`, which never set it.

So the pass has never run. On any wall. Ever — and it exists for exactly the case a muralist is in.

The capture view is now plumbed through and persisted (`GraffitiProject.fingerprintViewMatrix`, defaulted empty so old projects decode fine). A fingerprint supplied without one explicitly *clears* the flag rather than inheriting the previous one's view, which would warp to the wrong frontal frame.

## 3. Target creation refused anything but a green plane

The capture hit-test accepted only a `MATCH` plane — near-parallel, within 3 m. But `MATCH` judges how good the **view** is, not whether ARCore solved the plane; a `SUBOPTIMAL` plane's `centerPose` is exactly as metric. On a dim or obliquely-viewed wall, target creation refused outright and there was no way to proceed. Any tracked, un-subsumed plane under the tap is now accepted, green preferred.

## 4. Three silent bails on the confirm path

A confirmed target could vanish with no message at all:

- Fingerprint build failed → *"Not enough texture"* regardless of cause. Now distinguishes *"Only 6 features on this wall (need 20)"* from *"Found 340 features but only 4 landed on the wall surface"*.
- Missing bitmap/intrinsics/view matrix → bare `return`. These should always be present by confirm time, so it now says so.
- No open project → bare `return@launch` from inside a coroutine. A fingerprint is saved *into* a project, which is now the message.

## 5. The acquisition path was working against itself

- **Query detector starved.** Live frames detected with `ORB(500)`, matched against a fingerprint built with `ORB(1500)`. A third as many features on the query side throws matches away before the ratio test runs. Now symmetric.
- **Detection ran twice per cycle.** `relocThreadFunc` detected features, then `tryUpdateFingerprint` detected them again on the identical frame — with SuperPoint, a second whole ONNX forward pass for a byte-identical result. Now handed over.
- **Flat 5 Hz including while hunting.** A 200 ms sleep after every attempt capped the state that matters most: acquiring the first lock, or re-acquiring after a look-away. Now 60 ms while hunting, 200 ms once locked.
- **`FEW_MATCHES` was two different problems.** A handful of features in frame is a capture problem; a thousand that don't match is an aiming problem. The live detected count is now published and picks which advice to give.

## 6. The teleological stage was never wired

`TELEOLOGICAL_SLAM.md` claims that as painting progresses, corroborated marks contribute more to the pose and the overlay locks tighter. **That stage did not exist** — `ArRenderer` pinned `PoseFusion`'s `confGlobal` at `1f`, so painting progress reached the HUD and nothing else, and correction strength was identical at 0% and 100% painted. It now carries the measured corroboration, with `CONF_FLOOR` making the old behaviour the floor rather than the ceiling: a bare wall corrects as before, a fully corroborated one pulls exactly 2× harder.

## 7. Self-grow could not bootstrap

Promotion of validated new marks required a flat `inliers >= 20`. Self-grow exists to keep relocalization alive *as the original marks get painted over*, but a half-covered wall rarely reaches 20 raw inliers — so the fingerprint could only grow when it was already strong. `growTrusted` adds a ratio-based path (≥0.6 with ≥10 inliers), above the 0.5 bar PoseFusion itself trusts. RANSAC remains the geometric backstop.

## Also

- **Device-motion velocity bug**: `dt` was hardcoded to 1/20 s, matching only the pre-anchor feed rate. Post-anchor the same divisor was applied to a 2 Hz interval, inflating every reported velocity 10×. The deblur consumer reads these. Now measured from ARCore frame timestamps.
- **Post-anchor reloc feed** 2 Hz → 6 Hz — the rate the wall is re-checked while painting.
- Removed `setArtworkFingerprintFromComposite`: nothing called it, and it bailed on its first line because the depth API is disabled.
- `mLastRelocReject` was value-initialised to `0` = `kRelocOk`, so a fresh engine would have reported LOCKED before a single attempt. Starts at `kRelocNoFingerprint`.

## Open question — deliberately not fixed

**The display-rotation convention.** At capture the bitmap and intrinsics are rotated to display orientation but the view matrix is not, so `PlaneMarks` builds rays in a frame rotated about the optical axis relative to the plane it intersects them with. The depths come out skewed and the fingerprint's 3D structure isn't the real wall — which would leave PnP no consistent pose to find.

Two things make it fit: the error **vanishes for a head-on wall** (a `(0,0,±1)` normal is invariant under rotation about Z) and grows with obliquity; and the onboarding doodle path shares the convention, so it fails identically.

Not fixed because rotating the capture view alone is insufficient — the 3D points would move into the rotated frame while `PoseFusion` composes `inverse(V_current) · pnp · fpAnchor` with `V_current` unrotated, so the composition needs the same treatment and every rotation sign must be right or the overlay lands *worse*. Full algebra recorded in `docs/TELEOLOGICAL_SLAM.md` with a caution at the `PlaneMarks` call site.

**The diagnostics discriminate it:** a healthy match count with a low inlier ratio points here; `NO TARGET` / `NO FEATURES` / a low in-frame count point at what's already fixed above.

## Testing

CI is green on this head — both `unit-tests` and both `build-and-release` jobs, so the Kotlin, the C++ and the tests all pass.

`RelocDiagnosticsTest` pins the reject enum ordinal-for-ordinal against the native contract (the bridge reads by ordinal), the ratio maths, and that the defaults are the never-attempted state rather than a fake success. `PoseFusionTest` covers the newly-wired corroboration: it scales correction strength, full corroboration is exactly 2× bare, and out-of-range values clamp.

Everything else is **unverified on device** — no Android SDK here. Worth checking on hardware, in this order:

1. **Read the Reloc line in the Diagnostic Overlay.** That single reading says which of these was actually stopping you.
2. Whether `Oblique` shows a real angle (rectification firing) or `off`.
3. That accepting non-green planes doesn't produce fingerprints too weak to localize — which now shows as `FEW_MATCHES`/`FEW_INLIERS` rather than a silent refusal.
4. That the relaxed self-grow gate doesn't drift the fingerprint over a long session.