### PR TITLE
E0b prep: record the experiment's independent variable, close its escape hatch

### DIFF
--- a/docs/research/EVALUATION.md
+++ b/docs/research/EVALUATION.md
@@ -333,10 +333,28 @@ in landscape, then in portrait, same wall, same obliquity; then attempt
 relocalization from the same standing positions for each. Compare inlier ratio
 and lock rate.
 
-**Reasoning.** The cheapest experiment in the document, and it runs on the
-shipped build with no code change, because the independent variable is how you
-hold the phone. Do it *first*, before any of Phase 0's engineering — a negative
-result cancels that engineering entirely.
+**Reasoning.** The cheapest experiment in the document, and the independent
+variable is how you hold the phone. Do it *first*, before any of Phase 0's
+engineering — a negative result cancels that engineering entirely.
+
+**The independent variable is now recorded per CSV row**, as `rotationNeededDeg`
+(0/90/180/270, `-1` not sampled). It was not, and that was a hole in this
+protocol rather than a detail: the experiment's entire contrast lived in whoever
+ran it remembering which way they had been holding the phone, with nothing in the
+data to check that memory against. Worse, `screenOrientation="fullUser"` means the
+device can rotate *mid-run*, so a single CSV can straddle both conditions with no
+marker where it crossed over — the two populations would mix and the effect would
+average toward nothing, which reads exactly like a negative result. Group rows by
+`rotationNeededDeg` and compare within groups; do not compare file to file.
+
+Note `0` is the control condition, not a missing value — landscape is the
+orientation predicted to *work*, so those rows are the experiment's positive
+half, and `-1` is the only "no data" marker.
+
+This does mean E0b now needs a build, contrary to the cost line below. Running it
+on a stock build is still possible and still informative — the overlay signals
+below are unchanged — but the per-row grouping is what makes the result
+attributable.
 
 Watch two secondary signals in the diagnostics overlay, both predicted by the
 model: healthy match counts paired with a **low inlier ratio** (PnP cannot fit a
@@ -348,11 +366,20 @@ points surviving at 60° versus all 1600 at 40°.
 **Sets.** Nothing. It is the go/no-go on Phase 0.
 
 **Falsifies §8 entirely.** Identical behaviour in both orientations means the
-convention is not the cause and Phase 0 should be dropped. In that case check the
-assumption it rests on: that ARCore's `camera.pose` is in the physical camera
-frame rather than a display-oriented one.
+convention is not the cause and Phase 0 should be dropped.
 
-**Cost.** One session. No build required.
+The follow-up this line used to prescribe — "check whether `camera.pose` is
+display-oriented" — **has been done, and it is not the answer.** ARCore documents
+`getPose()` as the physical camera frame and `getDisplayOrientedPose()` as the
+display-oriented one, differing "by a local rotation about the Z axis by a
+multiple of 90°" (PAPER.md §8.2). The frames provably differ by the rotation the
+model assumes, so a negative result cannot be explained away there. Carry these
+instead: the depth error is real but swamped by other error sources; the reloc
+path does not consume `backProject`'s output the way §8 assumes; or the device's
+actual `rotationNeeded` is not what the formula predicts — which the new
+`rotationNeededDeg` column now lets you check directly rather than infer.
+
+**Cost.** One session, plus a build (see above).
 
 ---
 

--- a/docs/research/PAPER.md
+++ b/docs/research/PAPER.md
@@ -549,6 +549,24 @@ mechanism described two paragraphs below. Quoting the unfiltered figure claimed
 an error 3.3× larger than the code can produce. Rows 0°–50° are unaffected;
 nothing is dropped there, so filtered and unfiltered agree exactly.
 
+**Reproduced independently**, from the geometry rather than from `backProject`'s
+code path, and every cell above matches — including the 1280/1600 survival at 60°
+and the 6913 mm unfiltered mean. Two conventions had to be recovered by trial to
+get there, and neither is stated above, so they are stated here: *"a wall at 2 m"*
+means the **perpendicular** distance from the camera to the plane, not the
+distance along the optical axis (reading it the other way scales every row by
+$\cos\theta$ — 251 mm rather than 267 mm at 20°); and the wall is tilted about
+the camera's **Y** axis.
+
+That second one is not cosmetic. At $\text{rotationNeeded} = 90$ the tilt axis
+does not matter, but at **180 it does**: tilting about Y gives 265 mm at 20°,
+tilting about X gives **486 mm**. The 60° row is likewise tilt-dependent once the
+depth filter engages — 2107 mm about Y, 6913 mm about X, with nothing dropped in
+the latter. So the table is a slice through a parameter the table does not name,
+and the 180° figure in §8.2 is the Y-tilt value specifically. Any device
+measurement compared against these numbers has to match the tilt axis too, or the
+comparison is between two different quantities.
+
 ### 8.2 A device test that does not require the fix
 
 `rotationNeeded = (sensorOrientation - displayDegrees + 360) \bmod 360`, and the
@@ -560,7 +578,7 @@ whether the bug is active at all:
 |---|---|---|
 | landscape | 0 | **0.0 mm — no mismatch** |
 | portrait | 90 | 267 mm |
-| landscape, other way | 180 | 265 mm |
+| landscape, other way | 180 | 265 mm (Y-tilt; 486 mm about X — see §8.1) |
 
 So the hypothesis is falsifiable on the current build with no code change:
 **capture a target in landscape, then in portrait, same wall, same angle.** If
@@ -573,11 +591,40 @@ diagnostics overlay: healthy match counts paired with a **low inlier ratio**
 $M$ landed on the wall surface" refusals, since mis-scaled depths fall outside
 `backProject`'s 0.1–10 m trust range and are silently dropped.
 
-**The assumption this all rests on** is that ARCore's `camera.pose` is in the
+**The assumption this all rests on** was that ARCore's `camera.pose` is in the
 physical camera frame rather than a display-oriented one — i.e. that ARCore
 handles display rotation through `setDisplayGeometry`/`transformCoordinates2d`
-and not by rotating the pose. If that is false there is no mismatch. It is the
-first thing to check if the device test comes back negative.
+and not by rotating the pose. If that were false there would be no mismatch, and
+it was recorded here as the first thing to check if the device test came back
+negative.
+
+**It is no longer an assumption. ARCore's reference documentation settles it, and
+settles it in favour of the diagnosis.** `Camera.getPose()` is specified as the
+pose of the *physical* camera, with "right" and "up" *"relative to the image
+readout in the usual left-to-right, top-to-bottom order"* — the raw sensor frame.
+`Camera.getDisplayOrientedPose()` is a separate method returning the virtual
+camera pose with "right" and "up" *"relative to current logical display
+orientation"*, and the docs state the two *"differ by a local rotation about the Z
+axis by a multiple of 90°"* — which is precisely the $R_z$ posited above, named by
+Google in the same terms. `Camera.getImageIntrinsics()`, the source of the
+intrinsics the capture path then rotates by hand, is likewise documented as
+*"the **unrotated** camera intrinsics for the CPU image."*
+
+The codebase demonstrates it knows the difference: `ArRenderer` reads
+`camera.displayOrientedPose` for motion estimation, and `camera.pose.inverse()`
+for the mapping view matrix that reaches `backProject`. So the two frames are
+distinguished deliberately elsewhere and conflated here.
+
+Two consequences for E0b. First, its prior should be much stronger than "plausible
+mechanism" — the frames provably differ by exactly the rotation the model uses.
+Second, and more usefully, **a negative E0b result can no longer be explained by
+this assumption failing.** The paper's designated escape hatch is closed. If the
+device shows identical behaviour in both orientations, the explanation has to be
+found somewhere else — that the depth error is real but dominated by other error
+sources, that the reloc path never reaches `backProject`'s output in the way
+assumed, or that `rotationNeeded` is not what the device actually computes. Those
+are the hypotheses to carry into a negative result, and they are not
+interchangeable with the one that was written here.
 
 ### 8.3 Why the correction is not local
 

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -48,10 +48,32 @@ set*). `PARAMETERS.md` is a lookup table, not prose.
 
 ## Status
 
