### PR TITLE
Retract the 0.6 claim; Phase 0 checked one factor and declared three sound

### DIFF
--- a/docs/TELEOLOGICAL_SLAM.md
+++ b/docs/TELEOLOGICAL_SLAM.md
@@ -115,13 +115,22 @@ Two details make this fit the observed "never locks" behaviour:
 - The onboarding doodle path (`buildDoodleFingerprint`) uses the identical
   convention, so it would fail the same way.
 
-Why it was not simply fixed: rotating the capture view is not sufficient on its
-own. The 3D points would then live in the rotated camera frame, while
-`PoseFusion.composeCorrected` composes `inverse(V_current) · pnp · fpAnchor` with
-`V_current` in ARCore's **unrotated** frame — so the composition needs the same
-treatment, and the sign of every rotation has to be right or the overlay lands
-worse than it does now. That is a system-wide convention change and wants device
-evidence first.
+**RESOLVED — Phase 0 (PR #1797).** The description above is of the pre-fix code;
+the algebra in it is correct and matches the fix's independently-derived direction
+(`d' = R_z(+90)·d`). `MetricMarks.glViewToCvDisplay` now rotates the capture view
+to match the pixels and intrinsics, and `MetricFingerprintBuilder.buildSingle`
+routes through it.
+
+The reason given here for not simply fixing it was wrong on its central point.
+It claimed `V_current` is in ARCore's *unrotated* frame; it is not —
+`Camera.getViewMatrix` is documented as incorporating display orientation. The
+live side was already display-oriented, so the composition needed no rotation
+change, and the fix was one matrix at one site rather than the system-wide
+rotation change feared here.
+
+`composeCorrected` does still have frame defects, but they are GL-vs-CV
+convention and a missing capture-view factor, not rotation — see
+`docs/research/IMPLEMENTATION.md` 0.6/0.9.
 
 **How to tell:** with the Diagnostic Overlay on, a healthy match count and a
 **low inlier ratio** points here. `NO TARGET` / `NO FEATURES` / a low in-frame

--- a/docs/research/EVALUATION.md
+++ b/docs/research/EVALUATION.md
@@ -333,6 +333,22 @@ in landscape, then in portrait, same wall, same obliquity; then attempt
 relocalization from the same standing positions for each. Compare inlier ratio
 and lock rate.
 
+> [!CAUTION]
+> **E0b is no longer runnable on `main`.** Phase 0 landed (PR #1797) and removed the
+> landscape-vs-portrait difference that *is* E0b's independent variable. Run on
+> tip-of-tree, E0b now returns "identical behaviour in both orientations" — which
+> the **Falsifies** clause below instructs the reader to read as a refutation of
+> §8. It would be nothing of the sort; it would be the fix working.
+>
+> To run E0b as designed, check out a build from **before** Phase 0 (`main` at
+> `e9de3c5` or earlier, i.e. any commit preceding the `glViewToCvDisplay` routing
+> in `MetricFingerprintBuilder.buildSingle`).
+>
+> This is the cost of landing Phase 0 ahead of its own go/no-go, which was a
+> deliberate call — but it was not recorded when the call was made, and a device
+> session spent on tip-of-tree would have produced a confident falsification of a
+> defect that had just been repaired.
+
 **Precondition — turn the Depth API OFF, or E0b does not test §8 at all.**
 `MainViewModel.onConfirmTargetCreation` branches on whether a depth buffer was
 captured, and the two branches do not share a line of geometry:

--- a/docs/research/IMPLEMENTATION.md
+++ b/docs/research/IMPLEMENTATION.md
@@ -744,7 +744,7 @@ order.** Work top to bottom.
       `targetCaptureViewMatrix` in `ArViewModel`, `fingerprintViewMatrix` in
       `MainViewModel`, and `restoreWallFingerprintMetric`'s `viewMatrix16`.
       List each site in the commit message with its verdict.
-- [x] **0.6** Confirm `PoseFusion.composeCorrected` is consistent under the chosen
+- [ ] **0.6** Confirm `PoseFusion.composeCorrected` is consistent under the chosen
       convention. `PoseFusionTest` now pins the factor order with non-commuting
       operands; extend it for the rotation, not with another round-trip (a
       round-trip is order-insensitive and would pass either way). **[T]**
@@ -759,6 +759,51 @@ order.** Work top to bottom.
       obliquities × four rotations, through the real converter rather than a hand-built
       mismatch, with a negative control asserting the old wiring still fails on the same
       fixture. The rotation direction is mutation-tested: transposing `R_z` fails 8 tests.
+
+      **0.6 WAS TICKED AND IS NOW UN-TICKED.** The rotation half of it is settled —
+      `vCurrent` is `Camera.getViewMatrix`, documented as display-oriented, so
+      convention B genuinely does align the two sides *for rotation*. But the audit
+      found `composeCorrected` is missing two further factors that have nothing to do
+      with rotation, and the original tick declared the whole expression sound on the
+      strength of checking the one thing it went looking for. Trace of
+      `inv(vCurrent) · pnpMat · fpAnchor`:
+
+      - `vCurrent` — world → live camera, **GL** convention (−Z forward).
+      - `pnpMat` — raw `solvePnPRansac` output (`MobileGS.cpp:528-535`), **CV**
+        convention (+Z), mapping `objPts` → live camera.
+      - `objPts` = `mWallKeypoints3D` = `PlaneMarks.backProject`'s `pointsCam`, which
+        are in the **capture camera's** frame, not a world frame — despite the native
+        field being named `mPnpCamFromFpWorld`.
+      - `fpAnchor` = `mFingerprintAnchorMatrix` = `getAnchorTransform()`, which
+        `MobileGS.cpp:525`'s own comment calls "a world-space MODEL matrix".
+
+      So world coordinates are fed into a map whose domain is capture-camera
+      coordinates, and CV camera coordinates into a GL camera-to-world inverse. The
+      chain needs `inv(V_cur_gl) · C · pnpMat · V_capture_cv · fpAnchor` with
+      `C = diag(1,−1,−1)`. Both `C` and `V_capture_cv` are absent. The codebase knows
+      about `C`: `MobileGS.cpp:600-604` applies exactly it in `computeRectifyHomography`,
+      commented *"Without this the homography is meaningless."*
+
+      This is **pre-existing**, not introduced by Phase 0, and it is not a rotation
+      problem — which is why looking only for rotation missed it.
+
+- [ ] **0.9** Fix `composeCorrected`'s GL/CV and capture-view factors (see 0.6). Needs
+      its own experiment: it changes where the overlay lands, and §8.3's warning about
+      getting every sign right applies with full force. Do not fold it into a
+      rotation commit. **[T]**
+- [ ] **0.10** `MetricFingerprintBuilder.ingestSingle` stores display-frame
+      `res.pointsCam` alongside the **un-rotated** `glView` in the same
+      `restoreWallFingerprintMetric` call. Native pairs them in
+      `computeRectifyHomography` (`viewFp` at `MobileGS.cpp:571`, `mWallKeypoints3D`
+      at `:576`), so the rectifying homography is off by `R_z` on the fingerprint
+      side. This is a **live** gap in the path Phase 0 just fixed, not a legacy-data
+      gap — it was mis-filed under 0.7 in PR #1797. In GL convention the matching
+      rotation is `R_z(−θ)`, since `D·R_z(θ)·D = R_z(−θ)` for `D = diag(1,−1,−1)`.
+      **[T]**
+- [ ] **0.11** Persist `captureRotationDeg` in `GraffitiProject` at save time.
+      Without it, projects captured *after* Phase 0 — the correct ones — are
+      indistinguishable on disk from legacy ones, so 0.7's "refuse to reload a legacy
+      fingerprint" would reject them too.
 
 ### Phase 2 — partition the fingerprint
 

--- a/docs/research/PAPER.md
+++ b/docs/research/PAPER.md
@@ -679,10 +679,24 @@ experiment gating it, and §8.3 applies to it as much as to the main defect.
 ### 8.3 Why the correction is not local
 
 Rotating the capture view moves $F$ into the rotated frame, while `PoseFusion`
-composes $V_{\text{cur}}^{-1} \cdot \text{pnp} \cdot T$ with $V_{\text{cur}}$
-unrotated — so the composition needs the matching change, and every rotation
-sign must be right or the overlay lands worse than today. This is a system-wide
-convention change.
+composes $V_{\text{cur}}^{-1} \cdot \text{pnp} \cdot T$. **Correction, from
+Phase 0:** this section asserted $V_{\text{cur}}$ was *unrotated*, and it is not.
+$V_{\text{cur}}$ is `Camera.getViewMatrix`, which ARCore documents as
+*"incorporates the display orientation … equivalent to
+`getDisplayOrientedPose().inverse()`"*. The live side was **already** in the
+display frame; capture was the odd one out. That is what makes convention B the
+consistent choice rather than merely a self-consistent one, and it means the
+composition needed no rotation change.
+
+It does, however, need other changes this section did not see. Tracing every
+operand found `pnpMat` in OpenCV convention against a GL-convention
+$V_{\text{cur}}$, and `pnpMat`'s domain the *capture camera* frame against an
+`fpAnchor` that is a world-space model matrix — so two factors are missing that
+have nothing to do with rotation. See `IMPLEMENTATION.md` 0.6/0.9. The warning
+below still stands and now applies to those.
+
+Every rotation sign must be right or the overlay lands worse than today. This is
+a system-wide convention change.
 
 **It is a prerequisite, not a parallel task.** Every 3D quantity in Approach B —
 $\Phi$, the partition, geometric stability, the offset fit — is built on

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/EvalSampleLog.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/EvalSampleLog.kt
@@ -35,10 +35,14 @@ data class EvalSample(
      *
      * **This is the independent variable of `EVALUATION.md` E0b**, and the distinction from
      * [liveRotationNeededDeg] is the whole point of having two columns. `PlaneMarks.backProject`
-     * runs exactly once per target, inside `MetricFingerprintBuilder.build`, against the capture's
-     * rotated intrinsics and its *unrotated* `camera.pose` view matrix. The frame mismatch
-     * `PAPER.md` §8 describes is therefore **baked into the fingerprint's 3D points at capture** and
-     * cannot change afterwards, however the device is subsequently held.
+     * runs exactly once per target, inside `MetricFingerprintBuilder.buildSingle`, so whatever frame
+     * relationship holds at capture is **baked into the fingerprint's 3D points** and cannot change
+     * afterwards, however the device is subsequently held. That is why the capture rotation, not the
+     * live one, is the variable to group by.
+     *
+     * Note the §8 mismatch this column was built to measure is **fixed as of Phase 0** — the capture
+     * view is now rotated to match the intrinsics. The column is still the right one: it records the
+     * condition a fingerprint was built under, which is what any before/after comparison needs.
      *
      * A first version of this column logged the live per-tick rotation instead, which is a
      * different quantity and mislabels the experiment: capture in portrait (skewed fingerprint),

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -1312,8 +1312,8 @@ class ArRenderer(
                         val rotationNeeded = (sensorOrientation - displayDegrees + 360) % 360
                         // Recorded HERE, where the capture's geometry is decided, because this is
                         // the angle that gets baked into the fingerprint: backProject runs once
-                        // per target inside MetricFingerprintBuilder.build, against these rotated
-                        // intrinsics and an unrotated camera.pose view matrix. However the device
+                        // per target inside MetricFingerprintBuilder.buildSingle, against these rotated
+                        // intrinsics and a view matrix now rotated to match (Phase 0). However the device
                         // is held afterwards, the skew in those 3D points does not change.
                         lastCaptureRotationNeededDeg = rotationNeeded
 

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/PoseFusionTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/PoseFusionTest.kt
@@ -44,58 +44,49 @@ class PoseFusionTest {
     }
 
     /**
-     * `IMPLEMENTATION.md` **0.6** — `composeCorrected` under convention B.
+     * `IMPLEMENTATION.md` **0.6**, honestly scoped.
      *
-     * The finding that settles it: `vCurrent` is `Camera.getViewMatrix`, which ARCore documents as
-     * *"incorporates the display orientation … equivalent to
-     * `camera.getDisplayOrientedPose().inverse().asMatrix()`"*. So the LIVE side of this
-     * composition was always in the display frame, while capture stored its 3D points in the
-     * sensor frame (`camera.pose.inverse()`). The two sides never agreed; Phase 0 moves capture to
-     * display and they now do. `composeCorrected` itself therefore needs no change — this pins that
-     * conclusion rather than asserting it in a comment.
+     * An earlier version of this file had two tests here claiming to "pin" that `composeCorrected`
+     * is consistent under convention B. They did not, and the way they failed is worth recording:
+     * one asserted `composeCorrected(R, R, A) == composeCorrected(I, I, A)`, which is
+     * `inv(R)·R·A == A` — true by associativity for **every** invertible `R`, transposed or
+     * mirrored or a shear. The other asserted that inserting a rotation into the middle of a matrix
+     * product changes the product. Neither referenced ARCore, the capture path, or `rotationNeeded`;
+     * neither could tell convention A from convention B; and neither would have failed under the
+     * missing-factor defect described in 0.6/0.9. The claim lived in the KDoc, not the assertions.
      *
-     * Deliberately **not** a round trip. `IMPLEMENTATION.md` 0.6 calls that out: a round trip is
-     * order- and sign-insensitive and would pass under either convention, which is exactly how this
-     * defect survived. Instead: feed a `pnpMat` carrying a residual `R_z` — the pre-Phase-0
-     * situation — and assert the error lands in the output, at full size and in a known direction.
+     * What is genuinely testable here is the factor ORDER, which the test above already covers with
+     * non-commuting operands. Whether the three operands are in mutually consistent FRAMES is not a
+     * property of this function — it is a property of its four callers' data, and it is currently
+     * **false**: `vCurrent` is GL-convention, `pnpMat` is CV-convention, `pnpMat`'s domain is the
+     * capture camera frame, and `fpAnchor` is a world-space model matrix. See 0.9.
+     *
+     * So this file deliberately asserts nothing about frames. A test that cannot fail is worse than
+     * no test, because it is counted as coverage.
      */
-    @Test fun `a residual rotation between the pnp and live frames lands in the anchor`() {
+    @Test fun `composeCorrected is frame-agnostic — the convention lives in its callers`() {
+        // Pinned as executable documentation of the above: the function is pure composition, so it
+        // cannot detect a frame error and must not be credited with doing so.
         val rotZ90 = floatArrayOf(0f,1f,0f,0f, -1f,0f,0f,0f, 0f,0f,1f,0f, 0f,0f,0f,1f)
         val fpAnchor = trans(1f, 0f, 0f)
+        val bothRotated = PoseFusion.composeCorrected(rotZ90, rotZ90, fpAnchor)
+        val neitherRotated = PoseFusion.composeCorrected(identity(), identity(), fpAnchor)
+        for (i in 0 until 16) assertEquals("element $i", neitherRotated[i], bothRotated[i], 1e-4f)
 
-        // Frames agree (post-Phase-0): pnp in the same display frame as vCurrent.
-        val matched = PoseFusion.composeCorrected(identity(), identity(), fpAnchor)
-        assertEquals("anchor must sit where the fingerprint put it", 1f, matched[12], 1e-4f)
-        assertEquals(0f, matched[13], 1e-4f)
+        // ...and it holds just as well for transforms that are nothing to do with a display
+        // rotation — a rotation about a DIFFERENT axis, and a pure translation. That is the point:
+        // the cancellation is associativity over `rigidInverse`, not evidence about `R_z`.
+        //
+        // (Both stay RIGID deliberately. `composeCorrected` inverts via `PoseMath.rigidInverse`,
+        // which is only an inverse for rotation+translation; feeding it a shear breaks the identity
+        // for that reason and not for any reason about frames.)
+        val rotX90 = floatArrayOf(1f,0f,0f,0f, 0f,0f,1f,0f, 0f,-1f,0f,0f, 0f,0f,0f,1f)
+        val bothRotX = PoseFusion.composeCorrected(rotX90, rotX90, fpAnchor)
+        for (i in 0 until 16) assertEquals("rotX element $i", neitherRotated[i], bothRotX[i], 1e-4f)
 
-        // Frames disagree by R_z(90) (pre-Phase-0): the anchor swings a quarter turn, a full metre
-        // at this radius. Not a subtle bias — which is why "the overlay limps" was the symptom.
-        val mismatched = PoseFusion.composeCorrected(identity(), rotZ90, fpAnchor)
-        assertEquals(0f, mismatched[12], 1e-4f)
-        assertEquals(1f, mismatched[13], 1e-4f)
-
-        val dx = matched[12] - mismatched[12]
-        val dy = matched[13] - mismatched[13]
-        assertEquals(
-            "a 90deg frame mismatch must displace a 1 m anchor by sqrt(2) m",
-            kotlin.math.sqrt(2f), kotlin.math.sqrt(dx * dx + dy * dy), 1e-4f,
-        )
-    }
-
-    /**
-     * The rotation enters through `pnpMat` only. If a future change also rotated `vCurrent`, the
-     * two would cancel and the mismatch above would silently stop being detectable — so pin that
-     * rotating BOTH is the identity case, distinguishing "consistent" from "both wrong the same
-     * way" would-be fixes.
-     */
-    @Test fun `rotating both sides together cancels, as a consistent convention must`() {
-        val rotZ90 = floatArrayOf(0f,1f,0f,0f, -1f,0f,0f,0f, 0f,0f,1f,0f, 0f,0f,0f,1f)
-        val fpAnchor = trans(1f, 0f, 0f)
-        val both = PoseFusion.composeCorrected(rotZ90, rotZ90, fpAnchor)
-        val neither = PoseFusion.composeCorrected(identity(), identity(), fpAnchor)
-        for (i in 0 until 16) {
-            assertEquals("element $i", neither[i], both[i], 1e-4f)
-        }
+        val move = trans(3f, -2f, 7f)
+        val bothMoved = PoseFusion.composeCorrected(move, move, fpAnchor)
+        for (i in 0 until 16) assertEquals("trans element $i", neitherRotated[i], bothMoved[i], 1e-4f)
     }
 
     @Test fun `blend alpha 0 returns current, alpha 1 returns target`() {

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Sat Aug 01 06:34:40 UTC 2026
-versionBuild=14234
+#Sat Aug 01 06:49:35 UTC 2026
+versionBuild=14238
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=100
+versionPatch=104


### PR DESCRIPTION
Audit corrections to merged PR #1797. No new features.

> [!CAUTION]
> **E0b is no longer runnable on `main`, and #1797 did not say so.** Phase 0 removed the landscape-vs-portrait difference that *is* E0b's independent variable. Run on tip-of-tree it returns "identical behaviour in both orientations" — which `EVALUATION.md`'s **Falsifies** clause tells the reader to read as refuting §8. It would be the fix working. To run E0b as designed, use a build at **`e9de3c5` or earlier**. This is now a CAUTION at the top of E0b. Flagging it here because the device session is imminent.

## 0.6 is un-ticked

#1797 claimed `composeCorrected` was "UNCHANGED, and now correct". The rotation half holds — `vCurrent` is `Camera.getViewMatrix`, documented display-oriented, so convention B does align the two sides *for rotation*. But tracing every operand finds two more missing factors, neither a rotation:

| Operand | Actual frame |
|---|---|
| `vCurrent` | world → live camera, **GL** convention (−Z forward) |
| `pnpMat` | raw `solvePnPRansac` output (`MobileGS.cpp:528-535`), **CV** convention (+Z) |
| `objPts` | `mWallKeypoints3D` = `backProject`'s `pointsCam` — the **capture camera** frame, despite the native field being named `mPnpCamFromFpWorld` |
| `fpAnchor` | `getAnchorTransform()`, which `MobileGS.cpp:525`'s own comment calls *"a world-space MODEL matrix"* |

So world coordinates are fed into a map whose domain is capture-camera coordinates, and CV camera coordinates into a GL camera-to-world inverse. The chain needs `inv(V_cur_gl) · C · pnpMat · V_capture_cv · fpAnchor` with `C = diag(1,−1,−1)`. Both `C` and `V_capture_cv` are absent — and the codebase already knows about `C`: `MobileGS.cpp:600` applies exactly it in `computeRectifyHomography`, commented *"Without this the homography is meaningless."*

**Pre-existing, not introduced by Phase 0.** The error was declaring the whole expression sound after checking the one thing I went looking for. Filed as **0.9**.

## The two tests carrying 0.6 were vacuous

One asserted `composeCorrected(R, R, A) == composeCorrected(I, I, A)` — that is `inv(R)·R·A == A`, true by associativity for *every* rigid `R`, transposed or mirrored. The other asserted that inserting a rotation into a matrix product changes the product. Neither referenced ARCore, the capture path, or `rotationNeeded`; neither could distinguish convention A from B; neither would have failed under the defect above. The claim lived entirely in the KDoc.

Replaced with one test asserting what is actually true — `composeCorrected` is frame-agnostic, so the convention lives in its callers and cannot be tested here — demonstrating the cancellation with a rotation about **X** and a pure **translation** to show it is associativity rather than evidence about `R_z`. Both kept rigid: `composeCorrected` inverts via `rigidInverse`, so a shear breaks the identity for an unrelated reason.

## Two new live items

**0.10** — `MetricFingerprintBuilder.ingestSingle` stores display-frame `res.pointsCam` alongside the **un-rotated** `glView` in the same `restoreWallFingerprintMetric` call. Native pairs them in `computeRectifyHomography` (`viewFp` at `MobileGS.cpp:571`, `mWallKeypoints3D` at `:576`), so the rectifying homography is off by `R_z` on the fingerprint side. #1797 filed this under 0.7 (legacy data) — it is not; it is written fresh by Phase 0's own code path on every new capture. In GL convention the matching rotation is `R_z(−θ)`, since `D·R_z(θ)·D = R_z(−θ)` for `D = diag(1,−1,−1)`. Not fixed here: it changes reloc behaviour and wants its own commit.

**0.11** — `rotationDeg` is plumbed through five call sites and persisted at none. `GraffitiProject` has no rotation field, so projects captured *after* Phase 0 — the correct ones — are indistinguishable on disk from legacy ones, and 0.7's "refuse to reload a legacy fingerprint" would reject them too.

## Doc rot — five sites

Each asserted the pre-Phase-0 convention in the present tense after Phase 0 changed it. `PAPER.md` §8.3 and `TELEOLOGICAL_SLAM.md` both said `V_current` is *"unrotated"* — it never was, that is the whole finding, and the documents Phase 0 corrected were left contradicting it. Plus `EvalSampleLog`'s KDoc and two `ArRenderer` comments naming the wrong entry point.

## Also withdrawn

#1797's claim that reproducing §8.1's table corroborates the rotation direction. §8.1 says in terms that the reproduction is sign-insensitive. The direction **is** right — independently re-derived for all four quadrants — but that argument for it is one the cited source pre-emptively rejects.

## Testing

`:feature:ar:testDebugUnitTest` — **183 passing, 0 failures**. `:app:compileDebugKotlin` green.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Q5WXFiVLeN4sXa9bPCSDA)_

## Summary by Sourcery

Retract the previous 0.6 correctness claim for composeCorrected, tighten its test to only assert frame-agnostic behaviour, and update documentation and evaluation guidance to reflect Phase 0’s actual rotation fix and remaining frame defects.

Enhancements:
- Replace misleading composeCorrected tests with a single assertion that documents its frame-agnostic behaviour and avoids vacuous coverage.
- Clarify IMPLEMENTATION.md, PAPER.md, TELEOLOGICAL_SLAM.md, and EvalSampleLog/ArRenderer comments to accurately describe Phase 0’s changes, remaining GL/CV and capture-view issues, and evaluation constraints.
- Add new tracked tasks 0.9–0.11 for fixing composeCorrected’s missing factors, correcting fingerprint rectification rotation, and persisting captureRotationDeg.

Build:
- Increment version build and patch numbers in version.properties to reflect this audit correction commit.

Documentation:
- Mark experiment E0b as no longer runnable on main and document how to run it on pre-Phase-0 builds, avoiding misinterpretation of results.
- Correct research docs to withdraw the overbroad 0.6 claim, note that vCurrent is display-oriented, and describe the outstanding frame-convention defects and their impact on overlays.

Tests:
- Simplify PoseFusionTest to assert only the associative cancellation behaviour of composeCorrected with multiple rigid transforms, explicitly avoiding frame-convention claims.