### PR TITLE
fix: two shipping relocalizer bugs and four defects in the research dossier, found by the audit agent

### DIFF
--- a/.claude/agents/glee.md
+++ b/.claude/agents/glee.md
@@ -33,10 +33,24 @@ sounding confident without evidence.
 
 So: every single finding carries a `file:line` and a concrete failure scenario.
 Inputs, state, and the wrong output that results. "This could be fragile" is not
-a finding. "At `MobileGS.cpp:807`, `growTrusted` is called with `pnpMatches` read
-outside the mutex at line 803, so a concurrent `mPnpMatchCount` store between
-those lines yields a ratio computed from mismatched numerator and denominator" is
-a finding.
+a finding. This is:
+
+> `clearWallFingerprint()` releases `mWallDescriptors` and `mWallKeypoints3D` but
+> not `mArtworkDescriptors`, and no other function in the tree clears those. So a
+> project switch leaves the previous project's artwork validator live:
+> `tryUpdateFingerprint` matches the new project's frames against the old
+> project's target and publishes a meaningless painting progress that reaches
+> both the user's readout and `PoseFusion`'s correction strength.
+
+Note what makes it a finding rather than an opinion: named symbols, a stated
+absence you can check with one grep, and a specific wrong output at the end of
+the chain.
+
+**Verify every line number before you cite it.** Do not cite from memory or from
+a nearby grep hit — open the file and look. A finding whose `file:line` points at
+a closing brace is not a near miss, it is a fabrication with a citation stapled
+on, and it will be read as authoritative precisely because the findings around it
+were real.
 
 If you check something and it is genuinely fine, say so in one line and move on.
 Do not pad. Do not invent. A short honest audit beats a long padded one, and

--- a/.gitignore
+++ b/.gitignore
@@ -70,7 +70,10 @@ gha-creds-*.json
 /project_source_*.txt
 .worktrees/
 /.agent/
-/.claude/
+# Trailing /* rather than /: git never descends into an EXCLUDED DIRECTORY, so a negation
+# for a path inside one is unreachable. Excluding the contents instead leaves the directory
+# itself traversable, which is what makes the next line work.
+/.claude/*
 # ...except shared agent definitions, which are part of the project.
 !/.claude/agents/
 strangerdanger-494206-082913abfaab.json

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -2173,9 +2173,9 @@ private fun EvalOverlay(
 ) {
     // Local UI state for the A/B switch; defaults to true to match ArRenderer.fusionEnabled.
     val fusionOn = androidx.compose.runtime.remember { androidx.compose.runtime.mutableStateOf(true) }
-    // Teleological self-grow defaults ON to match the native default (lets the reloc fingerprint
-    // self-grow so snap-back survives repainting; hard-guarded). Toggle to disable.
-    val selfGrowOn = androidx.compose.runtime.saveable.rememberSaveable { androidx.compose.runtime.mutableStateOf(true) }
+    // Teleological self-grow defaults OFF to match the native default (MobileGS.h). It permanently
+    // mutates the authoritative reloc fingerprint, so it is opt-in per session. Toggle to enable.
+    val selfGrowOn = androidx.compose.runtime.saveable.rememberSaveable { androidx.compose.runtime.mutableStateOf(false) }
     androidx.compose.foundation.layout.Column(
         androidx.compose.ui.Modifier
             .background(androidx.compose.ui.graphics.Color(0xAA000000))

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/Fingerprint.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/Fingerprint.kt
@@ -43,6 +43,14 @@ data class Fingerprint(
                     "descriptor row stride (${descriptorsData.size / descriptorsRows}) must be a multiple of descriptorsCols ($descriptorsCols)"
                 }
             }
+            // Same argument, second array. The reloc PnP subscripts the 3D point list by DESCRIPTOR
+            // ROW (`wallKps3d[match.trainIdx]`), so a file whose point count disagrees with its row
+            // count indexes past the end of the vector and feeds garbage 3D into solvePnPRansac. The
+            // blob check above was carried over from WallFeatureMap; this one was not.
+            require(points3d.isEmpty() || points3d.size / 3 == descriptorsRows) {
+                "points3d holds ${points3d.size / 3} points but $descriptorsRows descriptor rows were declared; " +
+                    "the reloc path indexes points by descriptor row, so they must be 1:1"
+            }
         }
     }
 

--- a/core/common/src/test/java/com/hereliesaz/graffitixr/common/model/FingerprintJniContractTest.kt
+++ b/core/common/src/test/java/com/hereliesaz/graffitixr/common/model/FingerprintJniContractTest.kt
@@ -39,7 +39,13 @@ class FingerprintJniContractTest {
     @Test
     fun `fromNative passes every field through unchanged`() {
         val keypoints = listOf(KeyPoint(1f, 2f, 3f, 4f, 5f, 6, 7))
-        val points3d = listOf(0.5f, -1.5f, 2f)
+        // TWO points for the two declared descriptor rows. The counts used to be arbitrary here —
+        // this test is about ABI pass-through, not geometry — but Fingerprint's init now requires
+        // points3d and descriptorsRows to be 1:1, because the reloc path subscripts the point list
+        // by descriptor row. A mismatched fixture would throw inside the factory, which is also
+        // what a mismatched NATIVE payload now does (buildFingerprintObject's ExceptionCheck bails
+        // to nullptr instead of handing back a fingerprint that reads out of bounds).
+        val points3d = listOf(0.5f, -1.5f, 2f, 3.5f, 4f, -6.25f)
         val descriptors = byteArrayOf(1, 2, 3, 4)
         val patch = byteArrayOf(9, 8)
         val center = listOf(0.1f, 0.2f, 0.3f)

--- a/core/common/src/test/java/com/hereliesaz/graffitixr/common/serialization/FingerprintSerializationTest.kt
+++ b/core/common/src/test/java/com/hereliesaz/graffitixr/common/serialization/FingerprintSerializationTest.kt
@@ -141,4 +141,38 @@ class FingerprintSerializationTest {
             )
         }
     }
+
+    /**
+     * The reloc PnP subscripts the 3D point list by DESCRIPTOR ROW (`wallKps3d[match.trainIdx]`), so
+     * a file declaring more rows than it carries points reads past the end of the vector and feeds
+     * garbage 3D into solvePnPRansac. The blob-vs-rows guard above did not cover this second array.
+     */
+    @Test
+    fun `Fingerprint rejects a points3d count that disagrees with the descriptor row count`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            Fingerprint(
+                keypoints = emptyList(),
+                points3d = listOf(0.5f, 0.25f, 0.75f), // 1 point …
+                descriptorsData = byteArrayOf(1, 2, 3, 4), // … but 2 rows of 2 declared below
+                descriptorsRows = 2,
+                descriptorsCols = 2,
+                descriptorsType = 0,
+            )
+        }
+    }
+
+    /** Points-free fingerprints (keypoint-only, older projects) stay legal at any row count. */
+    @Test
+    fun `Fingerprint allows an empty points3d list alongside descriptor rows`() {
+        val fp = Fingerprint(
+            keypoints = emptyList(),
+            points3d = emptyList(),
+            descriptorsData = byteArrayOf(1, 2, 3, 4),
+            descriptorsRows = 2,
+            descriptorsCols = 2,
+            descriptorsType = 0,
+        )
+        assertEquals(2, fp.descriptorsRows)
+        assertEquals(0, fp.points3d.size)
+    }
 }

