### PR TITLE
fix: E0b's new column logged the wrong occurrence of E0b's variable

### DIFF
--- a/docs/research/EVALUATION.md
+++ b/docs/research/EVALUATION.md
@@ -337,31 +337,48 @@ and lock rate.
 variable is how you hold the phone. Do it *first*, before any of Phase 0's
 engineering — a negative result cancels that engineering entirely.
 
-**The independent variable is now recorded per CSV row**, as `rotationNeededDeg`
-(0/90/180/270, `-1` not sampled). It was not, and that was a hole in this
-protocol rather than a detail: the experiment's entire contrast lived in whoever
-ran it remembering which way they had been holding the phone, with nothing in the
-data to check that memory against. Worse, `screenOrientation="fullUser"` means the
-device can rotate *mid-run*, so a single CSV can straddle both conditions with no
-marker where it crossed over — the two populations would mix and the effect would
-average toward nothing, which reads exactly like a negative result. Group rows by
-`rotationNeededDeg` and compare within groups; do not compare file to file.
+**The independent variable is now recorded per CSV row**, as
+`captureRotationNeededDeg` (0/90/180/270, `-1` unknown). It was not recorded at
+all, and that was a hole in this protocol rather than a detail: the experiment's
+entire contrast lived in whoever ran it remembering which way they had been
+holding the phone, with nothing in the data to check that memory against.
+
+**Group by `captureRotationNeededDeg`, never by `liveRotationNeededDeg`.** The two
+are different quantities and the distinction is the experiment. `backProject` runs
+exactly once per target, inside `MetricFingerprintBuilder.build`, so the frame
+mismatch is baked into the fingerprint's 3D points **at capture** and does not
+change however the device is held afterwards. A first version of this column
+logged the live per-tick rotation, which mislabels the central case: capture in
+portrait, relocalize in landscape, and every defect-bearing row is filed under
+`0` — the control arm — so a genuine effect averages toward nothing and reads as
+the falsification this experiment is supposed to be able to report. The live
+value is still logged as a secondary signal, because the reloc feed has frame
+handling of its own; rows where the two disagree are worth a second look.
 
 Note `0` is the control condition, not a missing value — landscape is the
 orientation predicted to *work*, so those rows are the experiment's positive
-half, and `-1` is the only "no data" marker.
+half, and `-1` is the only "no data" marker. A target restored from a saved
+project reads `-1`, because the renderer never observed that capture; re-capture
+before a run rather than trusting a loaded target.
 
-This does mean E0b now needs a build, contrary to the cost line below. Running it
-on a stock build is still possible and still informative — the overlay signals
-below are unchanged — but the per-row grouping is what makes the result
+This does mean E0b needs a build, which is what the **Cost** line below now says.
+Running it on a stock build is still possible and still informative — the overlay
+signals below are unchanged — but the per-row grouping is what makes the result
 attributable.
 
 Watch two secondary signals in the diagnostics overlay, both predicted by the
 model: healthy match counts paired with a **low inlier ratio** (PnP cannot fit a
 non-rigidly distorted cloud), and "found N features but only M landed on the wall
 surface" refusals, since mis-scaled depths fall outside `backProject`'s 0.1–10 m
-trust range. The second is measurable directly — §8.1 predicts 1280 of 1600
-points surviving at 60° versus all 1600 at 40°.
+trust range.
+
+The second is measurable directly, but **only if you tilt the wall the way §8.1
+does** — about the camera's Y axis, i.e. the phone's long axis. §8.1 predicts
+1280 of 1600 points surviving at 60° versus all 1600 at 40° *for that tilt*.
+Tilt about X instead and the same defect drops **nothing at all** at 60°, because
+the mis-scaled depths stay inside the trust range. A runner who tilts the other
+way sees 1600/1600, reads it as the prediction failing, and records a
+falsification that is a convention mismatch rather than a result.
 
 **Sets.** Nothing. It is the go/no-go on Phase 0.
 
@@ -372,12 +389,14 @@ The follow-up this line used to prescribe — "check whether `camera.pose` is
 display-oriented" — **has been done, and it is not the answer.** ARCore documents
 `getPose()` as the physical camera frame and `getDisplayOrientedPose()` as the
 display-oriented one, differing "by a local rotation about the Z axis by a
-multiple of 90°" (PAPER.md §8.2). The frames provably differ by the rotation the
-model assumes, so a negative result cannot be explained away there. Carry these
-instead: the depth error is real but swamped by other error sources; the reloc
-path does not consume `backProject`'s output the way §8 assumes; or the device's
-actual `rotationNeeded` is not what the formula predicts — which the new
-`rotationNeededDeg` column now lets you check directly rather than infer.
+multiple of 90°" (PAPER.md §8.2). The frames are documented to differ, and the
+code pairs one frame's rays with the other's plane, so a negative result cannot
+be explained away there. Carry these instead: the depth error is real but swamped
+by other error sources; the reloc path does not consume `backProject`'s output the
+way §8 assumes; or the device's actual `rotationNeeded` is not what the formula
+predicts — still live, because the documentation says "a multiple of 90°" without
+saying *which* multiple, and the new `captureRotationNeededDeg` column now lets
+you check that directly rather than infer it.
 
 **Cost.** One session, plus a build (see above).
 

