### PR TITLE
docs: E0b tests nothing unless the Depth API is off first

### DIFF
--- a/docs/research/EVALUATION.md
+++ b/docs/research/EVALUATION.md
@@ -333,6 +333,47 @@ in landscape, then in portrait, same wall, same obliquity; then attempt
 relocalization from the same standing positions for each. Compare inlier ratio
 and lock rate.
 
+**Precondition — turn the Depth API OFF, or E0b does not test §8 at all.**
+`MainViewModel.onConfirmTargetCreation` branches on whether a depth buffer was
+captured, and the two branches do not share a line of geometry:
+
+| Depth API | Capture path | Reaches `PlaneMarks.backProject`? |
+|---|---|---|
+| **off** | `handleSingleCapture` → `MetricFingerprintBuilder` | **yes — this is §8's path** |
+| on | `SlamManager.setWallFingerprint` → native `generateFingerprint` | no; 3D comes from the depth image |
+
+`depthApiEnabled` follows the `useArCoreDepthApi` setting (`ArViewModel`), and
+`ArRenderer` only populates the buffer when it is on. So on a depth-capable
+device with the setting left on, **`backProject` never runs during E0b** and a
+result either way says nothing about §8.
+
+Worse, it will not *look* uninformative. The depth path has an orientation
+dependence of its own, and it also singles out landscape. `generateFingerprint`
+(`MobileGS.cpp`) unprojects keypoints with the supplied `intr` and maps them to
+the depth image by linear scaling `depthW/image.cols`, so the bitmap, the depth
+image and the intrinsics must all be in one frame. The depth buffer is ARCore's
+raw sensor-frame image; the intrinsics handed over are the *display-rotated*
+`intrArr`, in every orientation; and the bitmap is conditionally un-rotated by a
+**hardcoded `postRotate(-90f)`** (`MainViewModel.kt:188`) gated on
+`isPortrait && height > width`. Working the four cases at
+$\text{sensorOrientation} = 90$:
+
+| display | `rotationNeeded` | bitmap after the fixup | intrinsics | consistent |
+|---|---|---|---|---|
+| `ROTATION_90` | 0 | sensor frame | unrotated | **yes** |
+| `ROTATION_0` | 90 | sensor frame (−90 is right here) | 90-rotated | no |
+| `ROTATION_180` | 270 | **180° off** (−90 applied, −270 needed) | 270-rotated | no |
+| `ROTATION_270` | 180 | **180° off** (no fixup fires) | 180-rotated | no |
+
+So a depth-path E0b run shows landscape working and portrait failing — the exact
+signature §8 predicts — for an entirely unrelated reason. Running E0b with depth
+on and reading the result as confirmation would be the strongest-looking evidence
+in the programme and would be measuring the wrong defect.
+
+This is unfixed and deliberately so: correcting it changes capture geometry with
+no experiment gating it, and §8.3's warning applies — every rotation sign has to
+be right or the overlay lands worse than today.
+
 **Reasoning.** The cheapest experiment in the document, and the independent
 variable is how you hold the phone. Do it *first*, before any of Phase 0's
 engineering — a negative result cancels that engineering entirely.

--- a/docs/research/PAPER.md
+++ b/docs/research/PAPER.md
@@ -653,6 +653,29 @@ assumed, or that `rotationNeeded` is not what the device actually computes. Thos
 are the hypotheses to carry into a negative result, and they are not
 interchangeable with the one that was written here.
 
+### 8.2b A second frame inconsistency, on the path §8 does not describe
+
+Everything above concerns the no-depth capture path, the one that reaches
+`PlaneMarks.backProject`. `MainViewModel.onConfirmTargetCreation` branches on
+whether a depth buffer was captured, and the depth branch does not call
+`backProject` at all — it hands the bitmap, the depth image and the intrinsics to
+native `generateFingerprint`, which unprojects keypoints with the supplied
+intrinsics and indexes the depth image by linear scaling. All three must
+therefore share a frame. They do not: the depth buffer is ARCore's raw
+sensor-frame image, the intrinsics are the display-rotated `intrArr` in every
+orientation, and the bitmap is conditionally un-rotated by a hardcoded
+`postRotate(-90f)` gated on `isPortrait && height > width` — correct only when
+$\text{rotationNeeded} = 90$, and leaving the bitmap a half-turn from the sensor
+frame at 180 and 270.
+
+This matters here for one reason: it also makes landscape the only clean
+orientation, by an unrelated mechanism. Any device test that does not first
+disable the Depth API therefore reproduces §8's predicted *signature* without
+exercising §8's *code*. `EVALUATION.md` E0b carries this as a precondition.
+
+It is recorded and not fixed. Correcting it changes capture geometry with no
+experiment gating it, and §8.3 applies to it as much as to the main defect.
+
 ### 8.3 Why the correction is not local
 
 Rotating the capture view moves $F$ into the rotated frame, while `PoseFusion`

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Fri Jul 31 22:56:13 UTC 2026
-versionBuild=14223
+#Sat Aug 01 01:03:57 UTC 2026
+versionBuild=14224
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=89
+versionPatch=90