-Nothing in `IMPLEMENTATION.md` is built yet. The defects it lists as "already
-fixed" were repaired in PRs #1785–#1788 and are on `main`; everything under
-Phase 1 onward is proposed.
+The defects `IMPLEMENTATION.md` lists as "already fixed" were repaired in PRs
+#1785–#1788 and are on `main`. Since then **Phase 1** (the footprint operator Φ,
+`anchor/Footprint.kt`), **Phase 5a** (splitting painting progress from
+corroboration confidence) and **Phase 6a** (eval telemetry: CSV shape guard,
+reloc diagnostics columns, run-identity sidecar) have landed. Phases 2, 3, 4 and
+5b are still proposed.
 
-One prerequisite is unresolved and gates Phase 3 — see
-[`../TELEOLOGICAL_SLAM.md`](../TELEOLOGICAL_SLAM.md) "Open question: the
-display-rotation convention", and §8 of the paper.
+**Phase 0 is next in the landing order and blocks all four.** It is gated on
+experiment **E0b**, which has not been run — it needs a physical ARCore device.
+What has been settled without one:
+
+- The source chain is confirmed. Capture rotates the bitmap
+  (`ArViewModel.onTargetCaptured`) and the intrinsics (`ArRenderer`'s
+  `rotationNeeded` branches) into display orientation, and pairs them with a view
+  matrix built from `camera.pose.inverse()`, which is not rotated.
+- **The assumption §8.2 flagged as load-bearing is closed by ARCore's own
+  reference documentation**, in favour of the diagnosis. `Camera.getPose()` is the
+  physical/image-readout frame; `getDisplayOrientedPose()` is the display one; the
+  docs state they differ "by a local rotation about the Z axis by a multiple of
+  90°". A negative E0b can no longer be explained by that assumption failing.
+- `PAPER.md` §8.1's error table reproduces exactly on an independent
+  recomputation, once two unstated sampling conventions are supplied — both are
+  now recorded in §8.1.
+- E0b's independent variable is now logged per CSV row (`rotationNeededDeg`). It
+  previously was not logged at all, which would have made the experiment's own
+  result unattributable.
+
+See §8 of the paper, and `../TELEOLOGICAL_SLAM.md` "Open question: the
+display-rotation convention".

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/DriftCostProbe.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/DriftCostProbe.kt
@@ -64,6 +64,9 @@ class DriftCostProbe(
      * @param reloc          last relocalization diagnostics, or null when not sampled. Logged so a
      *   null relocalization becomes a diagnosis rather than an absence: NO_FEATURES and FEW_INLIERS
      *   call for opposite fixes and the aggregate error number cannot tell them apart.
+     * @param rotationNeededDeg `(sensorOrientation - displayRotation*90 + 360) % 360` at this tick,
+     *   or -1 if the caller cannot supply it. E0b's independent variable — see
+     *   [EvalSample.rotationNeededDeg] for why it is sampled per tick and not once per run.
      */
     fun onTick(
         candidatePose: FloatArray,
@@ -72,6 +75,7 @@ class DriftCostProbe(
         stageMs: FloatArray,
         cpuPct: Float,
         reloc: com.hereliesaz.graffitixr.common.model.RelocDiagnostics? = null,
+        rotationNeededDeg: Int = EvalSampleLog.NOT_SAMPLED,
     ) {
         val file = logFile ?: return
         totalFrames++
@@ -109,6 +113,7 @@ class DriftCostProbe(
             relocDetected = reloc?.detected ?: EvalSampleLog.NOT_SAMPLED,
             relocObliquityDeg = reloc?.obliquityDeg ?: EvalSampleLog.NOT_SAMPLED,
             relocRectifiedCorr = reloc?.rectifiedCorrespondences ?: EvalSampleLog.NOT_SAMPLED,
+            rotationNeededDeg = rotationNeededDeg,
         )
         file.appendText(EvalSampleLog.toCsvRow(sample) + "\n")
 

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/EvalSampleLog.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/EvalSampleLog.kt
@@ -28,6 +28,21 @@ data class EvalSample(
     // device run be compared against PAPER.md 8.1's curve instead of argued about.
     val relocObliquityDeg: Int = -1,
     val relocRectifiedCorr: Int = -1,
+    /**
+     * `(sensorOrientation - displayRotation*90 + 360) % 360` for this tick — 0, 90, 180 or 270.
+     * -1 when not sampled.
+     *
+     * This is the independent variable of `EVALUATION.md` **E0b**. Capture rotates the bitmap and
+     * the intrinsics by this angle and leaves the view matrix in ARCore's physical-camera frame
+     * (`Camera.getPose()`), so it is also the exact angle of the frame mismatch `PAPER.md` §8
+     * describes: 0 means no mismatch exists, 90/180/270 mean one does.
+     *
+     * Per-**row** rather than in the run-identity sidecar, and that is not a stylistic choice. The
+     * app is `screenOrientation="fullUser"`, so the user can rotate the device mid-run and flip the
+     * condition between one CSV row and the next. A single per-run value would be a recorded
+     * average of two conditions, which is worse than no record at all — it would look like data.
+     */
+    val rotationNeededDeg: Int = -1,
 )
 
 object EvalSampleLog {
@@ -46,6 +61,7 @@ object EvalSampleLog {
         "cpuPct", "batteryMa", "tempC", "nativeHeapKb",
         "relocReject", "relocMatches", "relocInliers", "relocDetected",
         "relocObliquityDeg", "relocRectifiedCorr",
+        "rotationNeededDeg",
     )
 
     const val NOT_SAMPLED = -1
@@ -63,6 +79,7 @@ object EvalSampleLog {
             s.relocReject.toString(), s.relocMatches.toString(),
             s.relocInliers.toString(), s.relocDetected.toString(),
             s.relocObliquityDeg.toString(), s.relocRectifiedCorr.toString(),
+            s.rotationNeededDeg.toString(),
         )
     }
 

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -1193,6 +1193,13 @@ class ArRenderer(
                         // FloatArrays per tick. (An earlier comment here said "four atomics", which
                         // was neither the count nor the mechanism.)
                         reloc = slamManager.getRelocDiagnostics(),
+                        // E0b's independent variable, recomputed here by the same expression the
+                        // capture path uses (ArRenderer's capture block) so the logged condition is
+                        // the condition that was actually in force. Sampled every tick because
+                        // `screenOrientation="fullUser"` lets the device rotate mid-run: one CSV can
+                        // straddle both conditions, and a per-run value would silently average them.
+                        rotationNeededDeg =
+                            (sensorOrientation - displayRotationHelper.getRotation() * 90 + 360) % 360,
                     )
                 }
 

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/eval/EvalSampleLogTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/eval/EvalSampleLogTest.kt
@@ -40,7 +40,7 @@ class EvalSampleLogTest {
             "tsMs,deviceClass,marksVisible,errMm,errDeg,jitterMm,availability," +
                 "voxelUpdateMs,voxelKeyframeMs,surfaceMeshMs,drawMs,pnpRelocMs,cpuPct,batteryMa,tempC," +
                 "nativeHeapKb,relocReject,relocMatches,relocInliers,relocDetected," +
-                "relocObliquityDeg,relocRectifiedCorr",
+                "relocObliquityDeg,relocRectifiedCorr,rotationNeededDeg",
             EvalSampleLog.CSV_HEADER,
         )
     }
@@ -55,7 +55,7 @@ class EvalSampleLogTest {
         )
         assertEquals(
             "12,dual,true,1.5,0.25,3.0,1.0,2.0,0.0,4.0,1.0,8.0,30.0,-450.0,31.0,20480," +
-                "-1,-1,-1,-1,-1,-1",
+                "-1,-1,-1,-1,-1,-1,-1",
             EvalSampleLog.toCsvRow(row),
         )
     }
