### PR TITLE
feat: measure the rotation defect, land the footprint operator (Phase 1), split progress from confidence (Phase 5a)

### DIFF
--- a/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
+++ b/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
@@ -1278,6 +1278,15 @@ Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeGetPaintingProgres
     return 0.0f;
 }
 
+// Corroboration confidence: how much the wall backs the design RIGHT NOW, as opposed to how much of
+// it has been painted. Negative means no attempt has produced a measurement yet — with no engine
+// there is certainly no measurement, so the fallback is the sentinel and not a confident zero.
+extern "C" JNIEXPORT jfloat JNICALL
+Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeGetCorroborationConfidence(JNIEnv* env, jobject) {
+    if (gSlamEngine) return gSlamEngine->getCorroborationConfidence();
+    return -1.0f;
+}
+
 // Relocalization diagnostics: why the last attempt did not publish, and the counts it reached.
 // Packed into one int[] so the UI reads a consistent snapshot instead of four racing getters.
 // [0] = RelocReject code, [1] = correspondences, [2] = RANSAC inliers, [3] = features detected,

--- a/core/nativebridge/src/main/cpp/MobileGS.cpp
+++ b/core/nativebridge/src/main/cpp/MobileGS.cpp
@@ -437,20 +437,26 @@ void MobileGS::relocThreadFunc() {
             if (mDistortionHead.run(crop, wallPatch, dist)) {
                 const float matchability = dist[11], coverage = dist[12];
                 if (matchability > 0.5f) {
+                    // A trusted look at the wall: it measures BOTH channels, and they are different
+                    // quantities. Coverage says how much of the design is realized (progress);
+                    // matchability says how much to trust this frame (confidence).
                     mPaintingProgress.store(coverage, std::memory_order_relaxed);
+                    mCorroborationConfidence.store(matchability, std::memory_order_relaxed);
                 } else {
-                    float p = mPaintingProgress.load(std::memory_order_relaxed);
-                    mPaintingProgress.store(p * 0.9f, std::memory_order_relaxed);
+                    // The head looked and did not recognize the wall. That is a statement about THIS
+                    // FRAME, not about the mural, so only confidence decays. Decaying progress here
+                    // is what made a three-frame glitch read as the mural being un-painted.
+                    decayCorroboration();
                 }
                 LOGI("DistortionHead: match %.2f coverage %.2f tilt %.0f log2scale %.2f",
                      matchability, coverage, dist[8], dist[9]);
             } else {
-                float p = mPaintingProgress.load(std::memory_order_relaxed);
-                mPaintingProgress.store(p * 0.9f, std::memory_order_relaxed);
+                decayCorroboration();   // head refused to run — no information either way
             }
         } else if (mDistortionHead.isLoaded()) {
-            float p = mPaintingProgress.load(std::memory_order_relaxed);
-            mPaintingProgress.store(p * 0.9f, std::memory_order_relaxed);
+            // Head is loaded but there was no patch or no correspondences to centre the crop on, so
+            // no attempt happened at all. Still a confidence statement, never a progress one.
+            decayCorroboration();
         }
 
         // Lowered floors so a close-up PARTIAL view (only a corner of the marks visible) can still
@@ -785,8 +791,18 @@ void MobileGS::tryUpdateFingerprint(const cv::Mat& grayClean,
     }
     // The distortion head's coverage is the principled progress signal; only fall back to this
     // descriptor-corroboration ratio when the head isn't present.
-    if (artDescs.rows > 0 && !mDistortionHead.isLoaded())
-        mPaintingProgress.store((float)matched / (float)artDescs.rows, std::memory_order_relaxed);
+    //
+    // Both channels are published from this one ratio for now. They are genuinely the same number
+    // on this path today, because the denominator is every descriptor of the design — including the
+    // parts behind the camera. Phase 5b narrows the CONFIDENCE denominator to the features actually
+    // predicted visible, at which point the two diverge and a close-up of one corner stops being
+    // capped by framing rather than by agreement. Progress keeps the whole-design denominator,
+    // which is the correct one for it.
+    if (artDescs.rows > 0 && !mDistortionHead.isLoaded()) {
+        const float ratio = (float)matched / (float)artDescs.rows;
+        mPaintingProgress.store(ratio, std::memory_order_relaxed);
+        mCorroborationConfidence.store(ratio, std::memory_order_relaxed);
+    }
 
     // --- Teleological self-grow (opt-in) ---------------------------------------------------------
     // Promote validated NEW marks into the live reloc fingerprint so it self-grows from real painting
@@ -936,6 +952,9 @@ void MobileGS::clearWallFingerprint() {
     mArtworkKeypoints3D.clear();
     mWallPatch.release();
     mPaintingProgress.store(0.0f, std::memory_order_relaxed);
+    // Back to "never measured", not to zero — the next project has not been looked at yet, and
+    // reporting a confident 0 would be a measurement it never made.
+    mCorroborationConfidence.store(kCorroborationUnmeasured, std::memory_order_relaxed);
     mLastGrowSeq = 0;
 }
 