### PR DESCRIPTION
Follow-up to #1794 / #1795. The audit of #1794 left one unverified lead — a hardcoded `postRotate(-90f)` on the depth capture path. I chased it, and it is worse than a stray constant: **E0b as written can reproduce its own predicted signature without exercising any of the code §8 describes.**

Documentation only. Nothing is fixed here, deliberately — see the last section.

## The two capture paths share no geometry

`MainViewModel.onConfirmTargetCreation` branches on whether a depth buffer was captured:

| Depth API | Capture path | Reaches `PlaneMarks.backProject`? |
|---|---|---|
| **off** | `handleSingleCapture` → `MetricFingerprintBuilder` | **yes — §8's path** |
| on | `SlamManager.setWallFingerprint` → native `generateFingerprint` | no; 3D comes from the depth image |

`depthApiEnabled` follows the `useArCoreDepthApi` setting, and `ArRenderer` only fills the buffer when it is on. So on a depth-capable device with that setting left on, `backProject` never runs during E0b and neither outcome bears on §8.

## The trap: the wrong path fails the same way

It will not look uninformative. The depth path has an orientation dependence of its own, and it *also* singles out landscape.

Verified against the native contract (`MobileGS.cpp`): `generateFingerprint` unprojects keypoints with the supplied `intr` and indexes the depth image by linear scaling `depthW / image.cols`, so the bitmap, the depth image and the intrinsics must all share one frame. They do not:

- the depth buffer is ARCore's **raw sensor-frame** image;
- the intrinsics are the **display-rotated** `intrArr`, in every orientation;
- the bitmap is conditionally un-rotated by a hardcoded **`postRotate(-90f)`** (`MainViewModel.kt:188`), gated on `isPortrait && height > width`.

At `sensorOrientation = 90`:

| display | `rotationNeeded` | bitmap after the fixup | intrinsics | consistent |
|---|---|---|---|---|
| `ROTATION_90` | 0 | sensor frame | unrotated | **yes** |
| `ROTATION_0` | 90 | sensor frame (−90 is right here) | 90-rotated | no |
| `ROTATION_180` | 270 | **180° off** (−90 applied, −270 needed) | 270-rotated | no |
| `ROTATION_270` | 180 | **180° off** (guard never fires) | 180-rotated | no |

The `-90` is correct only at `rotationNeeded = 90`. At 270 it under-rotates by a half turn; at 180 the guard doesn't fire at all, because the bitmap stays landscape-shaped.

**Landscape one way is again the only clean case, by a completely unrelated mechanism.** A depth-path E0b run therefore shows landscape working and portrait failing — precisely §8's predicted signature — while measuring a different defect. Read as confirmation it would be the strongest-looking evidence in the programme, and it would be wrong.

## Not fixed, on purpose

Correcting the depth path changes capture geometry with no experiment gating it, and §8.3's warning applies to it as much as to the main defect: every rotation sign has to be right or the overlay lands worse than today. It wants its own experiment, not a drive-by patch alongside a documentation change.

Recorded as an E0b **precondition** in `EVALUATION.md` and as **§8.2b** in `PAPER.md`.

## Testing

Docs only. `:feature:ar:testDebugUnitTest` green; `docs/research/reproduce_8_1.py` still passes.

E0b still has not run — it needs a physical ARCore device. Phase 0 remains unimplemented and the characterization tests uninverted.

> Note: I first pushed this to a stray branch name (`claude/e0b-depth-path-confounder`) before moving it to the designated branch. Both refs point at this same commit; the proxy blocks ref deletion, so the stray needs removing via the GitHub UI.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Q5WXFiVLeN4sXa9bPCSDA)_

## Summary by Sourcery

Document the depth-path frame inconsistency and clarify that E0b only exercises §8 when the Depth API is disabled, without changing runtime behavior.

Build:
- Increment version build and patch numbers in version.properties.

Documentation:
- Clarify in EVALUATION.md that E0b requires the Depth API to be turned off and explain how the depth capture path can mimic §8’s signature without exercising its code.
- Add §8.2b to PAPER.md describing a separate frame inconsistency in the depth capture path and its impact on experimental interpretation.