@@ -192,6 +192,35 @@ class EvalSampleLogTest {
         val fields = EvalSampleLog.fields(sample(reloc = d))
         assertEquals("37", fields[EvalSampleLog.COLUMNS.indexOf("relocObliquityDeg")])
         assertEquals("12", fields[EvalSampleLog.COLUMNS.indexOf("relocRectifiedCorr")])
+    }
+
+    /**
+     * `EVALUATION.md` **E0b** compares relocalization between device orientations, so the
+     * orientation has to be *in the data*. Without this column the experiment's independent
+     * variable exists only in whoever ran it remembering which way they were holding the phone —
+     * and `screenOrientation="fullUser"` means a single run can straddle both conditions.
+     */
+    @Test
+    fun `rotationNeeded reaches its own column`() {
+        val fields = EvalSampleLog.fields(sample().copy(rotationNeededDeg = 90))
+        assertEquals("90", fields[EvalSampleLog.COLUMNS.indexOf("rotationNeededDeg")])
+    }
+
+    /**
+     * The trap this column could most easily fall into. **0 is E0b's control condition** — landscape,
+     * no frame mismatch, the orientation predicted to work — so it is the single most important
+     * value the column ever carries. Had it doubled as the not-sampled sentinel, every successful
+     * control row would have been indistinguishable from missing data, and the experiment would
+     * have been unable to report its own negative result.
+     */
+    @Test
+    fun `rotationNeeded zero is the landscape control, not a missing value`() {
+        val landscape = EvalSampleLog.fields(sample().copy(rotationNeededDeg = 0))
+        val unsampled = EvalSampleLog.fields(sample())
+        val i = EvalSampleLog.COLUMNS.indexOf("rotationNeededDeg")
+        assertEquals("0", landscape[i])
+        assertEquals("-1", unsampled[i])
+        assertTrue("the control condition must not read as absent", landscape[i] != unsampled[i])
     }
 
     /**

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Fri Jul 31 20:32:42 UTC 2026
-versionBuild=14219
+#Fri Jul 31 22:23:25 UTC 2026
+versionBuild=14220
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=85
+versionPatch=86


### PR DESCRIPTION
## E0b did not run

No `/dev/kvm`, and `/proc/cpuinfo` reports zero `vmx`/`svm` flags — no nested virtualisation, so no accelerated emulator, and ARCore requires one. **E0b needs a physical device.** I installed the Android SDK (platform 37.0) so Gradle and the unit tests run here, but that closes the build gap, not the device gap.

**Phase 0 is not implemented and the `PlaneMarksObliquityTest` characterization tests are not inverted.** E0b is the gate on both and it has not run. Nothing here presupposes its outcome.

What follows is everything E0b needed that could be settled without a device.

## The experiment's independent variable was not recorded anywhere

Not in the CSV, not in the run-identity sidecar. E0b's entire contrast — landscape vs portrait — lived in whoever ran it remembering how they had been holding the phone.

Worse: the app is `screenOrientation="fullUser"`, so a device rotated mid-run puts both conditions in one file with no marker at the crossover. The two populations mix and the effect averages toward nothing — which is indistinguishable from a genuine negative result. E0b could have "falsified" §8 by accident.

Adds `rotationNeededDeg` as a **per-row** CSV column, computed at the probe tick site by the same expression the capture path uses (`ArRenderer.kt:1279`). Per-row rather than per-run for the reason above.

`0` is E0b's **control** condition — landscape, the orientation predicted to work — so it is the most important value the column carries, and `-1` remains the only not-sampled sentinel. Had `0` doubled as the sentinel, every successful control row would have read as missing data. A test pins that specifically, and it was mutation-checked: defaulting the field to `0` fails it.

## §8.2's load-bearing assumption is closed, in favour of the diagnosis

The paper recorded this as the thing to check if E0b came back negative:

> the assumption this all rests on is that ARCore's `camera.pose` is in the physical camera frame rather than a display-oriented one … the first thing to check if the device test comes back negative.

ARCore's reference documentation settles it:

- `Camera.getPose()` — the **physical** camera, "right" and "up" *"relative to the image readout in the usual left-to-right, top-to-bottom order"*.
- `Camera.getDisplayOrientedPose()` — "right" and "up" *"relative to current logical display orientation"*.
- The two *"differ by a local rotation about the Z axis by a multiple of 90°"* — precisely the $R_z$ the paper posits.
- `Camera.getImageIntrinsics()` — *"the **unrotated** camera intrinsics for the CPU image."*

The codebase already distinguishes them: `ArRenderer.kt:1465` reads `camera.displayOrientedPose` for motion estimation, `ArRenderer.kt:1031` reads `camera.pose.inverse()` for the mapping view matrix that reaches `backProject`.

So a negative E0b can no longer be explained the way the paper said it would be. The alternative hypotheses are now written down in their place — that the depth error is real but swamped by other error sources, that the reloc path does not consume `backProject`'s output as assumed, or that the device's actual `rotationNeeded` differs from the formula (which the new column now lets you check directly rather than infer).

This raises E0b's prior. It does **not** establish that the mismatch is the operative cause of any observed relocalization failure — that is still what the device test is for.

## §8.1 reproduces exactly, but rests on two unstated conventions

Recomputed independently from the geometry rather than from `backProject`'s code path. Every cell matches, including 1280/1600 surviving at 60° and the 6913 mm unfiltered mean.

Getting there required recovering two conventions by trial, neither of which the table stated:

- **"A wall at 2 m" is the perpendicular distance to the plane**, not the distance along the optical axis. Reading it the other way scales every row by $\cos\theta$ — 251 mm rather than 267 mm at 20°.
- **The wall is tilted about the camera's Y axis.**

The second is not cosmetic. At `rotationNeeded=90` the tilt axis does not matter; at **180 it does** — 265 mm about Y versus **486 mm about X** at 20° obliquity. The 60° row is likewise tilt-dependent once the depth filter engages (2107 mm about Y, 6913 mm about X, nothing dropped in the latter). The published table is a slice through a parameter it does not name, and any device measurement compared against it has to match the tilt axis or the comparison is between two different quantities.

Both conventions are now recorded in §8.1.

## Source chain re-verified

Line numbers had drifted from those cited in the handoff, so this was re-derived rather than inherited:

| Step | Site |
|---|---|
| `rotationNeeded` computed | `ArRenderer.kt:1279` |
| Intrinsics rotated (fx/fy swap, principal point) | `ArRenderer.kt:1311-1324` |
| Bitmap rotated by the same angle | `ArViewModel.kt:1769` |
| View matrix alongside them, **unrotated** | `ArRenderer.kt:1031` (`camera.pose.inverse()`) |

## Testing

`:feature:ar:testDebugUnitTest` — **170 tests, 0 failures**, 1 pre-existing skip (`ArSessionTest`, unrelated). The two new tests were confirmed to run and were mutation-checked.

Kotlin only. This touches no JNI signature, and a green Kotlin run says nothing about the NDK build — that is a separate CI gate and it did not run here.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Q5WXFiVLeN4sXa9bPCSDA)_

## Summary by Sourcery

Record the experiment’s display-rotation condition per sample in eval telemetry and update the research docs to close the ARCore pose assumption and fully specify the evaluation protocol.

New Features:
- Add a per-row rotationNeededDeg field to AR evaluation samples and CSV output so device orientation is captured for experiment E0b.

Enhancements:
- Wire rotationNeededDeg from the renderer into DriftCostProbe logging so the recorded condition matches the capture path’s rotation at each tick.
- Clarify PAPER.md §8.1–§8.2 with the recovered sampling conventions, explicit tilt-axis choice, and ARCore pose documentation, removing the prior escape hatch for a negative E0b result.
- Update research README and EVALUATION docs to reflect landed phases, E0b’s gating role, and the need to group results by rotationNeededDeg rather than by file.

Build:
- Increment application build and patch versions in version.properties.

Tests:
- Extend EvalSampleLog tests to cover the new rotationNeededDeg column and assert that 0 is treated as the landscape control condition while -1 remains the not-sampled sentinel.