--- a/docs/research/IMPLEMENTATION.md
+++ b/docs/research/IMPLEMENTATION.md
@@ -5,8 +5,11 @@ this document says *where the code goes*, *what it is called*, *what breaks it*,
 and *how you know it worked*. It assumes the paper's vocabulary — the **footprint
 operator** Φ, the **backbone set** `F_out`, the **corroboration set** `F_in`.
 
-Nothing below Phase 0 is built. Everything cited as "already fixed" landed in PRs
-#1785–#1788 and is on `main`.
+Everything cited as "already fixed" landed in PRs #1785–#1788 and is on `main`.
+Since then Phase 1, Phase 5a and three of Phase 6a's four todos have landed;
+Phase 0 itself is still unbuilt and still gates Phases 2, 3, 4 and 5b. See
+[`README.md`](README.md) "Status" for the current picture — this line said
+"nothing below Phase 0 is built" long after that stopped being true.
 
 ---
 

--- a/docs/research/PAPER.md
+++ b/docs/research/PAPER.md
@@ -549,9 +549,29 @@ mechanism described two paragraphs below. Quoting the unfiltered figure claimed
 an error 3.3× larger than the code can produce. Rows 0°–50° are unaffected;
 nothing is dropped there, so filtered and unfiltered agree exactly.
 
-**Reproduced independently**, from the geometry rather than from `backProject`'s
-code path, and every cell above matches — including the 1280/1600 survival at 60°
-and the 6913 mm unfiltered mean. Two conventions had to be recovered by trial to
+**Recomputed, and every cell above matches** — including the 1280/1600 survival at
+60° and the 6914 mm unfiltered mean.
+
+Be precise about what that does and does not establish, because an earlier
+version of this paragraph claimed the recomputation was "independent, from the
+geometry rather than from `backProject`'s code path" and it was not. The
+recomputation evaluates $t = (n \cdot p)/(n \cdot d)$ — `backProject`'s own
+expression — for both the mismatched and the true frame, differing only in which
+frame $n$ is expressed in. A sign error, a swapped numerator, or the inverse
+applied on the wrong side *in the model of the mismatch* would reproduce the
+table exactly. So what is confirmed is the **sampling and the statistics** (the
+40×40 grid, the 0.1–10 m filter, $p95$), which is precisely where the earlier
+3.3× error lived and is worth confirming. The geometry is not independently
+confirmed by it.
+
+`PlaneMarksObliquityTest` already holds the standard this fell short of: it
+rejects an earlier version of *itself* for deriving truth "with the same
+$t = (n \cdot p)/(n \cdot d)$ the implementation uses, which made the control
+tests tautologies that would have passed with a sign flip". Its fix — construct
+the truth *forward*, placing points on the wall in its own basis and projecting
+them to pixels — is what an independent check of this table would require.
+
+Two conventions had to be recovered by trial to
 get there, and neither is stated above, so they are stated here: *"a wall at 2 m"*
 means the **perpendicular** distance from the camera to the plane, not the
 distance along the optical axis (reading it the other way scales every row by
@@ -615,8 +635,15 @@ The codebase demonstrates it knows the difference: `ArRenderer` reads
 for the mapping view matrix that reaches `backProject`. So the two frames are
 distinguished deliberately elsewhere and conflated here.
 
-Two consequences for E0b. First, its prior should be much stronger than "plausible
-mechanism" — the frames provably differ by exactly the rotation the model uses.
+Two consequences for E0b. First, its prior should be stronger than "plausible
+mechanism": the two frames are documented to differ by a rotation about $z$, and
+the code pairs one frame's rays with the other's plane. Note the limit of that —
+the documentation says "a multiple of 90°", not *which* multiple, so the
+identification of that multiple with
+$(\text{sensorOrientation} - \text{displayDegrees} + 360) \bmod 360$ remains an
+inference from how Android orients preview frames, not something Google states.
+It is a good inference and it is now measurable directly rather than assumed,
+which is what the `captureRotationNeededDeg` column is for.
 Second, and more usefully, **a negative E0b result can no longer be explained by
 this assumption failing.** The paper's designated escape hatch is closed. If the
 device shows identical behaviour in both orientations, the explanation has to be

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -50,10 +50,11 @@ set*). `PARAMETERS.md` is a lookup table, not prose.
 
 The defects `IMPLEMENTATION.md` lists as "already fixed" were repaired in PRs
 #1785–#1788 and are on `main`. Since then **Phase 1** (the footprint operator Φ,
-`anchor/Footprint.kt`), **Phase 5a** (splitting painting progress from
-corroboration confidence) and **Phase 6a** (eval telemetry: CSV shape guard,
-reloc diagnostics columns, run-identity sidecar) have landed. Phases 2, 3, 4 and
-5b are still proposed.
+`anchor/Footprint.kt`) and **Phase 5a** (splitting painting progress from
+corroboration confidence) have landed, and **Phase 6a is three of its four todos
+in** — 6a.4 (the eval-only fixed RNG seed and synchronous-reloc mode) is still
+open, so replay A/Bs continue to carry un-quantified RANSAC variance. Phases 2,
+3, 4 and 5b are still proposed.
 
 **Phase 0 is next in the landing order and blocks all four.** It is gated on
 experiment **E0b**, which has not been run — it needs a physical ARCore device.
@@ -68,12 +69,17 @@ What has been settled without one:
   physical/image-readout frame; `getDisplayOrientedPose()` is the display one; the
   docs state they differ "by a local rotation about the Z axis by a multiple of
   90°". A negative E0b can no longer be explained by that assumption failing.