--- a/core/nativebridge/src/main/cpp/MobileGS.cpp
+++ b/core/nativebridge/src/main/cpp/MobileGS.cpp
@@ -301,6 +301,12 @@ void MobileGS::relocThreadFunc() {
             const cv::Mat& descs = (preKps && preDescs) ? *preDescs : localDescs;
             if (descs.empty() || wallDescs.empty()) return;
             if (descs.type() != wallDescs.type()) return;
+            // trainIdx indexes wallDescs' ROWS but is used to subscript wallKps3d, so the two must be
+            // the same length. Every in-tree producer keeps them aligned; a truncated or hand-edited
+            // .gxr does not, and the result would be an out-of-bounds vector read feeding garbage 3D
+            // points into solvePnPRansac. The map path (below) already guards this; the wall path did
+            // not. Refuse rather than relocalize against nonsense.
+            if (wallKps3d.size() != (size_t)wallDescs.rows) return;
 
             cv::Ptr<cv::DescriptorMatcher>& matcher = (descs.type() == CV_32F) ? mL2Matcher : mMatcher;
             std::vector<std::vector<cv::DMatch>> matches;
@@ -807,7 +813,8 @@ void MobileGS::tryUpdateFingerprint(const cv::Mat& grayClean,
         wall = mWallKeypoints3D;
         if (growTrusted(inliers, pnpMatches)) mLastGrowSeq = seq; // claim it (yield or not)
     }
-    if (!growTrusted(inliers, pnpMatches) || fx <= 0 || fy <= 0 || wall.size() < 12 || wall.size() > 5000) return;
+    if (!growTrusted(inliers, pnpMatches) || fx <= 0 || fy <= 0 ||
+        wall.size() < 12 || wall.size() >= kMaxWallMarks) return;
 
     // Wall plane (n·X = pdist, pdist>0) in the fingerprint frame, fit to the existing marks.
     cv::Mat data((int)wall.size(), 3, CV_32F);
@@ -846,15 +853,26 @@ void MobileGS::tryUpdateFingerprint(const cv::Mat& grayClean,
     }
     if (newPts.empty()) return;
 
+    size_t promoted = 0, wallNow = 0;
     {
         std::lock_guard<std::mutex> lock(mMutex);
-        if (mWallDescriptors.type() != newDescs.type() || mWallDescriptors.cols != newDescs.cols || mWallKeypoints3D.size() > 5000) return;
-        for (int i = 0; i < (int)newPts.size(); ++i) {
+        if (mWallDescriptors.type() != newDescs.type() || mWallDescriptors.cols != newDescs.cols ||
+            mWallKeypoints3D.size() >= kMaxWallMarks) return;
+        // Fill to the cap exactly. Testing the size only BEFORE the loop let a wall sitting at
+        // kMaxWallMarks-1 grow by the full per-relock batch, so the documented ceiling was really
+        // ceiling + batch.
+        const size_t room = kMaxWallMarks - mWallKeypoints3D.size();
+        const size_t take = std::min(room, newPts.size());
+        for (size_t i = 0; i < take; ++i) {
             mWallKeypoints3D.push_back(newPts[i]);
-            mWallDescriptors.push_back(newDescs.row(i));
+            mWallDescriptors.push_back(newDescs.row((int)i));
         }
+        // Snapshot inside the lock: these feed a log line below, and reading the containers after
+        // the guard released races a concurrent restoreWallFingerprintMetric on the JNI thread.
+        promoted = take;
+        wallNow = mWallKeypoints3D.size();
     }
-    LOGI("Teleological self-grow: promoted %zu marks (wall now %zu)", newPts.size(), mWallKeypoints3D.size());
+    LOGI("Teleological self-grow: promoted %zu marks (wall now %zu)", promoted, wallNow);
 }
 void MobileGS::setArCoreTrackingState(bool t) { mIsArCoreTracking.store(t, std::memory_order_relaxed); }
 
@@ -907,6 +925,18 @@ void MobileGS::clearWallFingerprint() {
     static const float kIdentity16[16] = {1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1};
     memcpy(mFingerprintAnchorMatrix, kIdentity16, 16 * sizeof(float));
     memset(mFingerprintIntrinsics, 0, 4 * sizeof(float));
+    mHasFingerprintView = false;
+
+    // The ARTWORK side has to go too. It used to survive, and there is no other path that clears it:
+    // an un-fingerprinted project would then be validated against the PREVIOUS project's artwork by
+    // tryUpdateFingerprint, publishing a meaningless painting progress that reaches the user's
+    // progress readout AND PoseFusion's correction strength — and, with self-grow enabled, promoting
+    // this project's features into its map on the strength of a different project's target.
+    mArtworkDescriptors.release();
+    mArtworkKeypoints3D.clear();
+    mWallPatch.release();
+    mPaintingProgress.store(0.0f, std::memory_order_relaxed);
+    mLastGrowSeq = 0;
 }
 
 void MobileGS::restoreWallFeatureMap(const cv::Mat& d, const std::vector<cv::Point3f>& p,
@@ -1129,14 +1159,18 @@ void MobileGS::setArtworkFingerprint(const cv::Mat& composite, const uint8_t* de
         }
     }
 
+    int storedRows = 0; size_t storedPts = 0;
     {
         std::lock_guard<std::mutex> lock(mMutex);
         mArtworkDescriptors = keepDescs.clone();
         mArtworkKeypoints3D = std::move(pts3d);
         mPaintingProgress.store(0.0f, std::memory_order_relaxed);
+        // Snapshot under the lock — the reloc thread reads both of these, so logging them after the
+        // guard releases is a race on a cv::Mat header and a vector.
+        storedRows = mArtworkDescriptors.rows;
+        storedPts = mArtworkKeypoints3D.size();
     }
-    LOGI("setArtworkFingerprint: stored %d validator features (%zu with 3D)",
-         mArtworkDescriptors.rows, (size_t)mArtworkKeypoints3D.size());
+    LOGI("setArtworkFingerprint: stored %d validator features (%zu with 3D)", storedRows, storedPts);
 }
 
 void MobileGS::setWallPatch(const cv::Mat& img) {

--- a/core/nativebridge/src/main/cpp/include/MobileGS.h
+++ b/core/nativebridge/src/main/cpp/include/MobileGS.h
@@ -105,6 +105,9 @@ public:
         return (float)inliers / (float)matches >= 0.6f;  // above PoseFusion's 0.5 trust bar
     }
 
+    /** Hard ceiling on stored wall marks — a memory guard on the self-grow append. */
+    static constexpr size_t kMaxWallMarks = 5000;
+
     /** Last [RelocReject]. */
     int lastRelocReject() const { return mLastRelocReject.load(std::memory_order_relaxed); }
     /** Correspondences built by the last attempt, successful or not. */
@@ -295,9 +298,15 @@ private:
     // restored without a capture view (rectification is then skipped — plain matching still runs).
     float mFingerprintViewMatrix[16] = {1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1};
     bool mHasFingerprintView = false;
-    // Teleological self-grow: default ON + the last reloc seq we grew from (only grow on a fresh,
+    // Teleological self-grow: default OFF + the last reloc seq we grew from (only grow on a fresh,
     // confident relock so promoted marks are placed with a current pose, never a stale one).
-    std::atomic<bool> mSelfGrowEnabled{true};
+    //
+    // OFF, not ON. This is the only mechanism in the engine that permanently mutates the
+    // authoritative reloc fingerprint, so a bad promotion is not a transient error — it is written
+    // into the map and compounds. tryUpdateFingerprint's own comment says it "stays OFF unless
+    // explicitly enabled"; the initializer said otherwise and the header won, which meant every
+    // release build promoted unsupervised with no user-facing switch to stop it.
+    std::atomic<bool> mSelfGrowEnabled{false};
     long mLastGrowSeq = 0;
     cv::Mat mWallPatch; // raw 256x256 gray canonical patch for the distortion head (desc_fp source)
     // VIO view snapshot captured alongside the reloc frame, so the rectifying warp matches that frame.

--- a/docs/research/EVALUATION.md
+++ b/docs/research/EVALUATION.md
@@ -393,9 +393,10 @@ Levels are set far apart deliberately — screening asks "does it matter", and w
 levels maximize the signal against E2's noise floor. Fine resolution is E5–E8's
 job.
 
-**Sets.** The set of parameters that go on to be swept; everything else is fixed
-at its prior and marked insensitive in `PARAMETERS.md`, *with the screening
-evidence recorded*, so a future session does not re-litigate it.
+**Sets.** The *shortlist*, not any values. E4 decides which parameters are worth
+sweeping; **E11** assigns them numbers. Everything E4 rejects is fixed at its prior
+and marked insensitive in `PARAMETERS.md`, *with the screening evidence recorded*,
+so a future session does not re-litigate it.
 
 ---
 
@@ -555,6 +556,101 @@ error.
 
 ---
 