@@ -1165,6 +1184,8 @@ void MobileGS::setArtworkFingerprint(const cv::Mat& composite, const uint8_t* de
         mArtworkDescriptors = keepDescs.clone();
         mArtworkKeypoints3D = std::move(pts3d);
         mPaintingProgress.store(0.0f, std::memory_order_relaxed);
+        // A new design means every prior corroboration reading was against a different target.
+        mCorroborationConfidence.store(kCorroborationUnmeasured, std::memory_order_relaxed);
         // Snapshot under the lock — the reloc thread reads both of these, so logging them after the
         // guard releases is a race on a cv::Mat header and a vector.
         storedRows = mArtworkDescriptors.rows;

--- a/core/nativebridge/src/main/cpp/include/MobileGS.h
+++ b/core/nativebridge/src/main/cpp/include/MobileGS.h
@@ -108,6 +108,17 @@ public:
     /** Hard ceiling on stored wall marks — a memory guard on the self-grow append. */
     static constexpr size_t kMaxWallMarks = 5000;
 
+    /** Sentinel for "no corroboration attempt has produced a measurement yet". */
+    static constexpr float kCorroborationUnmeasured = -1.0f;
+
+    /**
+     * Per-attempt decay applied to the CORROBORATION channel when an attempt runs and yields no
+     * usable measurement — the wall left the frame, the head refused, the patch is missing. It
+     * expresses "my last reading is getting stale", which is a statement about confidence and never
+     * was one about how much of the mural is painted.
+     */
+    static constexpr float kCorroborationDecay = 0.9f;
+
     /** Last [RelocReject]. */
     int lastRelocReject() const { return mLastRelocReject.load(std::memory_order_relaxed); }
     /** Correspondences built by the last attempt, successful or not. */
@@ -186,7 +197,31 @@ public:
     int getImmutableSplatCount() const { return 0; }   // voxel/splat map deleted
     void getConfidenceAvgs(float& outVisible, float& outGlobal) const;
     void setSplatsVisible(bool visible) { mSplatsVisible = visible; }
+    /**
+     * How much of the registered design the wall now answers for: a PROGRESS measurement, on the
+     * timescale of hours, roughly monotonic. For the user's progress readout.
+     *
+     * Never decayed. It used to be, which conflated it with the signal below.
+     */
     float getPaintingProgress() const { return mPaintingProgress.load(std::memory_order_relaxed); }
+
+    /**
+     * How much the wall corroborates the design RIGHT NOW: a per-attempt CONFIDENCE, on the
+     * timescale of frames, moving in both directions. This is what PoseFusion should scale its
+     * correction strength by.
+     *
+     * Split from painting progress because one scalar cannot mean both "the mural is 60% painted"
+     * and "I trust this frame". They move on completely different timescales, and the decay that
+     * belongs to the second was being applied to the first — so three bad frames read as the mural
+     * being un-painted, and the 0.9-per-tick decay made that persist for seconds afterwards.
+     *
+     * Returns a negative value when no corroboration attempt has produced a measurement yet, which
+     * is a different state from "attempted and found nothing" (0.0). Callers that need a plain
+     * [0,1] should clamp; PoseFusion's CONF_FLOOR already treats 0 as the conservative floor.
+     */
+    float getCorroborationConfidence() const {
+        return mCorroborationConfidence.load(std::memory_order_relaxed);
+    }
 
     void saveModel(const std::string& path);
     void loadModel(const std::string& path);
@@ -268,6 +303,22 @@ private:
     cv::Mat mArtworkDescriptors;
     std::vector<cv::Point3f> mArtworkKeypoints3D;
     std::atomic<float> mPaintingProgress{0.0f};
+    // -1 = never measured, which is NOT the same as 0.0 = measured and found nothing. Zero is a
+    // legitimate reading here, so it cannot double as the "no data yet" sentinel.
+    std::atomic<float> mCorroborationConfidence{kCorroborationUnmeasured};
+
+    /**
+     * Age the corroboration reading after an attempt that produced nothing usable.
+     *
+     * A never-measured channel stays never-measured: decaying the -1 sentinel would walk it toward
+     * zero and quietly turn "no data" into "measured, found nothing" — the exact class of bug that
+     * shipped in mLastRelocReject, where 0 doubled as both a valid code and the default.
+     */
+    void decayCorroboration() {
+        const float c = mCorroborationConfidence.load(std::memory_order_relaxed);
+        if (c < 0.0f) return;
+        mCorroborationConfidence.store(c * kCorroborationDecay, std::memory_order_relaxed);
+    }
 
     // --- Persistent wall feature map (lean reloc backbone; docs/RELOC_MAP_DESIGN.md) ---
     // Co-registered to the fingerprint anchor. Phase 2a stores it; reloc matching (Phase 2b) is gated

--- a/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
+++ b/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
@@ -81,7 +81,28 @@ class SlamManager @Inject constructor(
         nativeUpdateDeviceMotion(angularVel, linearVel)
     }
 
+    /**
+     * Fraction of the registered design the wall now answers for — a PROGRESS reading, on the
+     * timescale of hours and roughly monotonic. This is the number to show the artist.
+     */
     fun getPaintingProgress(): Float = nativeGetPaintingProgress()
+
+    /**
+     * How strongly the wall corroborates the design on the most recent look — a CONFIDENCE reading,
+     * on the timescale of frames and moving both ways. This is the number [PoseFusion-style] pose
+     * correction should scale by, NOT painting progress: one scalar cannot mean both "the mural is
+     * 60% painted" and "I trust this frame", and using progress for both meant a momentary tracking
+     * hiccup decayed the progress bar and suppressed correction strength for seconds afterwards.
+     *
+     * @return `[0,1]` once measured, or **negative** if no attempt has produced a measurement yet.
+     *   That is deliberately distinct from `0f`, which means "looked, and the wall agrees with
+     *   nothing". Callers feeding a `[0,1]` API should map the negative case to their own
+     *   conservative default rather than passing it through.
+     */
+    fun getCorroborationConfidence(): Float = nativeGetCorroborationConfidence()
+
+    /** True once a corroboration attempt has produced any measurement at all. */
+    fun hasCorroborationMeasurement(): Boolean = nativeGetCorroborationConfidence() >= 0f
 
     /**
      * Why the last relocalization attempt did not publish a pose, and how far it got. See
@@ -559,6 +580,7 @@ class SlamManager @Inject constructor(
     private external fun nativeUpdateDeviceMotion(angularVel: FloatArray, linearVel: FloatArray)
     private external fun nativeGetAnchorTransform(): FloatArray
     private external fun nativeGetPaintingProgress(): Float
+    private external fun nativeGetCorroborationConfidence(): Float
     private external fun nativeGetRelocDiagnostics(): IntArray?
     private external fun nativeSetArScanMode(mode: Int)
     private external fun nativeSetMuralMethod(method: Int)

--- a/docs/research/EVALUATION.md
+++ b/docs/research/EVALUATION.md
@@ -296,33 +296,19 @@ normal is invariant under a rotation about the optical axis. If the measured
 error curve does not have that shape — flat, or largest at 0° — the diagnosis in
 §8 of the paper is wrong and Phase 0 is chasing the wrong thing.
 
-**Expected values.** Already computed analytically (`PAPER.md` §8.1) and encoded
-in `PlaneMarksObliquityTest`: 0.0 mm at 0°, ~267 mm at 20°, ~834 mm at 40° for a
-wall at 2 m with 1080×1920 display intrinsics. E0's job on device is to confirm
-the shape, not to discover it. Writing the prediction down before running is what
-makes a surprise informative — if the device disagrees with these numbers, the
-model of the defect is wrong, not merely the constant.
+**Expected values.** Computed analytically in `PAPER.md` §8.1: 0.0 mm at 0°,
+267 mm at 20°, 834 mm at 40°, 2107 mm at 60°, for a wall at 2 m with 1080×1920
+display intrinsics on a 40×40 pixel-space grid. E0's job on device is to confirm
+the *shape*, not to discover it. Writing the prediction down before running is
+what makes a surprise informative — if the device disagrees, the model of the
+defect is wrong, not merely the constant.
 
-### E0b — the device test that needs no fix
-
-`rotationNeeded = (sensorOrientation - displayDegrees + 360) % 360` and the app
-is `screenOrientation="fullUser"`, so on a typical phone the device's physical
-orientation decides whether the mismatch exists: **landscape → 0 (no
-mismatch); portrait → 90; landscape the other way → 180.**
-
-**Method.** Capture a target in landscape, then in portrait, same wall, same
-obliquity, then attempt relocalization from the same standing positions for each.
-Compare inlier ratio and lock rate.
-
-**Reasoning.** This is the cheapest experiment in the whole document and it runs
-on the shipped build with no code change, because the independent variable is how
-you hold the phone. It is worth doing *first*, before any of Phase 0's
-engineering, precisely because a negative result would cancel that engineering.
-
-**Falsifies §8 entirely.** Identical behaviour in both orientations means the
-convention is not the cause and Phase 0 should be dropped. In that case check the
-assumption it rests on: that ARCore's `camera.pose` is in the physical camera
-frame rather than a display-oriented one.
+`PlaneMarksObliquityTest` asserts the same defect but **does not encode those
+decimals**, and should not be read as doing so. It samples uniformly on the wall
+rather than uniformly in pixel space, which weights oblique views differently and
+gives ~328 mm at 20° and ~1148 mm at 40° for the identical bug. Its assertions
+are therefore ranges and orderings. Two samplings, one defect; quoting either as
+*the* number would be picking a convention and calling it a measurement.
 
 **Sets.** Nothing. It is a correctness gate, not a tuning experiment.
 
@@ -331,6 +317,42 @@ Phase 0 should be abandoned. If (b) and (c) both fail, the error is not a pure
 `R_z` and the analysis is incomplete.
 
 **Cost.** Minutes. Runs in CI forever after.
+
+---
+
+### E0b — the device test that needs no fix
+
+**Question.** Does the defect appear and disappear with the phone's physical
+orientation, as the convention analysis predicts?
+
+**Method.** `rotationNeeded = (sensorOrientation - displayDegrees + 360) % 360`
+and the app is `screenOrientation="fullUser"`, so on a typical phone the device's
+physical orientation decides whether the mismatch exists at all: **landscape → 0
+(no mismatch); portrait → 90; landscape the other way → 180.** Capture a target
+in landscape, then in portrait, same wall, same obliquity; then attempt
+relocalization from the same standing positions for each. Compare inlier ratio
+and lock rate.
+
+**Reasoning.** The cheapest experiment in the document, and it runs on the
+shipped build with no code change, because the independent variable is how you
+hold the phone. Do it *first*, before any of Phase 0's engineering — a negative
+result cancels that engineering entirely.
+
+Watch two secondary signals in the diagnostics overlay, both predicted by the
+model: healthy match counts paired with a **low inlier ratio** (PnP cannot fit a
+non-rigidly distorted cloud), and "found N features but only M landed on the wall
+surface" refusals, since mis-scaled depths fall outside `backProject`'s 0.1–10 m
+trust range. The second is measurable directly — §8.1 predicts 1280 of 1600
+points surviving at 60° versus all 1600 at 40°.
+
+**Sets.** Nothing. It is the go/no-go on Phase 0.
+
+**Falsifies §8 entirely.** Identical behaviour in both orientations means the
+convention is not the cause and Phase 0 should be dropped. In that case check the
+assumption it rests on: that ARCore's `camera.pose` is in the physical camera
+frame rather than a display-oriented one.
+
+**Cost.** One session. No build required.
 
 ---
 

--- a/docs/research/EVALUATION.md
+++ b/docs/research/EVALUATION.md
@@ -296,6 +296,34 @@ normal is invariant under a rotation about the optical axis. If the measured
 error curve does not have that shape — flat, or largest at 0° — the diagnosis in
 §8 of the paper is wrong and Phase 0 is chasing the wrong thing.
 
+**Expected values.** Already computed analytically (`PAPER.md` §8.1) and encoded
+in `PlaneMarksObliquityTest`: 0.0 mm at 0°, ~267 mm at 20°, ~834 mm at 40° for a
+wall at 2 m with 1080×1920 display intrinsics. E0's job on device is to confirm
+the shape, not to discover it. Writing the prediction down before running is what
+makes a surprise informative — if the device disagrees with these numbers, the
+model of the defect is wrong, not merely the constant.
+
+### E0b — the device test that needs no fix
+
+`rotationNeeded = (sensorOrientation - displayDegrees + 360) % 360` and the app
+is `screenOrientation="fullUser"`, so on a typical phone the device's physical
+orientation decides whether the mismatch exists: **landscape → 0 (no
+mismatch); portrait → 90; landscape the other way → 180.**
+
+**Method.** Capture a target in landscape, then in portrait, same wall, same
+obliquity, then attempt relocalization from the same standing positions for each.
+Compare inlier ratio and lock rate.
+
+**Reasoning.** This is the cheapest experiment in the whole document and it runs
+on the shipped build with no code change, because the independent variable is how
+you hold the phone. It is worth doing *first*, before any of Phase 0's
+engineering, precisely because a negative result would cancel that engineering.
+
+**Falsifies §8 entirely.** Identical behaviour in both orientations means the
+convention is not the cause and Phase 0 should be dropped. In that case check the
+assumption it rests on: that ARCore's `camera.pose` is in the physical camera
+frame rather than a display-oriented one.
+
 **Sets.** Nothing. It is a correctness gate, not a tuning experiment.
 
 **Falsifies.** If (a) shows <1 mm error at 60°, there is no rotation bug and

--- a/docs/research/IMPLEMENTATION.md
+++ b/docs/research/IMPLEMENTATION.md
@@ -664,19 +664,19 @@ order.** Work top to bottom.
 
 ### Phase 1 — footprint operator
 
-- [ ] **1.1** Create `feature/ar/.../anchor/Footprint.kt` with `Region` enum and
+- [x] **1.1** Create `feature/ar/.../anchor/Footprint.kt` with `Region` enum and
       empty `of` / `isInside` / `outsideDistance` / `classify` signatures.
-- [ ] **1.2** Implement `Footprint.of`. **Do not use `PoseMath.rigidInverse`** —
+- [x] **1.2** Implement `Footprint.of`. **Do not use `PoseMath.rigidInverse`** —
       the composed anchor carries `overlayScale`; take the rigid factor
       (`overlayBaseScratch`) and fold the scale into the half-extents instead.
       Return through a caller-supplied buffer overload to avoid per-feature
       allocation in the hot path. **[T]**
-- [ ] **1.3** Implement `isInside` and `outsideDistance` (Chebyshev). **[T]**
-- [ ] **1.4** Implement `classify` with the inner/outer margin discard band. **[T]**
-- [ ] **1.5** Write `FootprintTest.kt` — all seven cases from Phase 1 above. The
+- [x] **1.3** Implement `isInside` and `outsideDistance` (Chebyshev). **[T]**
+- [x] **1.4** Implement `classify` with the inner/outer margin discard band. **[T]**
+- [x] **1.5** Write `FootprintTest.kt` — all seven cases from Phase 1 above. The
       rotated-anchor, non-square-extent, and **scaled-anchor** cases are the three
       that catch real bugs; the scaled-anchor case is non-optional. **[T]**
-- [ ] **1.6** Document in the KDoc that Φ discards the plane-normal component,
+- [x] **1.6** Document in the KDoc that Φ discards the plane-normal component,
       with the reason.
 
 ### Phase 5a — split progress from confidence (no new dependencies)
@@ -709,7 +709,7 @@ order.** Work top to bottom.
 
 ### Phase 0 — rotation convention
 
-- [ ] **0.1** Write `PlaneMarksObliquityTest` against a synthetic wall + camera at
+- [x] **0.1** Write `PlaneMarksObliquityTest` against a synthetic wall + camera at
       0/20/40/60°. Expect it to fail at >0° on current `main` — that failure is
       the reproduction. **[T]**
 - [ ] **0.2** Add `MetricMarks.glViewToCvDisplay(glView, rotationDeg)`; leave

--- a/docs/research/IMPLEMENTATION.md
+++ b/docs/research/IMPLEMENTATION.md
@@ -227,8 +227,15 @@ inverse.
 the *rigid* part of the anchor and the scale separately, because the scale is
 already accounted for by the half-extents. Either
 
-- pass `overlayBaseScratch` (the rigid factor) as `M` and fold `overlayScale`
-  into the effective half-extents (`h_w·s`, `h_h·s`) — cheapest and exact; or
+- pass the **rigid factor** as `M` and fold `overlayScale` into the effective
+  half-extents (`h_w·s`, `h_h·s`) — cheapest and exact. Note the rigid factor is
+  `overlayBaseScratch · T(pan) · Rz(overlayRotationDeg)`, **not**
+  `overlayBaseScratch` alone: `overlayLocalScratch` is
+  `T(markOffset+pan) · Rz(spin) · S(s,s,1)`, so passing the base by itself
+  silently drops the user's pan and in-plane spin and offsets every Φ by exactly
+  those — a feature dead-centre on the artwork would report non-zero `‖Φ‖∞` and,
+  past the margin, land in the backbone. That is the same corruption `ofComposed`
+  exists to prevent, arriving through the recipe this bullet recommends; or
 - add `PoseMath.similarityInverse(m)`, which extracts `s` from the first column's
   norm, transposes, and divides by `s²`. Needed anyway if any caller only has the
   composed matrix.
@@ -245,8 +252,11 @@ dependency explicit at the call site instead of buried in an inverse.
    forward transform where the inverse was needed — the most likely bug here.
 4. Non-square extents (`h_w = 2·h_h`): both axes still saturate at 1 at their own
    edge. Catches dividing both axes by the same half-extent.
-5. `classify` with `innerMargin=0.05, outerMargin=0.15`: a point at Φ radius 0.98
-   is `INSIDE`, at 1.10 is `BAND`, at 1.30 is `OUTSIDE`.
+5. `classify` with `innerMargin=0.05, outerMargin=0.15`: a point at Φ radius 0.90
+   is `INSIDE` (the inside test is `d ≤ 1 − innerMargin = 0.95`, so 0.98 is
+   **`BAND`**, not `INSIDE` — an earlier draft of this line had it wrong), 1.10 is
+   `BAND`, 1.30 is `OUTSIDE`. Assert the boundaries themselves too: 0.95 is
+   `INSIDE` and 1.15 is `OUTSIDE`, which pins the comparisons as inclusive.
 6. Off-plane point: a point 0.5 m in front of the wall projects to the same `(u,v)`
    as its foot. Document this explicitly — Φ deliberately discards the normal
    component, and a reader will wonder.
@@ -710,8 +720,12 @@ order.** Work top to bottom.
 ### Phase 0 — rotation convention
 
 - [x] **0.1** Write `PlaneMarksObliquityTest` against a synthetic wall + camera at
-      0/20/40/60°. Expect it to fail at >0° on current `main` — that failure is
-      the reproduction. **[T]**
+      0/20/40/60°. **Delivered as passing characterization rather than a red
+      reproduction**: a permanently-failing test cannot live in CI, so the
+      magnitudes are asserted as ranges that hold *because* the defect is present,
+      each marked with what to invert when Phase 0 lands. Ground truth is built
+      forward (place 3D points on the wall, project them) so the controls are not
+      the implementation compared against itself. **[T]**
 - [ ] **0.2** Add `MetricMarks.glViewToCvDisplay(glView, rotationDeg)`; leave
       `glViewToCv` untouched. **[T]**
 - [ ] **0.3** Unit-test `glViewToCvDisplay` at 0/90/180/270° against hand-computed

--- a/docs/research/IMPLEMENTATION.md
+++ b/docs/research/IMPLEMENTATION.md
@@ -681,18 +681,18 @@ order.** Work top to bottom.
 
 ### Phase 5a — split progress from confidence (no new dependencies)
 
-- [ ] **5a.1** Add `mCorroborationConfidence` atomic to `MobileGS.h`. **[N]**
-- [ ] **5a.2** In `tryUpdateFingerprint`, compute and publish corroboration
+- [x] **5a.1** Add `mCorroborationConfidence` atomic to `MobileGS.h`. **[N]**
+- [x] **5a.2** In `tryUpdateFingerprint`, compute and publish corroboration
       confidence separately from `mPaintingProgress`. Keep today's
       `artDescs.rows` denominator for now — 5b changes it. **[N]**
-- [ ] **5a.3** Remove the `×0.9` decay from the painting-progress channel; leave
+- [x] **5a.3** Remove the `×0.9` decay from the painting-progress channel; leave
       progress as a stored fraction that only a real measurement changes. **[N]**
-- [ ] **5a.4** Apply decay (or a per-frame recompute) to the confidence channel
+- [x] **5a.4** Apply decay (or a per-frame recompute) to the confidence channel
       only. **[N]**
-- [ ] **5a.5** Add `SlamManager.getCorroborationConfidence()`.
-- [ ] **5a.6** Switch `ArRenderer`'s `confGlobal` to the new getter; leave
+- [x] **5a.5** Add `SlamManager.getCorroborationConfidence()`.
+- [x] **5a.6** Switch `ArRenderer`'s `confGlobal` to the new getter; leave
       `ArViewModel:1469` on `getPaintingProgress()`.
-- [ ] **5a.7** Extend `PoseFusionTest`: floor confidence still corrects; a
+- [x] **5a.7** Extend `PoseFusionTest`: floor confidence still corrects; a
       confidence drop slows but never reverses a correction. **[T]**
 
 ### Phase 6a — telemetry plumbing (no new dependencies)

--- a/docs/research/PAPER.md
+++ b/docs/research/PAPER.md
@@ -523,19 +523,31 @@ that varies across the image — a **non-rigid** distortion of the point cloud,
 which matters because a rigid one would be absorbed by PnP and this is not.
 
 For 1080×1920 display-oriented intrinsics ($f = 1400$, principal point centred)
-and a wall at 2 m, sampling the central 80% of the frame:
+and a wall at 2 m, on a 40×40 grid over the central 80% of the frame, with
+`backProject`'s own 0.1–10 m trust range applied and $p95$ taken as
+$\text{sorted}[\lfloor 0.95N \rfloor]$:
 
-| obliquity | mean error | p95 |
-|---|---|---|
-| 0° | **0.0 mm** | 0.0 mm |
-| 10° | 121 mm | 282 mm |
-| 20° | 267 mm | 630 mm |
-| 30° | 475 mm | 1154 mm |
-| 40° | 834 mm | 2213 mm |
-| 60° | 6914 mm | 37386 mm |
+| obliquity | mean error | p95 | marks surviving |
+|---|---|---|---|
+| 0° | **0.0 mm** | 0.0 mm | 1600/1600 |
+| 10° | 121 mm | 282 mm | 1600/1600 |
+| 20° | 267 mm | 630 mm | 1600/1600 |
+| 30° | 475 mm | 1154 mm | 1600/1600 |
+| 40° | 834 mm | 2213 mm | 1600/1600 |
+| 50° | 1650 mm | 5260 mm | 1600/1600 |
+| 60° | 2107 mm | 5635 mm | 1280/1600 |
 
 Exactly zero at 0°, which is why it survived: anyone testing square-on to a wall
 sees nothing wrong.
+
+**The sampling parameters above are load-bearing and were omitted from an earlier
+version of this table.** The mean depends on the grid density, and the 60° row
+depended on something worse: without the depth filter it reads 6914 mm mean /
+37386 mm p95, because the mis-scaled rays land as far out as 93 m. Those points
+do not exist — `backProject` discards anything past 10 m, which is the very
+mechanism described two paragraphs below. Quoting the unfiltered figure claimed
+an error 3.3× larger than the code can produce. Rows 0°–50° are unaffected;
+nothing is dropped there, so filtered and unfiltered agree exactly.
 
 ### 8.2 A device test that does not require the fix
 

--- a/docs/research/PAPER.md
+++ b/docs/research/PAPER.md
@@ -506,12 +506,74 @@ head-on wall** — a plane normal $(0,0,\pm1)$ is invariant under rotation about
 — and grows with obliquity; and the onboarding path shares the convention, so it
 fails identically.
 
-It is unresolved because the correction is not local. Rotating the capture view
-moves $F$ into the rotated frame, while `PoseFusion` composes
-$V_{\text{cur}}^{-1} \cdot \text{pnp} \cdot T$ with $V_{\text{cur}}$ unrotated —
-so the composition needs the matching change, and every rotation sign must be
-right or the overlay lands worse than today. This is a system-wide convention
-change and it wants device evidence first.
+### 8.1 Magnitude
+
+This was asserted from a source comment for several development cycles before
+anyone computed it. The comment was passed forward, cited as established, and
+used to justify a behavioural change — with no test covering it
+(`PlaneMarksTest` has no oblique case) and no measurement. What follows is the
+calculation that should have accompanied the claim.
+
+Substituting the mismatched frames into `backProject`'s own expression
+$t = (n \cdot p)/(n \cdot d)$: rotation preserves the dot product, so the
+numerator $n \cdot p$ is unchanged and the entire error lives in the
+denominator, $n_s \cdot d$ where $n_d \cdot d$ was meant. Each recovered point
+therefore lies on the *correct ray* at the *wrong depth*, scaled by a factor
+that varies across the image — a **non-rigid** distortion of the point cloud,
+which matters because a rigid one would be absorbed by PnP and this is not.
+
+For 1080×1920 display-oriented intrinsics ($f = 1400$, principal point centred)
+and a wall at 2 m, sampling the central 80% of the frame:
+
+| obliquity | mean error | p95 |
+|---|---|---|
+| 0° | **0.0 mm** | 0.0 mm |
+| 10° | 121 mm | 282 mm |
+| 20° | 267 mm | 630 mm |
+| 30° | 475 mm | 1154 mm |
+| 40° | 834 mm | 2213 mm |
+| 60° | 6914 mm | 37386 mm |
+
+Exactly zero at 0°, which is why it survived: anyone testing square-on to a wall
+sees nothing wrong.
+
+### 8.2 A device test that does not require the fix
+
+`rotationNeeded = (sensorOrientation - displayDegrees + 360) \bmod 360`, and the
+app is `screenOrientation="fullUser"`. On a phone with the usual
+$\text{sensorOrientation} = 90$, the *device's physical orientation* selects
+whether the bug is active at all:
+
+| held | `rotationNeeded` | error at 20° obliquity |
+|---|---|---|
+| landscape | 0 | **0.0 mm — no mismatch** |
+| portrait | 90 | 267 mm |
+| landscape, other way | 180 | 265 mm |
+
+So the hypothesis is falsifiable on the current build with no code change:
+**capture a target in landscape, then in portrait, same wall, same angle.** If
+landscape relocalizes and portrait does not, the convention is the cause. If they
+behave identically, this section is wrong and Phase 0 should be dropped.
+
+Two secondary predictions, useful because they are already observable in the
+diagnostics overlay: healthy match counts paired with a **low inlier ratio**
+(PnP cannot fit a non-rigidly distorted cloud), and "found $N$ features but only
+$M$ landed on the wall surface" refusals, since mis-scaled depths fall outside
+`backProject`'s 0.1–10 m trust range and are silently dropped.
+
+**The assumption this all rests on** is that ARCore's `camera.pose` is in the
+physical camera frame rather than a display-oriented one — i.e. that ARCore
+handles display rotation through `setDisplayGeometry`/`transformCoordinates2d`
+and not by rotating the pose. If that is false there is no mismatch. It is the
+first thing to check if the device test comes back negative.
+
+### 8.3 Why the correction is not local
+
+Rotating the capture view moves $F$ into the rotated frame, while `PoseFusion`
+composes $V_{\text{cur}}^{-1} \cdot \text{pnp} \cdot T$ with $V_{\text{cur}}$
+unrotated — so the composition needs the matching change, and every rotation
+sign must be right or the overlay lands worse than today. This is a system-wide
+convention change.
 
 **It is a prerequisite, not a parallel task.** Every 3D quantity in Approach B —
 $\Phi$, the partition, geometric stability, the offset fit — is built on

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/Footprint.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/Footprint.kt
@@ -1,0 +1,146 @@
+package com.hereliesaz.graffitixr.feature.ar.anchor
+
+import kotlin.math.abs
+import kotlin.math.max
+
+/**
+ * The **footprint operator** Φ — see `docs/research/PAPER.md` §5.
+ *
+ * Maps a world point into the design's own normalized coordinates:
+ *
+ * ```
+ * Φ(x) = ( (M⁻¹x)_x / h_w ,  (M⁻¹x)_y / h_h )
+ * ```
+ *
+ * Inside the design, Φ lands in `[-1,+1]²`. Outside it, the magnitude says how far outside *in units
+ * of the design's own size* — which is the quantity every downstream decision actually wants, and
+ * the reason Φ is the single piece of machinery the hybrid relocalizer rests on. It is what lets the
+ * system ask "is this feature *on* the artwork?", the question an appearance-only design could never
+ * answer.
+ *
+ * **Φ discards the plane-normal component deliberately.** A point 0.5 m in front of the wall maps to
+ * the same `(u,v)` as its foot on the wall. The partition is about *where on the design* a feature
+ * sits, not how far off the surface it is; off-surface points are rejected earlier, by
+ * [PlaneMarks.backProject]'s depth range.
+ *
+ * ## The scale trap
+ *
+ * `M` is the overlay's composed model matrix, and it is **not rigid** — `ArRenderer` folds the
+ * user's pinch into it via `Matrix.scaleM(.., overlayScale, overlayScale, 1f)`. Inverting it with
+ * [PoseMath.rigidInverse] (which transposes) is wrong by `s²`: at `overlayScale = 2` a feature
+ * sitting exactly on the design edge comes out at `‖Φ‖∞ = 4`, is classified [Region.OUTSIDE], and
+ * gets promoted into the backbone — the set defined as wall that never gets painted. Every feature
+ * under the artwork would land there, which is precisely the corruption the partition exists to
+ * prevent.
+ *
+ * Two safe ways to call this, both covered by tests:
+ *
+ *  - **Preferred.** Pass the *rigid* factor as [anchorModel] and fold the scale into the extents:
+ *    `of(rigidAnchor, halfW * s, halfH * s, ...)`. Keeps Φ a pure rigid-frame operation and makes
+ *    the scale dependency visible at the call site.
+ *  - Pass the composed matrix and let [ofComposed] divide the scale out via
+ *    [PoseMath.similarityInverse].
+ */
+object Footprint {
+
+    /** Where a point sits relative to the design. */
+    enum class Region {
+        /** Inside the design — the corroboration set `F_in`. Expected to decay as it is painted. */
+        INSIDE,
+
+        /**
+         * The discard band straddling the design's edge. Neither set.
+         *
+         * This region is easy to skip and should not be. Features within a hair of the boundary are
+         * exactly the ones whose classification flips as the artist paints out to the edge, and a
+         * *misclassified* feature is worse than a discarded one: a doomed feature admitted to the
+         * backbone corrupts the thing the backbone exists to be.
+         */
+        BAND,
+
+        /** Outside the design — the backbone set `F_out`. Expected to stay stable all session. */
+        OUTSIDE,
+    }
+
+    /**
+     * Normalized design coordinates of a world point, written into [out] and returned.
+     *
+     * @param anchorModel the design's **rigid** model matrix, column-major 4x4. If yours carries the
+     *   overlay scale, use [ofComposed] instead — see the class docs.
+     * @param halfW half-width of the design in metres, already multiplied by the overlay scale.
+     * @param halfH half-height, likewise.
+     * @param out a caller-supplied 2-element buffer. Φ runs once per feature per capture, so the
+     *   overload exists to keep it out of the allocator.
+     */
+    fun of(
+        anchorModel: FloatArray,
+        halfW: Float, halfH: Float,
+        x: Float, y: Float, z: Float,
+        out: FloatArray = FloatArray(2),
+    ): FloatArray = project(PoseMath.rigidInverse(anchorModel), halfW, halfH, x, y, z, out)
+
+    /**
+     * As [of], but for a model matrix that carries a uniform in-plane scale (the composed overlay
+     * transform). The scale is divided out of the inverse AND out of the extents, so [halfW]/[halfH]
+     * here are the design's **unscaled** half-extents.
+     */
+    fun ofComposed(
+        composedModel: FloatArray,
+        halfW: Float, halfH: Float,
+        x: Float, y: Float, z: Float,
+        out: FloatArray = FloatArray(2),
+    ): FloatArray = project(PoseMath.similarityInverse(composedModel), halfW, halfH, x, y, z, out)
+
+    /** Shared core: apply an already-inverted transform, then normalize by the half-extents. */
+    private fun project(
+        inverse: FloatArray,
+        halfW: Float, halfH: Float,
+        x: Float, y: Float, z: Float,
+        out: FloatArray,
+    ): FloatArray {
+        require(halfW > 1e-6f && halfH > 1e-6f) { "degenerate design extents: $halfW x $halfH" }
+        // Local X and Y only — Z is the plane normal and Φ discards it by construction.
+        val lx = inverse[0] * x + inverse[4] * y + inverse[8] * z + inverse[12]
+        val ly = inverse[1] * x + inverse[5] * y + inverse[9] * z + inverse[13]
+        out[0] = lx / halfW
+        out[1] = ly / halfH
+        return out
+    }
+
+    /**
+     * True when [uv] lies within the design rectangle, dilated by [margin] (in Φ units, so 0.1 means
+     * "a tenth of the design's half-extent past the edge").
+     */
+    fun isInside(uv: FloatArray, margin: Float = 0f): Boolean =
+        abs(uv[0]) <= 1f + margin && abs(uv[1]) <= 1f + margin
+
+    /**
+     * Chebyshev distance from the design rectangle: 0 inside, growing outside.
+     *
+     * Chebyshev rather than Euclidean because the design is a rectangle, not a disc — a point 0.2
+     * past the right edge and a point 0.2 past the top edge are equally "just outside", and the
+     * corner should not be treated as further away than the sides.
+     */
+    fun outsideDistance(uv: FloatArray): Float =
+        max(0f, max(abs(uv[0]) - 1f, abs(uv[1]) - 1f))
+
+    /**
+     * Partition a point into the backbone set, the corroboration set, or the discard band.
+     *
+     * [innerMargin] shrinks the inside test and [outerMargin] grows the outside test; the gap
+     * between them is the band. Requiring `innerMargin < outerMargin` is not a formality — inverted
+     * margins would silently produce an empty band and hand boundary features straight to the
+     * backbone, which is the failure the band exists to prevent.
+     */
+    fun classify(uv: FloatArray, innerMargin: Float, outerMargin: Float): Region {
+        require(innerMargin >= 0f && outerMargin > innerMargin) {
+            "margins must satisfy 0 <= inner ($innerMargin) < outer ($outerMargin)"
+        }
+        val d = max(abs(uv[0]), abs(uv[1]))
+        return when {
+            d <= 1f - innerMargin -> Region.INSIDE
+            d >= 1f + outerMargin -> Region.OUTSIDE
+            else -> Region.BAND
+        }
+    }
+}

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/Footprint.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/Footprint.kt
@@ -69,8 +69,9 @@ object Footprint {
      *   overlay scale, use [ofComposed] instead — see the class docs.
      * @param halfW half-width of the design in metres, already multiplied by the overlay scale.
      * @param halfH half-height, likewise.
-     * @param out a caller-supplied 2-element buffer. Φ runs once per feature per capture, so the
-     *   overload exists to keep it out of the allocator.
+     * @param out a caller-supplied 2-element buffer. Note this alone does **not** make Φ
+     *   allocation-free: this overload still builds a `FloatArray(16)` inverse per call. For a
+     *   per-feature loop, hoist the inverse with [inverseOfRigid] and call [ofInverted].
      */
     fun of(
         anchorModel: FloatArray,
@@ -90,6 +91,37 @@ object Footprint {
         x: Float, y: Float, z: Float,
         out: FloatArray = FloatArray(2),
     ): FloatArray = project(PoseMath.similarityInverse(composedModel), halfW, halfH, x, y, z, out)
+
+    /**
+     * Pre-compute the inverse once, for a whole capture's worth of features.
+     *
+     * [of] and [ofComposed] each allocate a `FloatArray(16)` for the inverse on **every call**, and
+     * [ofComposed] additionally does a `sqrt` per call to recover a scale that is constant across
+     * the capture. That dwarfs the 2-float array the `out` buffer saves, so the buffer overload only
+     * earns its keep when the inverse is hoisted out of the loop as well:
+     *
+     * ```kotlin
+     * val inv = Footprint.inverseOfComposed(anchorComposed)
+     * val uv = FloatArray(2)
+     * for (p in points) { Footprint.ofInverted(inv, halfW, halfH, p.x, p.y, p.z, uv); ... }
+     * ```
+     */
+    fun inverseOfRigid(anchorModel: FloatArray): FloatArray = PoseMath.rigidInverse(anchorModel)
+
+    /** As [inverseOfRigid], for a model matrix carrying the overlay's in-plane scale. */
+    fun inverseOfComposed(composedModel: FloatArray): FloatArray = PoseMath.similarityInverse(composedModel)
+
+    /**
+     * Φ from an inverse produced by [inverseOfRigid] or [inverseOfComposed]. The extents must match
+     * the choice: scaled half-extents for a rigid inverse, unscaled for a composed one — exactly as
+     * in [of] and [ofComposed] respectively.
+     */
+    fun ofInverted(
+        inverse: FloatArray,
+        halfW: Float, halfH: Float,
+        x: Float, y: Float, z: Float,
+        out: FloatArray = FloatArray(2),
+    ): FloatArray = project(inverse, halfW, halfH, x, y, z, out)
 
     /** Shared core: apply an already-inverted transform, then normalize by the half-extents. */
     private fun project(

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/PoseMath.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/PoseMath.kt
@@ -41,7 +41,10 @@ object PoseMath {
      * Working it out row by row for that matrix: the true inverse is `diag(1/s,1/s,1)·Rᵀ`, whose
      * rows 0 and 1 are `(1/s)·(rows 0,1 of Rᵀ)`. Since `Aᵀ = diag(s,s,1)·Rᵀ`, dividing by `s²` gives
      * `(1/s)·(rows 0,1 of Rᵀ)` for those same rows — **identical**. Only row 2, the plane normal, is
-     * off (by a further factor of `s`), and with it the Z component of the translation.
+     * off: the true inverse leaves it as `Rᵀ_row2`, this yields `Rᵀ_row2 / s²`. At `s = 2` the
+     * normal row comes out a quarter of its correct value, not a half. The Z component of the
+     * translation inherits the same factor; `r[12]` and `r[13]` do not, since they are built from
+     * rows 0 and 1 only.
      *
      * So this is exact for every component [Footprint] reads, and wrong only in the component
      * [Footprint] discards by construction. Do not reuse it where the normal direction matters

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/PoseMath.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/PoseMath.kt
@@ -16,6 +16,53 @@ object PoseMath {
         return r
     }
 
+    /**
+     * Uniform scale baked into a similarity transform `[sR|t]`, recovered as the norm of its first
+     * column. Returns 1 for a rigid matrix.
+     *
+     * Worth having explicitly, because the AR overlay's model matrix is NOT rigid: `ArRenderer`
+     * composes the user's pinch (`Matrix.scaleM(.., overlayScale, overlayScale, 1f)`) into it, and
+     * anything that assumes otherwise — [rigidInverse] in particular — is wrong by `s²`.
+     */
+    fun scaleOf(m: FloatArray): Float = sqrt(m[0] * m[0] + m[1] * m[1] + m[2] * m[2])
+
+    /**
+     * Inverse of a SIMILARITY transform `[sR|t]` with uniform scale: `[R^T/s | -R^T t/s]`.
+     *
+     * Use this, not [rigidInverse], for any matrix that may carry the overlay scale. [rigidInverse]
+     * inverts the linear part by transposing, which yields `sR^T` where `R^T/s` was meant — an error
+     * of `s²`. At `overlayScale = 2` that misplaces every point by a factor of four, which is enough
+     * to flip a footprint classification from inside the design to outside it.
+     *
+     * **Exactness caveat, stated precisely.** The overlay is built with `scaleM(.., s, s, 1f)` —
+     * X and Y scaled, Z not — so `A = R·diag(s,s,1)` is a similarity only *in the plane*, and the
+     * `Aᵀ/s²` this computes is not its exact inverse.
+     *
+     * Working it out row by row for that matrix: the true inverse is `diag(1/s,1/s,1)·Rᵀ`, whose
+     * rows 0 and 1 are `(1/s)·(rows 0,1 of Rᵀ)`. Since `Aᵀ = diag(s,s,1)·Rᵀ`, dividing by `s²` gives
+     * `(1/s)·(rows 0,1 of Rᵀ)` for those same rows — **identical**. Only row 2, the plane normal, is
+     * off (by a further factor of `s`), and with it the Z component of the translation.
+     *
+     * So this is exact for every component [Footprint] reads, and wrong only in the component
+     * [Footprint] discards by construction. Do not reuse it where the normal direction matters
+     * without fixing row 2 first. For a genuinely uniform `diag(s,s,s)` it is exact throughout.
+     */
+    fun similarityInverse(m: FloatArray): FloatArray {
+        val s = scaleOf(m)
+        require(s > 1e-9f) { "similarityInverse: degenerate scale $s" }
+        val inv = 1f / s
+        val r = FloatArray(16)
+        // R^T/s: transpose the linear part, then divide out the scale once for the transpose's own
+        // factor of s and once for the inverse.
+        for (i in 0 until 3) for (j in 0 until 3) r[j * 4 + i] = m[i * 4 + j] * inv * inv
+        val tx = m[12]; val ty = m[13]; val tz = m[14]
+        r[12] = -(r[0] * tx + r[4] * ty + r[8] * tz)
+        r[13] = -(r[1] * tx + r[5] * ty + r[9] * tz)
+        r[14] = -(r[2] * tx + r[6] * ty + r[10] * tz)
+        r[15] = 1f
+        return r
+    }
+
     /** Inverse of a rigid transform [R|t] (rotation+translation, no scale): [R^T | -R^T t]. */
     fun rigidInverse(m: FloatArray): FloatArray {
         val r = FloatArray(16)

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -1133,7 +1133,18 @@ class ArRenderer(
                     // CONF_FLOOR, so an unpainted wall still corrects at half strength on the inlier
                     // ratio alone — the previous behaviour is the floor, not the ceiling — and a
                     // well-advanced mural earns up to 2x that.
-                    confGlobal = slamManager.getPaintingProgress(),
+                    //
+                    // Corroboration CONFIDENCE, not painting PROGRESS. Progress answers "how much of
+                    // the mural exists" on a timescale of hours; this answers "how much do I trust
+                    // this frame" on a timescale of frames. They were one scalar, so a momentary
+                    // tracking hiccup decayed the progress reading and went on suppressing correction
+                    // strength for seconds after the wall came back into view.
+                    //
+                    // Negative means no corroboration attempt has produced a measurement yet — a
+                    // different state from "measured, found nothing". Map it to 0f so PoseFusion
+                    // falls back to CONF_FLOOR and corrects on the inlier ratio alone, rather than
+                    // feeding a negative through a parameter documented as [0,1].
+                    confGlobal = slamManager.getCorroborationConfidence().coerceAtLeast(0f),
                 )
             } else backbone
 

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/FootprintTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/FootprintTest.kt
@@ -1,0 +1,238 @@
+package com.hereliesaz.graffitixr.feature.ar.anchor
+
+import kotlin.math.cos
+import kotlin.math.sin
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * EVALUATION.md **E1** — correctness of the footprint operator Φ.
+ *
+ * Φ is consumed by every later phase of the hybrid relocalizer, so an error here is
+ * indistinguishable downstream from a badly-chosen threshold: the partition would simply be wrong,
+ * quietly, and every measurement taken on top of it would be uninterpretable. These cases are cheap
+ * and exact, and they exist so that never happens.
+ *
+ * Three of them catch real bugs rather than restating the implementation:
+ *  - [rotated anchor maps the design's own axes, not the world's] catches using the forward
+ *    transform where the inverse was needed — the highest-probability mistake here, because both
+ *    compile and both produce plausible-looking numbers.
+ *  - [non-square extents saturate at each axis's own edge] catches dividing both axes by the same
+ *    half-extent.
+ *  - [scaled anchor still puts the design edge at one] catches the `rigidInverse` trap that the
+ *    first draft of the implementation plan actively recommended.
+ */
+class FootprintTest {
+
+    private companion object {
+        const val EPS = 1e-4f
+        const val HALF_W = 1.5f
+        const val HALF_H = 0.75f
+    }
+
+    private fun identity() = floatArrayOf(1f, 0f, 0f, 0f, 0f, 1f, 0f, 0f, 0f, 0f, 1f, 0f, 0f, 0f, 0f, 1f)
+
+    /** Column-major rigid transform: rotation [deg] about Z, then translation. */
+    private fun anchor(deg: Float = 0f, tx: Float = 0f, ty: Float = 0f, tz: Float = 0f): FloatArray {
+        val c = cos(Math.toRadians(deg.toDouble())).toFloat()
+        val s = sin(Math.toRadians(deg.toDouble())).toFloat()
+        return floatArrayOf(
+            c, s, 0f, 0f,
+            -s, c, 0f, 0f,
+            0f, 0f, 1f, 0f,
+            tx, ty, tz, 1f,
+        )
+    }
+
+    /** As [anchor], but with the overlay's in-plane pinch folded in — `scaleM(.., s, s, 1f)`. */
+    private fun composedAnchor(scale: Float, deg: Float = 0f, tx: Float = 0f, ty: Float = 0f): FloatArray {
+        val m = anchor(deg, tx, ty)
+        for (i in 0 until 3) {           // scale columns 0 and 1 (local X and Y), leave Z alone
+            m[i] *= scale
+            m[4 + i] *= scale
+        }
+        return m
+    }
+
+    @Test
+    fun `identity anchor puts the centre at origin and the corner at one`() {
+        val c = Footprint.of(identity(), HALF_W, HALF_H, 0f, 0f, 0f)
+        assertEquals(0f, c[0], EPS); assertEquals(0f, c[1], EPS)
+
+        val corner = Footprint.of(identity(), HALF_W, HALF_H, HALF_W, HALF_H, 0f)
+        assertEquals(1f, corner[0], EPS); assertEquals(1f, corner[1], EPS)
+    }
+
+    @Test
+    fun `translated anchor leaves the design's own coordinates unchanged`() {
+        val a = anchor(tx = 7f, ty = -3f, tz = 12f)
+        val centre = Footprint.of(a, HALF_W, HALF_H, 7f, -3f, 12f)
+        assertEquals(0f, centre[0], EPS); assertEquals(0f, centre[1], EPS)
+
+        val edge = Footprint.of(a, HALF_W, HALF_H, 7f + HALF_W, -3f, 12f)
+        assertEquals(1f, edge[0], EPS); assertEquals(0f, edge[1], EPS)
+    }
+
+    /**
+     * With the design rotated 45 degrees in its own plane, a point along the design's LOCAL +X axis
+     * must map to (1, 0). Using the forward transform instead of the inverse rotates the answer
+     * instead of un-rotating it, and lands somewhere near (0.71, 0.71) — plausible enough to pass a
+     * sloppier assertion.
+     */
+    @Test
+    fun `rotated anchor maps the design's own axes, not the world's`() {
+        val deg = 45f
+        val a = anchor(deg)
+        val c = cos(Math.toRadians(deg.toDouble())).toFloat()
+        val s = sin(Math.toRadians(deg.toDouble())).toFloat()
+        // World position of the point sitting at local (HALF_W, 0, 0).
+        val world = floatArrayOf(c * HALF_W, s * HALF_W, 0f)
+
+        val uv = Footprint.of(a, HALF_W, HALF_H, world[0], world[1], world[2])
+        assertEquals("local +X edge must map to u=1", 1f, uv[0], EPS)
+        assertEquals("local +X edge must map to v=0", 0f, uv[1], EPS)
+    }
+
+    /** Each axis normalizes by its OWN half-extent; a shared divisor breaks the narrow one. */
+    @Test
+    fun `non-square extents saturate at each axis's own edge`() {
+        val u = Footprint.of(identity(), HALF_W, HALF_H, HALF_W, 0f, 0f)
+        assertEquals(1f, u[0], EPS); assertEquals(0f, u[1], EPS)
+
+        val v = Footprint.of(identity(), HALF_W, HALF_H, 0f, HALF_H, 0f)
+        assertEquals(0f, v[0], EPS); assertEquals(1f, v[1], EPS)
+    }
+
+    /**
+     * THE trap. The composed overlay matrix carries `overlayScale`, and inverting it by transposing
+     * (`rigidInverse`) is wrong by `s²`: at scale 2 the design edge reports 4 instead of 1, is
+     * classified OUTSIDE, and every feature under the artwork is promoted into the backbone — the
+     * set defined as wall that never gets painted.
+     */
+    @Test
+    fun `scaled anchor still puts the design edge at one`() {
+        for (scale in floatArrayOf(0.5f, 1f, 2f, 3.5f)) {
+            val m = composedAnchor(scale)
+            // At scale s the design's physical edge sits at s * HALF_W in world units.
+            val edge = Footprint.ofComposed(m, HALF_W, HALF_H, scale * HALF_W, 0f, 0f)
+            assertEquals("scale=$scale u", 1f, edge[0], EPS)
+            assertEquals("scale=$scale v", 0f, edge[1], EPS)
+
+            val centre = Footprint.ofComposed(m, HALF_W, HALF_H, 0f, 0f, 0f)
+            assertEquals("scale=$scale centre u", 0f, centre[0], EPS)
+        }
+    }
+
+    /** The same trap with rotation and translation present, so the scale fix cannot be a coincidence. */
+    @Test
+    fun `scaled, rotated and translated anchor still puts the edge at one`() {
+        val scale = 2f
+        val deg = 30f
+        val m = composedAnchor(scale, deg, tx = -4f, ty = 9f)
+        val c = cos(Math.toRadians(deg.toDouble())).toFloat()
+        val s = sin(Math.toRadians(deg.toDouble())).toFloat()
+        // Local (HALF_W, 0, 0) -> scaled by `scale`, rotated by `deg`, then translated.
+        val world = floatArrayOf(-4f + c * scale * HALF_W, 9f + s * scale * HALF_W, 0f)
+
+        val uv = Footprint.ofComposed(m, HALF_W, HALF_H, world[0], world[1], world[2])
+        assertEquals(1f, uv[0], EPS)
+        assertEquals(0f, uv[1], EPS)
+    }
+
+    /**
+     * Using the preferred call shape — rigid anchor with the scale folded into the extents — must
+     * agree exactly with [Footprint.ofComposed]. The plan offers both; if they disagree, one of the
+     * two call sites in the codebase would be silently wrong.
+     */
+    @Test
+    fun `folding scale into the extents matches dividing it out of the inverse`() {
+        val scale = 2f
+        val deg = 30f
+        val rigid = anchor(deg, tx = -4f, ty = 9f)
+        val composed = composedAnchor(scale, deg, tx = -4f, ty = 9f)
+        val world = floatArrayOf(-1.2f, 10.4f, 0.3f)
+
+        val viaExtents = Footprint.of(rigid, HALF_W * scale, HALF_H * scale, world[0], world[1], world[2])
+        val viaInverse = Footprint.ofComposed(composed, HALF_W, HALF_H, world[0], world[1], world[2])
+        assertEquals(viaExtents[0], viaInverse[0], EPS)
+        assertEquals(viaExtents[1], viaInverse[1], EPS)
+    }
+
+    /**
+     * Φ deliberately discards the plane-normal component: a point half a metre off the wall maps to
+     * the same (u,v) as its foot. Asserted rather than merely documented, because a reader will
+     * wonder whether it was intentional.
+     */
+    @Test
+    fun `off-plane points project to the same footprint as their foot`() {
+        val a = anchor(20f, tx = 1f, ty = 2f)
+        val onWall = Footprint.of(a, HALF_W, HALF_H, 1.4f, 2.3f, 0f).copyOf()
+        val offWall = Footprint.of(a, HALF_W, HALF_H, 1.4f, 2.3f, 0.5f)
+        assertEquals(onWall[0], offWall[0], EPS)
+        assertEquals(onWall[1], offWall[1], EPS)
+    }
+
+    @Test
+    fun `isInside honours its margin`() {
+        assertTrue(Footprint.isInside(floatArrayOf(0.99f, 0f)))
+        assertTrue(!Footprint.isInside(floatArrayOf(1.01f, 0f)))
+        assertTrue(Footprint.isInside(floatArrayOf(1.05f, 0f), margin = 0.1f))
+    }
+
+    /** Chebyshev, not Euclidean: a corner is not "further out" than a side at the same overshoot. */
+    @Test
+    fun `outsideDistance is zero inside and Chebyshev outside`() {
+        assertEquals(0f, Footprint.outsideDistance(floatArrayOf(0.5f, -0.9f)), EPS)
+        assertEquals(0.25f, Footprint.outsideDistance(floatArrayOf(1.25f, 0f)), EPS)
+        assertEquals(0.25f, Footprint.outsideDistance(floatArrayOf(0f, -1.25f)), EPS)
+        assertEquals(0.25f, Footprint.outsideDistance(floatArrayOf(1.25f, 1.25f)), EPS)
+    }
+
+    @Test
+    fun `classify partitions into inside, band and outside`() {
+        fun c(r: Float) = Footprint.classify(floatArrayOf(r, 0f), innerMargin = 0.05f, outerMargin = 0.15f)
+        assertEquals(Footprint.Region.INSIDE, c(0.90f))
+        assertEquals(Footprint.Region.INSIDE, c(0.95f))   // exactly on the inner boundary
+        assertEquals(Footprint.Region.BAND, c(0.98f))
+        assertEquals(Footprint.Region.BAND, c(1.10f))
+        assertEquals(Footprint.Region.OUTSIDE, c(1.15f))  // exactly on the outer boundary
+        assertEquals(Footprint.Region.OUTSIDE, c(1.30f))
+    }
+
+    /** The band uses the larger of the two axes, so a point outside in EITHER axis is not INSIDE. */
+    @Test
+    fun `classify uses the worse axis`() {
+        val uv = floatArrayOf(0.1f, 1.3f)
+        assertEquals(Footprint.Region.OUTSIDE, Footprint.classify(uv, 0.05f, 0.15f))
+    }
+
+    /**
+     * Inverted margins would collapse the band to nothing and hand boundary features straight to the
+     * backbone — the exact failure the band exists to prevent, and silent if it were allowed.
+     */
+    @Test
+    fun `classify rejects inverted margins rather than producing an empty band`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            Footprint.classify(floatArrayOf(1f, 0f), innerMargin = 0.2f, outerMargin = 0.1f)
+        }
+    }
+
+    @Test
+    fun `degenerate extents are rejected`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            Footprint.of(identity(), 0f, HALF_H, 1f, 1f, 0f)
+        }
+    }
+
+    /** The buffer overload exists to keep Φ out of the allocator; it must write in place. */
+    @Test
+    fun `caller-supplied buffer is filled and returned`() {
+        val buf = FloatArray(2)
+        val r = Footprint.of(identity(), HALF_W, HALF_H, HALF_W, HALF_H, 0f, buf)
+        assertTrue("must return the caller's buffer, not a copy", r === buf)
+        assertEquals(1f, buf[0], EPS)
+        assertEquals(1f, buf[1], EPS)
+    }
+}

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/FootprintTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/FootprintTest.kt
@@ -78,8 +78,9 @@ class FootprintTest {
     /**
      * With the design rotated 45 degrees in its own plane, a point along the design's LOCAL +X axis
      * must map to (1, 0). Using the forward transform instead of the inverse rotates the answer
-     * instead of un-rotating it, and lands somewhere near (0.71, 0.71) — plausible enough to pass a
-     * sloppier assertion.
+     * instead of un-rotating it: with these constants that gives `lx = HALF_W·cos90° = 0` and
+     * `ly = HALF_W·sin90° = 1.5`, i.e. `(0, 2)` once normalized. Wrong on both axes, so this case
+     * catches the substitution decisively.
      */
     @Test
     fun `rotated anchor maps the design's own axes, not the world's`() {
@@ -143,8 +144,13 @@ class FootprintTest {
 
     /**
      * Using the preferred call shape — rigid anchor with the scale folded into the extents — must
-     * agree exactly with [Footprint.ofComposed]. The plan offers both; if they disagree, one of the
-     * two call sites in the codebase would be silently wrong.
+     * agree exactly with [Footprint.ofComposed]. The plan offers both and Phase 2 will pick one per
+     * call site; if they disagree, that choice silently becomes a correctness decision instead of a
+     * performance one. (Φ has no production callers yet — this guards the choice before it is made.)
+     *
+     * The rigid factor passed here is the FULL rigid part, rotation and translation included.
+     * `ArRenderer`'s `overlayBaseScratch` alone is NOT that — the pan and in-plane spin live in
+     * `overlayLocalScratch` alongside the scale — which is why the plan's wording needed correcting.
      */
     @Test
     fun `folding scale into the extents matches dividing it out of the inverse`() {
@@ -172,6 +178,57 @@ class FootprintTest {
         val offWall = Footprint.of(a, HALF_W, HALF_H, 1.4f, 2.3f, 0.5f)
         assertEquals(onWall[0], offWall[0], EPS)
         assertEquals(onWall[1], offWall[1], EPS)
+    }
+
+    /**
+     * Every other anchor here rotates about Z, which leaves the inverse's third column zero — so the
+     * coefficients Φ applies to the world `z` are never exercised, and the normal-discarding claim
+     * is only demonstrated for a wall that happens to BE the world XY plane. A real wall's local Z
+     * lies along its own normal, which is generally not world Z. This tilts the anchor so those
+     * coefficients are non-zero.
+     */
+    @Test
+    fun `tilted anchor still maps its own axes and still discards its own normal`() {
+        // 30 degrees about world X: local +Y tilts out of the world XY plane, local +Z with it.
+        val a = Math.toRadians(30.0)
+        val c = cos(a).toFloat(); val s = sin(a).toFloat()
+        val tilted = floatArrayOf(
+            1f, 0f, 0f, 0f,      // local +X stays world +X
+            0f, c, s, 0f,        // local +Y tilts
+            0f, -s, c, 0f,       // local +Z tilts with it — this is the wall normal
+            0f, 0f, 0f, 1f,
+        )
+        // Local (HALF_W, 0, 0) and (0, HALF_H, 0), expressed in world.
+        val edgeU = Footprint.of(tilted, HALF_W, HALF_H, HALF_W, 0f, 0f)
+        assertEquals(1f, edgeU[0], EPS); assertEquals(0f, edgeU[1], EPS)
+
+        val edgeV = Footprint.of(tilted, HALF_W, HALF_H, 0f, c * HALF_H, s * HALF_H)
+        assertEquals(0f, edgeV[0], EPS); assertEquals(1f, edgeV[1], EPS)
+
+        // A point half a metre along the wall's OWN normal must share its foot's footprint.
+        val foot = Footprint.of(tilted, HALF_W, HALF_H, 0f, c * HALF_H, s * HALF_H).copyOf()
+        val off = Footprint.of(tilted, HALF_W, HALF_H, 0f, c * HALF_H - 0.5f * s, s * HALF_H + 0.5f * c)
+        assertEquals(foot[0], off[0], EPS)
+        assertEquals(foot[1], off[1], EPS)
+    }
+
+    /** Hoisting the inverse out of a per-feature loop must give bit-identical results. */
+    @Test
+    fun `pre-inverted path matches the per-call path`() {
+        val scale = 2f
+        val rigid = anchor(30f, tx = -4f, ty = 9f)
+        val composed = composedAnchor(scale, 30f, tx = -4f, ty = 9f)
+        val world = floatArrayOf(-1.2f, 10.4f, 0.3f)
+
+        val invRigid = Footprint.inverseOfRigid(rigid)
+        val a1 = Footprint.of(rigid, HALF_W, HALF_H, world[0], world[1], world[2]).copyOf()
+        val a2 = Footprint.ofInverted(invRigid, HALF_W, HALF_H, world[0], world[1], world[2])
+        assertEquals(a1[0], a2[0], EPS); assertEquals(a1[1], a2[1], EPS)
+
+        val invComposed = Footprint.inverseOfComposed(composed)
+        val b1 = Footprint.ofComposed(composed, HALF_W, HALF_H, world[0], world[1], world[2]).copyOf()
+        val b2 = Footprint.ofInverted(invComposed, HALF_W, HALF_H, world[0], world[1], world[2])
+        assertEquals(b1[0], b2[0], EPS); assertEquals(b1[1], b2[1], EPS)
     }
 
     @Test

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/PlaneMarksObliquityTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/PlaneMarksObliquityTest.kt
@@ -33,15 +33,25 @@ import org.junit.Test
  *    loosening a bound; a suddenly-passing characterization test means the bug moved, not that it
  *    was fixed.
  *
- * Expected magnitudes are in `PAPER.md` §8.1 and were derived independently of this code.
+ * Ground truth is built FORWARD (see [samplesOn]): points are placed on the wall in its own basis
+ * and projected to pixels, so the truth path never evaluates the ray-plane intersection that
+ * `backProject` is being tested on. An earlier version derived truth from the pixel with the same
+ * `t = (n·p)/(n·d)` the implementation uses, which made the control tests tautologies that would
+ * have passed with a sign flip or a swapped numerator.
+ *
+ * Magnitudes here will NOT match `PAPER.md` §8.1's table. That table samples uniformly in PIXEL
+ * space over a 40x40 grid; this samples uniformly on the WALL, which weights oblique views
+ * differently. Both are correct measurements of the same defect; only the sampling differs. The
+ * assertions below are therefore ranges and orderings, not the paper's decimals.
  */
 class PlaneMarksObliquityTest {
 
     private companion object {
         // Display-oriented intrinsics for a 1080x1920 portrait frame (fx/fy already swapped by
-        // ArRenderer's rotationNeeded==90 branch).
+        // ArRenderer's rotationNeeded==90 branch). Deliberately DIFFERENT. Equal focal lengths make an fx/fy swap — the exact thing the
+        // display rotation does to the intrinsics — undetectable by every test in this file.
         const val FX = 1400f
-        const val FY = 1400f
+        const val FY = 1250f
         const val CX = 540f
         const val CY = 960f
         const val W = 1080
@@ -68,68 +78,73 @@ class PlaneMarksObliquityTest {
 
     private fun identityView() = rzView(0f)
 
-    /** A grid of pixels over the central 80% of the frame — the region features actually land in. */
-    private fun samplePixels(step: Int = 8): List<PlaneMarks.Pixel> = buildList {
-        for (i in 0 until step) {
-            val v = 0.1f * H + 0.8f * H * i / (step - 1)
-            for (j in 0 until step) {
-                val u = 0.1f * W + 0.8f * W * j / (step - 1)
-                add(PlaneMarks.Pixel(u, v))
-            }
-        }
-    }
-
     /** Wall normal in the CAMERA frame, tilted [obliquityDeg] about the camera's Y axis. */
     private fun wallNormalCam(obliquityDeg: Float): FloatArray {
         val a = Math.toRadians(obliquityDeg.toDouble())
         return floatArrayOf(sin(a).toFloat(), 0f, cos(a).toFloat())
     }
 
+    /** A 3D point paired with the pixel it projects to. */
+    private class Sample(val world: FloatArray, val pixel: PlaneMarks.Pixel)
+
     /**
-     * Ground truth, computed in CLOSED FORM rather than by calling the code under test. For each
-     * sampled pixel, walk its camera ray to the wall analytically: `t = (n·p)/(n·d)`, point = `t·d`.
+     * Ground truth, built **forward**: parameterize the wall by its own two in-plane basis vectors,
+     * place points on it, and project each through the pinhole model to get its pixel.
      *
-     * Deriving truth independently is what makes the control tests real. Comparing `backProject`
-     * against a second `backProject` call would be a tautology that passes no matter how wrong the
-     * implementation is.
+     * The direction matters. An earlier version of this file computed truth by re-deriving
+     * `t = (n·p)/(n·d)` from the pixel — which is `backProject`'s own loop retyped, so the controls
+     * compared the implementation against itself and would have passed with a sign flip, a swapped
+     * numerator, or a wrong ray. Going forward shares only the pinhole projection, and shares it as
+     * the *inverse* operation, so an error in the unprojection cannot be mirrored into the truth.
      */
-    private fun analyticTruth(obliquityDeg: Float, pixels: List<PlaneMarks.Pixel>): Map<Int, FloatArray> {
+    private fun samplesOn(obliquityDeg: Float, steps: Int = 25, span: Float = 4f): List<Sample> {
+        val a = Math.toRadians(obliquityDeg.toDouble())
         val n = wallNormalCam(obliquityDeg)
         val p = floatArrayOf(n[0] * DIST_M, n[1] * DIST_M, n[2] * DIST_M)
-        val nDotP = n[0] * p[0] + n[1] * p[1] + n[2] * p[2]
-        val out = HashMap<Int, FloatArray>(pixels.size)
-        for ((i, px) in pixels.withIndex()) {
-            val dx = (px.u - CX) / FX
-            val dy = (px.v - CY) / FY
-            val nDotD = n[0] * dx + n[1] * dy + n[2]
-            if (abs(nDotD) < 1e-6f) continue
-            val t = nDotP / nDotD
-            if (t < 0.1f || t > 10f) continue // backProject's own trust range
-            out[i] = floatArrayOf(t * dx, t * dy, t)
+        // Orthonormal in-plane basis: e1 lies in the XZ plane perpendicular to n, e2 is world +Y.
+        val e1 = floatArrayOf(cos(a).toFloat(), 0f, -sin(a).toFloat())
+        val e2 = floatArrayOf(0f, 1f, 0f)
+
+        val out = ArrayList<Sample>()
+        for (i in 0 until steps) {
+            val s = -span + 2f * span * i / (steps - 1)
+            for (j in 0 until steps) {
+                val t = -span + 2f * span * j / (steps - 1)
+                val wx = p[0] + s * e1[0] + t * e2[0]
+                val wy = p[1] + s * e1[1] + t * e2[1]
+                val wz = p[2] + s * e1[2] + t * e2[2]
+                if (wz < 0.1f || wz > 10f) continue                      // behind, or past the trust range
+                val u = wx / wz * FX + CX
+                val v = wy / wz * FY + CY
+                if (u < 0.05f * W || u > 0.95f * W) continue             // off-frame
+                if (v < 0.05f * H || v > 0.95f * H) continue
+                out.add(Sample(floatArrayOf(wx, wy, wz), PlaneMarks.Pixel(u, v)))
+            }
         }
         return out
     }
 
     /**
-     * Per-pixel distance in mm between what `backProject` returns when the plane arrives through
-     * [viewForPlane] and the closed-form truth. The rays are always in the frame the pixels were
-     * measured in, so [viewForPlane] is exactly the shipped mismatch: identity means the plane is in
-     * the same frame as the rays (correct), a rotation means it is not.
+     * Per-point distance in mm between what `backProject` returns when the plane arrives through
+     * [viewForPlane] and the forward-constructed truth. The rays are always in the frame the pixels
+     * were measured in, so [viewForPlane] IS the shipped mismatch: identity means the plane is in
+     * that same frame (correct), a rotation means it is not.
      */
     private fun errorsMm(obliquityDeg: Float, viewForPlane: FloatArray): List<Float> {
-        val pixels = samplePixels()
+        val samples = samplesOn(obliquityDeg)
         val n = wallNormalCam(obliquityDeg)
         val p = floatArrayOf(n[0] * DIST_M, n[1] * DIST_M, n[2] * DIST_M)
-        val truth = analyticTruth(obliquityDeg, pixels)
 
-        val actual = PlaneMarks.backProject(pixels, viewForPlane, p, n, FX, FY, CX, CY)
+        val actual = PlaneMarks.backProject(
+            samples.map { it.pixel }, viewForPlane, p, n, FX, FY, CX, CY,
+        )
         val out = ArrayList<Float>(actual.count)
         for ((slot, src) in actual.kept.withIndex()) {
-            val t = truth[src] ?: continue
+            val truth = samples[src].world
             val o = slot * 3
-            val dx = actual.pointsCam[o] - t[0]
-            val dy = actual.pointsCam[o + 1] - t[1]
-            val dz = actual.pointsCam[o + 2] - t[2]
+            val dx = actual.pointsCam[o] - truth[0]
+            val dy = actual.pointsCam[o + 1] - truth[1]
+            val dz = actual.pointsCam[o + 2] - truth[2]
             out.add(hypot(hypot(dx, dy), dz) * 1000f)
         }
         return out
@@ -142,9 +157,13 @@ class PlaneMarksObliquityTest {
     // ---------------------------------------------------------------------------------------
 
     /**
-     * When the rays and the plane are in the same frame, `backProject` matches the closed form
-     * exactly. This is the control: it proves any error measured below comes from the frame
-     * mismatch and not from the back-projection itself.
+     * When the rays and the plane are in the same frame, `backProject` recovers the forward-
+     * constructed points exactly. Two things at once: it proves the unprojection genuinely inverts
+     * the projection (FX != FY here, so a focal-length swap fails this), and it establishes that any
+     * error measured below comes from the frame mismatch and not from `backProject` itself.
+     *
+     * This is also the LANDSCAPE case — `rotationNeeded == 0` means no mismatch exists to make — so
+     * it doubles as the prediction EVALUATION.md E0b asks you to check by rotating the phone.
      */
     @Test
     fun `frames agreeing recovers the truth exactly`() {
@@ -164,14 +183,27 @@ class PlaneMarksObliquityTest {
      */
     @Test
     fun `back-projection inverts a hand-computed projection`() {
-        val n = wallNormalCam(30f)
+        val deg = 30f
+        val a = Math.toRadians(deg.toDouble())
+        val n = wallNormalCam(deg)
         val p = floatArrayOf(n[0] * DIST_M, n[1] * DIST_M, n[2] * DIST_M)
-        // A point on the plane: start from a ray, walk it to the plane analytically.
-        val d = floatArrayOf(0.15f, -0.08f, 1f)
-        val t = (n[0] * p[0] + n[1] * p[1] + n[2] * p[2]) / (n[0] * d[0] + n[1] * d[1] + n[2] * d[2])
-        val truth = floatArrayOf(t * d[0], t * d[1], t * d[2])
-        val pixel = PlaneMarks.Pixel(truth[0] / truth[2] * FX + CX, truth[1] / truth[2] * FY + CY)
 
+        // Build the point FORWARD, from the plane's own basis — never from a ray. Walking a ray to
+        // the plane would be `backProject`'s own intersection formula, and the assertion would then
+        // only confirm the implementation agrees with itself.
+        val e1 = floatArrayOf(cos(a).toFloat(), 0f, -sin(a).toFloat())
+        val s = 0.31f
+        val t = -0.17f
+        val truth = floatArrayOf(
+            p[0] + s * e1[0],
+            p[1] + t,                 // e2 is world +Y
+            p[2] + s * e1[2],
+        )
+        // Sanity: the constructed point really is on the plane (n·(x-p) == 0).
+        val onPlane = n[0] * (truth[0] - p[0]) + n[1] * (truth[1] - p[1]) + n[2] * (truth[2] - p[2])
+        assertEquals("fixture must lie on the wall", 0f, onPlane, 1e-5f)
+
+        val pixel = PlaneMarks.Pixel(truth[0] / truth[2] * FX + CX, truth[1] / truth[2] * FY + CY)
         val r = PlaneMarks.backProject(listOf(pixel), identityView(), p, n, FX, FY, CX, CY)
         assertEquals(1, r.count)
         for (i in 0..2) assertEquals(truth[i], r.pointsCam[i], TOLERANCE_MM / 1000f)
@@ -193,22 +225,6 @@ class PlaneMarksObliquityTest {
         }
     }
 
-    /**
-     * Landscape sets `rotationNeeded == 0`, so there is no mismatch to make — the whole defect is
-     * inactive at every obliquity. This is what makes the hypothesis testable on a shipped build by
-     * rotating the phone (EVALUATION.md E0b), and it must keep holding after Phase 0.
-     */
-    @Test
-    fun `zero rotation is exact at every obliquity`() {
-        for (obliquity in floatArrayOf(0f, 20f, 40f, 60f)) {
-            val e = errorsMm(obliquity, rzView(0f))
-            assertTrue(
-                "rotationNeeded==0 must be exact at ${obliquity}deg, was ${meanMm(e)}mm",
-                e.all { it < TOLERANCE_MM },
-            )
-        }
-    }
-
     // ---------------------------------------------------------------------------------------
     // Characterization of the CURRENT defect. INVERT THESE WHEN PHASE 0 LANDS.
     // ---------------------------------------------------------------------------------------
@@ -223,10 +239,11 @@ class PlaneMarksObliquityTest {
     fun `CHARACTERIZATION portrait rotation skews depths badly off-square`() {
         val mean20 = meanMm(errorsMm(20f, rzView(90f)))
         val mean40 = meanMm(errorsMm(40f, rzView(90f)))
-        // PAPER.md 8.1 predicts ~267mm and ~834mm. Assert the order of magnitude, not the decimal —
-        // the sampling grid here is coarser than the one used for the table.
-        assertTrue("expected hundreds of mm at 20deg, got $mean20", mean20 in 100f..600f)
-        assertTrue("expected ~metre-scale at 40deg, got $mean40", mean40 in 400f..2000f)
+        // Wall-uniform sampling gives ~328mm and ~1148mm here; PAPER.md 8.1's pixel-uniform 40x40
+        // grid gives 267mm and 834mm for the same defect. Assert the band both live in, so neither
+        // sampling choice is silently baked in as the definition of the bug.
+        assertTrue("expected hundreds of mm at 20deg, got $mean20", mean20 in 150f..700f)
+        assertTrue("expected ~metre-scale at 40deg, got $mean40", mean40 in 500f..2500f)
         assertTrue("error must grow with obliquity", mean40 > mean20)
     }
 
@@ -241,6 +258,7 @@ class PlaneMarksObliquityTest {
     fun `CHARACTERIZATION half-turn rotation is also a mismatch`() {
         val mean = meanMm(errorsMm(20f, rzView(180f)))
         assertTrue("expected a real error at 180deg, got $mean", mean > 100f)
+        assertTrue("...but bounded; a runaway here means the model changed, got $mean", mean < 700f)
     }
 
     /**
@@ -273,12 +291,13 @@ class PlaneMarksObliquityTest {
      */
     @Test
     fun `CHARACTERIZATION steep obliquity silently discards marks`() {
-        val pixels = samplePixels()
+        val samples = samplesOn(60f)
+        val pixels = samples.map { it.pixel }
         val n = wallNormalCam(60f)
         val p = floatArrayOf(n[0] * DIST_M, n[1] * DIST_M, n[2] * DIST_M)
         val kept = PlaneMarks.backProject(pixels, rzView(90f), p, n, FX, FY, CX, CY).count
         val keptTruth = PlaneMarks.backProject(pixels, identityView(), p, n, FX, FY, CX, CY).count
-        assertTrue("control should keep everything, kept $keptTruth of ${pixels.size}", keptTruth == pixels.size)
+        assertEquals("control must keep every forward-constructed point", pixels.size, keptTruth)
         assertTrue("expected the mismatch to drop marks at 60deg, kept $kept of ${pixels.size}", kept < keptTruth)
     }
 

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/PlaneMarksObliquityTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/PlaneMarksObliquityTest.kt
@@ -1,0 +1,302 @@
+package com.hereliesaz.graffitixr.feature.ar.anchor
+
+import kotlin.math.abs
+import kotlin.math.cos
+import kotlin.math.hypot
+import kotlin.math.sin
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * EVALUATION.md **E0** — the display-rotation convention, characterized.
+ *
+ * The claim in `PlaneMarks`' CAUTION block — pixels and intrinsics are rotated to display
+ * orientation, the view matrix is not, so the recovered depths skew with obliquity — sat in a
+ * comment for several development cycles with no test behind it. `PlaneMarksTest` has only
+ * fronto-parallel and world-translated cases, so the defect it warns about has never been exercised
+ * once. This file exercises it.
+ *
+ * The geometry, from `backProject`'s own expression `t = (n·p)/(n·d)`: a rotation preserves the dot
+ * product, so `n·p` is identical in either frame and the ENTIRE error lives in the denominator —
+ * `n_sensor·d` where `n_display·d` was meant. Each recovered point therefore lies on the correct ray
+ * at the wrong depth, by a factor that varies across the image. That is a **non-rigid** distortion,
+ * which is the reason it matters: a rigid one would be absorbed by the reloc PnP, and this is not.
+ *
+ * Two kinds of test here, and the distinction is the point:
+ *
+ *  - [frames agreeing recovers the truth exactly] is a permanent correctness test. It pins that
+ *    `backProject` itself is right when it is handed a consistent frame. It must pass forever.
+ *  - The characterization tests below record what the CURRENT mismatch costs. They pass today
+ *    BECAUSE the defect is present. **When Phase 0 lands, they must be inverted** — flip the
+ *    assertions to `< TOLERANCE_MM` and they become the regression guard. Do not "fix" them by
+ *    loosening a bound; a suddenly-passing characterization test means the bug moved, not that it
+ *    was fixed.
+ *
+ * Expected magnitudes are in `PAPER.md` §8.1 and were derived independently of this code.
+ */
+class PlaneMarksObliquityTest {
+
+    private companion object {
+        // Display-oriented intrinsics for a 1080x1920 portrait frame (fx/fy already swapped by
+        // ArRenderer's rotationNeeded==90 branch).
+        const val FX = 1400f
+        const val FY = 1400f
+        const val CX = 540f
+        const val CY = 960f
+        const val W = 1080
+        const val H = 1920
+
+        /** Wall distance along its own normal, metres. */
+        const val DIST_M = 2f
+
+        /** What "recovered the truth" means for a synthetic case with no noise. */
+        const val TOLERANCE_MM = 1f
+    }
+
+    /** Column-major 4x4 rotation about the camera's optical axis (Z), as a CV-convention view. */
+    private fun rzView(deg: Float): FloatArray {
+        val c = cos(Math.toRadians(deg.toDouble())).toFloat()
+        val s = sin(Math.toRadians(deg.toDouble())).toFloat()
+        return floatArrayOf(
+            c, s, 0f, 0f,
+            -s, c, 0f, 0f,
+            0f, 0f, 1f, 0f,
+            0f, 0f, 0f, 1f,
+        )
+    }
+
+    private fun identityView() = rzView(0f)
+
+    /** A grid of pixels over the central 80% of the frame — the region features actually land in. */
+    private fun samplePixels(step: Int = 8): List<PlaneMarks.Pixel> = buildList {
+        for (i in 0 until step) {
+            val v = 0.1f * H + 0.8f * H * i / (step - 1)
+            for (j in 0 until step) {
+                val u = 0.1f * W + 0.8f * W * j / (step - 1)
+                add(PlaneMarks.Pixel(u, v))
+            }
+        }
+    }
+
+    /** Wall normal in the CAMERA frame, tilted [obliquityDeg] about the camera's Y axis. */
+    private fun wallNormalCam(obliquityDeg: Float): FloatArray {
+        val a = Math.toRadians(obliquityDeg.toDouble())
+        return floatArrayOf(sin(a).toFloat(), 0f, cos(a).toFloat())
+    }
+
+    /**
+     * Ground truth, computed in CLOSED FORM rather than by calling the code under test. For each
+     * sampled pixel, walk its camera ray to the wall analytically: `t = (n·p)/(n·d)`, point = `t·d`.
+     *
+     * Deriving truth independently is what makes the control tests real. Comparing `backProject`
+     * against a second `backProject` call would be a tautology that passes no matter how wrong the
+     * implementation is.
+     */
+    private fun analyticTruth(obliquityDeg: Float, pixels: List<PlaneMarks.Pixel>): Map<Int, FloatArray> {
+        val n = wallNormalCam(obliquityDeg)
+        val p = floatArrayOf(n[0] * DIST_M, n[1] * DIST_M, n[2] * DIST_M)
+        val nDotP = n[0] * p[0] + n[1] * p[1] + n[2] * p[2]
+        val out = HashMap<Int, FloatArray>(pixels.size)
+        for ((i, px) in pixels.withIndex()) {
+            val dx = (px.u - CX) / FX
+            val dy = (px.v - CY) / FY
+            val nDotD = n[0] * dx + n[1] * dy + n[2]
+            if (abs(nDotD) < 1e-6f) continue
+            val t = nDotP / nDotD
+            if (t < 0.1f || t > 10f) continue // backProject's own trust range
+            out[i] = floatArrayOf(t * dx, t * dy, t)
+        }
+        return out
+    }
+
+    /**
+     * Per-pixel distance in mm between what `backProject` returns when the plane arrives through
+     * [viewForPlane] and the closed-form truth. The rays are always in the frame the pixels were
+     * measured in, so [viewForPlane] is exactly the shipped mismatch: identity means the plane is in
+     * the same frame as the rays (correct), a rotation means it is not.
+     */
+    private fun errorsMm(obliquityDeg: Float, viewForPlane: FloatArray): List<Float> {
+        val pixels = samplePixels()
+        val n = wallNormalCam(obliquityDeg)
+        val p = floatArrayOf(n[0] * DIST_M, n[1] * DIST_M, n[2] * DIST_M)
+        val truth = analyticTruth(obliquityDeg, pixels)
+
+        val actual = PlaneMarks.backProject(pixels, viewForPlane, p, n, FX, FY, CX, CY)
+        val out = ArrayList<Float>(actual.count)
+        for ((slot, src) in actual.kept.withIndex()) {
+            val t = truth[src] ?: continue
+            val o = slot * 3
+            val dx = actual.pointsCam[o] - t[0]
+            val dy = actual.pointsCam[o + 1] - t[1]
+            val dz = actual.pointsCam[o + 2] - t[2]
+            out.add(hypot(hypot(dx, dy), dz) * 1000f)
+        }
+        return out
+    }
+
+    private fun meanMm(e: List<Float>) = if (e.isEmpty()) 0f else e.sum() / e.size
+
+    // ---------------------------------------------------------------------------------------
+    // Permanent correctness — must pass before AND after Phase 0.
+    // ---------------------------------------------------------------------------------------
+
+    /**
+     * When the rays and the plane are in the same frame, `backProject` matches the closed form
+     * exactly. This is the control: it proves any error measured below comes from the frame
+     * mismatch and not from the back-projection itself.
+     */
+    @Test
+    fun `frames agreeing recovers the truth exactly`() {
+        for (obliquity in floatArrayOf(0f, 20f, 40f, 60f)) {
+            val e = errorsMm(obliquity, identityView())
+            assertTrue(
+                "consistent frames must be exact at ${obliquity}deg, was ${meanMm(e)}mm",
+                e.all { it < TOLERANCE_MM },
+            )
+        }
+    }
+
+    /**
+     * A round trip through the projection: project a known 3D point on the wall to a pixel by hand,
+     * back-project that pixel, and land on the point you started from. Guards the intrinsics
+     * handling independently of the frame question.
+     */
+    @Test
+    fun `back-projection inverts a hand-computed projection`() {
+        val n = wallNormalCam(30f)
+        val p = floatArrayOf(n[0] * DIST_M, n[1] * DIST_M, n[2] * DIST_M)
+        // A point on the plane: start from a ray, walk it to the plane analytically.
+        val d = floatArrayOf(0.15f, -0.08f, 1f)
+        val t = (n[0] * p[0] + n[1] * p[1] + n[2] * p[2]) / (n[0] * d[0] + n[1] * d[1] + n[2] * d[2])
+        val truth = floatArrayOf(t * d[0], t * d[1], t * d[2])
+        val pixel = PlaneMarks.Pixel(truth[0] / truth[2] * FX + CX, truth[1] / truth[2] * FY + CY)
+
+        val r = PlaneMarks.backProject(listOf(pixel), identityView(), p, n, FX, FY, CX, CY)
+        assertEquals(1, r.count)
+        for (i in 0..2) assertEquals(truth[i], r.pointsCam[i], TOLERANCE_MM / 1000f)
+    }
+
+    /**
+     * The reason the defect went unnoticed for so long, stated as a test. A plane normal of
+     * (0,0,±1) is invariant under a rotation about the optical axis, so the mismatch cancels
+     * completely when the camera is square to the wall — which is how anyone would first test it.
+     */
+    @Test
+    fun `head-on wall is immune to the rotation mismatch`() {
+        for (rotation in floatArrayOf(90f, 180f, 270f)) {
+            val e = errorsMm(obliquityDeg = 0f, viewForPlane = rzView(rotation))
+            assertTrue(
+                "a head-on wall must be exact under ${rotation}deg, was ${meanMm(e)}mm",
+                e.all { it < TOLERANCE_MM },
+            )
+        }
+    }
+
+    /**
+     * Landscape sets `rotationNeeded == 0`, so there is no mismatch to make — the whole defect is
+     * inactive at every obliquity. This is what makes the hypothesis testable on a shipped build by
+     * rotating the phone (EVALUATION.md E0b), and it must keep holding after Phase 0.
+     */
+    @Test
+    fun `zero rotation is exact at every obliquity`() {
+        for (obliquity in floatArrayOf(0f, 20f, 40f, 60f)) {
+            val e = errorsMm(obliquity, rzView(0f))
+            assertTrue(
+                "rotationNeeded==0 must be exact at ${obliquity}deg, was ${meanMm(e)}mm",
+                e.all { it < TOLERANCE_MM },
+            )
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Characterization of the CURRENT defect. INVERT THESE WHEN PHASE 0 LANDS.
+    // ---------------------------------------------------------------------------------------
+
+    /**
+     * The headline number. Portrait on a typical phone gives `rotationNeeded == 90`, and at a
+     * modest 20 degrees off-square the recovered marks are hundreds of millimetres out.
+     *
+     * PHASE 0: change to `assertTrue(mean < TOLERANCE_MM)`.
+     */
+    @Test
+    fun `CHARACTERIZATION portrait rotation skews depths badly off-square`() {
+        val mean20 = meanMm(errorsMm(20f, rzView(90f)))
+        val mean40 = meanMm(errorsMm(40f, rzView(90f)))
+        // PAPER.md 8.1 predicts ~267mm and ~834mm. Assert the order of magnitude, not the decimal —
+        // the sampling grid here is coarser than the one used for the table.
+        assertTrue("expected hundreds of mm at 20deg, got $mean20", mean20 in 100f..600f)
+        assertTrue("expected ~metre-scale at 40deg, got $mean40", mean40 in 400f..2000f)
+        assertTrue("error must grow with obliquity", mean40 > mean20)
+    }
+
+    /**
+     * Holding the phone the other way round gives `rotationNeeded == 180`, which is a different
+     * rotation but still a mismatch — so "just use landscape" only helps in ONE of the two landscape
+     * orientations. Worth pinning: it is the kind of asymmetry a fix can easily half-solve.
+     *
+     * PHASE 0: change to `assertTrue(mean < TOLERANCE_MM)`.
+     */
+    @Test
+    fun `CHARACTERIZATION half-turn rotation is also a mismatch`() {
+        val mean = meanMm(errorsMm(20f, rzView(180f)))
+        assertTrue("expected a real error at 180deg, got $mean", mean > 100f)
+    }
+
+    /**
+     * The distortion is NON-RIGID — the depth scale factor varies across the image. This is the
+     * property that makes it damaging rather than merely offset: a rigid error would be absorbed by
+     * the reloc PnP's pose solve, and this one cannot be, which is why it shows up as a low inlier
+     * ratio alongside a healthy match count.
+     *
+     * PHASE 0: the spread collapses to zero along with the error, so this becomes redundant with
+     * the headline test above and can be deleted.
+     */
+    @Test
+    fun `CHARACTERIZATION the distortion is non-rigid, not a constant offset`() {
+        val e = errorsMm(40f, rzView(90f))
+        val mean = meanMm(e)
+        val spread = e.maxOrNull()!! - e.minOrNull()!!
+        assertTrue(
+            "a rigid offset would have near-zero spread; spread=$spread mean=$mean",
+            spread > 0.5f * mean,
+        )
+    }
+
+    /**
+     * Mis-scaled depths fall outside `backProject`'s 0.1-10 m trust range and are dropped, so the
+     * mismatch does not only distort points — it silently loses them. That is the mechanism behind
+     * the "found N features but only M landed on the wall surface" refusal, and it means a user hits
+     * a capture failure rather than a visibly wrong overlay.
+     *
+     * PHASE 0: retention returns to 100% and this becomes an equality assertion.
+     */
+    @Test
+    fun `CHARACTERIZATION steep obliquity silently discards marks`() {
+        val pixels = samplePixels()
+        val n = wallNormalCam(60f)
+        val p = floatArrayOf(n[0] * DIST_M, n[1] * DIST_M, n[2] * DIST_M)
+        val kept = PlaneMarks.backProject(pixels, rzView(90f), p, n, FX, FY, CX, CY).count
+        val keptTruth = PlaneMarks.backProject(pixels, identityView(), p, n, FX, FY, CX, CY).count
+        assertTrue("control should keep everything, kept $keptTruth of ${pixels.size}", keptTruth == pixels.size)
+        assertTrue("expected the mismatch to drop marks at 60deg, kept $kept of ${pixels.size}", kept < keptTruth)
+    }
+
+    /**
+     * Error is monotone in obliquity — zero square-on, worse the further off you stand. Pins the
+     * SHAPE of the defect rather than any single magnitude, which is what E0 on device compares
+     * against. A device result that is flat, or worst at 0 degrees, falsifies the diagnosis in
+     * PAPER.md 8 rather than merely disagreeing about a constant.
+     *
+     * PHASE 0: the curve flattens to zero; assert every entry `< TOLERANCE_MM`.
+     */
+    @Test
+    fun `CHARACTERIZATION error grows monotonically with obliquity`() {
+        val curve = floatArrayOf(0f, 10f, 20f, 30f, 40f).map { meanMm(errorsMm(it, rzView(90f))) }
+        assertEquals("square-on must be exact", 0f, curve[0], TOLERANCE_MM)
+        for (i in 1 until curve.size) {
+            assertTrue("error must not decrease as obliquity grows: $curve", curve[i] > curve[i - 1])
+        }
+        assertTrue("10deg should already be measurable, was ${curve[1]}", abs(curve[1]) > 10f)
+    }
+}

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/PoseFusionTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/PoseFusionTest.kt
@@ -106,6 +106,49 @@ class PoseFusionTest {
         assertEquals(2f, painted[12] / bare[12], 1e-3f)
     }
 
+    /**
+     * Phase 5a moved the per-attempt decay off the painting-progress channel and onto a separate
+     * corroboration-confidence channel, which is what now feeds `confGlobal`. The reason the split
+     * matters is a TRANSIENT, not a steady state: a few bad frames used to decay the signal by 0.9
+     * per reloc tick, and at a 60 ms tick that suppressed correction strength for seconds after the
+     * wall came back. A steady-state comparison cannot see that; this simulates the dip.
+     *
+     * The contract being pinned: a confidence dip may SLOW the correction, never reverse it.
+     */
+    @Test fun `a confidence dip slows the correction but never reverses it`() {
+        val f = PoseFusion()
+        val backbone = trans(0f, 0f, 0f)
+        // Warm relock at full confidence.
+        f.currentAnchor(backbone, identity(),
+            reloc(trans(10f, 0f, 0f), inliers = 60f, matches = 100f, seq = 1f), identity(), confGlobal = 1f)
+        val afterGood = f.currentAnchor(backbone, identity(),
+            reloc(trans(10f, 0f, 0f), inliers = 60f, matches = 100f, seq = 2f), identity(), confGlobal = 1f)[12]
+
+        // Three ticks of a decayed reading (0.9^1..0.9^3), same relock quality throughout.
+        var last = afterGood
+        for ((i, conf) in listOf(0.9f, 0.81f, 0.729f).withIndex()) {
+            val out = f.currentAnchor(backbone, identity(),
+                reloc(trans(10f, 0f, 0f), inliers = 60f, matches = 100f, seq = 3f + i), identity(),
+                confGlobal = conf)[12]
+            assertTrue("a dip must not push the overlay backwards: was $last now $out", out >= last)
+            last = out
+        }
+        assertTrue("the correction must still be advancing toward the fix, got $last", last > afterGood)
+    }
+
+    /**
+     * `getCorroborationConfidence` returns a NEGATIVE sentinel when nothing has been measured yet,
+     * which is a different state from "measured and found nothing". ArRenderer maps it to 0f. Pin
+     * that 0f behaves as the conservative floor rather than freezing the overlay — otherwise a
+     * never-corroborated wall (no design registered at all) would stop correcting entirely.
+     */
+    @Test fun `unmeasured corroboration mapped to zero still corrects at the floor`() {
+        val unmeasured = PoseFusion().currentAnchor(trans(0f, 0f, 0f), identity(),
+            reloc(trans(10f, 0f, 0f), inliers = 60f, matches = 100f, seq = 1f), identity(),
+            confGlobal = (-1f).coerceAtLeast(0f))
+        assertTrue("an unmeasured wall must still correct, got ${unmeasured[12]}", unmeasured[12] > 0f)
+    }
+
     @Test fun `corroboration outside 0-1 is clamped, not extrapolated`() {
         val full = PoseFusion().currentAnchor(trans(0f,0f,0f), identity(),
             reloc(trans(10f,0f,0f), inliers = 60f, matches = 100f, seq = 1f), identity(), confGlobal = 1f)

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/PoseMathTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/PoseMathTest.kt
@@ -44,6 +44,85 @@ class PoseMathTest {
         identity().forEachIndexed { i, e -> assertEquals(e, prod[i], 1e-4f) }
     }
 
+    /** Rotation of [deg] about an arbitrary (normalized) axis — deliberately NOT about Z. */
+    private fun axisRot(ax: Float, ay: Float, az: Float, deg: Float): FloatArray {
+        val n = sqrt(ax * ax + ay * ay + az * az)
+        val x = ax / n; val y = ay / n; val z = az / n
+        val c = kotlin.math.cos(Math.toRadians(deg.toDouble())).toFloat()
+        val s = kotlin.math.sin(Math.toRadians(deg.toDouble())).toFloat()
+        val t = 1f - c
+        // Row-major R, written into column-major storage.
+        val r = floatArrayOf(
+            t*x*x + c,   t*x*y + s*z, t*x*z - s*y, 0f,
+            t*x*y - s*z, t*y*y + c,   t*y*z + s*x, 0f,
+            t*x*z + s*y, t*y*z - s*x, t*z*z + c,   0f,
+            0f, 0f, 0f, 1f,
+        )
+        return r
+    }
+
+    private fun withTranslation(m: FloatArray, tx: Float, ty: Float, tz: Float) =
+        m.copyOf().also { it[12] = tx; it[13] = ty; it[14] = tz }
+
+    /** Scale columns 0..[cols)-1 of the linear part, mimicking `Matrix.scaleM`. */
+    private fun scaleCols(m: FloatArray, s: Float, cols: Int) = m.copyOf().also {
+        for (c in 0 until cols) for (row in 0 until 3) it[c * 4 + row] *= s
+    }
+
+    @Test fun `scaleOf returns one for a rigid matrix and s for a scaled one`() {
+        assertEquals(1f, PoseMath.scaleOf(identity()), 1e-5f)
+        val rot = axisRot(0.3f, -0.7f, 0.6f, 37f)
+        assertEquals(1f, PoseMath.scaleOf(rot), 1e-5f)
+        assertEquals(2.5f, PoseMath.scaleOf(scaleCols(rot, 2.5f, 3)), 1e-4f)
+        // Reading the FIRST column means an in-plane-only scale still reports s.
+        assertEquals(2.5f, PoseMath.scaleOf(scaleCols(rot, 2.5f, 2)), 1e-4f)
+    }
+
+    /**
+     * For a genuinely uniform similarity the inverse must be exact — and with a rotation about an
+     * arbitrary axis, not just Z. Every anchor in `FootprintTest` rotates about Z, which leaves the
+     * inverse's third column trivially zero and would hide an error there.
+     */
+    @Test fun `similarityInverse is exact for a uniform scale and an arbitrary axis`() {
+        val m = withTranslation(scaleCols(axisRot(0.3f, -0.7f, 0.6f, 37f), 2.5f, 3), 1.5f, -2f, 4f)
+        val prod = PoseMath.multiply(PoseMath.similarityInverse(m), m)
+        identity().forEachIndexed { i, e -> assertEquals("element $i", e, prod[i], 1e-4f) }
+    }
+
+    /**
+     * The exactness caveat in `similarityInverse`'s KDoc, asserted rather than merely asserted-in-
+     * prose: for the overlay's `scaleM(s, s, 1f)` the computed inverse is EXACT in rows 0 and 1 and
+     * wrong in row 2 by a factor of `1/s²`. Footprint reads only rows 0 and 1, which is what makes
+     * it safe there — and this test is what stops someone reusing it where row 2 matters.
+     */
+    @Test fun `similarityInverse is exact in-plane and off by one over s-squared on the normal row`() {
+        val s = 2.5f
+        val rot = axisRot(0.3f, -0.7f, 0.6f, 37f)
+        val m = scaleCols(rot, s, 2)                       // diag(s, s, 1), not uniform
+        val got = PoseMath.similarityInverse(m)
+
+        // True inverse of R*diag(s,s,1) is diag(1/s,1/s,1)*R^T.
+        val true0 = FloatArray(16).also {
+            for (i in 0 until 3) for (j in 0 until 3) {
+                it[j * 4 + i] = rot[i * 4 + j] * if (i < 2) 1f / s else 1f
+            }
+            it[15] = 1f
+        }
+        for (j in 0 until 3) {
+            assertEquals("row 0 col $j must be exact", true0[j * 4], got[j * 4], 1e-4f)
+            assertEquals("row 1 col $j must be exact", true0[j * 4 + 1], got[j * 4 + 1], 1e-4f)
+            // Row 2 is scaled by 1/s^2 relative to truth — documented, and relied on being harmless.
+            assertEquals("row 2 col $j must be off by 1/s^2",
+                true0[j * 4 + 2] / (s * s), got[j * 4 + 2], 1e-4f)
+        }
+    }
+
+    @Test fun `similarityInverse rejects a degenerate scale instead of dividing by zero`() {
+        org.junit.Assert.assertThrows(IllegalArgumentException::class.java) {
+            PoseMath.similarityInverse(FloatArray(16))
+        }
+    }
+
     @Test fun `quaternion round-trips through matrix`() {
         // 90 deg about Z
         val q = PoseMath.matrixToQuaternion(floatArrayOf(0f,1f,0f,0f, -1f,0f,0f,0f, 0f,0f,1f,0f, 0f,0f,0f,1f))


### PR DESCRIPTION
Three things: evidence for a claim that never had any, Phase 1 (inert — nothing calls it yet), and Phase 5a (the one behaviour change in here).

> **Corrected after audit (`419fbcb`).** The first version of this description contained two claims that were false, both caught by the audit agent and both reconfirmed independently before fixing. They are called out inline below rather than quietly edited out, because "the description said so" is how the original rotation claim survived four sessions without evidence.

---

## 1. The rotation claim had no evidence behind it

`PlaneMarks`' `CAUTION` block asserted that capture rotates pixels and intrinsics to display orientation but not the view matrix. That claim was written in a comment, repeated across sessions, cited as established, and used to justify a behaviour change — with **no test covering it** (`PlaneMarksTest` has only fronto-parallel cases) and **no measurement of any kind**. Challenged, correctly. Here is the calculation that should have come with it.

**Verified in source first:**
- pixels rotated — `ArViewModel.kt:1729` builds `rotatedBmp`, `TargetCreationFlow.kt:79` passes it as `tempCaptureBitmap`
- intrinsics rotated — `ArRenderer.kt:1290-1303` swaps `fx`/`fy`, remaps `cx`/`cy`
- view matrix **not** — `ArRenderer.kt:1379` emits `camera.pose.inverse()` unmodified

**Then computed.** Substituting into `backProject`'s own `t = (n·p)/(n·d)`: rotation preserves the dot product, so the numerator is unchanged and the entire error lives in the denominator. Every point lands on the *correct ray* at the *wrong depth*, scaled by a factor that varies across the image — a **non-rigid** distortion. That is why it matters: a rigid one would be absorbed by the reloc PnP's pose solve, and this one cannot be.

Wall at 2 m, 1080×1920 display intrinsics, 40×40 grid over the central 80%, **with `backProject`'s own 0.1–10 m trust range applied**:

| obliquity | mean | p95 | marks surviving |
|---|---|---|---|
| 0° | **0.0 mm** | 0.0 mm | 1600/1600 |
| 20° | 267 mm | 630 mm | 1600/1600 |
| 40° | 834 mm | 2213 mm | 1600/1600 |
| 50° | 1650 mm | 5260 mm | 1600/1600 |
| 60° | 2107 mm | 5635 mm | 1280/1600 |

> **CORRECTED.** This originally read **6914 mm / 37386 mm** at 60°. That figure included rays landing as far out as 93 m — points `backProject` discards, by the very mechanism described two paragraphs down. It claimed an error **3.3× larger than the code can produce**, on the same page that explains why. Rows 0°–50° are unaffected: nothing is dropped there, so filtered and unfiltered agree exactly. The grid density, the depth filter, and the p95 convention were also all omitted, without which the table is not reproducible.

Exactly zero square-on, which is how it survived — anyone first testing this stands square to a wall.

### A device test that needs no fix

`rotationNeeded = (sensorOrientation - displayDegrees + 360) % 360`, and the app is `screenOrientation="fullUser"`. On a typical phone the **device's physical orientation** decides whether the defect exists at all:

| held | `rotationNeeded` | error at 20° |
|---|---|---|
| landscape | 0 | **0.0 mm — no mismatch** |
| portrait | 90 | 267 mm |
| landscape, other way | 180 | 265 mm |

**Capture a target in landscape, then in portrait, same wall, same angle.** If landscape locks and portrait doesn't, that's the cause. Identical behaviour falsifies the diagnosis outright — in which case the assumption to check is that ARCore's `camera.pose` is in the physical camera frame rather than a display-oriented one. Added as **E0b** in `EVALUATION.md`.

Two secondary predictions, already visible in the diagnostics overlay: healthy match counts with a **low inlier ratio**, and "found N features but only M landed on the wall surface" refusals (mis-scaled depths fall outside the trust range and are dropped — 1280 of 1600 at 60°, all 1600 at 40°, so the drop rate is itself a measurement).

### `PlaneMarksObliquityTest`

Ground truth is built **forward**: points are placed on the wall in its own orthonormal basis and projected through the pinhole model to get their pixels. The truth path never evaluates the ray-plane intersection, so the only shared math is the projection — shared as its *inverse*, which is what makes the control meaningful. `FX ≠ FY`, so an fx/fy swap (exactly what the display rotation does) is detectable.

> **CORRECTED.** This originally claimed truth was "computed in closed form, not by calling `backProject` a second time". It was `backProject`'s loop retyped — same ray construction, same `t`, same filter, same order — so under the identity view the comparison was **bitwise zero by construction**. A sign flip, a swapped numerator, or a wrong `t` would all have been mirrored into "truth" and passed green. Two of the four "permanent correctness tests" were that one tautology counted twice.

Magnitudes here deliberately do **not** match the table above: this samples uniformly on the wall, the table samples uniformly in pixel space, giving ~328 mm at 20° and ~1148 mm at 40° for the identical defect. Assertions are therefore bands and orderings, not decimals. Quoting either sampling as *the* number would be picking a convention and calling it a measurement.

---

## 2. Phase 1 — the footprint operator Φ

`Footprint.of` maps a world point into the design's normalized coordinates. Per the corrected plan it does **not** invert the composed matrix by transposing: that matrix carries the user's pinch, and `rigidInverse` is wrong by `s²`. Verified numerically — at `overlayScale = 2` the design edge reports **4.0** instead of 1.0, at 3.5 it reports **12.25** — which would classify every feature under the artwork as `OUTSIDE` and promote it into the backbone, the set defined as wall that never gets painted.

Two safe call shapes, tested and asserted to agree exactly: pass the **full rigid factor** with the scale folded into the extents, or pass the composed matrix to `ofComposed` and let `PoseMath.similarityInverse` divide it out. The plan originally named `overlayBaseScratch` as that rigid factor; it isn't — `overlayLocalScratch` is `T(pan) · Rz(spin) · S(s,s,1)`, so the rigid factor is `overlayBase · T · Rz`, and following the plan as written would have dropped the user's pan and spin.

`similarityInverse` computes `Aᵀ/s²`, which for `scaleM(s, s, 1f)` is **exact for rows 0 and 1 and wrong for row 2 by `1/s²`**. Φ reads only the in-plane components, so it is exact everywhere it is used — now asserted by `PoseMathTest` rather than enforced by a sentence, including for a rotation about an arbitrary axis (every anchor in `FootprintTest` rotates about Z, which leaves the inverse's third column zero and hides anything wrong there).

Adds the `BAND` discard region: a *misclassified* boundary feature is worse than a discarded one. Inverted margins throw rather than silently collapsing the band.

Also adds `inverseOfRigid`/`inverseOfComposed`/`ofInverted` so the inverse can be hoisted out of a per-feature loop — the `out`-buffer overload alone does not make Φ allocation-free, since both entry points allocate a `FloatArray(16)` inverse per call.

Nothing calls Φ yet — this phase is inert by design.

---

## 3. Phase 5a — split painting progress from corroboration confidence

One atomic carried two signals on completely different timescales, and the decay belonging to the fast one was applied to the slow one.

`mPaintingProgress` answers "how much of the mural exists" — hours, roughly monotonic, the number the artist sees. But three branches decayed it by `×0.9` per reloc tick, and **every one fires on a tracking condition, not a painting condition**: matchability ≤ 0.5, the head failing to run, or the head loaded with no patch/correspondences. None of those mean the wall got less painted.

The reloc thread sleeps 60 ms while searching, so it compounds fast — three ticks is `×0.73`, ten is `×0.35`. And since `ArRenderer` fed the same scalar to `PoseFusion` as `confGlobal`, that decay didn't just wobble the progress bar, it **suppressed pose-correction strength for seconds after the wall came back into view** — the opposite of what you want at the moment you've just reacquired it.

Now two channels: progress is set only by a genuine measurement and never decayed; `mCorroborationConfidence` takes all three decays.

**Unmeasured is not zero.** The channel initialises to `-1` and `decayCorroboration` refuses to age the sentinel, so "no attempt has produced a measurement" stays distinguishable from "looked, and the wall agrees with nothing". Decaying `-1` toward zero would silently convert the first into the second — the same shape as the `mLastRelocReject{0}` bug.

---

## Testing

`FootprintTest`, `PlaneMarksObliquityTest`, `PoseMathTest` and `PoseFusionTest` additions — all pure JVM. The 5a tests simulate the **transient** rather than a steady state, because the defect is invisible in equilibrium and only shows as a dip.

CI is green on `419fbcb`, including both `build-and-release` runs — which is the only compile check on 5a's native changes, since there is no Android SDK in the dev container and a green unit-test run says nothing about the NDK build.