-- `PAPER.md` §8.1's error table reproduces exactly on an independent
-  recomputation, once two unstated sampling conventions are supplied — both are
-  now recorded in §8.1.
-- E0b's independent variable is now logged per CSV row (`rotationNeededDeg`). It
-  previously was not logged at all, which would have made the experiment's own
-  result unattributable.
+- `PAPER.md` §8.1's error table reproduces exactly on recomputation, once two
+  unstated sampling conventions are supplied — both are now recorded in §8.1,
+  along with the limit of that check: it confirms the sampling and statistics,
+  not the geometry, because it evaluates `backProject`'s own expression.
+- E0b's independent variable is now logged per CSV row, as
+  `captureRotationNeededDeg`. It previously was not logged at all. Note it is the
+  rotation at **capture** — the mismatch is baked into the fingerprint's 3D points
+  there and does not change with how the device is held afterwards. A first
+  attempt logged the live per-tick rotation, which files a portrait-captured,
+  landscape-relocalized run under the control condition and turns a real effect
+  into a null result; `liveRotationNeededDeg` is kept only as a secondary signal.
 
 See §8 of the paper, and `../TELEOLOGICAL_SLAM.md` "Open question: the
 display-rotation convention".

--- a/docs/research/reproduce_8_1.py
+++ b/docs/research/reproduce_8_1.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Recompute PAPER.md 8.1's error table, and the 8.2 orientation table.
+
+Run with no arguments; it prints both tables and asserts them against the
+published figures, exiting non-zero on any mismatch.
+
+    python3 docs/research/reproduce_8_1.py
+
+WHY THIS FILE EXISTS. 8.1 opens by complaining that a figure was asserted from a
+source comment for several development cycles with no measurement retained. The
+correction then asserted a *reproduction* with no artifact retained either, which
+is the same failure one level up. This is the artifact.
+
+WHAT IT DOES AND DOES NOT ESTABLISH. It evaluates t = (n.p)/(n.d) — backProject's
+own expression — for both the mismatched and the true frame, differing only in
+which frame n is expressed in. A sign error, a swapped numerator, or the inverse
+applied on the wrong side IN THE MODEL OF THE MISMATCH would reproduce the table
+exactly. So this confirms the sampling and the statistics (the 40x40 grid, the
+0.1-10 m trust filter, p95 = sorted[floor(0.95N)]) — which is where the earlier
+3.3x error lived — and NOT the geometry.
+
+For an independent check of the geometry, see PlaneMarksObliquityTest, which
+constructs its truth forward: it places points on the wall in the wall's own
+basis and projects them to pixels, so the truth path never evaluates the
+ray-plane intersection under test.
+
+THE TWO CONVENTIONS the table depends on and did not state:
+  * "a wall at 2 m" is the PERPENDICULAR distance to the plane, not the distance
+    along the optical axis. Reading it the other way scales every row by cos(t):
+    251 mm rather than 267 mm at 20 degrees.
+  * the wall is tilted about the camera's Y axis. At rotationNeeded=90 the tilt
+    axis does not matter; at 180 it does (265 mm vs 486 mm), and at 60 degrees it
+    decides whether the depth filter drops anything at all.
+"""
+
+import math
+import sys
+
+W, H = 1080.0, 1920.0          # display-oriented frame
+FX = FY = 1400.0
+CX, CY = W / 2.0, H / 2.0
+DIST = 2.0                     # PERPENDICULAR distance to the wall, metres
+NG = 40                        # 40x40 grid
+FRAC = 0.8                     # central 80% of the frame
+MIN_D, MAX_D = 0.1, 10.0       # backProject's own trust range
+EPS = 1e-6
+
+# PAPER.md 8.1, rotationNeeded=90, tilt about camera Y: mean mm, p95 mm, surviving.
+PAPER_8_1 = {
+    0:  (0,    0,     1600),
+    10: (121,  282,   1600),
+    20: (267,  630,   1600),
+    30: (475,  1154,  1600),
+    40: (834,  2213,  1600),
+    50: (1650, 5260,  1600),
+    60: (2107, 5635,  1280),
+}
+PAPER_8_1_UNFILTERED_60 = (6914, 37386)
+PAPER_8_2 = {0: 0.0, 90: 267.0, 180: 265.0}      # 20 deg obliquity, tilt about Y
+PAPER_8_2_180_X_TILT = 486.0
+
+
+def dot(a, b):
+    return a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+
+
+def rz_transpose_apply(deg, v):
+    """Rz(deg)^T applied to v. The view matrix is camera.pose.inverse(), i.e. the
+    sensor frame, while the rays are built from display-oriented intrinsics. The
+    normal backProject actually dots with is therefore Rz^T n_display."""
+    c, s = math.cos(math.radians(deg)), math.sin(math.radians(deg))
+    # Rz = [[c,-s,0],[s,c,0],[0,0,1]]; Rz^T v = (c*vx + s*vy, -s*vx + c*vy, vz)
+    return (c * v[0] + s * v[1], -s * v[0] + c * v[1], v[2])
+
+
+def grid():
+    lo, hi = (1 - FRAC) / 2, 1 - (1 - FRAC) / 2
+    step = lambda i: lo + (hi - lo) * i / (NG - 1)
+    return [(W * step(i), H * step(j)) for i in range(NG) for j in range(NG)]
+
+
+def errors_mm(obliquity_deg, rotation_deg, axis="y", apply_filter=True):
+    th = math.radians(obliquity_deg)
+    n_d = (math.sin(th), 0.0, -math.cos(th)) if axis == "y" else (0.0, math.sin(th), -math.cos(th))
+    p_d = (0.0, 0.0, DIST / math.cos(th))          # perpendicular distance == DIST
+    n_s = rz_transpose_apply(rotation_deg, n_d)     # what the code dots with
+    num = dot(n_d, p_d)                             # rotation-invariant; same either way
+
+    errs, dropped = [], 0
+    for (u, v) in grid():
+        d = ((u - CX) / FX, (v - CY) / FY, 1.0)
+        den_buggy, den_true = dot(n_s, d), dot(n_d, d)
+        if abs(den_buggy) < EPS or abs(den_true) < EPS:
+            dropped += 1
+            continue
+        t_buggy = num / den_buggy
+        if apply_filter and not (MIN_D <= t_buggy <= MAX_D):
+            dropped += 1                            # exactly what backProject discards
+            continue
+        # Same ray, wrong depth: the error is along d.
+        errs.append(abs(t_buggy - num / den_true) * math.sqrt(dot(d, d)))
+    return errs, dropped
+
+
+def p95(xs):
+    return sorted(xs)[int(math.floor(0.95 * len(xs)))]
+
+
+def main():
+    failures = []
+
+    def check(label, got, want, tol):
+        ok = abs(got - want) <= tol
+        if not ok:
+            failures.append(f"{label}: got {got:.1f}, published {want}")
+        return "ok" if ok else "MISMATCH"
+
+    print("PAPER.md 8.1 — rotationNeeded=90, wall tilted about camera Y, 2 m perpendicular")
+    print(f"{'obliq':>6} {'mean mm':>9} {'p95 mm':>9} {'surviving':>12}  {'vs paper':>9}")
+    for deg, (pm, pp, ps) in PAPER_8_1.items():
+        e, dropped = errors_mm(deg, 90)
+        n = len(e)
+        mean = sum(e) / n
+        v = p95(e)
+        verdict = check(f"8.1 {deg}deg mean", mean * 1000, pm, 1.0)
+        check(f"8.1 {deg}deg p95", v * 1000, pp, 1.0)
+        if n != ps:
+            failures.append(f"8.1 {deg}deg surviving: got {n}, published {ps}")
+        print(f"{deg:>5}° {mean*1000:>9.0f} {v*1000:>9.0f} {n:>6}/{n+dropped}  {verdict:>9}")
+
+    e, _ = errors_mm(60, 90, apply_filter=False)
+    um, up = sum(e) / len(e) * 1000, p95(e) * 1000
+    print(f"\nunfiltered 60°: mean {um:.0f} mm, p95 {up:.0f} mm "
+          f"(published {PAPER_8_1_UNFILTERED_60[0]} / {PAPER_8_1_UNFILTERED_60[1]}) — "
+          f"{check('8.1 unfiltered 60 mean', um, PAPER_8_1_UNFILTERED_60[0], 1.0)}")
+    check("8.1 unfiltered 60 p95", up, PAPER_8_1_UNFILTERED_60[1], 1.0)
+
+    print("\nPAPER.md 8.2 — 20° obliquity, tilt about camera Y")
+    for rot, want in PAPER_8_2.items():
+        e, _ = errors_mm(20, rot)
+        mean = sum(e) / len(e) * 1000
+        print(f"  rotationNeeded={rot:>3}: {mean:>7.1f} mm (published {want}) — "
+              f"{check(f'8.2 rot={rot}', mean, want, 1.0)}")
+
+    e, _ = errors_mm(20, 180, axis="x")
+    mean_x = sum(e) / len(e) * 1000
+    print(f"\n  ...and the same 180° case tilted about X: {mean_x:.1f} mm "
+          f"(published {PAPER_8_2_180_X_TILT}) — "
+          f"{check('8.2 rot=180 X-tilt', mean_x, PAPER_8_2_180_X_TILT, 1.0)}")
+    print("  The tilt axis is load-bearing at 180° and irrelevant at 90°.")
+
+    e_x, drop_x = errors_mm(60, 90, axis="x")
+    print(f"  At 60° about X the filter drops {drop_x} points, not 320 — "
+          f"mean {sum(e_x)/len(e_x)*1000:.0f} mm. EVALUATION.md's E0b "
+          f"'1280 of 1600' prediction assumes the Y tilt.")
+    if drop_x != 0:
+        failures.append(f"60deg X-tilt expected 0 dropped, got {drop_x}")
+
+    if failures:
+        print("\nFAILED:")
+        for f in failures:
+            print("  -", f)
+        return 1
+    print("\nAll published figures reproduced.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/DriftCostProbe.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/DriftCostProbe.kt
@@ -64,9 +64,12 @@ class DriftCostProbe(
      * @param reloc          last relocalization diagnostics, or null when not sampled. Logged so a
      *   null relocalization becomes a diagnosis rather than an absence: NO_FEATURES and FEW_INLIERS
      *   call for opposite fixes and the aggregate error number cannot tell them apart.
-     * @param rotationNeededDeg `(sensorOrientation - displayRotation*90 + 360) % 360` at this tick,
-     *   or -1 if the caller cannot supply it. E0b's independent variable — see
-     *   [EvalSample.rotationNeededDeg] for why it is sampled per tick and not once per run.
+     * @param captureRotationNeededDeg `rotationNeeded` at the moment the ACTIVE TARGET was
+     *   captured, or -1 if unknown. **E0b's independent variable** — the frame mismatch is baked
+     *   into the fingerprint at capture, so this and not [liveRotationNeededDeg] is what results
+     *   must be grouped by. See [EvalSample.captureRotationNeededDeg].
+     * @param liveRotationNeededDeg `rotationNeeded` for this tick — how the device is held right
+     *   now. Secondary; see [EvalSample.liveRotationNeededDeg].
      */
     fun onTick(
         candidatePose: FloatArray,
@@ -75,7 +78,8 @@ class DriftCostProbe(
         stageMs: FloatArray,
         cpuPct: Float,
         reloc: com.hereliesaz.graffitixr.common.model.RelocDiagnostics? = null,
-        rotationNeededDeg: Int = EvalSampleLog.NOT_SAMPLED,
+        captureRotationNeededDeg: Int = EvalSampleLog.NOT_SAMPLED,
+        liveRotationNeededDeg: Int = EvalSampleLog.NOT_SAMPLED,
     ) {
         val file = logFile ?: return
         totalFrames++
@@ -113,7 +117,8 @@ class DriftCostProbe(
             relocDetected = reloc?.detected ?: EvalSampleLog.NOT_SAMPLED,
             relocObliquityDeg = reloc?.obliquityDeg ?: EvalSampleLog.NOT_SAMPLED,
             relocRectifiedCorr = reloc?.rectifiedCorrespondences ?: EvalSampleLog.NOT_SAMPLED,
-            rotationNeededDeg = rotationNeededDeg,
+            captureRotationNeededDeg = captureRotationNeededDeg,
+            liveRotationNeededDeg = liveRotationNeededDeg,
         )
         file.appendText(EvalSampleLog.toCsvRow(sample) + "\n")
 

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/EvalSampleLog.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/EvalSampleLog.kt
@@ -29,20 +29,41 @@ data class EvalSample(
     val relocObliquityDeg: Int = -1,
     val relocRectifiedCorr: Int = -1,
     /**
-     * `(sensorOrientation - displayRotation*90 + 360) % 360` for this tick — 0, 90, 180 or 270.
-     * -1 when not sampled.
+     * `rotationNeeded` **at the moment the active target was captured** — 0, 90, 180 or 270, or -1
+     * when no target has been captured this session (a project restored from disk reads -1; see
+     * below).
      *
-     * This is the independent variable of `EVALUATION.md` **E0b**. Capture rotates the bitmap and
-     * the intrinsics by this angle and leaves the view matrix in ARCore's physical-camera frame
-     * (`Camera.getPose()`), so it is also the exact angle of the frame mismatch `PAPER.md` §8
-     * describes: 0 means no mismatch exists, 90/180/270 mean one does.
+     * **This is the independent variable of `EVALUATION.md` E0b**, and the distinction from
+     * [liveRotationNeededDeg] is the whole point of having two columns. `PlaneMarks.backProject`
+     * runs exactly once per target, inside `MetricFingerprintBuilder.build`, against the capture's
+     * rotated intrinsics and its *unrotated* `camera.pose` view matrix. The frame mismatch
+     * `PAPER.md` §8 describes is therefore **baked into the fingerprint's 3D points at capture** and
+     * cannot change afterwards, however the device is subsequently held.
      *
-     * Per-**row** rather than in the run-identity sidecar, and that is not a stylistic choice. The
-     * app is `screenOrientation="fullUser"`, so the user can rotate the device mid-run and flip the
-     * condition between one CSV row and the next. A single per-run value would be a recorded
-     * average of two conditions, which is worse than no record at all — it would look like data.
+     * A first version of this column logged the live per-tick rotation instead, which is a
+     * different quantity and mislabels the experiment: capture in portrait (skewed fingerprint),
+     * then relocalize in landscape, and every defect-bearing row is filed under 0 — the *control*
+     * condition — so a real §8 effect averages toward nothing and reads as a falsification. The
+     * justification given for per-tick sampling was that `screenOrientation="fullUser"` lets the
+     * user rotate mid-run and flip the condition; rotating mid-run does not flip the condition,
+     * because the fingerprint was already built. That is precisely the case it labels wrongly.
+     *
+     * Known gap: the renderer only observes a capture it performed, so a target restored from a
+     * saved project reads -1 rather than its original rotation. -1 is honest there; a 0 would not
+     * be. Persisting this on `Fingerprint` is `IMPLEMENTATION.md` todo 0.7.
      */
-    val rotationNeededDeg: Int = -1,
+    val captureRotationNeededDeg: Int = -1,
+    /**
+     * `(sensorOrientation - displayRotation*90 + 360) % 360` for *this tick* — how the device is
+     * being held right now, during relocalization. -1 when not sampled.
+     *
+     * Secondary. It is **not** E0b's independent variable (see [captureRotationNeededDeg]), and
+     * grouping by it is the mistake this pair of columns exists to prevent. It is logged because
+     * the live path has frame handling of its own — the reloc feed is rotated by `cvRotateCode`
+     * while `mappingProjMatrix` is built from *unrotated* `imageIntrinsics` — so a run where the
+     * two columns disagree is the one worth looking at twice.
+     */
+    val liveRotationNeededDeg: Int = -1,
 )
 
 object EvalSampleLog {
@@ -61,7 +82,7 @@ object EvalSampleLog {
         "cpuPct", "batteryMa", "tempC", "nativeHeapKb",
         "relocReject", "relocMatches", "relocInliers", "relocDetected",
         "relocObliquityDeg", "relocRectifiedCorr",
-        "rotationNeededDeg",
+        "captureRotationNeededDeg", "liveRotationNeededDeg",
     )
 
     const val NOT_SAMPLED = -1
@@ -79,7 +100,7 @@ object EvalSampleLog {
             s.relocReject.toString(), s.relocMatches.toString(),
             s.relocInliers.toString(), s.relocDetected.toString(),
             s.relocObliquityDeg.toString(), s.relocRectifiedCorr.toString(),
-            s.rotationNeededDeg.toString(),
+            s.captureRotationNeededDeg.toString(), s.liveRotationNeededDeg.toString(),
         )
     }
 

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -324,7 +324,29 @@ class ArRenderer(
     @Volatile private var cameraNotFeedingReported = false
     var onCameraNotFeeding: (() -> Unit)? = null
     private var watchdog: Thread? = null
-    private var sensorOrientation = 90
+    // Written under `sessionLock` off the GL thread (attachSession, and its catch fallback) and
+    // read on the GL thread without it, so it needs the visibility guarantee. It was a plain var:
+    // no happens-before, so the GL thread could keep observing the initializer on a device where
+    // the real value is 270. That now decides an eval column's value, not just a rotation.
+    //
+    // The initializer is also the commonest real value AND the exception fallback, so a
+    // getCameraCharacteristics failure yields a plausible, indistinguishable reading. Not changed
+    // here — every rotation consumer would need a "sensor orientation unknown" path — but recorded
+    // because `captureRotationNeededDeg` inherits it, and E0b's attributability rests on it.
+    @Volatile private var sensorOrientation = 90
+
+    /**
+     * `rotationNeeded` at the moment the active target was captured, or [NOT_SAMPLED] if this
+     * renderer has not performed a capture. **E0b's independent variable**; see
+     * `EvalSample.captureRotationNeededDeg`. Set where the capture's geometry is fixed, not where
+     * the eval tick happens to run.
+     *
+     * Stays [NOT_SAMPLED] for a target restored from a saved project — the renderer never saw that
+     * capture. That is the honest reading; a 0 would silently file it as E0b's control condition.
+     */
+    @Volatile
+    private var lastCaptureRotationNeededDeg =
+        com.hereliesaz.graffitixr.feature.ar.eval.EvalSampleLog.NOT_SAMPLED
     private var isSurfaceCreated = false
 
     private var lastPoseX = 0f
@@ -1193,12 +1215,16 @@ class ArRenderer(
                         // FloatArrays per tick. (An earlier comment here said "four atomics", which
                         // was neither the count nor the mechanism.)
                         reloc = slamManager.getRelocDiagnostics(),
-                        // E0b's independent variable, recomputed here by the same expression the
-                        // capture path uses (ArRenderer's capture block) so the logged condition is
-                        // the condition that was actually in force. Sampled every tick because
-                        // `screenOrientation="fullUser"` lets the device rotate mid-run: one CSV can
-                        // straddle both conditions, and a per-run value would silently average them.
-                        rotationNeededDeg =
+                        // E0b's independent variable is the rotation that was in force AT CAPTURE,
+                        // because that is the one baked into the fingerprint's 3D points. Sampling
+                        // the live rotation here instead — which an earlier version of this call
+                        // did — files a portrait-captured, landscape-relocalized run under 0, the
+                        // control condition, and turns a real effect into a null result.
+                        captureRotationNeededDeg = lastCaptureRotationNeededDeg,
+                        // The live rotation is still logged, as a secondary signal: the reloc feed
+                        // has frame handling of its own, so rows where the two disagree are the
+                        // ones worth a second look.
+                        liveRotationNeededDeg =
                             (sensorOrientation - displayRotationHelper.getRotation() * 90 + 360) % 360,
                     )
                 }
@@ -1284,6 +1310,12 @@ class ArRenderer(
 
                         val displayDegrees = displayRotationHelper.getRotation() * 90
                         val rotationNeeded = (sensorOrientation - displayDegrees + 360) % 360
+                        // Recorded HERE, where the capture's geometry is decided, because this is
+                        // the angle that gets baked into the fingerprint: backProject runs once
+                        // per target inside MetricFingerprintBuilder.build, against these rotated
+                        // intrinsics and an unrotated camera.pose view matrix. However the device
+                        // is held afterwards, the skew in those 3D points does not change.
+                        lastCaptureRotationNeededDeg = rotationNeeded
 
                         var depthBuffer: ByteBuffer? = null
                         var depthWidth = 0

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/eval/EvalSampleLogTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/eval/EvalSampleLogTest.kt
@@ -40,7 +40,8 @@ class EvalSampleLogTest {
             "tsMs,deviceClass,marksVisible,errMm,errDeg,jitterMm,availability," +
                 "voxelUpdateMs,voxelKeyframeMs,surfaceMeshMs,drawMs,pnpRelocMs,cpuPct,batteryMa,tempC," +
                 "nativeHeapKb,relocReject,relocMatches,relocInliers,relocDetected," +
-                "relocObliquityDeg,relocRectifiedCorr,rotationNeededDeg",
+                "relocObliquityDeg,relocRectifiedCorr," +
+                "captureRotationNeededDeg,liveRotationNeededDeg",
             EvalSampleLog.CSV_HEADER,
         )
     }
@@ -55,7 +56,7 @@ class EvalSampleLogTest {
         )
         assertEquals(
             "12,dual,true,1.5,0.25,3.0,1.0,2.0,0.0,4.0,1.0,8.0,30.0,-450.0,31.0,20480," +
-                "-1,-1,-1,-1,-1,-1,-1",
+                "-1,-1,-1,-1,-1,-1,-1,-1",
             EvalSampleLog.toCsvRow(row),
         )
     }
@@ -202,8 +203,49 @@ class EvalSampleLogTest {
      */
     @Test
     fun `rotationNeeded reaches its own column`() {
-        val fields = EvalSampleLog.fields(sample().copy(rotationNeededDeg = 90))
-        assertEquals("90", fields[EvalSampleLog.COLUMNS.indexOf("rotationNeededDeg")])
+        val fields = EvalSampleLog.fields(sample().copy(captureRotationNeededDeg = 90))
+        assertEquals("90", fields[EvalSampleLog.COLUMNS.indexOf("captureRotationNeededDeg")])
+    }
+
+    /**
+     * The defect this pair of columns was split to fix, pinned as a test.
+     *
+     * `PlaneMarks.backProject` runs once per target inside `MetricFingerprintBuilder.build`, so
+     * §8's frame mismatch is baked into the fingerprint's 3D points **at capture**. E0b's
+     * independent variable is therefore the capture rotation, and the live rotation is a different
+     * quantity that can legitimately differ from it on the very same row.
+     *
+     * The scenario below is the one a single column got wrong: captured in portrait (skewed
+     * fingerprint), relocalized in landscape. Collapsing these two into one value files this row
+     * under 0 — E0b's *control* condition — and a genuine effect averages toward nothing, which is
+     * indistinguishable from the falsification E0b is supposed to be able to report.
+     */
+    @Test
+    fun `a portrait capture relocalized in landscape keeps both rotations distinct`() {
+        val fields = EvalSampleLog.fields(
+            sample().copy(captureRotationNeededDeg = 90, liveRotationNeededDeg = 0),
+        )
+        val capture = fields[EvalSampleLog.COLUMNS.indexOf("captureRotationNeededDeg")]
+        val live = fields[EvalSampleLog.COLUMNS.indexOf("liveRotationNeededDeg")]
+        assertEquals("the fingerprint was built under the mismatch", "90", capture)
+        assertEquals("the device is held square right now", "0", live)
+        assertTrue(
+            "grouping E0b by the live rotation would file this defect-bearing row as the control",
+            capture != live,
+        )
+    }
+
+    /**
+     * A target restored from a saved project was never captured by this renderer, so its rotation
+     * is genuinely unknown. It must read as unknown and not as landscape — `-1` excludes the row
+     * from E0b's grouping, `0` would silently enrol it in the control arm.
+     */
+    @Test
+    fun `an unobserved capture reads unknown, never as the landscape control`() {
+        val fields = EvalSampleLog.fields(sample().copy(liveRotationNeededDeg = 0))
+        assertEquals(
+            "-1", fields[EvalSampleLog.COLUMNS.indexOf("captureRotationNeededDeg")],
+        )
     }
 
     /**
@@ -215,9 +257,9 @@ class EvalSampleLogTest {
      */
     @Test
     fun `rotationNeeded zero is the landscape control, not a missing value`() {
-        val landscape = EvalSampleLog.fields(sample().copy(rotationNeededDeg = 0))
+        val landscape = EvalSampleLog.fields(sample().copy(captureRotationNeededDeg = 0))
         val unsampled = EvalSampleLog.fields(sample())
-        val i = EvalSampleLog.COLUMNS.indexOf("rotationNeededDeg")
+        val i = EvalSampleLog.COLUMNS.indexOf("captureRotationNeededDeg")
         assertEquals("0", landscape[i])
         assertEquals("-1", unsampled[i])
         assertTrue("the control condition must not read as absent", landscape[i] != unsampled[i])

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Fri Jul 31 22:23:25 UTC 2026
-versionBuild=14220
+#Fri Jul 31 22:44:09 UTC 2026
+versionBuild=14222
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=86
+versionPatch=88


### PR DESCRIPTION
Follow-up to #1794. An adversarial audit of that PR found that the one piece of code it shipped for E0b logs the **wrong quantity**, in a way that would have inverted the experiment's central case. This fixes that, plus the doc overclaims the same audit caught.

## The defect

`captureRotationNeededDeg` vs the merged `rotationNeededDeg`: E0b's independent variable is the display rotation in force **at capture**, not per eval tick.

`PlaneMarks.backProject` runs exactly once per target, inside `MetricFingerprintBuilder.build`, against the capture's rotated intrinsics and its *unrotated* `camera.pose` view matrix. The frame mismatch is therefore **baked into the fingerprint's 3D points at capture** and cannot change afterwards, however the device is subsequently held.

The failure case is E0b's own method — "capture a target in landscape, then in portrait … *then* attempt relocalization":

> Capture in portrait (`rotationNeeded == 90`, fingerprint skewed). Rotate to landscape. Relocalize. **Every defect-bearing row logs `0`** — which `EvalSampleLog` documents as "no mismatch exists" and `EVALUATION.md` calls the control condition.

A real §8 effect then averages toward nothing, which `EVALUATION.md` itself says "reads exactly like a negative result". The instrumentation could have falsified §8 on its own.

The justification I gave for per-tick sampling was self-defeating: that `screenOrientation="fullUser"` lets the user rotate mid-run and flip the condition between rows. Rotating mid-run does **not** flip the condition, because the fingerprint was already built — that is precisely the case per-tick sampling labels wrongly.

## The fix

Two columns, because they are two quantities:

| Column | What it is |
|---|---|
| `captureRotationNeededDeg` | **E0b's independent variable.** Recorded in the capture block where the geometry is decided. Group by this. |
| `liveRotationNeededDeg` | How the device is held *now*. Secondary — the reloc feed rotates its YUV while `mappingProjMatrix` is built from unrotated `imageIntrinsics`, so rows where the two disagree are worth a second look. |

A target restored from a saved project reads `-1`, not `0` — the renderer never observed that capture, and `-1` excludes it from grouping where `0` would enrol it in the control arm. Persisting on `Fingerprint` is todo 0.7.

`sensorOrientation` is now `@Volatile`. It is written under `sessionLock` off the GL thread and read on the GL thread without it, so there was no happens-before and the GL thread could keep observing the initializer on a device where the real value is 270. It now decides an eval column. Its default (90) is *also* the commonest real value *and* the `getCameraCharacteristics` failure fallback — not changed here, but recorded in the code, because E0b's attributability rests on it.

## Doc corrections, same audit

- **§8.1 claimed the recomputation was "independent, from the geometry rather than from `backProject`'s code path". It was not.** It evaluates $t = (n \cdot p)/(n \cdot d)$ for both frames, so a sign error *in the model of the mismatch* reproduces the table exactly. It confirms the sampling and statistics — where the earlier 3.3× error lived — not the geometry. `PlaneMarksObliquityTest` already states this standard and rejects an earlier version of *itself* for failing it.
- **"the frames provably differ by exactly the rotation the model uses"** overstated the documentation, which says "a multiple of 90°" without saying *which* multiple. `EVALUATION.md` contradicted itself three lines later by listing that same identification as a live fallback. Both softened; the narrower claim that §8.2's escape hatch is closed stands.
- **E0b told the runner to expect "1280 of 1600 points surviving at 60°"** as a directly measurable check, without the tilt qualifier the same commit added to §8.1. Tilted about X instead of Y, the identical defect drops **nothing at all** at 60°. A runner tilting the other way would have recorded a falsification that was a convention mismatch.
- **README said Phase 6a "landed"** — 6a.4 is unchecked and `ArViewModel` still passes `rngSeed = null, syncReloc = false`. Now stated as three of four.
- README's rewrite **contradicted `IMPLEMENTATION.md`'s "Nothing below Phase 0 is built"**, which was itself stale. Reconciled.
- §8.1's cross-reference said 6913 where the table cell says 6914.
- `EVALUATION.md`'s "contrary to the cost line below" described the pre-edit state of a line the same commit had changed.

## Retained artifact

Adds `docs/research/reproduce_8_1.py` — run and passing, asserting every published figure and exiting non-zero on mismatch. §8.1's own opening complaint is that a number was asserted with no measurement retained; the correction then asserted a *reproduction* with none retained either. Its header is explicit that it confirms the sampling, not the geometry.

## Not fixable

#1794's commit message and PR body cite `ArRenderer.kt:1279` and `:1311-1324`. Those are the **pre-commit** line numbers — that commit inserted 7 lines above both sites, so at `de45fa8` they are `:1286` and `:1318-1331`. The single sentence boasting about correcting line-number drift reintroduced it. Both are immutable now; recorded in the commit message instead.

## Testing

`:feature:ar:testDebugUnitTest` — **172 tests, 0 failures**. `:app:compileDebugKotlin` green. Two new tests pin the capture/live distinction directly, including the portrait-capture/landscape-relocalize row that a single column got wrong.

E0b itself **still has not run** — it needs a physical ARCore device, and nothing here presupposes its outcome. Phase 0 remains unimplemented and `PlaneMarksObliquityTest`'s characterization tests remain uninverted.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Q5WXFiVLeN4sXa9bPCSDA)_

## Summary by Sourcery

Correct E0b’s telemetry to log display rotation at capture as the experiment’s independent variable, distinguish it from live device rotation, and align documentation and reproducibility artifacts with this interpretation.

New Features:
- Add separate CSV columns for capture-time and live display rotation to support correct grouping of E0b results.
- Introduce a reproducibility script that recomputes PAPER.md §8.1 and §8.2 tables and asserts them against published figures.

Bug Fixes:
- Fix E0b’s logging to avoid mislabeling defect-bearing rows as the control condition by using capture-time rotation rather than per-tick live rotation.
- Ensure targets restored from saved projects are treated as having unknown capture rotation so they are excluded from E0b grouping instead of silently joining the control set.
- Make sensor orientation volatile to guarantee correct rotation computation across threads when deciding evaluation columns.

Enhancements:
- Clarify the semantic roles of capture and live rotation in evaluation telemetry and tests, explicitly encoding the portrait-capture/landscape-relocalize scenario.
- Strengthen tests around rotation logging to pin the capture/live distinction and the landscape control vs missing-value semantics.

Documentation:
- Revise EVALUATION.md, PAPER.md, README.md, and IMPLEMENTATION.md to accurately describe E0b’s independent variable, the limits of the §8.1 recomputation, the wall-tilt conventions, and the current phase/implementation status.