+### E11 — Sweeping the screened survivors
+
+**Question.** For each parameter E4 flagged as mattering, what value minimizes the
+objective in §4.2?
+
+**Method.** One-dimensional sweep of each survivor, holding the others at their
+screened-best, on the synthetic progression at 0/50/100% coverage. Any pair whose
+E4 interaction estimate is non-negligible gets a small 2-D grid instead. Levels
+come from `PARAMETERS.md`; the candidate set is expected to include the PnP
+reprojection threshold, `MIN_INLIER_RATIO`, `BASE_ALPHA`, `CONF_FLOOR`, the two
+reloc-thread sleeps (under the E9 cost constraint), and the three
+`SEARCH_RADIUS_*` bounds.
+
+**Reasoning.** §4.1 describes screen → sweep → confirm, and this is the sweep. It
+is a separate experiment rather than a clause inside E4 because E4's job is
+*selection* and E11's is *assignment*, and conflating them is how a table ends up
+routing a dozen parameters to an experiment that sets nothing. The 1-D sweep is
+only legitimate for parameters E4 showed to be interaction-free — that
+qualification is the reason E4 has to run first and has to be Resolution IV.
+
+**Sets.** Every parameter in `PARAMETERS.md` whose "Set by" cell names E11.
+
+**Falsifies.** Nothing on its own. If a swept parameter's response curve is flat
+across its whole range, E4's screening produced a false positive and the parameter
+returns to its prior with that recorded as the evidence.
+
+---
+
+### E12 — Does the partition earn its place?
+
+**Question.** Is relocalization availability at ≥50% coverage higher with the
+footprint partition than without it?
+
+**Method.** A/B on identical replayed synthetic-progression datasets: Phase 2
+enabled versus Phase 2 forced to "everything is backbone" (the rollback constant
+from `IMPLEMENTATION.md`, which reproduces `main`'s behaviour exactly). Measure
+`availability` and `errMm` at coverage 0/25/50/75/100%.
+
+**Reasoning.** This is **P1**, and P1 is the prediction that justifies the
+partition — the single largest structural change in the plan. Every other
+experiment from E5 onward tunes *within* the new design and takes the partition as
+given; none of them compares it to not having it. Without E12 the partition would
+ship on the strength of its argument alone, which is precisely the failure mode
+the paper spends §4 documenting.
+
+The rollback constant makes this a genuinely controlled A/B: same code path, same
+build, one boolean. Nothing else differs, so a difference in availability is
+attributable to the partition and not to anything that landed alongside it.
+
+The ≥50% threshold is where the prediction lives — below that, too little of
+`F_in` has decayed for the two conditions to diverge, and a null result at 25%
+would be uninformative rather than falsifying.
+
+**Sets.** Nothing. It is the go/no-go on Phase 2.
+
+**Falsifies P1.** If availability is equal or worse with the partition at every
+coverage level, the backbone is not more durable than the undifferentiated set,
+and Phase 2 should be reverted rather than tuned. Check `backboneFeatures` before
+concluding that — an empty or tiny `F_out` (the wall-filling-design case) makes
+P1 untestable rather than false.
+
+---
+
+### E13 — Does disagreement predict pose error?
+
+**Question.** Does the rigid-offset fit over corroborated `F_in` features correlate
+with measured overlay error?
+
+**Method.** On the synthetic progression, at each frame with ≥8 corroborated
+features, fit the rigid 2-D offset between predicted and observed footprint
+positions (§5.6 of the paper). Log the fitted offset magnitude alongside `errMm`.
+Compute the correlation over frames, bucketed by coverage: 0–30%, 30–60%, 60–100%.
+
+**Reasoning.** This is **P5**, which had no experiment. It matters for two
+reasons beyond completeness. First, if the correlation holds, the offset fit
+becomes a *free error estimate* — a signal the system can act on in real time
+without ground truth, which is otherwise unavailable on a real wall. Second, it is
+the designated detector for the anchor-drift threat in §7 of the paper: if the fit
+correlates with anchor error rather than pose error, P5 passes while P1 fails, and
+that specific pattern is what tells you to stop tuning the relocalizer.
+
+The ≥8-feature floor and the coverage bucketing are both necessary. Below 8
+features the fit is dominated by noise; and the prediction is explicitly that the
+correlation appears *once coverage exceeds ~30%*, so pooling all coverages would
+average a real effect against a regime where none is expected.
+
+**Sets.** Nothing directly. If P5 holds, it justifies a follow-on: feeding the
+fitted offset into the Phase 4 search radius as a better uncertainty estimate than
+`errMm`, which is only available in evaluation.
+
+**Falsifies P5.** Correlation at `r ≤ 0.7` above 30% coverage. Combined with a
+passing P1, that points at anchor drift rather than relocalization error.
+
+---
+
 ## 6. Analysis conventions
 
 **Report medians and interquartile ranges, not means and standard deviations.**
@@ -591,12 +687,18 @@ information per hour:
    invalidate everything else. Non-negotiable.
 2. **E2** — the baseline. Without it there is no comparison.
 3. **E3** — the progress/confidence split. Cheapest real improvement in the plan.
-4. **E7** — the `ρ` × ratio grid. Tests the paper's central mechanism directly and
+4. **E12** — does the partition earn its place? One boolean, two runs, and it is
+   the go/no-go on the plan's largest structural change.
+5. **E7** — the `ρ` × ratio grid. Tests the paper's central mechanism directly and
    sets the two parameters that matter most.
-5. **E10** — the thesis.
+6. **E10** — the thesis.
 
-E4 can be skipped by fixing the insensitive parameters at their priors and
-accepting the risk. E5 can be skipped entirely by shipping promotion disabled,
-which is the default anyway. E6 is subsumed by E7's grid. E8's margins can take
-their priors. E9 must not be skipped before shipping, but can be deferred until
+E4/E11 can be collapsed by fixing the insensitive parameters at their priors and
+sweeping only the two or three you most distrust. E5 can be skipped entirely by
+shipping promotion disabled, which is the default. E6 is subsumed by E7's grid.
+E8's margins can take their priors. E13 is skippable — P5 is a nice-to-have, not
+load-bearing. E9 must not be skipped before shipping, but can be deferred until
 after the mechanism is shown to work.
+
+**E12 is not skippable.** It is the only experiment that asks whether the
+partition helps at all, and it is cheap: one boolean, two runs.

--- a/docs/research/IMPLEMENTATION.md
+++ b/docs/research/IMPLEMENTATION.md
@@ -43,7 +43,9 @@ halves of one convention. Phase 0 exists because of this.
 
 ## Phase 0 — Resolve the display-rotation convention
 
-**Status: prerequisite. Gates Phase 3. Does not gate Phases 1, 2, 4, 5.**
+**Status: prerequisite. Gates every phase that consumes 3D wall points — 2, 3, 4,
+and 5b. Does not gate Phase 1 (pure math on points supplied by the caller), 5a,
+or 6a.**
 
 ### The defect
 
@@ -72,13 +74,27 @@ in; `vCurrent` is the live ARCore view. If the stored points carry a baked-in
 — and it is wrong in a way that partially cancels the back-projection error,
 which is why the system limps rather than failing outright.
 
-### Why it must be settled before Phase 3
+### Why it must be settled before any 3D-consuming phase
 
-Phase 3 promotes new observations into the fingerprint using the current
-relocalized pose (`mPnpCamFromFpWorld` in `tryUpdateFingerprint`). If the pose
-carries a rotation error, promotion *writes that error into the map* and it
-compounds. Building geometric promotion on an unresolved convention converts a
-static bias into a divergent one.
+**Phase 2 (partition).** Φ classifies the very 3D points `backProject` produced.
+Skewed points land in the wrong region, in proportion to capture obliquity, and
+the partition — the structural claim of the whole design — is then computed on
+geometry that is wrong in a way nothing downstream can detect.
+
+**Phase 4 (corroboration).** The search radius is derived from a projected
+prediction. A skewed point predicts the wrong pixel, so the local search looks in
+the wrong place, and a low corroboration rate would be read as the mechanism
+failing rather than the frame convention.
+
+**Phase 3 (promotion), worst.** Promotion writes new observations into the
+fingerprint using the current relocalized pose (`mPnpCamFromFpWorld` in
+`tryUpdateFingerprint`). If the pose carries a rotation error, promotion *writes
+that error into the map* and it compounds — a static bias becomes a divergent one.
+
+The general form, which is §8 of the paper's point: any failure measured on top
+of an unresolved convention is unattributable between the new mechanism and the
+old bug. That is why Phase 0 lands before Phase 2 in the order below, despite
+being the slowest and most careful piece of work in the plan.
 
 ### The decision to make
 
@@ -181,9 +197,44 @@ boundary — they belong to neither set and should be discarded rather than
 assigned. `innerMargin` shrinks the inside test, `outerMargin` grows the outside
 test, and the gap between them is the discard band.
 
-`Footprint.of` needs a 4×4 inverse. The anchor model is rigid, so use
-`PoseMath.rigidInverse` — it already exists, it is already tested, and it avoids
-a general inverse.
+#### `M` is not rigid — do not use `rigidInverse`
+
+`Footprint.of` needs a 4×4 inverse, and the obvious move is `PoseMath.rigidInverse`,
+which already exists and is already tested. **It is the wrong function here, and
+using it silently inverts the partition.**
+
+`M` is `overlayComposedScratch` (`ArRenderer.kt:1763`), built as
+`overlayBaseScratch · overlayLocalScratch` — and `overlayLocalScratch` ends with
+
+```kotlin
+Matrix.scaleM(overlayLocalScratch, 0, overlayScale, overlayScale, 1f)
+```
+
+where `overlayScale` is the user's pinch gesture (`MainScreen.kt:236`). So `M`
+carries a similarity scale, not just rotation and translation.
+
+`rigidInverse` inverts the linear part by **transposing** it, which is the inverse
+only when there is no scale. For `A = R·S` with `S = diag(s, s, 1)`, the transpose
+gives `S·Rᵀ` where the true inverse is `S⁻¹·Rᵀ` — off by a factor of `s²` on the
+`x` and `y` components, plus a wrong translation. At `overlayScale = 2`, a feature
+sitting exactly on the design edge yields `‖Φ‖∞ = 4`, gets classified `OUTSIDE`,
+and is promoted into the backbone — the set defined as *wall that never gets
+painted*. Every feature under the artwork lands in `F_out`. That is precisely the
+corruption the partition exists to prevent, produced by the partition's own
+inverse.
+
+**Do this instead.** Decompose rather than inverting the composite: `Φ` only needs
+the *rigid* part of the anchor and the scale separately, because the scale is
+already accounted for by the half-extents. Either
+
+- pass `overlayBaseScratch` (the rigid factor) as `M` and fold `overlayScale`
+  into the effective half-extents (`h_w·s`, `h_h·s`) — cheapest and exact; or
+- add `PoseMath.similarityInverse(m)`, which extracts `s` from the first column's
+  norm, transposes, and divides by `s²`. Needed anyway if any caller only has the
+  composed matrix.
+
+Prefer the first. It keeps `Φ` a pure rigid-frame operation and makes the scale
+dependency explicit at the call site instead of buried in an inverse.
 
 ### Tests — `FootprintTest.kt`
 
@@ -199,6 +250,9 @@ a general inverse.
 6. Off-plane point: a point 0.5 m in front of the wall projects to the same `(u,v)`
    as its foot. Document this explicitly — Φ deliberately discards the normal
    component, and a reader will wonder.
+7. **Scaled anchor.** With `overlayScale = 2`, a point on the design's edge still
+   maps to `‖Φ‖∞ = 1`, not 4 and not 0.25. This is the case that catches the
+   `rigidInverse` trap above, and without it the suite ships that bug green.
 
 ### Risk
 
@@ -256,14 +310,25 @@ fun build(
 
 and the same two parameters on the single-view `PlaneMarks` path.
 
-**Snapshot the extents at capture.** `OverlayRenderer`'s extents change when the
-user scales the design. The fingerprint's regions are only meaningful against the
-extents in force when it was built, so store `halfW`/`halfH` in the `Fingerprint`
-alongside the regions. If the user rescales the design afterwards, the stored
-regions are stale — recompute them from the stored 3D points and the new extents
-rather than forcing a recapture. That is a cheap pure-Kotlin pass over the point
-array and it is worth doing because rescaling the design is a normal thing for a
-user to do mid-session.
+**Snapshot the effective footprint at capture — and watch the right variable.**
+The regions are only meaningful against the design's size at the moment they were
+computed, so store that size in the `Fingerprint`. But be precise about what
+actually changes when the user resizes the design:
+
+`OverlayRenderer.setExtent` has exactly two call sites — `ArRenderer.kt:499` (a
+fixed constant at surface-created) and `ArRenderer.kt:1664` (a one-shot initial
+screen-fit, guarded by `quadInitialFitApplied`). **Neither is driven by the user.**
+The user's resize is `overlayScale` (`ArRenderer.kt:369`, set from
+`MainScreen.kt:236`), and it enters the *model matrix*, not the extents.
+
+So a `reclassify(anchorModel, halfW, halfH)` that watches the extents would
+recompute regions from two numbers that never moved, while the quantity that did
+move sits in the transform. Store and compare **`overlayScale`** — or, following
+the Phase 1 recommendation, store the effective half-extents `h_w·s`, `h_h·s`,
+which folds both into one number per axis and makes the staleness check a single
+float comparison. Recompute regions from the stored 3D points when it changes;
+that is a cheap pure-Kotlin pass and much better than forcing a recapture, because
+pinching the design is a normal thing to do mid-session.
 
 ### Native side
 
@@ -315,7 +380,7 @@ returns to `main` exactly.
 
 ## Phase 3 — Geometric promotion
 
-**Depends on: Phase 0 (hard) and Phase 2.**
+**Depends on: Phase 0 (hard), Phase 1, and Phase 2. Lands last.**
 
 ### What changes
 
@@ -376,7 +441,7 @@ dataset.
 
 ## Phase 4 — Spatially-constrained corroboration
 
-**Depends on: Phases 1 and 2. Independent of 3.**
+**Depends on: Phase 0, Phase 1, and Phase 2. Independent of 3.**
 
 ### What changes
 
@@ -434,7 +499,7 @@ scaling `r` with the *measured* recent pose error (already available as the
 
 ## Phase 5 — Separate progress from pose error
 
-**Depends on: Phase 2. Independent of 3 and 4.**
+**5a depends on nothing — land it early. 5b depends on Phases 2 and 4.**
 
 ### The defect
 
@@ -505,7 +570,7 @@ Low, and it is the highest value-per-risk item in the plan. Do it early.
 
 ## Phase 6 — Telemetry so the evaluation is possible at all
 
-**Depends on: 2. Should land alongside 2.**
+**6a depends on nothing — land it early. 6b lands with each phase that sources its columns.**
 
 `EVALUATION.md` cannot run without these channels. Extend
 `EvalSampleLog.CSV_HEADER` — currently:
@@ -539,24 +604,52 @@ project and every new number should appear there.
 
 ## Dependency graph
 
+Two phases split, because each has a part that is genuinely independent and a
+part that is not:
+
+- **5a** — publish `corroborationConfidence` as its own channel, move the ×0.9
+  decay off the progress channel. Keeps today's `artDescs.rows` denominator.
+  Depends on nothing.
+- **5b** — change the denominator to *predicted-visible* `F_in`. Depends on 2 and 4.
+- **6a** — the telemetry plumbing: sidecar metadata, the CSV-shape test, and the
+  columns whose sources already exist (`relocReject`, the existing
+  `RelocDiagnostics` fields). Depends on nothing.
+- **6b** — the columns sourced from new phases (`backbone*` from 2, `inlierSpread`
+  from 3, `corrob*` and `searchRadiusPx` from 4). Each lands *with* its phase.
+
 ```
-Phase 0 (rotation)  ──────────────┐
-                                  ▼
-Phase 1 (Φ) ──► Phase 2 (partition) ──► Phase 3 (promotion)   [gated by 0]
-                     │
-                     ├──────────► Phase 4 (local corroboration)
-                     │
-                     ├──────────► Phase 5 (split signals)
-                     │
-                     └──────────► Phase 6 (telemetry)
+Phase 1 (Φ) ─────────────────────────────┐
+                                         ▼
+Phase 0 (rotation) ──► Phase 2 (partition) ──► Phase 3 (promotion)
+                            │                       │
+                            ├──► Phase 4 (local corroboration)
+                            │         │
+                            │         └──► Phase 5b (visible denominator)
+                            │
+                            └──► Phase 6b (partition columns)
+
+Phase 5a (split signals) ── independent
+Phase 6a (telemetry plumbing) ── independent
 ```
 
-Recommended landing order, which is not the numeric order: **1 → 6 → 5 → 2 → 4 →
-0 → 3.** Rationale: Phase 1 is free and unblocks everything; Phase 6 makes every
-later change measurable; Phase 5 is the best risk-adjusted fix and is
-independent; Phase 2 is the structural change; Phase 4 is the payoff; Phase 0 is
-slow and careful and Phase 3 is the only one that can do lasting damage, so both
-go last.
+**Phase 0 gates Phase 2, not only Phase 3.** Φ classifies 3D points that
+`PlaneMarks.backProject` produced. If those points are skewed by the rotation
+convention, the partition is computed on skewed geometry and a feature's region
+is wrong in proportion to capture obliquity. This is what §8 of the paper means
+by "prerequisite, not a parallel task" — an earlier draft of this document said
+Phase 0 gated only Phase 3, which contradicted the paper and would have put every
+E4–E8 measurement on an unattributable footing.
+
+Recommended landing order, which is not the numeric order:
+
+**1 → 5a → 6a → 0 → 2 (+6b) → 4 (+6b) → 5b → 3**
+
+Rationale: Phase 1 is free, pure, and unblocks everything. 5a is the best
+risk-adjusted fix in the plan and needs nothing. 6a makes every later change
+measurable. Phase 0 then lands *before* any 3D-consuming work, per the paragraph
+above. Phase 2 is the structural change and carries its own telemetry columns
+with it; Phase 4 is the payoff; 5b closes out the denominator once its inputs
+exist. Phase 3 is the only phase that can do lasting damage, so it goes last.
 
 ---
 
@@ -566,58 +659,86 @@ Each item is one commit-sized unit of work. Checkboxes are for tracking across
 sessions. `[T]` = has a test that must be written with it. `[N]` = touches native
 code, so CI's NDK build is the only compile check.
 
+**Sections are in landing order (1 → 5a → 6a → 0 → 2 → 4 → 5b → 3), not numeric
+order.** Work top to bottom.
+
 ### Phase 1 — footprint operator
 
 - [ ] **1.1** Create `feature/ar/.../anchor/Footprint.kt` with `Region` enum and
       empty `of` / `isInside` / `outsideDistance` / `classify` signatures.
-- [ ] **1.2** Implement `Footprint.of` using `PoseMath.rigidInverse`; return a
-      reused 2-element `FloatArray` from a caller-supplied buffer overload to
-      avoid per-feature allocation in the hot path. **[T]**
+- [ ] **1.2** Implement `Footprint.of`. **Do not use `PoseMath.rigidInverse`** —
+      the composed anchor carries `overlayScale`; take the rigid factor
+      (`overlayBaseScratch`) and fold the scale into the half-extents instead.
+      Return through a caller-supplied buffer overload to avoid per-feature
+      allocation in the hot path. **[T]**
 - [ ] **1.3** Implement `isInside` and `outsideDistance` (Chebyshev). **[T]**
 - [ ] **1.4** Implement `classify` with the inner/outer margin discard band. **[T]**
-- [ ] **1.5** Write `FootprintTest.kt` — all six cases from Phase 1 above,
-      including the rotated-anchor case and the non-square-extent case. **[T]**
+- [ ] **1.5** Write `FootprintTest.kt` — all seven cases from Phase 1 above. The
+      rotated-anchor, non-square-extent, and **scaled-anchor** cases are the three
+      that catch real bugs; the scaled-anchor case is non-optional. **[T]**
 - [ ] **1.6** Document in the KDoc that Φ discards the plane-normal component,
       with the reason.
 
-### Phase 6 — telemetry (land before behaviour changes)
+### Phase 5a — split progress from confidence (no new dependencies)
 
-- [ ] **6.1** Extend `RelocDiagnostics` with `backboneFeatures`, `inlierSpread`,
-      `corrobPredicted`, `corrobMatched`. Defaults must encode "not measured",
-      not "zero" — follow the existing `obliquityDeg = -1` precedent. **[T]**
-- [ ] **6.2** Extend `RelocDiagnosticsTest` for the new defaults and for the
-      independence of each new counter.
-- [ ] **6.3** Add the matching fields to the native diagnostics publish path in
-      `MobileGS.cpp`; keep the ordinal contract with the Kotlin enum intact. **[N]**
-- [ ] **6.4** Extend `EvalSampleLog.CSV_HEADER` with the nine columns above and
-      the matching `EvalLiveMetrics` fields.
-- [ ] **6.5** Add a CSV-shape test: header column count equals the emitted row's
+- [ ] **5a.1** Add `mCorroborationConfidence` atomic to `MobileGS.h`. **[N]**
+- [ ] **5a.2** In `tryUpdateFingerprint`, compute and publish corroboration
+      confidence separately from `mPaintingProgress`. Keep today's
+      `artDescs.rows` denominator for now — 5b changes it. **[N]**
+- [ ] **5a.3** Remove the `×0.9` decay from the painting-progress channel; leave
+      progress as a stored fraction that only a real measurement changes. **[N]**
+- [ ] **5a.4** Apply decay (or a per-frame recompute) to the confidence channel
+      only. **[N]**
+- [ ] **5a.5** Add `SlamManager.getCorroborationConfidence()`.
+- [ ] **5a.6** Switch `ArRenderer`'s `confGlobal` to the new getter; leave
+      `ArViewModel:1469` on `getPaintingProgress()`.
+- [ ] **5a.7** Extend `PoseFusionTest`: floor confidence still corrects; a
+      confidence drop slows but never reverses a correction. **[T]**
+
+### Phase 6a — telemetry plumbing (no new dependencies)
+
+- [ ] **6a.1** Add the run-identity sidecar JSON next to every `DriftCostProbe`
+      CSV: recording hash, git commit, all parameter values, RNG seed, sync/async
+      mode, device model. A CSV without a sidecar is not evidence.
+- [ ] **6a.2** Add a CSV-shape test: header column count equals the emitted row's
       field count. This is the class of bug that silently corrupts every
       downstream analysis. **[T]**
-- [ ] **6.6** Surface the new numbers in `RelocDiagnosticsOverlay`, laid out so
-      the backbone and corroboration groups are visually separated.
+- [ ] **6a.3** Add the `relocReject` ordinal column — its source already exists.
+- [ ] **6a.4** Add the eval-only fixed RNG seed and the synchronous-reloc mode
+      from `EVALUATION.md` §3.1. Both must be inert in release builds.
 
-### Phase 5 — split progress from confidence
+### Phase 0 — rotation convention
 
-- [ ] **5.1** Add `mCorroborationConfidence` atomic to `MobileGS.h`. **[N]**
-- [ ] **5.2** In `tryUpdateFingerprint`, compute and publish corroboration
-      confidence separately from `mPaintingProgress`. **[N]**
-- [ ] **5.3** Remove the `×0.9` decay from the painting-progress channel; leave
-      progress as a stored fraction that only a real measurement changes. **[N]**
-- [ ] **5.4** Apply decay (or a per-frame recompute) to the confidence channel
-      only. **[N]**
-- [ ] **5.5** Add `SlamManager.getCorroborationConfidence()`.
-- [ ] **5.6** Switch `ArRenderer`'s `confGlobal` to the new getter; leave
-      `ArViewModel:1469` on `getPaintingProgress()`.
-- [ ] **5.7** Extend `PoseFusionTest`: floor confidence still corrects; a
-      confidence drop slows but never reverses a correction. **[T]**
+- [ ] **0.1** Write `PlaneMarksObliquityTest` against a synthetic wall + camera at
+      0/20/40/60°. Expect it to fail at >0° on current `main` — that failure is
+      the reproduction. **[T]**
+- [ ] **0.2** Add `MetricMarks.glViewToCvDisplay(glView, rotationDeg)`; leave
+      `glViewToCv` untouched. **[T]**
+- [ ] **0.3** Unit-test `glViewToCvDisplay` at 0/90/180/270° against hand-computed
+      matrices. **[T]**
+- [ ] **0.4** Route the capture path through the new converter.
+- [ ] **0.5** Audit *every* consumer of the capture view matrix for the same
+      convention — `MetricFingerprintBuilder`, `PlaneMarks` callers,
+      `targetCaptureViewMatrix` in `ArViewModel`, `fingerprintViewMatrix` in
+      `MainViewModel`, and `restoreWallFingerprintMetric`'s `viewMatrix16`.
+      List each site in the commit message with its verdict.
+- [ ] **0.6** Confirm `PoseFusion.composeCorrected` is consistent under the chosen
+      convention. `PoseFusionTest` now pins the factor order with non-commuting
+      operands; extend it for the rotation, not with another round-trip (a
+      round-trip is order-insensitive and would pass either way). **[T]**
+- [ ] **0.7** Add `captureRotationDeg` to `Fingerprint`; default `-1`; refuse to
+      reload a legacy fingerprint and prompt for re-capture. **[T]**
+- [ ] **0.8** Re-run `0.1` and confirm <1 mm at all four obliquities.
 
 ### Phase 2 — partition the fingerprint
 
 - [ ] **2.1** Add `regions: ByteArray`, `captureHalfW`, `captureHalfH` to
       `Fingerprint`; empty `regions` means legacy all-backbone. **[T]**
-- [ ] **2.2** Add `Fingerprint.reclassify(anchorModel, halfW, halfH)` for the
-      user-rescales-the-design case; pure Kotlin over the stored points. **[T]**
+- [ ] **2.2** Add `Fingerprint.reclassify(...)` for the user-rescales-the-design
+      case; pure Kotlin over the stored points. Key the staleness check on
+      **`overlayScale`** (or the effective scaled half-extents), NOT on
+      `OverlayRenderer`'s extents — those have no user-driven call site and never
+      change. **[T]**
 - [ ] **2.3** Thread `overlayHalfW` / `overlayHalfH` into
       `MetricFingerprintBuilder.build` and the `PlaneMarks` single-view path.
 - [ ] **2.4** Classify each surviving point via `Footprint.classify` during
@@ -634,6 +755,9 @@ code, so CI's NDK build is the only compile check.
 - [ ] **2.9** Add a persistence round-trip test including the legacy-empty path. **[T]**
 - [ ] **2.10** Verify on a replayed recording that a legacy fingerprint produces
       byte-identical inlier counts to `main`.
+- [ ] **2.11** (6b) Add `backboneFeatures` / `backboneMatches` / `backboneInliers`
+      to `RelocDiagnostics`, the CSV, and the overlay. Defaults encode "not
+      measured", not zero — follow the `obliquityDeg = -1` precedent. **[T][N]**
 
 ### Phase 4 — spatially-constrained corroboration
 
@@ -654,26 +778,13 @@ code, so CI's NDK build is the only compile check.
       "not measured" rather than 0.0 — those are different states and
       `PoseFusion` must not read the second as the first.
 
-### Phase 0 — rotation convention
+### Phase 5b — the predicted-visible denominator
 
-- [ ] **0.1** Write `PlaneMarksObliquityTest` against a synthetic wall + camera at
-      0/20/40/60°. Expect it to fail at >0° on current `main` — that failure is
-      the reproduction. **[T]**
-- [ ] **0.2** Add `MetricMarks.glViewToCvDisplay(glView, rotationDeg)`; leave
-      `glViewToCv` untouched. **[T]**
-- [ ] **0.3** Unit-test `glViewToCvDisplay` at 0/90/180/270° against hand-computed
-      matrices. **[T]**
-- [ ] **0.4** Route the capture path through the new converter.
-- [ ] **0.5** Audit *every* consumer of the capture view matrix for the same
-      convention — `MetricFingerprintBuilder`, `PlaneMarks` callers,
-      `targetCaptureViewMatrix` in `ArViewModel`, `fingerprintViewMatrix` in
-      `MainViewModel`, and `restoreWallFingerprintMetric`'s `viewMatrix16`.
-      List each site in the commit message with its verdict.
-- [ ] **0.6** Confirm `PoseFusion.composeCorrected` is consistent under the chosen
-      convention; add a composition test that round-trips a known pose. **[T]**
-- [ ] **0.7** Add `captureRotationDeg` to `Fingerprint`; default `-1`; refuse to
-      reload a legacy fingerprint and prompt for re-capture. **[T]**
-- [ ] **0.8** Re-run `0.1` and confirm <1 mm at all four obliquities.
+- [ ] **5b.1** Switch `corroborationConfidence`'s denominator from
+      `artDescs.rows` to the Phase 4 predicted-visible count, so a close-up of
+      one corner is no longer capped by framing rather than by agreement. **[N]**
+- [ ] **5b.2** Re-derive `CONF_FLOOR` against the new denominator. Its current
+      0.5 was reasoned against the old one and does not transfer unexamined. **[T]**
 
 ### Phase 3 — geometric promotion
 
@@ -687,7 +798,10 @@ code, so CI's NDK build is the only compile check.
 - [ ] **3.5** Route `INSIDE` promotions into `F_in` with a bounded lifetime, or
       drop them — decide from E5's result, not in advance.
 - [ ] **3.6** Keep `setSelfGrowEnabled` defaulted **off**. Flip only after E5
-      shows a positive replayed-dataset effect.
+      shows a positive replayed-dataset effect. (The native default and the eval
+      overlay's toggle both said ON until this was corrected — re-check both
+      `MobileGS.h`'s initializer and `MainActivity`'s `selfGrowOn` if you touch
+      either, because the comment and the initializer disagreed for months.)
 
 ### Cross-cutting
 

--- a/docs/research/PAPER.md
+++ b/docs/research/PAPER.md
@@ -21,9 +21,10 @@ goal state as an additional source of evidence. The deployed implementation used
 the goal state as an **appearance validator**: a live camera feature corroborates
 the target if its descriptor matches a descriptor extracted from the design image.
 
-We report two findings. First, the mechanism was never reachable — three of its
-four stages were disconnected in ways that are individually verifiable from source
-(§4.2), so no field evidence about the approach exists. Second, and independently,
+We report two findings. First, the mechanism was never reachable — of four defects
+verifiable from source (§4.2), three are outright disconnections between stages and
+the fourth is a gate set too strictly to fire, so no field evidence about the
+approach exists. Second, and independently,
 the appearance-validator formulation asks the goal state for the one kind of
 information it supplies least reliably: a cross-modal descriptor comparison
 between a synthetic image and photographed pigment, executed as an unconstrained
@@ -280,7 +281,7 @@ F = \underbrace{\{\,i : \|\Phi(\mathbf{x}_i)\|_\infty > 1 + \mu\,\}}_{F_{\text{o
 $$
 
 The margin $\mu$ absorbs anchor error, overlay adjustment after capture, and
-overspray. It should be tuned (§`EVALUATION.md` E4), not guessed.
+overspray. It should be tuned (§`EVALUATION.md` E8), not guessed.
 
 The two sets are not two priorities on one list. They differ in what they are
 *for* and in what they may assume:
@@ -427,22 +428,24 @@ Steps 1–9 exist. Steps 3–5, 10–19 are new. Step 20 exists and is retained.
 
 ## 6. Predictions
 
-Stated so they can be falsified. Protocols in `EVALUATION.md`.
+Stated so they can be falsified. Each names the experiment that would falsify it;
+protocols are in `EVALUATION.md`. A prediction with no experiment is an opinion,
+so the mapping is given here rather than left to be reconstructed.
 
-- **P1.** Relocalization availability at ≥50% coverage is higher with the
+- **P1** *(→ E12)*. Relocalization availability at ≥50% coverage is higher with the
   partition than without, on identical replayed sessions. *(The backbone is drawn
   from wall that was never painted.)*
-- **P2.** For fixed precision, the local test (§5.5) admits a strictly larger Lowe
-  threshold than the global test. *(Direct consequence of candidate-set size; if
+- **P2** *(→ E7)*. For fixed precision, the local test (§5.5) admits a strictly larger
+  Lowe threshold than the global test. *(Direct consequence of candidate-set size; if
   this fails, the search-space argument is wrong.)*
-- **P3.** Corroboration false-positive rate under the local test is at least an
-  order of magnitude below the global test at matched recall.
-- **P4.** Geometric promotion (§5.4) yields a lower fingerprint-corruption rate
-  than appearance promotion, measured as PnP inlier ratio over session time.
-- **P5.** The rigid-offset fit (§5.6) correlates with measured overlay error
+- **P3** *(→ E6)*. Corroboration false-positive rate under the local test is at least
+  an order of magnitude below the global test at matched recall.
+- **P4** *(→ E5)*. Geometric promotion (§5.4) yields a lower fingerprint-corruption
+  rate than appearance promotion, measured as PnP inlier ratio over session time.
+- **P5** *(→ E13)*. The rigid-offset fit (§5.6) correlates with measured overlay error
   (`errMm`) at $r > 0.7$ once coverage exceeds ~30%.
-- **P6.** End-to-end overlay error at 100% coverage does not exceed error at 0%
-  coverage. *This is the whole thesis.* Failing P6 while passing P1–P5 would mean
+- **P6** *(→ E10)*. End-to-end overlay error at 100% coverage does not exceed error at
+  0% coverage. *This is the whole thesis.* Failing P6 while passing P1–P5 would mean
   the mechanism works and the premise does not.
 
 ---
@@ -522,8 +525,8 @@ new design and the old convention bug. Resolve it first (`EVALUATION.md` E0).
 
 The teleological observation is sound and, as far as we can tell, novel. The
 deployed realization used the goal state's weakest channel — global cross-modal
-appearance matching — and was in any case disconnected at three of four stages, so
-it has never been tested.
+appearance matching — and was in any case broken at all four stages examined
+(three disconnected, one gated shut), so it has never been tested.
 
 The proposed realization partitions the goal state. The spatial channel is exact
 and available immediately; it protects the durable reference and constrains the

--- a/docs/research/PARAMETERS.md
+++ b/docs/research/PARAMETERS.md
@@ -27,17 +27,17 @@ Basis legend:
 | Parameter | Location | Current | Basis | Sweep? | Set by |
 |---|---|---|---|---|---|
 | Reloc Lowe ratio | `MobileGS.cpp:310,403,697,774` | `0.75` | conventional | fixed | — |
-| ORB feature count (query) | `MobileGS.cpp:86` | `1500` | measured — matched to the fingerprint side; the comment at `:80` records why not 500 | screen | E4 |
+| ORB feature count (query) | `MobileGS.cpp:86` | `1500` | derived — symmetry with the fingerprint side; the comment at `:80` is an argument, not an observation | screen | E4 → E11 |
 | ORB feature count (artwork) | `MobileGS.cpp:1094` | `1500` | derived — must match the query side for the type-compatible match | fixed | — |
 | CLAHE clip limit | `MobileGS.cpp:25` | `2.0` | conventional | screen | E4 |
 | CLAHE tile grid | `MobileGS.cpp:25` | `8×8` | conventional | fixed | — |
 | PnP RANSAC iterations | `MobileGS.cpp:476` | `100` | conventional | screen | E4 |
-| PnP reprojection threshold | `MobileGS.cpp:476` | `8.0` px | guessed | **sweep** | E4 → E5 |
+| PnP reprojection threshold | `MobileGS.cpp:476` | `8.0` px | guessed | **sweep** | E4 → **E11** |
 | PnP RANSAC confidence | `MobileGS.cpp:476` | `0.99` | conventional | fixed | — |
-| Min correspondences for PnP | `MobileGS.cpp:454,461` | `8` | derived — PnP needs ≥6, plus margin | fixed | — |
+| Min correspondences for PnP | `MobileGS.cpp:455,462` | `8` | derived — PnP needs ≥6, plus margin | fixed | — |
 | Min inliers to accept | `MobileGS.cpp` (`inliers.size() < 6`) | `6` | derived — minimum for a determined pose | fixed | — |
-| Reloc thread sleep (locked) | `MobileGS.cpp` | `200` ms | guessed | screen | E9 |
-| Reloc thread sleep (searching) | `MobileGS.cpp` | `60` ms | guessed | screen | E9 |
+| Reloc thread sleep (locked) | `MobileGS.cpp:547` | `200` ms | guessed | screen | E4 → **E11** (cost-constrained) |
+| Reloc thread sleep (searching) | `MobileGS.cpp:547` | `60` ms | guessed | screen | E4 → **E11** (cost-constrained) |
 
 **Note on the 8.0 px reprojection threshold.** This is the highest-leverage
 existing constant that nobody has measured. It trades inlier count against pose
@@ -52,19 +52,27 @@ All in `feature/ar/.../anchor/PoseFusion.kt`, companion object.
 
 | Parameter | Current | Basis | Sweep? | Set by |
 |---|---|---|---|---|
-| `MIN_INLIER_RATIO` | `0.5` | guessed | **sweep** | E4 |
-| `BASE_ALPHA` | `0.25` | guessed | **sweep** | E4 |
-| `CONF_FLOOR` | `0.5` | guessed, but with a stated rationale: at 0.5 a fully corroborated wall pulls exactly twice as hard as a bare one | **sweep** | E3, E4 |
-| `COLD_SNAP_INLIER_RATIO` | `0.7` | guessed | screen | E4 |
-| `COLD_SNAP_MIN_INLIERS` | `20` | guessed | screen | E4 |
-| `COLD_SNAP_DIST_M` | `0.20` m | guessed | screen | E4 |
-| `COLD_SNAP_ANGLE_DEG` | `15°` | guessed | screen | E4 |
+| `MIN_INLIER_RATIO` | `0.5` | guessed | **sweep** | E4 → **E11** |
+| `BASE_ALPHA` | `0.25` | guessed | **sweep** | E4 → **E11** |
+| `CONF_FLOOR` | `0.5` | guessed, but with a stated rationale: at 0.5 a fully corroborated wall pulls exactly twice as hard as a bare one | **sweep** | E4 → **E11**; re-derived against the new denominator in Phase 5b |
+| `COLD_SNAP_INLIER_RATIO` | `0.7` | guessed | screen | E4 → E11 |
+| `COLD_SNAP_MIN_INLIERS` | `20` | guessed | screen | E4 → E11 |
+| `COLD_SNAP_DIST_M` | `0.20` m | guessed | screen | E4 → E11 |
+| `COLD_SNAP_ANGLE_DEG` | `15°` | guessed | screen | E4 → E11 |
 
-`CONF_FLOOR` changes meaning under Phase 5 — its input becomes
+`CONF_FLOOR` changes meaning under Phase 5b — its input becomes
 `corroborationConfidence` with a predicted-visible denominator instead of
 `paintingProgress` over all design features. The current value's rationale does
-not survive that change intact, so E3 must re-derive it rather than assume it
-transfers.
+not survive that change intact, so it must be re-derived (todo 5b.2) rather than
+assumed to transfer. E3 tests that the *contract* still holds; **E11** sets the
+number.
+
+**"E4 → E11" is not a typo.** E4 is the screening stage and sets nothing but the
+shortlist; it decides *which* parameters are worth sweeping. E11 is the sweep that
+assigns them values. An earlier draft of this table routed eleven parameters
+straight to E4, E5, E7 or E9 — experiments whose own "Sets." line says they set
+nothing, or set something else — which meant a third of the table had no
+experiment that closed it.
 
 ---
 
@@ -75,12 +83,20 @@ transfers.
 | `growTrusted` absolute inlier pass | `MobileGS.cpp:~805` | `≥20` | guessed | **sweep** | E5 |
 | `growTrusted` hard reject | same | `<10` | guessed | **sweep** | E5 |
 | `growTrusted` ratio floor | same | `0.6` | guessed | **sweep** | E5 |
-| Wall mark count floor | `MobileGS.cpp:810` | `12` | guessed | screen | E5 |
-| Wall mark count ceiling | `MobileGS.cpp:810` | `5000` | guessed — a memory guard, not a quality one | fixed | — |
+| Wall mark count floor | `MobileGS.cpp:810` | `12` | guessed | screen | E4 → E5 |
+| `kMaxWallMarks` (ceiling) | `MobileGS.h` | `5000` | guessed — a memory guard, not a quality one | fixed | — |
 | `PROMOTION_MIN_SPREAD` | *proposed*, Phase 3b | — | proposed | **sweep**, incl. an off level | E5 |
 
 The off level for `PROMOTION_MIN_SPREAD` is there so E5 can delete the term if it
 earns nothing.
+
+**`mSelfGrowEnabled` defaults to `false`** (`MobileGS.h`), and so does the eval
+overlay's toggle. It shipped as `true` for months while the function's own comment,
+this plan, and the evaluation plan all said otherwise — meaning the one mechanism
+that permanently mutates the reloc map ran unsupervised in every release build with
+no user-facing switch. If any future change touches promotion, re-check **both** the
+native initializer and `MainActivity`'s `selfGrowOn`; they are two places that have
+to agree and nothing enforces it.
 
 ---
 
@@ -109,9 +125,9 @@ From Phase 4. These two are the most important numbers in the plan.
 |---|---|---|---|
 | `CORROB_SEARCH_RHO` | `0.05` | The paper's §5.5 worked example: at ρ=0.05 the candidate set is ~0.2% of the design | E6, refined by E7 |
 | `CORROB_LOWE_RATIO` | `0.85` | Looser than the reloc path's 0.75, which is the entire point — a smaller candidate set should admit a looser threshold at the same precision | E7 |
-| `SEARCH_RADIUS_MIN_PX` | `4` | Below a few pixels the radius is inside the keypoint localization noise | E7 |
-| `SEARCH_RADIUS_MAX_PX` | `120` | Above this the "local" search is not local and the argument collapses | E7 |
-| `SEARCH_RADIUS_ERR_GAIN` | `1.0` | Radius scales linearly with measured `errMm`; gain 1.0 is the neutral prior | E7 |
+| `SEARCH_RADIUS_MIN_PX` | `4` | Below a few pixels the radius is inside the keypoint localization noise | **E11** |
+| `SEARCH_RADIUS_MAX_PX` | `120` | Above this the "local" search is not local and the argument collapses | **E11** |
+| `SEARCH_RADIUS_ERR_GAIN` | `1.0` | Radius scales linearly with measured `errMm`; gain 1.0 is the neutral prior | **E11** |
 
 `CORROB_LOWE_RATIO` at 0.85 is a *prediction*, not a setting. P2 says the local
 test admits a larger threshold than the global one; 0.85 is where we expect to

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -10,6 +10,28 @@ mechanism that keeps a projected mural locked to a wall that is being repainted.
 | [`EVALUATION.md`](EVALUATION.md) | The testing. How to obtain ground truth, how to make runs repeatable, which constants to tune, and the reasoning behind each experiment. |
 | [`PARAMETERS.md`](PARAMETERS.md) | The reference table. Every tunable constant, where it lives, its current value, its prior, and the experiment that sets it. |
 
+## The auditor found things
+
+Glee's first pass audited these documents against the code and found real defects
+in both. The corrections are folded in; recording them here because the pattern
+matters more than the individual fixes.
+
+**In the code** — two shipping bugs the documents had asserted were fine:
+`mSelfGrowEnabled` defaulted to `true`, so the only mechanism that permanently
+mutates the reloc map ran unsupervised in every release build while five separate
+places said it defaulted off; and `clearWallFingerprint()` never cleared the
+artwork validator, so a project switch left the previous project's target driving
+this project's painting progress and correction strength.
+
+**In these documents** — the plan prescribed `PoseMath.rigidInverse` for a matrix
+that carries the user's overlay scale (which would have inverted the partition it
+exists to build), ordered phases against its own dependency graph, routed a third
+of `PARAMETERS.md` to experiments whose own "Sets" line says they set nothing, and
+left two of six predictions with no experiment.
+
+None of that was found by writing more carefully. It was found by an agent whose
+job was to want it to be wrong.
+
 ## The auditor
 
 `.claude/agents/glee.md` defines **Glee**, an adversarial auditor whose sole

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/PoseFusionTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/PoseFusionTest.kt
@@ -21,6 +21,28 @@ class PoseFusionTest {
         identity().forEachIndexed { i, e -> assertEquals(e, r[i], 1e-4f) }
     }
 
+    /**
+     * The test above uses a pure translation for all three operands, so `inverse(V)·pnp·fpAnchor` is
+     * order-independent for that input and a composition written in any order passes it. Use a
+     * rotation and a translation that do not commute so the ORDER of the three factors is actually
+     * pinned — this is the composition PlaneMarks' documented rotation-convention question turns on,
+     * and it had no test that could see a swap.
+     */
+    @Test fun `composeCorrected pins the order of its three factors`() {
+        // 90 deg about Z, no translation.
+        val rotZ = floatArrayOf(0f,1f,0f,0f, -1f,0f,0f,0f, 0f,0f,1f,0f, 0f,0f,0f,1f)
+        val v = rotZ                       // world -> camera is a pure rotation
+        val pnp = identity()               // camera -> fingerprint world is identity
+        val fpAnchor = trans(1f, 0f, 0f)   // anchor sits +1 along the fingerprint frame's X
+
+        // inverse(V)·pnp·fpAnchor = rotZ⁻¹ · I · trans(1,0,0). rotZ⁻¹ maps +X to -Y, so the composed
+        // anchor sits at (0, -1, 0). A composition in any other order does not land there.
+        val r = PoseFusion.composeCorrected(vCurrent = v, pnpMat = pnp, fpAnchor = fpAnchor)
+        assertEquals(0f, r[12], 1e-4f)
+        assertEquals(-1f, r[13], 1e-4f)
+        assertEquals(0f, r[14], 1e-4f)
+    }
+
     @Test fun `blend alpha 0 returns current, alpha 1 returns target`() {
         val cur = trans(0f,0f,0f); val tgt = trans(10f,0f,0f)
         assertEquals(0f, PoseFusion.blend(cur, tgt, 0f)[12], 1e-4f)

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/PoseMathTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/PoseMathTest.kt
@@ -13,6 +13,29 @@ class PoseMathTest {
         assertEquals(m.toList(), PoseMath.multiply(identity(), m).toList())
     }
 
+    /**
+     * The identity and inverse tests above both COMMUTE (A*I == I*A, M⁻¹*M == M*M⁻¹), so an
+     * implementation of multiply(a, b) that returned b*a passes every one of them. Argument order is
+     * the thing the whole PoseFusion composition depends on, so pin it with operands that do not
+     * commute: rotate-then-translate is not translate-then-rotate.
+     */
+    @Test fun `multiply is not commutative and applies b in a's frame`() {
+        // 90 deg about Z (column-major: local +X maps to world +Y).
+        val rot = floatArrayOf(0f,1f,0f,0f, -1f,0f,0f,0f, 0f,0f,1f,0f, 0f,0f,0f,1f)
+        val tr = floatArrayOf(1f,0f,0f,0f, 0f,1f,0f,0f, 0f,0f,1f,0f, 2f,0f,0f,1f) // translate +2 along X
+
+        // multiply(rot, tr): the translation happens in rot's frame, so +2 along local X lands at
+        // world (0, 2, 0).
+        val rotThenTr = PoseMath.multiply(rot, tr)
+        assertEquals(0f, rotThenTr[12], 1e-4f)
+        assertEquals(2f, rotThenTr[13], 1e-4f)
+
+        // multiply(tr, rot): the translation is applied in world, so the origin stays at (2, 0, 0).
+        val trThenRot = PoseMath.multiply(tr, rot)
+        assertEquals(2f, trThenRot[12], 1e-4f)
+        assertEquals(0f, trThenRot[13], 1e-4f)
+    }
+
     @Test fun `rigidInverse undoes a translation+rotation`() {
         // 90 deg about Z then translate (1,2,3). inverse(M)*M == identity.
         val c = 0f; val s = 1f


### PR DESCRIPTION
The adversarial audit agent added in #1790 was pointed at everything — its own documents, the code they describe, the tests, and its own definition. It found real defects in all four. Every finding below was independently re-verified before being acted on.

## Shipping bugs

**Self-grow shipped ON.** `mSelfGrowEnabled` initialised to `true`, so the only mechanism in the engine that *permanently mutates the authoritative reloc fingerprint* ran in every release build with no user-facing switch — while `tryUpdateFingerprint`'s own comment ("it stays OFF unless explicitly enabled"), `IMPLEMENTATION.md`, `EVALUATION.md`, and the eval overlay's toggle all said it defaulted off. Five places agreed; the initializer won. Now `false`, and `MainActivity`'s `selfGrowOn` initialises to match instead of contradicting it.

**Cross-project contamination.** `clearWallFingerprint()` released the wall descriptors and points but never `mArtworkDescriptors`, `mWallPatch`, or `mPaintingProgress` — and no other code path clears them. Opening a project without a target left the *previous* project's artwork driving this project's painting-progress readout and `PoseFusion`'s correction strength, and (with self-grow on) promoting this project's features into its map on the strength of a different project's design. The function's own comment said "so a later project can't inherit this one's co-registration"; it inherited everything else.

**Out-of-bounds read in the reloc path.** The correspondence builder subscripts the 3D point vector by *descriptor row* (`wallKps3d[match.trainIdx]`) without checking the two arrays are the same length. The map path already guarded this; the wall path did not. A truncated `.gxr` fed out-of-bounds reads into `solvePnPRansac`. Guarded natively, and in `Fingerprint`'s `init`, which validated the descriptor blob against its declared rows and never the point array — the same argument, the second array, not carried over.

**Cap overshoot and two data races.** The self-grow append tested its 5000-mark ceiling only *before* the loop, so a wall at the cap grew by a full batch past it; it now fills to the cap exactly via a shared `kMaxWallMarks`. Two log statements read mutex-guarded containers after releasing the guard.

## Tests that could not fail

`PoseMathTest`'s multiply coverage used only operands that **commute** — `A·I == I·A`, `M⁻¹·M == M·M⁻¹` — so an implementation of `multiply(a, b)` returning `b·a` passed every one of them. `PoseFusionTest`'s composition test used a pure translation for all three factors, so the order of `inverse(V)·pnp·fpAnchor` was equally unpinned. Both now use a rotation and a translation that do not commute. This is the composition the whole display-rotation question turns on, and nothing in the suite could see a swap in it.

## Defects in the dossier

**The plan prescribed the wrong inverse.** It specified `PoseMath.rigidInverse` for the footprint operator Φ, on the stated grounds that the anchor model is rigid. It is not — `overlayComposedScratch` carries the user's pinch scale (`ArRenderer.kt:1761`), and `rigidInverse` inverts by *transposing*, which is off by `scale²`. At `overlayScale = 2`, a feature on the design edge yields `‖Φ‖∞ = 4`, is classified `OUTSIDE`, and is promoted into the backbone — the set defined as *wall that never gets painted*. Every feature under the artwork would have landed in `F_out`. That is the exact corruption the partition exists to prevent, produced by the partition's own inverse. Fixed, with a scaled-anchor test case; the original six-case suite would have shipped it green.

**Phase 2's rescale mitigation watched the wrong variable** — `OverlayRenderer`'s extents, which have no user-driven call site and never change — instead of `overlayScale`, which does.

**The landing order violated the dependency graph printed above it.** Phases 5 and 6 were landed two and three positions ahead of the Phase 2 they declare a dependency on, which would have produced seven telemetry columns with no source. Phase 0 was described as gating only Phase 3, while the paper says it gates everything built on 3D geometry — and the paper is right, because Φ classifies the very points the rotation bug skews. Phases 5 and 6 now split into a genuinely independent part and a dependent part, the order respects the graph, and the two documents agree.

**A third of `PARAMETERS.md` had no experiment that closed it.** Eleven constants were routed to E4, E5, E7 or E9 — experiments whose own "Sets." line says they set nothing, or set something else. Screening was being asked to assign values. Added **E11** (the sweep that screening feeds), plus **E12** and **E13** for predictions **P1** and **P5**, which had no experiment at all. P1 is the one that justifies the partition, so the largest structural change in the plan was going to ship without any comparison against not having it. Every prediction now names the experiment that falsifies it.

Smaller: an ORB count tagged "measured" on the strength of an argument rather than an observation, a `file:line` citation off by one on both numbers, the margin μ sent to E4 instead of E8, and a defect count that read "three" in the prose and four in the table.

## The agent's own definition

Its one worked example of "this is what a real finding looks like" was itself **fabricated** — correct-sounding, precisely cited, and false in every clause (the cited line is a matrix construction, the variable is read *inside* the lock, and the call is two lines further down). That is exactly the failure the surrounding paragraph calls "the most embarrassing thing you could possibly do." Replaced with a verified example, plus an explicit rule to open the file before citing a line.

**And the `.gitignore` negation never worked.** Git does not descend into an excluded directory, so `!/.claude/agents/` under `/.claude/` is unreachable; `glee.md` survived only because it was force-added, and the next agent file would have been silently invisible. Now `/.claude/*` plus the negation, verified with `git check-ignore`.

## Testing

Kotlin unit tests cover the new `Fingerprint` guard and both non-commuting matrix tests. The native changes are compile-checked only by CI's NDK build — a green unit-test run says nothing about them, which is a ground rule in `IMPLEMENTATION.md` for exactly this reason.

**Note on the self-grow default flip:** it is a real behaviour change, made because five places in the code and docs already asserted it. If you want promotion on while testing, it is one word in `MobileGS.h` and one in `MainActivity.kt`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E3E6oVmJoHRHoUpwatsVwv)_

## Summary by Sourcery

Align self-grow behavior and fingerprint handling with documented defaults, strengthen safety around relocalization data, and correct several inconsistencies in the research plan and auditor definition surfaced by the adversarial audit.

New Features:
- Add explicit E11, E12, and E13 experiments to the evaluation plan, mapping all predictions and tunable parameters to concrete experiments.
- Document the adversarial auditor Glee, its findings, and its role in validating the research dossier.

Bug Fixes:
- Default teleological self-grow to OFF in native code and evaluation UI to match documentation and avoid unsupervised map mutation.
- Ensure clearWallFingerprint clears artwork-side descriptors, keypoints, patch, and painting progress to prevent cross-project contamination.
- Guard the reloc PnP path and Fingerprint initialization against descriptor/3D-point count mismatches that could cause out-of-bounds reads.
- Fix self-grow’s wall mark ceiling to honor a shared kMaxWallMarks cap exactly and eliminate data races in promotion and artwork logging.

Enhancements:
- Clarify that Phase 0 gates all 3D-consuming phases, update dependency graph and landing order, and split Phases 5 and 6 into independent and dependent sub-phases.
- Correct the footprint operator design to avoid using rigidInverse on a scaled anchor and add a scaled-anchor test case to catch this class of bug.
- Refine the rescale mitigation plan to track overlayScale/effective half-extents instead of static extents when recomputing fingerprint regions.
- Make prediction–experiment links explicit in PAPER.md and EVALUATION.md, and correct parameter routing and basis notes in PARAMETERS.md.
- Strengthen PoseMath and PoseFusion tests to pin non-commuting matrix composition order, ensuring the rotation convention is actually testable.
- Clarify auditor guidance in glee.md with a verified example and an explicit requirement to validate cited file:line locations.
- Update research README to record the auditor’s findings and the nature of the corrections made.

Documentation:
- Update IMPLEMENTATION.md, EVALUATION.md, PARAMETERS.md, PAPER.md, and README.md to fix defects in the plan, parameter setting, dependency graph, and prediction coverage, and to document the new experiments and auditor findings.

Tests:
- Add Kotlin unit tests for Fingerprint descriptor/points3d consistency and legacy points-free fingerprints.
- Extend PoseMathTest and PoseFusionTest with non-commutative matrix composition cases that pin argument/order semantics.

Chores:
- Introduce a shared kMaxWallMarks constant in MobileGS to centralize the wall mark ceiling configuration.