### PR TITLE
feat(phase 6a): CSV shape guard, reloc diagnostics column, run-identity sidecar

### DIFF
--- a/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
+++ b/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
@@ -1288,13 +1288,20 @@ Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeGetCorroborationCo
 }
 
 // Relocalization diagnostics: why the last attempt did not publish, and the counts it reached.
-// Packed into one int[] so the UI reads a consistent snapshot instead of four racing getters.
+// Packed into one int[] so the UI reads a consistent snapshot instead of six racing getters.
 // [0] = RelocReject code, [1] = correspondences, [2] = RANSAC inliers, [3] = features detected,
 // [4] = obliquity in degrees (-1 when the rectification pass wasn't eligible), [5] = correspondences
 // the rectification pass contributed.
 extern "C" JNIEXPORT jintArray JNICALL
 Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeGetRelocDiagnostics(JNIEnv* env, jobject) {
-    jint vals[6] = {0, 0, 0, 0, -1, 0};
+    // NOT {0, ...}: zero is kRelocOk, so a no-engine fallback of 0 reports a SUCCESSFUL LOCK with
+    // zero correspondences — and the reject histogram this feeds would then count "the engine was
+    // not initialized" as a win. That is the same defect MobileGS.h guards against in
+    // mLastRelocReject's initializer, reintroduced here two files away. 7 is RelocReject.UNKNOWN,
+    // the Kotlin-only code that absorbs anything the native side cannot account for; the counts are
+    // -1 (not sampled) rather than 0, because zero matches is a real measurement.
+    static constexpr jint kRelocUnknownOrdinal = 7;
+    jint vals[6] = {kRelocUnknownOrdinal, -1, -1, -1, -1, -1};
     if (gSlamEngine) {
         vals[0] = gSlamEngine->lastRelocReject();
         vals[1] = gSlamEngine->lastRelocMatches();

--- a/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
+++ b/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
@@ -106,8 +106,9 @@ class SlamManager @Inject constructor(
 
     /**
      * Why the last relocalization attempt did not publish a pose, and how far it got. See
-     * [RelocDiagnostics]; the native side packs the three values into one int[] so the read is a
-     * consistent snapshot rather than three racing getters.
+     * [RelocDiagnostics]; the native side packs SIX values into one int[] so the read is a
+     * consistent snapshot rather than six racing getters. (Three separate comments used to say
+     * three, four and six; the array has always been six wide.)
      */
     fun getRelocDiagnostics(): RelocDiagnostics {
         val v = nativeGetRelocDiagnostics()

--- a/docs/research/IMPLEMENTATION.md
+++ b/docs/research/IMPLEMENTATION.md
@@ -707,15 +707,18 @@ order.** Work top to bottom.
 
 ### Phase 6a — telemetry plumbing (no new dependencies)
 
-- [ ] **6a.1** Add the run-identity sidecar JSON next to every `DriftCostProbe`
+- [x] **6a.1** Add the run-identity sidecar JSON next to every `DriftCostProbe`
       CSV: recording hash, git commit, all parameter values, RNG seed, sync/async
       mode, device model. A CSV without a sidecar is not evidence.
-- [ ] **6a.2** Add a CSV-shape test: header column count equals the emitted row's
+- [x] **6a.2** Add a CSV-shape test: header column count equals the emitted row's
       field count. This is the class of bug that silently corrupts every
       downstream analysis. **[T]**
-- [ ] **6a.3** Add the `relocReject` ordinal column — its source already exists.
+- [x] **6a.3** Add the `relocReject` ordinal column — its source already exists.
 - [ ] **6a.4** Add the eval-only fixed RNG seed and the synchronous-reloc mode
-      from `EVALUATION.md` §3.1. Both must be inert in release builds.
+      from `EVALUATION.md` §3.1. Both must be inert in release builds. *(The
+      sidecar already records `rngSeed` and `syncReloc` so a run states which it
+      used; the native plumbing that honours them is still outstanding, and until
+      it lands every replay A/B carries un-quantified RANSAC variance.)*
 
 ### Phase 0 — rotation convention
 

--- a/docs/research/IMPLEMENTATION.md
+++ b/docs/research/IMPLEMENTATION.md
@@ -582,15 +582,15 @@ Low, and it is the highest value-per-risk item in the plan. Do it early.
 
 **6a depends on nothing — land it early. 6b lands with each phase that sources its columns.**
 
-`EVALUATION.md` cannot run without these channels. Extend
-`EvalSampleLog.CSV_HEADER` — currently:
+`EVALUATION.md` cannot run without these channels. Extend the CSV.
 
-```
-tsMs,deviceClass,marksVisible,errMm,errDeg,jitterMm,availability,voxelUpdateMs,
-voxelKeyframeMs,surfaceMeshMs,drawMs,pnpRelocMs,cpuPct,batteryMa,tempC,nativeHeapKb
-```
+**Do not restate the header here.** An earlier version of this section
+hand-copied the 16-column header as "currently:", and the commit whose headline
+change was *"header and row now derive from one `COLUMNS` list"* added four
+columns without updating this third copy — inside the same commit. The list lives
+in `EvalSampleLog.COLUMNS`; read it there.
 
-with:
+Columns to add:
 
 | Column | Source | Why the eval needs it |
 |---|---|---|

--- a/feature/ar/build.gradle.kts
+++ b/feature/ar/build.gradle.kts
@@ -6,12 +6,26 @@ plugins {
     alias(libs.plugins.ksp)
 }
 
+/**
+ * Short git commit for the eval run-identity sidecar (EVALUATION.md 3.2).
+ *
+ * A CSV whose build is unknown cannot be compared against another run, so this is recorded rather
+ * than inferred. Resolved at configure time and never allowed to fail the build: CI shallow clones,
+ * source archives and worktrees can all leave git unusable, and "unknown" is an honest answer where
+ * a crashed build is not.
+ */
+val gitCommitForEval: String = providers.exec {
+    commandLine("git", "rev-parse", "--short", "HEAD")
+}.standardOutput.asText.map { it.trim() }.orElse("unknown").getOrElse("unknown")
+    .ifBlank { "unknown" }
+
 android {
     namespace = "com.hereliesaz.graffitixr.feature.ar"
     compileSdk = 37
     defaultConfig {
         minSdk = 26
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        buildConfigField("String", "GIT_COMMIT", "\"$gitCommitForEval\"")
     }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
@@ -26,6 +40,7 @@ android {
 
     buildFeatures {
         compose = true
+        buildConfig = true   // for GIT_COMMIT, above
     }
 
     testOptions {

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -317,10 +317,50 @@ class ArViewModel @Inject constructor(
     @Volatile private var evalLogging = false
 
     fun evalStartLog() {
-        evalProbe.start()
+        // Every run gets its identity sidecar. Making `identity` optional on start() shipped a
+        // serializer with no caller — a run-identity feature that produced zero run identities,
+        // ticked as done. EVALUATION.md 3.2's rule is that a CSV without a sidecar is not evidence,
+        // so the call site has to supply one or the whole thing is decoration.
+        evalProbe.start(buildEvalRunIdentity())
         renderer?.driftCostProbe = evalProbe
         evalLogging = true
     }
+
+    /**
+     * Snapshot of everything needed to reconstruct this run: build, device, and the tunables whose
+     * values the numbers depend on.
+     *
+     * `rngSeed` and `syncReloc` are reported as "not set" because the native plumbing that would
+     * honour them does not exist yet (IMPLEMENTATION.md todo 6a.4). That is deliberately stated
+     * rather than defaulted: `solvePnPRansac` draws random samples, so an unseeded replay A/B is not
+     * a controlled comparison, and the reader can only know that if the field says so.
+     */
+    private fun buildEvalRunIdentity() = com.hereliesaz.graffitixr.feature.ar.eval.EvalRunIdentity(
+        gitCommit = BuildConfig.GIT_COMMIT,
+        recordingName = evalRecorder.currentPlaybackName,
+        recordingSha256 = null, // hashing a multi-hundred-MB MP4 on the UI path is not worth it
+        deviceModel = "${android.os.Build.MANUFACTURER} ${android.os.Build.MODEL}",
+        androidRelease = android.os.Build.VERSION.RELEASE ?: "unknown",
+        deviceClass = if (_uiState.value.isHardwareStereoActive) "dual" else "mono",
+        rngSeed = null,
+        syncReloc = false,
+        parameters = mapOf(
+            "MIN_INLIER_RATIO" to
+                com.hereliesaz.graffitixr.feature.ar.anchor.PoseFusion.MIN_INLIER_RATIO.toString(),
+            "BASE_ALPHA" to
+                com.hereliesaz.graffitixr.feature.ar.anchor.PoseFusion.BASE_ALPHA.toString(),
+            "CONF_FLOOR" to
+                com.hereliesaz.graffitixr.feature.ar.anchor.PoseFusion.CONF_FLOOR.toString(),
+            "COLD_SNAP_INLIER_RATIO" to
+                com.hereliesaz.graffitixr.feature.ar.anchor.PoseFusion.COLD_SNAP_INLIER_RATIO.toString(),
+            "COLD_SNAP_MIN_INLIERS" to
+                com.hereliesaz.graffitixr.feature.ar.anchor.PoseFusion.COLD_SNAP_MIN_INLIERS.toString(),
+            "COLD_SNAP_DIST_M" to
+                com.hereliesaz.graffitixr.feature.ar.anchor.PoseFusion.COLD_SNAP_DIST_M.toString(),
+            "COLD_SNAP_ANGLE_DEG" to
+                com.hereliesaz.graffitixr.feature.ar.anchor.PoseFusion.COLD_SNAP_ANGLE_DEG.toString(),
+        ),
+    )
 
     fun evalStopLog() {
         evalLogging = false

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/ArRecordingController.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/ArRecordingController.kt
@@ -50,14 +50,31 @@ class ArRecordingController(private val context: Context) {
         }
     }
 
+    /**
+     * Name of the dataset currently set for playback, or null for a live session.
+     *
+     * Recorded so the eval run-identity sidecar can state which recording a run replayed — without
+     * it, two CSVs from different datasets are indistinguishable after the fact and their numbers
+     * are not comparable. Cleared by [clearPlayback] so a live run after a replay does not inherit
+     * the stale name.
+     */
+    @Volatile
+    var currentPlaybackName: String? = null
+        private set
+
     /** Set a recorded dataset for playback. Session must be paused; caller resumes after. */
     fun startPlayback(session: Session, file: File): Boolean = try {
         session.setPlaybackDatasetUri(Uri.fromFile(file))
+        currentPlaybackName = file.name
         true
     } catch (e: Exception) {
         Timber.w(e, "eval: startPlayback failed (set the dataset while the session is paused)")
+        currentPlaybackName = null
         false
     }
+
+    /** Forget the playback dataset, so a subsequent live run reports itself as live. */
+    fun clearPlayback() { currentPlaybackName = null }
 
     fun isPlaying(session: Session): Boolean = session.playbackStatus == PlaybackStatus.OK
 

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/DriftCostProbe.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/DriftCostProbe.kt
@@ -107,6 +107,8 @@ class DriftCostProbe(
             relocMatches = reloc?.matches ?: EvalSampleLog.NOT_SAMPLED,
             relocInliers = reloc?.inliers ?: EvalSampleLog.NOT_SAMPLED,
             relocDetected = reloc?.detected ?: EvalSampleLog.NOT_SAMPLED,
+            relocObliquityDeg = reloc?.obliquityDeg ?: EvalSampleLog.NOT_SAMPLED,
+            relocRectifiedCorr = reloc?.rectifiedCorrespondences ?: EvalSampleLog.NOT_SAMPLED,
         )
         file.appendText(EvalSampleLog.toCsvRow(sample) + "\n")
 

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/DriftCostProbe.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/DriftCostProbe.kt
@@ -29,10 +29,21 @@ class DriftCostProbe(
         context.getSystemService(Context.BATTERY_SERVICE) as BatteryManager
     }
 
-    fun start(): File {
+    /**
+     * Begin a run. Pass [identity] so the CSV gets its run-identity sidecar — `EVALUATION.md` §3.2:
+     * a CSV without one is not evidence, because the parameter values, build and determinism
+     * settings that produced it are not recoverable from the numbers afterwards.
+     *
+     * [identity] is nullable only so ad-hoc debugging can still start a probe; any run whose numbers
+     * are meant to be compared against another run must supply it.
+     */
+    fun start(identity: EvalRunIdentity? = null): File {
         val dir = File(context.filesDir, "eval").apply { mkdirs() }
         val f = File(dir, "eval_${deviceClass}_${nowMs()}.csv")
         f.writeText(EvalSampleLog.CSV_HEADER + "\n")
+        if (identity != null) {
+            File(dir, identity.sidecarNameFor(f.name)).writeText(identity.toJson())
+        }
         logFile = f
         usableFrames = 0; totalFrames = 0; lossMs = null; relockMs = null
         recentTranslations.clear()
@@ -50,6 +61,9 @@ class DriftCostProbe(
      * @param isTracking    whether the mechanism currently has a usable lock (for recovery/availability)
      * @param stageMs        native stage timings from SlamManager.getStageTimings()
      * @param cpuPct         caller-sampled CPU percent (or -1 if unavailable)
+     * @param reloc          last relocalization diagnostics, or null when not sampled. Logged so a
+     *   null relocalization becomes a diagnosis rather than an absence: NO_FEATURES and FEW_INLIERS
+     *   call for opposite fixes and the aggregate error number cannot tell them apart.
      */
     fun onTick(
         candidatePose: FloatArray,
@@ -57,6 +71,7 @@ class DriftCostProbe(
         isTracking: Boolean,
         stageMs: FloatArray,
         cpuPct: Float,
+        reloc: com.hereliesaz.graffitixr.common.model.RelocDiagnostics? = null,
     ) {
         val file = logFile ?: return
         totalFrames++
@@ -86,6 +101,12 @@ class DriftCostProbe(
             batteryMa = sampleBatteryMa(),
             tempC = -1f, // wired from caller's thermal sample if available; -1 = not sampled
             nativeHeapKb = android.os.Debug.getNativeHeapAllocatedSize() / 1024L,
+            // -1 throughout when not sampled. Zero matches and zero detected are both legitimate
+            // readings, so they cannot double as the "no data" marker.
+            relocReject = reloc?.reject?.ordinal ?: EvalSampleLog.NOT_SAMPLED,
+            relocMatches = reloc?.matches ?: EvalSampleLog.NOT_SAMPLED,
+            relocInliers = reloc?.inliers ?: EvalSampleLog.NOT_SAMPLED,
+            relocDetected = reloc?.detected ?: EvalSampleLog.NOT_SAMPLED,
         )
         file.appendText(EvalSampleLog.toCsvRow(sample) + "\n")
 

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/EvalRunIdentity.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/EvalRunIdentity.kt
@@ -1,0 +1,90 @@
+package com.hereliesaz.graffitixr.feature.ar.eval
+
+/**
+ * Everything needed to reconstruct what produced a `DriftCostProbe` CSV — written as a JSON sidecar
+ * next to it (`EVALUATION.md` §3.2, todo 6a.1).
+ *
+ * The rule that motivates this: **a CSV without a sidecar is not evidence.** A run's numbers are
+ * only interpretable against the parameter values, the build, and the replay determinism settings
+ * that produced them, and none of those are recoverable from the CSV afterwards. Two runs that
+ * differ only in an unrecorded constant look like noise; two that differ only in device thermal
+ * state look like a parameter effect.
+ *
+ * Deliberately hand-rolled rather than serialized through a library: this module has no
+ * kotlinx-serialization dependency, the schema is flat, and the file is written once per run.
+ */
+data class EvalRunIdentity(
+    /** Git commit the build came from. `"unknown"` when not injected at build time. */
+    val gitCommit: String,
+    /** Playback recording this run replayed, or null for a live session. */
+    val recordingName: String? = null,
+    /** Content hash of that recording, so a re-recorded file with the same name is distinguishable. */
+    val recordingSha256: String? = null,
+    val deviceModel: String,
+    val androidRelease: String,
+    /** "dual" or "mono" — the camera configuration under test. */
+    val deviceClass: String,
+    /**
+     * Fixed RNG seed for the run, or null if the run was not seeded.
+     *
+     * `solvePnPRansac` draws random samples, so two replays of the same recording can differ without
+     * this. An unseeded A/B is not a controlled comparison, and the difference it reports may be
+     * entirely RANSAC.
+     */
+    val rngSeed: Long? = null,
+    /**
+     * True when relocalization ran inline on a fixed frame cadence rather than on its own thread.
+     *
+     * Async numbers are what users get; sync numbers are what is comparable between runs. Reporting
+     * one while the reader assumes the other is how scheduling noise becomes a parameter effect.
+     */
+    val syncReloc: Boolean = false,
+    /** Every tunable that was in force, `PARAMETERS.md` name → value. */
+    val parameters: Map<String, String> = emptyMap(),
+) {
+    /** Sidecar filename for a CSV named `eval_mono_123.csv` → `eval_mono_123.run.json`. */
+    fun sidecarNameFor(csvName: String): String = csvName.removeSuffix(".csv") + ".run.json"
+
+    fun toJson(): String {
+        val sb = StringBuilder(256)
+        sb.append("{\n")
+        val entries = buildList {
+            add("gitCommit" to jsonString(gitCommit))
+            add("recordingName" to (recordingName?.let { jsonString(it) } ?: "null"))
+            add("recordingSha256" to (recordingSha256?.let { jsonString(it) } ?: "null"))
+            add("deviceModel" to jsonString(deviceModel))
+            add("androidRelease" to jsonString(androidRelease))
+            add("deviceClass" to jsonString(deviceClass))
+            add("rngSeed" to (rngSeed?.toString() ?: "null"))
+            add("syncReloc" to syncReloc.toString())
+            add("parameters" to parameters.entries
+                .sortedBy { it.key }   // stable order so two sidecars diff cleanly
+                .joinToString(prefix = "{", postfix = "}") { "${jsonString(it.key)}:${jsonString(it.value)}" })
+        }
+        entries.forEachIndexed { i, (k, v) ->
+            sb.append("  ").append(jsonString(k)).append(": ").append(v)
+            if (i != entries.lastIndex) sb.append(',')
+            sb.append('\n')
+        }
+        sb.append("}\n")
+        return sb.toString()
+    }
+
+    private companion object {
+        /** Minimal JSON string escaping — enough for paths, model names and parameter values. */
+        fun jsonString(v: String): String {
+            val sb = StringBuilder(v.length + 2)
+            sb.append('"')
+            for (c in v) when (c) {
+                '"' -> sb.append("\\\"")
+                '\\' -> sb.append("\\\\")
+                '\n' -> sb.append("\\n")
+                '\r' -> sb.append("\\r")
+                '\t' -> sb.append("\\t")
+                else -> if (c < ' ') sb.append("\\u%04x".format(c.code)) else sb.append(c)
+            }
+            sb.append('"')
+            return sb.toString()
+        }
+    }
+}

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/EvalSampleLog.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/EvalSampleLog.kt
@@ -23,6 +23,11 @@ data class EvalSample(
     val relocMatches: Int = -1,
     val relocInliers: Int = -1,
     val relocDetected: Int = -1,
+    // The remaining two RelocDiagnostics fields. obliquityDeg in particular is the quantity
+    // PlaneMarksObliquityTest predicts the error scales with, so having it per-row is what lets a
+    // device run be compared against PAPER.md 8.1's curve instead of argued about.
+    val relocObliquityDeg: Int = -1,
+    val relocRectifiedCorr: Int = -1,
 )
 
 object EvalSampleLog {
@@ -40,6 +45,7 @@ object EvalSampleLog {
         "voxelUpdateMs", "voxelKeyframeMs", "surfaceMeshMs", "drawMs", "pnpRelocMs",
         "cpuPct", "batteryMa", "tempC", "nativeHeapKb",
         "relocReject", "relocMatches", "relocInliers", "relocDetected",
+        "relocObliquityDeg", "relocRectifiedCorr",
     )
 
     const val NOT_SAMPLED = -1
@@ -56,12 +62,17 @@ object EvalSampleLog {
             s.cpuPct.toString(), s.batteryMa.toString(), s.tempC.toString(), s.nativeHeapKb.toString(),
             s.relocReject.toString(), s.relocMatches.toString(),
             s.relocInliers.toString(), s.relocDetected.toString(),
+            s.relocObliquityDeg.toString(), s.relocRectifiedCorr.toString(),
         )
     }
 
     fun toCsvRow(s: EvalSample): String {
         val f = fields(s)
-        // Cheap, and it fires at the first row of a run rather than during analysis weeks later.
+        // Belt-and-braces only. `fields()` returns a literal list, so its arity is a source constant
+        // and no input can make this fire at runtime — the real guard is EvalSampleLogTest, which
+        // catches the drift at build time. Kept because it costs nothing and localizes the failure
+        // if someone later makes `fields()` conditional. (`check`, not `assert`: `assert` is gated
+        // by -ea and would be inert in exactly the builds that write eval logs.)
         check(f.size == COLUMNS.size) {
             "CSV shape drift: ${f.size} fields for ${COLUMNS.size} columns"
         }

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/EvalSampleLog.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/EvalSampleLog.kt
@@ -15,20 +15,69 @@ data class EvalSample(
     val batteryMa: Float,      // BatteryManager CURRENT_NOW (µA→mA); negative = discharging
     val tempC: Float,
     val nativeHeapKb: Long,    // Debug.getNativeHeapAllocatedSize()/1024 — memory cost proxy
+    // Relocalization diagnostics (EVALUATION.md §6: "log the reject histogram"). Without these a
+    // null result is a null result; with them it is a diagnosis, and a configuration whose failures
+    // are NO_FEATURES needs different work from one whose failures are FEW_INLIERS.
+    // -1 = not sampled, which is distinct from 0. Zero detected features is a real measurement.
+    val relocReject: Int = -1,      // RelocReject ordinal
+    val relocMatches: Int = -1,
+    val relocInliers: Int = -1,
+    val relocDetected: Int = -1,
 )
 
 object EvalSampleLog {
-    const val CSV_HEADER =
-        "tsMs,deviceClass,marksVisible,errMm,errDeg,jitterMm,availability," +
-            "voxelUpdateMs,voxelKeyframeMs,surfaceMeshMs,drawMs,pnpRelocMs,cpuPct,batteryMa,tempC,nativeHeapKb"
 
-    fun toCsvRow(s: EvalSample): String {
+    /**
+     * The single source of truth for the CSV shape.
+     *
+     * Header and row used to be written out independently, which is the class of bug that silently
+     * corrupts every downstream analysis: add a field to one and the columns shift under every
+     * consumer without anything failing. [toCsvRow] is checked against this list at runtime and
+     * `EvalSampleLogTest` checks it again in CI.
+     */
+    val COLUMNS: List<String> = listOf(
+        "tsMs", "deviceClass", "marksVisible", "errMm", "errDeg", "jitterMm", "availability",
+        "voxelUpdateMs", "voxelKeyframeMs", "surfaceMeshMs", "drawMs", "pnpRelocMs",
+        "cpuPct", "batteryMa", "tempC", "nativeHeapKb",
+        "relocReject", "relocMatches", "relocInliers", "relocDetected",
+    )
+
+    const val NOT_SAMPLED = -1
+
+    val CSV_HEADER: String = COLUMNS.joinToString(",")
+
+    /** Field values for [s], in [COLUMNS] order. */
+    fun fields(s: EvalSample): List<String> {
         val st = FloatArray(5).also { System.arraycopy(s.stageMs, 0, it, 0, minOf(5, s.stageMs.size)) }
         return listOf(
-            s.tsMs.toString(), s.deviceClass, s.marksVisible.toString(),
+            s.tsMs.toString(), csvEscape(s.deviceClass), s.marksVisible.toString(),
             s.errMm.toString(), s.errDeg.toString(), s.jitterMm.toString(), s.availability.toString(),
             st[0].toString(), st[1].toString(), st[2].toString(), st[3].toString(), st[4].toString(),
             s.cpuPct.toString(), s.batteryMa.toString(), s.tempC.toString(), s.nativeHeapKb.toString(),
-        ).joinToString(",")
+            s.relocReject.toString(), s.relocMatches.toString(),
+            s.relocInliers.toString(), s.relocDetected.toString(),
+        )
     }
+
+    fun toCsvRow(s: EvalSample): String {
+        val f = fields(s)
+        // Cheap, and it fires at the first row of a run rather than during analysis weeks later.
+        check(f.size == COLUMNS.size) {
+            "CSV shape drift: ${f.size} fields for ${COLUMNS.size} columns"
+        }
+        return f.joinToString(",")
+    }
+
+    /**
+     * Quote a value that could otherwise break the column alignment.
+     *
+     * `deviceClass` is a free-form string reaching the log from a caller, and one comma in it shifts
+     * every subsequent column of that row — silently, since the file still parses.
+     */
+    fun csvEscape(v: String): String =
+        if (v.any { it == ',' || it == '"' || it == '\n' || it == '\r' }) {
+            "\"" + v.replace("\"", "\"\"") + "\""
+        } else {
+            v
+        }
 }

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -1183,6 +1183,11 @@ class ArRenderer(
                         isTracking = anchorEstablished,
                         stageMs = stageMs,
                         cpuPct = -1f, // CPU% sampled by overlay; -1 here keeps the GL thread cheap
+                        // Why the last attempt did not publish, logged per row. EVALUATION.md §6:
+                        // a configuration whose failures are NO_FEATURES needs different work from
+                        // one whose failures are FEW_INLIERS, and the aggregate error number cannot
+                        // tell them apart. This is a cheap read of four atomics.
+                        reloc = slamManager.getRelocDiagnostics(),
                     )
                 }
 

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -1186,7 +1186,12 @@ class ArRenderer(
                         // Why the last attempt did not publish, logged per row. EVALUATION.md §6:
                         // a configuration whose failures are NO_FEATURES needs different work from
                         // one whose failures are FEW_INLIERS, and the aggregate error number cannot
-                        // tell them apart. This is a cheap read of four atomics.
+                        // tell them apart. Cost: one JNI transition, six relaxed atomic loads, and
+                        // two short-lived allocations (the jintArray and the RelocDiagnostics). Not
+                        // free — but this whole block is inside `driftCostProbe?.let`, so it does
+                        // not exist outside an eval run, and the block already allocates two
+                        // FloatArrays per tick. (An earlier comment here said "four atomics", which
+                        // was neither the count nor the mechanism.)
                         reloc = slamManager.getRelocDiagnostics(),
                     )
                 }

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/eval/EvalRunIdentityTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/eval/EvalRunIdentityTest.kt
@@ -1,0 +1,105 @@
+package com.hereliesaz.graffitixr.feature.ar.eval
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * IMPLEMENTATION.md todo **6a.1** — the run-identity sidecar.
+ *
+ * The rule it enforces (`EVALUATION.md` §3.2): a CSV without a sidecar is not evidence. Two runs
+ * differing only in an unrecorded constant look like noise; two differing only in thermal state look
+ * like a parameter effect. Neither is recoverable from the numbers afterwards.
+ */
+class EvalRunIdentityTest {
+
+    private fun identity() = EvalRunIdentity(
+        gitCommit = "419fbcb",
+        recordingName = "wall_oblique_01.mp4",
+        recordingSha256 = "abc123",
+        deviceModel = "Pixel 8",
+        androidRelease = "15",
+        deviceClass = "mono",
+        rngSeed = 42L,
+        syncReloc = true,
+        parameters = mapOf("CONF_FLOOR" to "0.5", "BASE_ALPHA" to "0.25"),
+    )
+
+    @Test
+    fun `sidecar name is derived from the csv name`() {
+        assertEquals("eval_mono_123.run.json", identity().sidecarNameFor("eval_mono_123.csv"))
+    }
+
+    /** A name without the extension must not silently produce a collidng or extension-less file. */
+    @Test
+    fun `sidecar name handles a csv name without the extension`() {
+        assertEquals("eval_mono_123.run.json", identity().sidecarNameFor("eval_mono_123"))
+    }
+
+    @Test
+    fun `every field reaches the json`() {
+        val j = identity().toJson()
+        for (needle in listOf(
+            "\"gitCommit\": \"419fbcb\"",
+            "\"recordingName\": \"wall_oblique_01.mp4\"",
+            "\"recordingSha256\": \"abc123\"",
+            "\"deviceModel\": \"Pixel 8\"",
+            "\"androidRelease\": \"15\"",
+            "\"deviceClass\": \"mono\"",
+            "\"rngSeed\": 42",
+            "\"syncReloc\": true",
+        )) {
+            assertTrue("missing $needle in:\n$j", j.contains(needle))
+        }
+        assertTrue(j.contains("\"CONF_FLOOR\":\"0.5\""))
+        assertTrue(j.contains("\"BASE_ALPHA\":\"0.25\""))
+    }
+
+    /**
+     * An unseeded run must say so rather than reporting a plausible-looking seed. `solvePnPRansac`
+     * draws random samples, so an unseeded A/B is not a controlled comparison and the difference it
+     * reports may be entirely RANSAC — which the reader can only know if the field is honest.
+     */
+    @Test
+    fun `an unseeded live run reports nulls, not defaults`() {
+        val j = EvalRunIdentity(
+            gitCommit = "unknown", deviceModel = "Pixel 8", androidRelease = "15",
+            deviceClass = "dual",
+        ).toJson()
+        assertTrue(j.contains("\"rngSeed\": null"))
+        assertTrue(j.contains("\"recordingName\": null"))
+        assertTrue(j.contains("\"recordingSha256\": null"))
+        assertTrue(j.contains("\"syncReloc\": false"))
+        assertTrue(j.contains("\"parameters\": {}"))
+    }
+
+    /** Stable key order, so two sidecars from an A/B diff to just the parameter that changed. */
+    @Test
+    fun `parameters are emitted in a stable sorted order`() {
+        val a = EvalRunIdentity(
+            gitCommit = "x", deviceModel = "m", androidRelease = "15", deviceClass = "mono",
+            parameters = linkedMapOf("zeta" to "1", "alpha" to "2", "mid" to "3"),
+        ).toJson()
+        val b = EvalRunIdentity(
+            gitCommit = "x", deviceModel = "m", androidRelease = "15", deviceClass = "mono",
+            parameters = linkedMapOf("mid" to "3", "alpha" to "2", "zeta" to "1"),
+        ).toJson()
+        assertEquals("insertion order must not change the output", a, b)
+        assertTrue(a.indexOf("alpha") < a.indexOf("mid"))
+        assertTrue(a.indexOf("mid") < a.indexOf("zeta"))
+    }
+
+    /** Model names and paths carry quotes and backslashes; unescaped, they produce invalid JSON. */
+    @Test
+    fun `strings needing escapes do not corrupt the json`() {
+        val j = EvalRunIdentity(
+            gitCommit = "a\"b", deviceModel = "back\\slash", androidRelease = "1\n5",
+            deviceClass = "mono",
+        ).toJson()
+        assertTrue(j.contains("\"a\\\"b\""))
+        assertTrue(j.contains("\"back\\\\slash\""))
+        assertTrue(j.contains("\"1\\n5\""))
+        // Balanced quotes is a cheap proxy for "still parseable".
+        assertEquals(0, j.count { it == '"' } % 2)
+    }
+}

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/eval/EvalRunIdentityTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/eval/EvalRunIdentityTest.kt
@@ -99,7 +99,76 @@ class EvalRunIdentityTest {
         assertTrue(j.contains("\"a\\\"b\""))
         assertTrue(j.contains("\"back\\\\slash\""))
         assertTrue(j.contains("\"1\\n5\""))
-        // Balanced quotes is a cheap proxy for "still parseable".
-        assertEquals(0, j.count { it == '"' } % 2)
+        assertStructurallyValidJson(j)
+    }
+
+    /** Control characters must become \uXXXX escapes rather than raw bytes in the output. */
+    @Test
+    fun `control characters are escaped`() {
+        val j = EvalRunIdentity(
+            // Built rather than written as a literal: a raw control byte in a source file is
+            // fragile (editors and tooling silently eat it), and the escape form is easy to
+            // mistake for the two-character sequence it is meant to test.
+            gitCommit = "a" + 1.toChar() + "b",
+            deviceModel = "m", androidRelease = "15", deviceClass = "mono",
+        ).toJson()
+        assertTrue("expected a \\u0001 escape in:\n$j", j.contains("\"a\\u0001b\""))
+        assertTrue("no raw control byte may survive", j.none { it < ' ' && it != '\n' })
+        assertStructurallyValidJson(j)
+    }
+
+    /** Parameter KEYS come from `PARAMETERS.md` names but are still strings that must be escaped. */
+    @Test
+    fun `a parameter key needing escapes stays valid`() {
+        val j = EvalRunIdentity(
+            gitCommit = "x", deviceModel = "m", androidRelease = "15", deviceClass = "mono",
+            parameters = mapOf("odd\"key" to "va\\lue"),
+        ).toJson()
+        assertTrue(j.contains("\"odd\\\"key\""))
+        assertTrue(j.contains("\"va\\\\lue\""))
+        assertStructurallyValidJson(j)
+    }
+
+    @Test
+    fun `the ordinary case is structurally valid too`() {
+        assertStructurallyValidJson(identity().toJson())
+    }
+
+    /**
+     * Escape-aware structural validation: every string closes, braces balance, and nothing nests
+     * negative.
+     *
+     * The first version of this file used `j.count { it == '"' } % 2 == 0` as a "cheap proxy for
+     * still parseable". It is not a proxy for that — it counts *escaped* quotes as delimiters, so a
+     * correctly-escaped `"a\"b"` reads as unbalanced and the assertion fails on valid output. It did
+     * fail, in CI, on correct code. A test whose failure mode is "the implementation was right" is
+     * worse than no test: it trains you to loosen the assertion rather than look.
+     */
+    private fun assertStructurallyValidJson(j: String) {
+        var depth = 0
+        var inString = false
+        var escaped = false
+        var unescapedQuotes = 0
+        for (c in j) {
+            if (inString) {
+                when {
+                    escaped -> escaped = false
+                    c == '\\' -> escaped = true
+                    c == '"' -> { inString = false; unescapedQuotes++ }
+                }
+            } else {
+                when (c) {
+                    '"' -> { inString = true; unescapedQuotes++ }
+                    '{', '[' -> depth++
+                    '}', ']' -> {
+                        depth--
+                        assertTrue("closed more than was opened in:\n$j", depth >= 0)
+                    }
+                }
+            }
+        }
+        assertEquals("unterminated string in:\n$j", false, inString)
+        assertEquals("unbalanced braces in:\n$j", 0, depth)
+        assertEquals("odd number of string delimiters in:\n$j", 0, unescapedQuotes % 2)
     }
 }

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/eval/EvalRunIdentityTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/eval/EvalRunIdentityTest.kt
@@ -30,10 +30,23 @@ class EvalRunIdentityTest {
         assertEquals("eval_mono_123.run.json", identity().sidecarNameFor("eval_mono_123.csv"))
     }
 
-    /** A name without the extension must not silently produce a collidng or extension-less file. */
+    /**
+     * An extension-less input yields the SAME name as its `.csv` form — `removeSuffix` is a no-op
+     * when the suffix is absent, so the two are indistinguishable in the output.
+     *
+     * Recorded as the actual behaviour rather than dressed up as collision-safety, which is what an
+     * earlier version of this KDoc claimed while asserting the collision. It is unreachable today:
+     * the only caller passes `File.name` for a file it just created as `eval_*.csv`. If a second
+     * caller ever appears, this is the constraint it has to respect.
+     */
     @Test
-    fun `sidecar name handles a csv name without the extension`() {
+    fun `sidecar name is not disambiguated for an extension-less input`() {
         assertEquals("eval_mono_123.run.json", identity().sidecarNameFor("eval_mono_123"))
+        assertEquals(
+            "the two inputs collide by design; see the KDoc",
+            identity().sidecarNameFor("eval_mono_123.csv"),
+            identity().sidecarNameFor("eval_mono_123"),
+        )
     }
 
     @Test

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/eval/EvalSampleLogTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/eval/EvalSampleLogTest.kt
@@ -30,6 +30,8 @@ class EvalSampleLogTest {
         relocMatches = reloc?.matches ?: EvalSampleLog.NOT_SAMPLED,
         relocInliers = reloc?.inliers ?: EvalSampleLog.NOT_SAMPLED,
         relocDetected = reloc?.detected ?: EvalSampleLog.NOT_SAMPLED,
+        relocObliquityDeg = reloc?.obliquityDeg ?: EvalSampleLog.NOT_SAMPLED,
+        relocRectifiedCorr = reloc?.rectifiedCorrespondences ?: EvalSampleLog.NOT_SAMPLED,
     )
 
     @Test
@@ -37,7 +39,8 @@ class EvalSampleLogTest {
         assertEquals(
             "tsMs,deviceClass,marksVisible,errMm,errDeg,jitterMm,availability," +
                 "voxelUpdateMs,voxelKeyframeMs,surfaceMeshMs,drawMs,pnpRelocMs,cpuPct,batteryMa,tempC," +
-                "nativeHeapKb,relocReject,relocMatches,relocInliers,relocDetected",
+                "nativeHeapKb,relocReject,relocMatches,relocInliers,relocDetected," +
+                "relocObliquityDeg,relocRectifiedCorr",
             EvalSampleLog.CSV_HEADER,
         )
     }
@@ -51,7 +54,8 @@ class EvalSampleLogTest {
             nativeHeapKb = 20480L,
         )
         assertEquals(
-            "12,dual,true,1.5,0.25,3.0,1.0,2.0,0.0,4.0,1.0,8.0,30.0,-450.0,31.0,20480,-1,-1,-1,-1",
+            "12,dual,true,1.5,0.25,3.0,1.0,2.0,0.0,4.0,1.0,8.0,30.0,-450.0,31.0,20480," +
+                "-1,-1,-1,-1,-1,-1",
             EvalSampleLog.toCsvRow(row),
         )
     }
@@ -100,11 +104,46 @@ class EvalSampleLogTest {
     /**
      * `deviceClass` reaches the log as a free-form string from a caller. One comma in it shifts every
      * subsequent column of that row — silently, because the file still parses.
+     *
+     * Asserted by PARSING the row, not by looking for a quote. An earlier version of this test only
+     * checked that `"mono,rear"` appeared somewhere in the output, under a name promising the
+     * columns could not shift — which it never checked. Note a naive `split(",")` on this row gives
+     * one token too many; that is the bug, and it is why the reader below is quote-aware.
      */
     @Test
     fun `a comma in a free-form field cannot shift the columns`() {
         val row = EvalSampleLog.toCsvRow(sample(deviceClass = "mono,rear"))
         assertTrue("the value must be quoted, got: $row", row.contains("\"mono,rear\""))
+
+        val parsed = parseCsvRow(row)
+        assertEquals("column count must survive an embedded comma", EvalSampleLog.COLUMNS.size, parsed.size)
+        assertEquals("mono,rear", parsed[EvalSampleLog.COLUMNS.indexOf("deviceClass")])
+        // And the column AFTER it must still be itself, which is what "shift" would break.
+        assertEquals("true", parsed[EvalSampleLog.COLUMNS.indexOf("marksVisible")])
+
+        // The naive reader really does miscount — recorded so the quoting is not mistaken for
+        // cosmetic, and so a future consumer written with split(",") is a known-bad choice.
+        assertEquals(EvalSampleLog.COLUMNS.size + 1, row.split(",").size)
+    }
+
+    /** Minimal RFC4180 field splitter: quote-aware, handles doubled quotes inside a quoted field. */
+    private fun parseCsvRow(row: String): List<String> {
+        val out = ArrayList<String>()
+        val cur = StringBuilder()
+        var inQuotes = false
+        var i = 0
+        while (i < row.length) {
+            val c = row[i]
+            when {
+                inQuotes && c == '"' && i + 1 < row.length && row[i + 1] == '"' -> { cur.append('"'); i++ }
+                c == '"' -> inQuotes = !inQuotes
+                c == ',' && !inQuotes -> { out.add(cur.toString()); cur.setLength(0) }
+                else -> cur.append(c)
+            }
+            i++
+        }
+        out.add(cur.toString())
+        return out
     }
 
     @Test
@@ -142,6 +181,17 @@ class EvalSampleLogTest {
         assertEquals("40", fields[EvalSampleLog.COLUMNS.indexOf("relocMatches")])
         assertEquals("7", fields[EvalSampleLog.COLUMNS.indexOf("relocInliers")])
         assertEquals("1200", fields[EvalSampleLog.COLUMNS.indexOf("relocDetected")])
+    }
+
+    @Test
+    fun `obliquity and rectified correspondences reach their own columns`() {
+        val d = RelocDiagnostics(
+            RelocReject.OK, matches = 40, inliers = 30, detected = 900,
+            obliquityDeg = 37, rectifiedCorrespondences = 12,
+        )
+        val fields = EvalSampleLog.fields(sample(reloc = d))
+        assertEquals("37", fields[EvalSampleLog.COLUMNS.indexOf("relocObliquityDeg")])
+        assertEquals("12", fields[EvalSampleLog.COLUMNS.indexOf("relocRectifiedCorr")])
     }
 
     /**

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/eval/EvalSampleLogTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/eval/EvalSampleLogTest.kt
@@ -1,15 +1,44 @@
 package com.hereliesaz.graffitixr.feature.ar.eval
 
+import com.hereliesaz.graffitixr.common.model.RelocDiagnostics
+import com.hereliesaz.graffitixr.common.model.RelocReject
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
+/**
+ * IMPLEMENTATION.md todo **6a.2** — the CSV shape guard, plus the original exact-output checks.
+ *
+ * Column drift is the class of bug that silently corrupts every downstream analysis rather than
+ * failing: add a field to the row and forget the header (or the reverse) and every column past the
+ * insertion point shifts, in a file that still parses cleanly. Nothing errors — the numbers are just
+ * wrong, and the mistake surfaces weeks later while interpreting results, if at all.
+ *
+ * Header and row now derive from one [EvalSampleLog.COLUMNS] list, so the drift is structurally
+ * hard; these make it impossible to land unnoticed anyway.
+ */
 class EvalSampleLogTest {
+
+    private fun sample(deviceClass: String = "mono", reloc: RelocDiagnostics? = null) = EvalSample(
+        tsMs = 1_700_000_000_000L,
+        deviceClass = deviceClass,
+        marksVisible = true,
+        errMm = 4.25f, errDeg = 0.5f, jitterMm = 1.5f, availability = 0.98f,
+        stageMs = floatArrayOf(1f, 2f, 3f, 4f, 5f),
+        cpuPct = 42f, batteryMa = -350f, tempC = 31.5f, nativeHeapKb = 123_456L,
+        relocReject = reloc?.reject?.ordinal ?: EvalSampleLog.NOT_SAMPLED,
+        relocMatches = reloc?.matches ?: EvalSampleLog.NOT_SAMPLED,
+        relocInliers = reloc?.inliers ?: EvalSampleLog.NOT_SAMPLED,
+        relocDetected = reloc?.detected ?: EvalSampleLog.NOT_SAMPLED,
+    )
+
     @Test
     fun `header lists all columns in order`() {
         assertEquals(
             "tsMs,deviceClass,marksVisible,errMm,errDeg,jitterMm,availability," +
-                "voxelUpdateMs,voxelKeyframeMs,surfaceMeshMs,drawMs,pnpRelocMs,cpuPct,batteryMa,tempC,nativeHeapKb",
-            EvalSampleLog.CSV_HEADER
+                "voxelUpdateMs,voxelKeyframeMs,surfaceMeshMs,drawMs,pnpRelocMs,cpuPct,batteryMa,tempC," +
+                "nativeHeapKb,relocReject,relocMatches,relocInliers,relocDetected",
+            EvalSampleLog.CSV_HEADER,
         )
     }
 
@@ -22,8 +51,108 @@ class EvalSampleLogTest {
             nativeHeapKb = 20480L,
         )
         assertEquals(
-            "12,dual,true,1.5,0.25,3.0,1.0,2.0,0.0,4.0,1.0,8.0,30.0,-450.0,31.0,20480",
-            EvalSampleLog.toCsvRow(row)
+            "12,dual,true,1.5,0.25,3.0,1.0,2.0,0.0,4.0,1.0,8.0,30.0,-450.0,31.0,20480,-1,-1,-1,-1",
+            EvalSampleLog.toCsvRow(row),
         )
+    }
+
+    @Test
+    fun `header column count equals emitted field count`() {
+        assertEquals(
+            "header and row must stay in lockstep",
+            EvalSampleLog.COLUMNS.size,
+            EvalSampleLog.fields(sample()).size,
+        )
+        assertEquals(
+            EvalSampleLog.CSV_HEADER.split(",").size,
+            EvalSampleLog.toCsvRow(sample()).split(",").size,
+        )
+    }
+
+    @Test
+    fun `header is derived from the column list, not restated`() {
+        assertEquals(EvalSampleLog.COLUMNS.joinToString(","), EvalSampleLog.CSV_HEADER)
+    }
+
+    /** A duplicated name makes two quantities indistinguishable to any consumer selecting by name. */
+    @Test
+    fun `column names are unique`() {
+        assertEquals(EvalSampleLog.COLUMNS.size, EvalSampleLog.COLUMNS.toSet().size)
+    }
+
+    /**
+     * A short stageMs array must not shorten the row. The contract is five stages; a caller that
+     * supplies fewer should pad, not shift every following column left.
+     */
+    @Test
+    fun `a short stage array still emits five stage columns`() {
+        val short = sample().copy(stageMs = floatArrayOf(1f, 2f))
+        assertEquals(EvalSampleLog.COLUMNS.size, EvalSampleLog.fields(short).size)
+    }
+
+    /** …and an over-long one must not lengthen it. */
+    @Test
+    fun `an over-long stage array still emits five stage columns`() {
+        val long = sample().copy(stageMs = FloatArray(9) { it.toFloat() })
+        assertEquals(EvalSampleLog.COLUMNS.size, EvalSampleLog.fields(long).size)
+    }
+
+    /**
+     * `deviceClass` reaches the log as a free-form string from a caller. One comma in it shifts every
+     * subsequent column of that row — silently, because the file still parses.
+     */
+    @Test
+    fun `a comma in a free-form field cannot shift the columns`() {
+        val row = EvalSampleLog.toCsvRow(sample(deviceClass = "mono,rear"))
+        assertTrue("the value must be quoted, got: $row", row.contains("\"mono,rear\""))
+    }
+
+    @Test
+    fun `a quote in a free-form field is doubled`() {
+        assertEquals("\"a\"\"b\"", EvalSampleLog.csvEscape("a\"b"))
+    }
+
+    @Test
+    fun `plain values are not quoted`() {
+        assertEquals("mono", EvalSampleLog.csvEscape("mono"))
+    }
+
+    /**
+     * Not-sampled is -1, not 0. Zero matches and zero detected features are both real measurements —
+     * "the detector found nothing" is exactly the diagnosis the reject histogram exists to surface —
+     * so zero cannot double as the marker for "this row carries no reloc data".
+     */
+    @Test
+    fun `unsampled reloc diagnostics are minus one, not zero`() {
+        val fields = EvalSampleLog.fields(sample(reloc = null))
+        assertEquals("-1", fields[EvalSampleLog.COLUMNS.indexOf("relocReject")])
+        assertEquals("-1", fields[EvalSampleLog.COLUMNS.indexOf("relocMatches")])
+        assertEquals("-1", fields[EvalSampleLog.COLUMNS.indexOf("relocInliers")])
+        assertEquals("-1", fields[EvalSampleLog.COLUMNS.indexOf("relocDetected")])
+    }
+
+    @Test
+    fun `sampled reloc diagnostics land in their named columns`() {
+        val d = RelocDiagnostics(RelocReject.FEW_INLIERS, matches = 40, inliers = 7, detected = 1200)
+        val fields = EvalSampleLog.fields(sample(reloc = d))
+        assertEquals(
+            RelocReject.FEW_INLIERS.ordinal.toString(),
+            fields[EvalSampleLog.COLUMNS.indexOf("relocReject")],
+        )
+        assertEquals("40", fields[EvalSampleLog.COLUMNS.indexOf("relocMatches")])
+        assertEquals("7", fields[EvalSampleLog.COLUMNS.indexOf("relocInliers")])
+        assertEquals("1200", fields[EvalSampleLog.COLUMNS.indexOf("relocDetected")])
+    }
+
+    /**
+     * A zero-detected reading must log as 0 and stay distinguishable from not-sampled. This is the
+     * exact pair the sentinel choice exists to separate.
+     */
+    @Test
+    fun `zero detected is logged as zero, distinct from not sampled`() {
+        val d = RelocDiagnostics(RelocReject.NO_FEATURES, matches = 0, inliers = 0, detected = 0)
+        val fields = EvalSampleLog.fields(sample(reloc = d))
+        assertEquals("0", fields[EvalSampleLog.COLUMNS.indexOf("relocDetected")])
+        assertEquals("0", fields[EvalSampleLog.COLUMNS.indexOf("relocMatches")])
     }
 }


### PR DESCRIPTION
Telemetry plumbing, landed **before** the phases that need it so their changes are measurable when they arrive.

> **Corrected after audit (`69571ae`).** The first version of this PR shipped a run-identity sidecar that nothing ever wrote, a JNI fallback that files "engine absent" as a successful lock, and a test that fails on correct output. Called out inline rather than quietly edited, because the whole point of this phase is that unverified claims are how bad measurements happen.

## Header and row can no longer drift

They were written out independently. Add a field to one and forget the other, and every column past the insertion point shifts — in a file that still parses cleanly. Nothing errors; the numbers are simply wrong, and the mistake surfaces weeks later while interpreting results, if at all.

Both now derive from one `EvalSampleLog.COLUMNS` list, checked by `EvalSampleLogTest` in CI.

> **CORRECTED.** The commit claimed `toCsvRow`'s `check()` "fires at the first row of a run". It cannot: `fields()` returns a literal list, so its arity is a source constant and no input can change it. The real guard is the CI test; the runtime check is belt-and-braces and now says so. (`check`, not `assert` — `assert` is gated by `-ea` and would be inert in exactly the builds that write eval logs.)

`deviceClass` reaches the log as a free-form string from a caller and was joined raw — one comma silently shifts that row's remaining columns. Now quoted per RFC 4180.

> **CORRECTED.** The test named *"a comma cannot shift the columns"* only checked that a quote pair appeared; it never counted a column. It now parses the row with a quote-aware reader, asserts the column count **and** the column immediately after `deviceClass`, and records that a naive `split(",")` really does miscount — so the quoting isn't mistaken for cosmetic.

## Reloc diagnostics per row

All six `RelocDiagnostics` fields: `relocReject`, `relocMatches`, `relocInliers`, `relocDetected`, `relocObliquityDeg`, `relocRectifiedCorr`. Without them a null relocalization is an *absence* rather than a *diagnosis* — `NO_FEATURES` and `FEW_INLIERS` need opposite fixes and the aggregate error number can't separate them.

**`relocObliquityDeg` is the one to watch.** It's the exact quantity `PlaneMarksObliquityTest` predicts the back-projection error scales with, so having it per row is what lets a device run be compared against `PAPER.md` §8.1's curve instead of argued about.

> **CORRECTED.** The first version dropped `obliquityDeg` and `rectifiedCorrespondences` while `IMPLEMENTATION.md` scoped 6a to "the existing `RelocDiagnostics` fields" — both are already populated natively. Restored.

### A real bug this surfaced

`nativeGetRelocDiagnostics`'s no-engine fallback was `{0,0,0,0,-1,0}`. **`kRelocOk` is `0`**, so a null `gSlamEngine` reported a *successful lock with zero correspondences* — and the reject histogram this phase exists to produce would have counted "the engine was not initialized" as a win.

`MobileGS.h` guards against precisely this in `mLastRelocReject`'s initializer, with a comment explaining why. The JNI undid it two files away, and the Kotlin fallback that returns `UNKNOWN` is unreachable because the native side never returns null. Now `{7, -1, -1, -1, -1, -1}` — `7` is `RelocReject.UNKNOWN`, counts are not-sampled rather than zero.

## Run-identity sidecar

`EvalRunIdentity` writes a JSON sidecar next to each CSV: git commit, recording name, device model and Android release, RNG seed, sync/async mode, and every `PoseFusion` tunable in force. The rule (`EVALUATION.md` §3.2): **a CSV without a sidecar is not evidence.**

> **CORRECTED — the important one.** `start(identity: EvalRunIdentity? = null)` wrote the sidecar only when passed one, and the sole production call site was `start()` with no argument. **Nothing constructed an `EvalRunIdentity` anywhere.** What landed was a serializer and a write path, not a sidecar — every CSV had none, which is exactly the state the ticked todo calls "not evidence". `evalStartLog` now builds one.
>
> Doing that honestly needed two things I'd referenced without checking, and neither existed: `BuildConfig.GIT_COMMIT` (`feature:ar` didn't even enable `buildConfig`) and `ArRecordingController.currentPlaybackName()`. Both are now real — a `GIT_COMMIT` field resolved from git at configure time with an `"unknown"` fallback that cannot fail the build, and a `currentPlaybackName` set on `startPlayback` / cleared by `clearPlayback` so a live run after a replay doesn't inherit a stale dataset name.

> **CORRECTED.** `EvalRunIdentityTest`'s JSON validity check was `j.count { it == '"' } % 2 == 0`, described as "a cheap proxy for still parseable". It isn't — it counts *escaped* quotes as delimiters, so correctly-escaped `"a\"b"` reads as unbalanced. **It failed CI on correct output.** Replaced with escape-aware structural validation, verified independently against a real JSON parser across all five shapes the class emits. Also added the cases it was standing in for and never checked: a control character becoming `\uXXXX`, and a parameter *key* needing escapes.

## Still open

**Todo 6a.4.** The sidecar *records* `rngSeed` and `syncReloc`, but nothing honours them yet. `solvePnPRansac` draws random samples, so until that lands every replay A/B carries un-quantified RANSAC variance. The sidecar being able to say "unseeded" is the point, not a substitute for seeding.

## Testing

`EvalSampleLogTest` (14) and `EvalRunIdentityTest` (9) — pure JVM.

**This PR does touch native code** (`GraffitiJNI.cpp`, for the reject fallback above), so CI's NDK build is the only compile check on it — a green unit-test run says nothing. The earlier "no native code touched" was true of the first commit and is no longer true of the diff.