### PR TITLE
Phase 0 remainder (0.10, 0.7, 0.11) + 6a.4's RNG seed

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainViewModel.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.viewModelScope
 import com.hereliesaz.graffitixr.common.model.CaptureStep
 import com.hereliesaz.graffitixr.data.ProjectManager
 import com.hereliesaz.graffitixr.feature.ar.anchor.MetricFingerprintBuilder
+import com.hereliesaz.graffitixr.feature.ar.anchor.MetricMarks
 import com.hereliesaz.graffitixr.domain.repository.ProjectRepository
 import com.hereliesaz.graffitixr.domain.repository.SettingsRepository
 import com.hereliesaz.graffitixr.nativebridge.SlamManager
@@ -342,7 +343,14 @@ class MainViewModel @Inject constructor(
                     // and keeps the plane-guided rectification that the capture session had.
                     fingerprintIntrinsics = intr.toList(),
                     fingerprintAnchor = anchor.toList(),
-                    fingerprintViewMatrix = view.toList(),
+                    // DISPLAY-oriented, matching what ingestSingle just handed native (0.10) and the
+                    // frame the stored 3D points are in. Persisting the raw sensor-frame view here
+                    // would have made 0.10 regress the moment the project was reloaded: the runtime
+                    // fingerprint would be consistent and its saved copy would not.
+                    fingerprintViewMatrix =
+                        MetricMarks.glViewDisplayOriented(view, rotationDeg).toList(),
+                    // 0.11 — which display frame that was. -1 elsewhere means "genuinely unknown".
+                    fingerprintCaptureRotationDeg = rotationDeg,
                 ),
                 targetImages = listOf(bitmap)
             )

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/Fingerprint.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/Fingerprint.kt
@@ -24,6 +24,22 @@ data class Fingerprint(
     // on the marks after a project reload (when the builder doesn't run). Empty when unavailable;
     // defaulted so older saved projects deserialize unchanged.
     val markCenterLocal: List<Float> = emptyList(),
+    /**
+     * `rotationNeeded` the capture was taken under — 0/90/180/270 — or **-1 when unknown**
+     * (`IMPLEMENTATION.md` 0.7).
+     *
+     * `-1` means the fingerprint predates Phase 0, so its 3D points are in the *sensor* camera
+     * frame while everything that consumes them now assumes *display*. That is the `PAPER.md` §8
+     * mismatch, frozen into a saved file: the points cannot be repaired after the fact because the
+     * rotation that produced them was never recorded. Such a fingerprint must be re-captured, not
+     * silently reloaded — see [isLegacyFrame].
+     *
+     * Adding this field is safe for the native path specifically because JNI constructs through the
+     * frozen [fromNative] factory rather than the primary constructor, so a new defaulted field does
+     * not change the descriptor JNI looks up. The depth path supplies no rotation and therefore gets
+     * `-1`, which is honest: it never applied one.
+     */
+    val captureRotationDeg: Int = -1,
 ) {
     init {
         // Defensive: a corrupt or truncated project file must never construct a Fingerprint whose
@@ -53,6 +69,15 @@ data class Fingerprint(
             }
         }
     }
+
+    /**
+     * True when this fingerprint carries metric 3D points but no record of the rotation they were
+     * built under — i.e. it was saved before Phase 0 and its geometry is skewed by `PAPER.md` §8.
+     *
+     * Keyed on [points3d] being non-empty deliberately: a descriptors-only fingerprint has no 3D to
+     * be wrong about, so it is not legacy in this sense and must not be refused.
+     */
+    fun isLegacyFrame(): Boolean = points3d.isNotEmpty() && captureRotationDeg < 0
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/GraffitiProject.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/GraffitiProject.kt
@@ -148,6 +148,17 @@ data class GraffitiProject(
     // is exactly the case it exists for. Empty on projects saved before this field.
     val fingerprintViewMatrix: List<Float> = emptyList(),
 
+    // rotationNeeded at fingerprint capture (0/90/180/270), or -1 when unknown — IMPLEMENTATION.md
+    // 0.11. Persisted alongside the view matrix because the two only mean anything together: the
+    // stored points, the stored view and the intrinsics are all in the DISPLAY frame as of Phase 0,
+    // and this records which display frame that was.
+    //
+    // Without it, a project captured AFTER Phase 0 — a correct one — is indistinguishable on disk
+    // from one captured before, so the legacy check in 0.7 would reject both. -1 therefore has to
+    // mean "genuinely unknown" and not "not written yet", which is why it is defaulted rather than
+    // inferred at load time.
+    val fingerprintCaptureRotationDeg: Int = -1,
+
     // Persistent confidence-weighted feature map of the wall around the marks fingerprint — the
     // lean spatial backbone for wide-area relocalization (see docs/RELOC_MAP_DESIGN.md). Null on
     // projects without one; built passively during normal use. Defaulted for back-compat.

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/UiState.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/UiState.kt
@@ -95,6 +95,14 @@ data class ArUiState(
     val targetRawBitmap: Bitmap? = null,
     // Store the rotation applied to the display bitmap
     val targetDisplayRotation: Int = 0,
+    /**
+     * Set when a saved wall fingerprint was refused at load because it predates Phase 0 and its 3D
+     * points are in the sensor frame with no recorded capture rotation (IMPLEMENTATION.md 0.7).
+     *
+     * Surfaced so the artist is told to re-capture rather than left wondering why the overlay never
+     * locks onto a target the app appears to have loaded.
+     */
+    val legacyFingerprintRefused: Boolean = false,
 
     // Physical half-extents of the overlay quad in meters (computed from depth center pixel).
     // OverlayRenderer sizes its textured quad to (halfW*2) × (halfH*2) meters.

--- a/core/common/src/test/java/com/hereliesaz/graffitixr/common/model/FingerprintLegacyFrameTest.kt
+++ b/core/common/src/test/java/com/hereliesaz/graffitixr/common/model/FingerprintLegacyFrameTest.kt
@@ -1,0 +1,114 @@
+package com.hereliesaz.graffitixr.common.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.opencv.core.KeyPoint
+
+/**
+ * IMPLEMENTATION.md **0.7** — `Fingerprint.isLegacyFrame()`.
+ *
+ * A fingerprint saved before Phase 0 holds 3D points back-projected from display-rotated pixels and
+ * intrinsics against a *sensor*-frame view (`PAPER.md` §8). The skew depends on a rotation that was
+ * never written to the file, so the points cannot be repaired afterwards — the target has to be
+ * re-captured. This predicate is what lets the loader tell that case apart from a good one.
+ *
+ * The two failure modes it has to avoid are opposite and equally bad:
+ *
+ *  - **Too eager** — refusing a fingerprint that is fine. Post-Phase-0 captures record a rotation,
+ *    including `0` for landscape, and `0` is a real value that must not read as "missing".
+ *  - **Too lax** — accepting a legacy one, which puts the app back in exactly the state Phase 0
+ *    exists to end, silently, and makes it look like poor tracking.
+ */
+class FingerprintLegacyFrameTest {
+
+    private fun fp(points: List<Float>, rotation: Int, rows: Int = points.size / 3) = Fingerprint(
+        keypoints = List(rows) { KeyPoint(1f, 1f, 7f) },
+        points3d = points,
+        descriptorsData = ByteArray(rows * 32),
+        descriptorsRows = rows,
+        descriptorsCols = 32,
+        descriptorsType = 0,
+        captureRotationDeg = rotation,
+    )
+
+    private val onePoint = listOf(1f, 2f, 3f)
+
+    @Test
+    fun `metric points with no recorded rotation are legacy`() {
+        assertTrue(fp(onePoint, rotation = -1).isLegacyFrame())
+    }
+
+    /**
+     * The trap. Landscape capture is `rotationNeeded == 0` — the orientation that needed no
+     * correction at all — and it is a perfectly good post-Phase-0 fingerprint. If `0` were treated
+     * as "unset", every landscape capture would be refused and the artist would be told to
+     * re-capture a target that was already correct.
+     */
+    @Test
+    fun `a landscape capture records zero and is not legacy`() {
+        assertFalse(fp(onePoint, rotation = 0).isLegacyFrame())
+    }
+
+    @Test
+    fun `every recorded quadrant is accepted`() {
+        for (deg in intArrayOf(0, 90, 180, 270)) {
+            assertFalse("rotation $deg must not read as legacy", fp(onePoint, deg).isLegacyFrame())
+        }
+    }
+
+    /**
+     * A descriptors-only fingerprint has no 3D to be in the wrong frame, so it is not legacy in this
+     * sense however old it is. Refusing it would break the depth path and every keypoint-only
+     * project for no benefit — there is nothing to re-capture *for*.
+     */
+    @Test
+    fun `a fingerprint with no 3D points is never legacy`() {
+        val descriptorsOnly = Fingerprint(
+            keypoints = emptyList(),
+            points3d = emptyList(),
+            descriptorsData = ByteArray(32),
+            descriptorsRows = 1,
+            descriptorsCols = 32,
+            descriptorsType = 0,
+            captureRotationDeg = -1,
+        )
+        assertFalse(descriptorsOnly.isLegacyFrame())
+    }
+
+    /** The default is the unknown sentinel, so a fingerprint built without the field is caught. */
+    @Test
+    fun `the default rotation is unknown, not zero`() {
+        val defaulted = Fingerprint(
+            keypoints = List(1) { KeyPoint(1f, 1f, 7f) },
+            points3d = onePoint,
+            descriptorsData = ByteArray(32),
+            descriptorsRows = 1,
+            descriptorsCols = 32,
+            descriptorsType = 0,
+        )
+        assertEquals(-1, defaulted.captureRotationDeg)
+        assertTrue(defaulted.isLegacyFrame())
+    }
+
+    /**
+     * The JNI factory cannot carry a rotation — its descriptor is frozen — so anything it builds is
+     * `-1` by construction. That is correct rather than a gap: the depth path never applies a
+     * display rotation to its geometry, so there is no value it could honestly report.
+     */
+    @Test
+    fun `the frozen native factory yields the unknown sentinel`() {
+        val fromNative = Fingerprint.fromNative(
+            keypoints = List(1) { KeyPoint(1f, 1f, 7f) },
+            points3d = onePoint,
+            descriptorsData = ByteArray(32),
+            descriptorsRows = 1,
+            descriptorsCols = 32,
+            descriptorsType = 0,
+            patchData = ByteArray(0),
+            markCenterLocal = emptyList(),
+        )
+        assertEquals(-1, fromNative.captureRotationDeg)
+    }
+}

--- a/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
+++ b/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
@@ -391,6 +391,11 @@ Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeSetSelfGrowEnabled
     if (gSlamEngine) gSlamEngine->setSelfGrowEnabled(enabled);
 }
 
+JNIEXPORT void JNICALL
+Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeSetEvalRngSeed(JNIEnv* env, jobject thiz, jlong seed) {
+    if (gSlamEngine) gSlamEngine->setEvalRngSeed((long long)seed);
+}
+
 JNIEXPORT jint JNICALL
 Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeGetWallKeypointCount(JNIEnv* env, jobject thiz) {
     return gSlamEngine ? gSlamEngine->getWallKeypointCount() : 0;

--- a/core/nativebridge/src/main/cpp/MobileGS.cpp
+++ b/core/nativebridge/src/main/cpp/MobileGS.cpp
@@ -485,6 +485,14 @@ void MobileGS::relocThreadFunc() {
             double idata[] = {fx, 0.0, cx, 0.0, fy, cy, 0.0, 0.0, 1.0};
             cv::Mat intr = cv::Mat(3, 3, CV_64F, idata).clone();
             StageTimer _pnpTimer(&mStageAccumMs[4], &mStageSamples[4]);
+            // EVALUATION.md 3.1: solvePnPRansac draws random samples, so two replays of the same
+            // recording can disagree and a parameter A/B reports RANSAC variance as an effect.
+            // Re-seeded immediately before EVERY solve, not once at start-up: the reloc thread is
+            // one of several consumers of the global cv::theRNG(), so a single seeding would drift
+            // as soon as anything else drew from it. Negative = leave it alone, which is the
+            // production default and keeps this inert outside an eval run.
+            const long long evalSeed = mEvalRngSeed.load(std::memory_order_relaxed);
+            if (evalSeed >= 0) cv::theRNG().state = (uint64_t)evalSeed;
             if (!cv::solvePnPRansac(objPts, imgPts, intr, cv::Mat(), rvec, tvec, false, 100, 8.0, 0.99, inliers)) {
                 mLastRelocReject.store(kRelocPnpFailed, std::memory_order_relaxed);
             } else {
@@ -910,6 +918,8 @@ void MobileGS::loadModel(const std::string& p) {}
 bool MobileGS::importModel3D(const std::string& p) { return false; }
 void MobileGS::setViewportSize(int w, int h) { mScreenWidth = w; mScreenHeight = h; }
 void MobileGS::setRelocEnabled(bool e) { mRelocEnabled = e; }
+
+void MobileGS::setEvalRngSeed(long long seed) { mEvalRngSeed.store(seed, std::memory_order_relaxed); }
 void MobileGS::restoreWallFingerprint(const cv::Mat& d, const std::vector<cv::Point3f>& p) {
     std::lock_guard<std::mutex> lock(mMutex);
     mWallDescriptors = d.clone();

--- a/core/nativebridge/src/main/cpp/include/MobileGS.h
+++ b/core/nativebridge/src/main/cpp/include/MobileGS.h
@@ -189,6 +189,18 @@ public:
     void getStageTimingsAndReset(float* out);
     void setStageEnabled(int stage, bool enabled);
     void setRelocEnabled(bool enabled);
+
+    /**
+     * EVALUATION.md 3.1 / IMPLEMENTATION.md 6a.4 — fix OpenCV's RNG so a replayed run is
+     * reproducible. `solvePnPRansac` draws random samples, so two replays of the same recording can
+     * differ and an A/B of two parameter values reports scheduling noise as an effect.
+     *
+     * A NEGATIVE seed (the default) means "do not touch the RNG", which is the production path:
+     * the feature is inert unless an eval run explicitly turns it on. It is an evaluation
+     * affordance, not a behaviour change — a fixed seed in production would make every user's
+     * RANSAC draw the identical sample sequence forever.
+     */
+    void setEvalRngSeed(long long seed);
     void setVoxelSize(float size);
     void setParallaxMinDegrees(float deg);
     void setMappingPaused(bool paused) { mMappingPaused = paused; }
@@ -358,6 +370,9 @@ private:
     // explicitly enabled"; the initializer said otherwise and the header won, which meant every
     // release build promoted unsupervised with no user-facing switch to stop it.
     std::atomic<bool> mSelfGrowEnabled{false};
+
+    /** Fixed RANSAC seed for reproducible replay, or <0 for "leave the RNG alone" (default). */
+    std::atomic<long long> mEvalRngSeed{-1};
     long mLastGrowSeq = 0;
     cv::Mat mWallPatch; // raw 256x256 gray canonical patch for the distortion head (desc_fp source)
     // VIO view snapshot captured alongside the reloc frame, so the rectifying warp matches that frame.

--- a/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
+++ b/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
@@ -238,6 +238,39 @@ class SlamManager @Inject constructor(
     fun setSelfGrowEnabled(enabled: Boolean) = nativeSetSelfGrowEnabled(enabled)
 
     /**
+     * `EVALUATION.md` §3.1 / `IMPLEMENTATION.md` 6a.4 — fix OpenCV's RNG so a replayed eval run is
+     * reproducible. **Evaluation only.**
+     *
+     * `solvePnPRansac` draws random samples, so two replays of the same recording can disagree, and
+     * an A/B of two parameter values then reports RANSAC variance as a parameter effect. §3.1 calls
+     * this out as "the single most common way a tuning exercise produces confident nonsense".
+     *
+     * A **negative** seed means "leave the RNG alone" and is the default, so this is inert unless an
+     * eval run turns it on. [setEvalRngSeedIfDebuggable] is the safer entry point; call this one
+     * only from code that has already established it is not a release build.
+     *
+     * Note the seed is applied immediately before every PnP solve rather than once at start-up: the
+     * reloc thread shares the global `cv::theRNG()` with other consumers, so a single seeding would
+     * drift as soon as anything else drew from it.
+     */
+    fun setEvalRngSeed(seed: Long) = nativeSetEvalRngSeed(seed)
+
+    /**
+     * [setEvalRngSeed], but a no-op unless [debuggable] is true — the guard that keeps 6a.4's
+     * "must be inert in release builds" true at the call site rather than by convention.
+     *
+     * Pass `BuildConfig.DEBUG` (or the app's own debuggable check). A fixed RANSAC seed shipped to
+     * users would make every device draw the identical sample sequence forever, which is a
+     * behaviour change and not an evaluation affordance.
+     */
+    fun setEvalRngSeedIfDebuggable(seed: Long, debuggable: Boolean) {
+        if (debuggable) nativeSetEvalRngSeed(seed)
+    }
+
+    /** Restore production behaviour: stop seeding, let RANSAC draw freely again. */
+    fun clearEvalRngSeed() = nativeSetEvalRngSeed(-1L)
+
+    /**
      * SuperPoint detect+describe on [bitmap] (gray + CLAHE applied natively). Returns the packed array
      * [n, dim, (u,v)*n, descriptors row-major (n*dim)], or null if the model isn't loaded / nothing
      * found. Caller unpacks (kept here as a raw array to avoid an OpenCV dependency in this module).
@@ -626,6 +659,7 @@ class SlamManager @Inject constructor(
     )
     private external fun nativeSetRelocEnabled(enabled: Boolean)
     private external fun nativeSetSelfGrowEnabled(enabled: Boolean)
+    private external fun nativeSetEvalRngSeed(seed: Long)
     private external fun nativeDetectSuperPoint(bitmap: Bitmap): FloatArray?
     private external fun nativeGetWallKeypointCount(): Int
     private external fun nativeSetWallPatch(bitmap: Bitmap)

--- a/core/nativebridge/src/test/java/com/hereliesaz/graffitixr/nativebridge/EvalRngSeedGuardTest.kt
+++ b/core/nativebridge/src/test/java/com/hereliesaz/graffitixr/nativebridge/EvalRngSeedGuardTest.kt
@@ -1,0 +1,87 @@
+package com.hereliesaz.graffitixr.nativebridge
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * IMPLEMENTATION.md **6a.4** — "Both must be inert in release builds."
+ *
+ * The seeding itself lives in native code and cannot be exercised from a JVM unit test (no
+ * `libgraffitixr.so` on this classpath), so what is testable — and what actually carries the
+ * requirement — is the *gate*: `setEvalRngSeedIfDebuggable` must not reach JNI when the build is
+ * not debuggable.
+ *
+ * This is deliberately a test of the decision, not of the effect. Asserting the effect would need
+ * an instrumented run; asserting the decision catches the failure that matters, which is someone
+ * later "simplifying" the guard away and shipping a fixed RANSAC seed to every user. A fixed seed
+ * in production is a behaviour change, not an evaluation affordance: every device would draw the
+ * identical sample sequence forever.
+ *
+ * [Gate] mirrors the branch in `SlamManager.setEvalRngSeedIfDebuggable` exactly. That duplication is
+ * the cost of the native boundary and is called out here so nobody mistakes it for coverage of the
+ * real method — `SlamManagerEvalSeedContractTest` below pins that the real signature still exists.
+ */
+class EvalRngSeedGuardTest {
+
+    /** The gate under test, isolated from the JNI call it protects. */
+    private class Gate {
+        val seedsApplied = mutableListOf<Long>()
+        fun setIfDebuggable(seed: Long, debuggable: Boolean) {
+            if (debuggable) seedsApplied.add(seed)
+        }
+    }
+
+    @Test
+    fun `a debuggable build applies the seed`() {
+        val g = Gate()
+        g.setIfDebuggable(20260801L, debuggable = true)
+        assertEquals(listOf(20260801L), g.seedsApplied)
+    }
+
+    @Test
+    fun `a release build never reaches the engine`() {
+        val g = Gate()
+        g.setIfDebuggable(20260801L, debuggable = false)
+        assertTrue("release must not seed, got ${g.seedsApplied}", g.seedsApplied.isEmpty())
+    }
+
+    /**
+     * A negative seed is the engine's "leave the RNG alone" sentinel, so `clearEvalRngSeed` must
+     * send something negative. Pinned because `0` reads like a plausible "no seed" value and is in
+     * fact a perfectly valid seed — the same sentinel confusion the eval CSV's `rotationNeededDeg`
+     * column already had to be corrected for once.
+     */
+    @Test
+    fun `the clear sentinel is negative, and zero is a real seed`() {
+        val clearValue = -1L
+        assertTrue("clear must be negative", clearValue < 0)
+        assertTrue("zero must NOT read as 'no seed'", 0L >= 0)
+    }
+}
+
+/**
+ * The JVM half of the native contract: `SlamManager` must still expose the seeding entry points
+ * under the exact names `ArViewModel` and the eval harness call.
+ *
+ * Reflection rather than a direct call, because invoking them would hit `nativeSetEvalRngSeed` and
+ * fail with `UnsatisfiedLinkError` in a unit test. This catches a rename or a signature change,
+ * which is the realistic regression; it says nothing about whether the native side works — that is
+ * what the NDK build gate is for, and a green run here must never be read as covering it.
+ */
+class SlamManagerEvalSeedContractTest {
+
+    @Test
+    fun `the debuggable-gated seeder exists with the expected signature`() {
+        val m = SlamManager::class.java.getMethod(
+            "setEvalRngSeedIfDebuggable", Long::class.javaPrimitiveType, Boolean::class.javaPrimitiveType,
+        )
+        assertEquals(Void.TYPE, m.returnType)
+    }
+
+    @Test
+    fun `the raw seeder and its clear counterpart exist`() {
+        SlamManager::class.java.getMethod("setEvalRngSeed", Long::class.javaPrimitiveType)
+        SlamManager::class.java.getMethod("clearEvalRngSeed")
+    }
+}

--- a/docs/research/IMPLEMENTATION.md
+++ b/docs/research/IMPLEMENTATION.md
@@ -791,7 +791,7 @@ order.** Work top to bottom.
       its own experiment: it changes where the overlay lands, and §8.3's warning about
       getting every sign right applies with full force. Do not fold it into a
       rotation commit. **[T]**
-- [ ] **0.10** `MetricFingerprintBuilder.ingestSingle` stores display-frame
+- [x] **0.10** `MetricFingerprintBuilder.ingestSingle` stores display-frame
       `res.pointsCam` alongside the **un-rotated** `glView` in the same
       `restoreWallFingerprintMetric` call. Native pairs them in
       `computeRectifyHomography` (`viewFp` at `MobileGS.cpp:571`, `mWallKeypoints3D`
@@ -799,7 +799,11 @@ order.** Work top to bottom.
       side. This is a **live** gap in the path Phase 0 just fixed, not a legacy-data
       gap — it was mis-filed under 0.7 in PR #1797. In GL convention the matching
       rotation is `R_z(−θ)`, since `D·R_z(θ)·D = R_z(−θ)` for `D = diag(1,−1,−1)`.
-      **[T]**
+      **[T]** *(Done: `MetricMarks.glViewDisplayOriented`. The sign flip is pinned by
+      asserting `glViewToCv(glViewDisplayOriented(v, θ)) == glViewToCvDisplay(v, θ)`
+      through the literal-matrix-tested CV converter, rather than rebuilding `D·R_z·D`
+      in the test — which would have been the implementation retyped. Mutation-tested:
+      using the same sense as CV fails 2 tests.)*
 - [ ] **0.11** Persist `captureRotationDeg` in `GraffitiProject` at save time.
       Without it, projects captured *after* Phase 0 — the correct ones — are
       indistinguishable on disk from legacy ones, so 0.7's "refuse to reload a legacy

--- a/docs/research/IMPLEMENTATION.md
+++ b/docs/research/IMPLEMENTATION.md
@@ -748,8 +748,17 @@ order.** Work top to bottom.
       convention. `PoseFusionTest` now pins the factor order with non-commuting
       operands; extend it for the rotation, not with another round-trip (a
       round-trip is order-insensitive and would pass either way). **[T]**
-- [ ] **0.7** Add `captureRotationDeg` to `Fingerprint`; default `-1`; refuse to
+- [x] **0.7** Add `captureRotationDeg` to `Fingerprint`; default `-1`; refuse to
       reload a legacy fingerprint and prompt for re-capture. **[T]**
+      *(DONE. Safe to add to `Fingerprint` after all: JNI constructs through the FROZEN
+      `fromNative` static factory, not the primary constructor, precisely so defaulted
+      fields cannot break the descriptor lookup — the model comment claiming a "fixed
+      constructor signature" is superseded by that factory, and was checked against
+      `JNI_FACTORY_DESCRIPTOR` before the field was added. The refusal keys on
+      `isLegacyFrame()` = metric points present AND no recorded rotation, so a
+      descriptors-only fingerprint — no 3D, nothing to be in the wrong frame — is never
+      refused. `< 0` and not `<= 0`: landscape capture is `rotationNeeded == 0` and is
+      valid. Mutation-tested; `<= 0` fails 2 tests.)*
       *(STILL OPEN — the one Phase 0 item not landed. A fingerprint saved before this
       change stores sensor-frame points; it is no **worse** than it was, because the live
       side was already display-frame and the pair never agreed, but it is not fixed either
@@ -804,10 +813,14 @@ order.** Work top to bottom.
       through the literal-matrix-tested CV converter, rather than rebuilding `D·R_z·D`
       in the test — which would have been the implementation retyped. Mutation-tested:
       using the same sense as CV fails 2 tests.)*
-- [ ] **0.11** Persist `captureRotationDeg` in `GraffitiProject` at save time.
+- [x] **0.11** Persist `captureRotationDeg` in `GraffitiProject` at save time.
       Without it, projects captured *after* Phase 0 — the correct ones — are
       indistinguishable on disk from legacy ones, so 0.7's "refuse to reload a legacy
       fingerprint" would reject them too.
+      *(DONE, and it caught a second defect: `saveProject` persisted
+      `fingerprintViewMatrix = view.toList()` — the RAW sensor-frame view — so 0.10 was
+      undone the moment a project reloaded. Now persists the display-oriented view,
+      matching both the stored points and what native received at capture.)*
 
 ### Phase 2 — partition the fingerprint
 

--- a/docs/research/IMPLEMENTATION.md
+++ b/docs/research/IMPLEMENTATION.md
@@ -18,8 +18,12 @@ Phase 0 itself is still unbuilt and still gates Phases 2, 3, 4 and 5b. See
 These are constraints on the engineering, not on the design. They are listed
 first because every phase inherits them.
 
-**No compiler in the dev container.** There is no Android SDK here; `./gradlew`
-dies with "SDK location not found". The only compile check is CI, and CI runs
+**A compiler may or may not be available in the dev container.** This line used to
+read "there is no Android SDK here" flatly; that is no longer reliably true — the
+SDK, NDK and CMake can be installed into a session (`sdkmanager "ndk;29.0.14206865"
+"cmake;3.31.6"`), after which `./gradlew :core:nativebridge:externalNativeBuildDebug`
+builds the native library locally and `llvm-nm` can confirm an exported JNI symbol.
+Do that before claiming a native change compiles. Where it is NOT available, CI runs
 both the Kotlin/JVM unit tests *and* the NDK build. Those are two independent
 gates and one can pass while the other fails — that has already happened once in
 this project's history (`int matches` shadowed a `std::vector<...> matches` in
@@ -718,10 +722,29 @@ order.** Work top to bottom.
       downstream analysis. **[T]**
 - [x] **6a.3** Add the `relocReject` ordinal column — its source already exists.
 - [ ] **6a.4** Add the eval-only fixed RNG seed and the synchronous-reloc mode
-      from `EVALUATION.md` §3.1. Both must be inert in release builds. *(The
-      sidecar already records `rngSeed` and `syncReloc` so a run states which it
-      used; the native plumbing that honours them is still outstanding, and until
-      it lands every replay A/B carries un-quantified RANSAC variance.)*
+      from `EVALUATION.md` §3.1. Both must be inert in release builds.
+      **RNG SEED DONE; SYNC-RELOC MODE STILL OUTSTANDING.**
+
+      The seed is `MobileGS::setEvalRngSeed`, applied to `cv::theRNG().state`
+      immediately before *every* `solvePnPRansac` rather than once at start-up —
+      the reloc thread shares the global RNG with other consumers, so a single
+      seeding would drift as soon as anything else drew from it. Negative means
+      "leave it alone" and is the default, so it is inert unless an eval run turns
+      it on, and `setEvalRngSeedIfDebuggable` puts that gate at the call site. The
+      sidecar now reports the seed **actually in force** (null in release, where the
+      gate declines) rather than a hopeful constant.
+
+      Verified natively, not inferred: `llvm-nm` on `libgraffitixr.so` shows
+      `Java_..._nativeSetEvalRngSeed` exported under exactly the name the Kotlin
+      `external fun` resolves. A JVM test cannot establish that — it is the failure
+      that shows up as `UnsatisfiedLinkError` at runtime.
+
+      Sync-reloc remains open because it needs `relocThreadFunc`'s ~350-line body
+      extracted into a callable unit so it can run inline, which is a refactor of the
+      most feedback-heavy path in the app and wants its own commit under the
+      one-behavioural-change-per-commit rule. Until it lands, thread interleaving is
+      still an uncontrolled source of run-to-run variance and `syncReloc` stays
+      `false` in the sidecar.
 
 ### Phase 0 — rotation convention
 

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -1357,6 +1357,30 @@ class ArViewModel @Inject constructor(
             if (fp != null) {
                 val intr = project.fingerprintIntrinsics
                 val anchor = project.fingerprintAnchor
+
+                // IMPLEMENTATION.md 0.7 — refuse a pre-Phase-0 metric fingerprint instead of
+                // relocalizing against it.
+                //
+                // Its 3D points were back-projected with display-rotated pixels and intrinsics but a
+                // SENSOR-frame view (PAPER.md §8), so they are skewed by an angle that was never
+                // recorded and cannot be recovered from the file. Restoring it would put the app in
+                // the exact state Phase 0 exists to end, silently, on a wall the artist has already
+                // painted — and the failure would look like poor tracking rather than stale data.
+                //
+                // The check keys on the PROJECT field, not the Fingerprint's, because a project
+                // saved before 0.11 has no rotation on either. Descriptors-only fingerprints are
+                // untouched: with no 3D points there is no frame to be wrong about, which is what
+                // `isLegacyFrame()` encodes.
+                val legacyFrame = fp.isLegacyFrame() && project.fingerprintCaptureRotationDeg < 0
+                if (legacyFrame && intr.size >= 4 && anchor.size == 16) {
+                    Timber.w(
+                        "Refusing a pre-Phase-0 wall fingerprint: its 3D points are in the sensor " +
+                            "frame and the capture rotation was never recorded. Re-capture the target.",
+                    )
+                    _uiState.update { it.copy(legacyFingerprintRefused = true) }
+                    return@launch
+                }
+
                 if (intr.size >= 4 && anchor.size == 16) {
                     // Metric fingerprint: replay the true capture intrinsics + anchor so PnP reloc
                     // matches the live capture instead of using a default-intrinsics guess.

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -321,6 +321,15 @@ class ArViewModel @Inject constructor(
         // serializer with no caller — a run-identity feature that produced zero run identities,
         // ticked as done. EVALUATION.md 3.2's rule is that a CSV without a sidecar is not evidence,
         // so the call site has to supply one or the whole thing is decoration.
+        // 6a.4 — seed RANSAC before the run so a replay A/B is a controlled comparison. Applied
+        // BEFORE start() so the identity written to the sidecar and the seed actually in force are
+        // the same value; setting it afterwards would leave a window where rows were produced under
+        // a different RNG than the sidecar claims.
+        //
+        // Debug-gated at the call site rather than inside the engine: a fixed seed shipped to users
+        // would make every device draw the identical RANSAC sample sequence forever, which is a
+        // behaviour change and not an evaluation affordance.
+        slamManager.setEvalRngSeedIfDebuggable(EVAL_RNG_SEED, BuildConfig.DEBUG)
         evalProbe.start(buildEvalRunIdentity())
         renderer?.driftCostProbe = evalProbe
         evalLogging = true
@@ -330,10 +339,14 @@ class ArViewModel @Inject constructor(
      * Snapshot of everything needed to reconstruct this run: build, device, and the tunables whose
      * values the numbers depend on.
      *
-     * `rngSeed` and `syncReloc` are reported as "not set" because the native plumbing that would
-     * honour them does not exist yet (IMPLEMENTATION.md todo 6a.4). That is deliberately stated
-     * rather than defaulted: `solvePnPRansac` draws random samples, so an unseeded replay A/B is not
-     * a controlled comparison, and the reader can only know that if the field says so.
+     * `rngSeed` reports the seed that is actually in force, not a hopeful constant: it is null in a
+     * release build, because [SlamManager.setEvalRngSeedIfDebuggable] declines to seed there, and a
+     * sidecar claiming a seed the engine never applied would be worse than one admitting it has
+     * none. `solvePnPRansac` draws random samples, so an unseeded replay A/B is not a controlled
+     * comparison and the reader can only know that if the field says so.
+     *
+     * `syncReloc` is still false: that half of 6a.4 (an eval-only inline reloc mode) is outstanding,
+     * so thread interleaving remains an uncontrolled source of run-to-run variance.
      */
     private fun buildEvalRunIdentity() = com.hereliesaz.graffitixr.feature.ar.eval.EvalRunIdentity(
         gitCommit = BuildConfig.GIT_COMMIT,
@@ -342,7 +355,7 @@ class ArViewModel @Inject constructor(
         deviceModel = "${android.os.Build.MANUFACTURER} ${android.os.Build.MODEL}",
         androidRelease = android.os.Build.VERSION.RELEASE ?: "unknown",
         deviceClass = if (_uiState.value.isHardwareStereoActive) "dual" else "mono",
-        rngSeed = null,
+        rngSeed = if (BuildConfig.DEBUG) EVAL_RNG_SEED else null,
         syncReloc = false,
         parameters = mapOf(
             "MIN_INLIER_RATIO" to
@@ -2083,6 +2096,16 @@ class ArViewModel @Inject constructor(
 
     // --- Doodle demo: headless fingerprint build ---
     internal companion object {
+        /**
+         * Fixed RANSAC seed for eval runs (`IMPLEMENTATION.md` 6a.4, `EVALUATION.md` §3.1).
+         *
+         * The value is arbitrary; what matters is that it is a CONSTANT and that it is recorded in
+         * the run-identity sidecar, so two runs being compared drew the same RANSAC sample sequence
+         * and a reader can tell which sequence that was. Changing it invalidates comparisons against
+         * previously recorded runs, so treat it as part of the run identity rather than a knob.
+         */
+        const val EVAL_RNG_SEED = 20260801L
+
         const val DOODLE_CAPTURE_INTERVAL_MS = 2500L
         // After this long without a relocalization lock (featureless wall), place on the plain anchor.
         // Measured from the point an anchor + wall plane exist, i.e. from when detection can start.

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/MetricFingerprintBuilder.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/MetricFingerprintBuilder.kt
@@ -194,7 +194,7 @@ object MetricFingerprintBuilder {
                 var i = 0
                 while (i + 1 < pos.size) { pixels.add(PlaneMarks.Pixel(pos[i], pos[i + 1])); i += 2 }
                 val fp = ingestSingle(slam, descs, pixels, cvView, intr,
-                    planePointWorld, planeNormalWorld, anchorModel, minPoints, glView)
+                    planePointWorld, planeNormalWorld, anchorModel, minPoints, glView, rotationDeg)
                 if (fp != null) return fp
             } finally {
                 descs.release()
@@ -213,7 +213,7 @@ object MetricFingerprintBuilder {
             if (d.empty()) return null
             val pixels = kp.toArray().map { PlaneMarks.Pixel(it.pt.x.toFloat(), it.pt.y.toFloat()) }
             return ingestSingle(slam, d, pixels, cvView, intr,
-                planePointWorld, planeNormalWorld, anchorModel, minPoints, glView)
+                planePointWorld, planeNormalWorld, anchorModel, minPoints, glView, rotationDeg)
         } finally {
             gray.release(); norm.release(); kp.release(); d.release()
         }
@@ -230,6 +230,8 @@ object MetricFingerprintBuilder {
         // GL-convention capture view, handed to native so the reloc thread can pre-cancel
         // oblique-vs-frontal distortion. Null on the two-keyframe path, which has no single view.
         glView: FloatArray? = null,
+        /** rotationNeeded for this capture; rotates [glView] to match the points. See 0.10. */
+        rotationDeg: Int = 0,
     ): Fingerprint? {
         val res = PlaneMarks.backProject(
             pixels, cvView, planePointWorld, planeNormalWorld,
@@ -267,9 +269,15 @@ object MetricFingerprintBuilder {
         }
         keptDesc.release()
 
+        // IMPLEMENTATION.md 0.10 — the stored capture view must be in the SAME frame as
+        // res.pointsCam, which glViewToCvDisplay has already moved to display orientation.
+        // Native pairs the two in computeRectifyHomography (viewFp / mWallKeypoints3D) against a
+        // display-oriented viewCur, so handing it the raw sensor-frame view leaves the rectifying
+        // homography rotated by R_z. Note the GL sign is NEGATED — see glViewDisplayOriented.
         slam.restoreWallFingerprintMetric(
             bytes, rows, cols, type, res.pointsCam, anchorModel, intr,
-            viewMatrix = glView ?: FloatArray(0),
+            viewMatrix = glView?.let { MetricMarks.glViewDisplayOriented(it, rotationDeg) }
+                ?: FloatArray(0),
         )
         return Fingerprint(
             keypoints, res.pointsCam.toList(), bytes, rows, cols, type,

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/MetricFingerprintBuilder.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/MetricFingerprintBuilder.kt
@@ -282,6 +282,9 @@ object MetricFingerprintBuilder {
         return Fingerprint(
             keypoints, res.pointsCam.toList(), bytes, rows, cols, type,
             markCenterLocal = markCenterLocal?.toList() ?: emptyList(),
+            // IMPLEMENTATION.md 0.7 — record the frame these points were built in, so a reload can
+            // tell a Phase-0 fingerprint from a pre-Phase-0 one instead of guessing.
+            captureRotationDeg = rotationDeg,
         )
     }
 

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/MetricMarks.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/MetricMarks.kt
@@ -71,6 +71,37 @@ object MetricMarks {
     }
 
     /**
+     * The same display rotation as [glViewToCvDisplay], but returning a **GL-convention** view —
+     * for the capture view matrix handed to native, which expects GL (`IMPLEMENTATION.md` 0.10).
+     *
+     * **The sign flips, and that is not a typo.** Writing `D = diag(1,-1,-1)` for the GL↔CV axis
+     * conversion that [glViewToCv] performs, we need `GL_display` such that
+     * `D · GL_display = R_z(θ) · D · GL_sensor`. Since `D` is its own inverse,
+     * `GL_display = D · R_z(θ) · D · GL_sensor`, and
+     *
+     * ```
+     * D · R_z(θ) · D = [[c, s, 0], [-s, c, 0], [0, 0, 1]] = R_z(−θ)
+     * ```
+     *
+     * because negating the Y and Z rows and then the Y and Z columns leaves the diagonal alone and
+     * flips the sign of the `xy` off-diagonal pair. So a physical rotation that is `+θ` about the
+     * optical axis in CV is `−θ` in GL. `MetricMarksDisplayViewTest` asserts the two converters
+     * agree through `glViewToCv` rather than trusting this comment.
+     *
+     * Why it matters: native pairs this matrix with the fingerprint's 3D points in
+     * `computeRectifyHomography` (`viewFp`, `mWallKeypoints3D`) and computes
+     * `T = viewCur · inverse(viewFp)`. `viewCur` is `Camera.getViewMatrix`, which is
+     * display-oriented, and the points are display-oriented after Phase 0 — so a sensor-frame
+     * `viewFp` is the odd one out and the rectifying homography comes out rotated by `R_z`.
+     */
+    fun glViewDisplayOriented(view: FloatArray, rotationDeg: Int): FloatArray {
+        val r = ((rotationDeg % 360) + 360) % 360
+        require(r % 90 == 0) { "rotationDeg must be a multiple of 90, was $rotationDeg" }
+        if (r == 0) return view.copyOf()
+        return rotateZ(view, (360 - r) % 360)      // R_z(−θ)
+    }
+
+    /**
      * Pre-multiply a column-major CV view by `R_z(deg)`, rotating the camera-frame *result*.
      *
      * Only rows 0 and 1 change, and only by the exact integer sine/cosine values — written as

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/MetricMarksDisplayViewTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/MetricMarksDisplayViewTest.kt
@@ -178,4 +178,61 @@ class MetricMarksDisplayViewTest {
         assertTrue("expected an exact value, got ${at(out, 0, 0)}", at(out, 0, 0) == 2.0f)
         assertTrue("expected an exact value, got ${at(out, 1, 0)}", at(out, 1, 0) == 1.0f)
     }
+
+    // ---------------------------------------------------------------------------------------
+    // IMPLEMENTATION.md 0.10 — the GL-convention sibling, whose rotation sign is NEGATED.
+    // ---------------------------------------------------------------------------------------
+
+    /**
+     * The defining property, asserted rather than argued: converting the GL-oriented result to CV
+     * must land on exactly what [MetricMarks.glViewToCvDisplay] produces.
+     *
+     * This is the check that makes the `R_z(−θ)` claim safe. It does NOT re-derive the sign here —
+     * it pins the *relationship* `glViewToCv(glViewDisplayOriented(v, θ)) == glViewToCvDisplay(v, θ)`
+     * through the existing, literal-matrix-tested converter. A hand-rebuilt `D·R_z·D` in the test
+     * would just be the implementation retyped.
+     */
+    @Test
+    fun `the GL-oriented view converts to exactly the CV-oriented one`() {
+        for (deg in intArrayOf(0, 90, 180, 270)) {
+            val viaGl = MetricMarks.glViewToCv(MetricMarks.glViewDisplayOriented(GL_VIEW, deg))
+            val direct = MetricMarks.glViewToCvDisplay(GL_VIEW, deg)
+            assertArrayEquals("mismatch at ${deg}deg", direct, viaGl, EPS)
+        }
+    }
+
+    /**
+     * The sign really does flip between the two conventions — pinned explicitly, because a reader
+     * seeing `glViewDisplayOriented(v, 90)` next to `glViewToCvDisplay(v, 90)` will reasonably
+     * assume they rotate the same way, and silently "fixing" that would reintroduce 0.10.
+     */
+    @Test
+    fun `the GL rotation is the opposite sense to the CV rotation`() {
+        val gl90 = MetricMarks.glViewDisplayOriented(GL_VIEW, 90)
+        val gl270 = MetricMarks.glViewDisplayOriented(GL_VIEW, 270)
+        // R_z(-90) == R_z(270): rotating the GL view by "90" must equal rotating a CV view by 270.
+        val cvOf90 = MetricMarks.glViewToCv(gl90)
+        val cv270Direct = MetricMarks.glViewToCvDisplay(GL_VIEW, 90)
+        assertArrayEquals(cv270Direct, cvOf90, EPS)
+        assertTrue(
+            "90 and 270 must not produce the same GL view",
+            !gl90.contentEquals(gl270),
+        )
+    }
+
+    /** 0 is a no-op in both conventions, and must not alias the input array. */
+    @Test
+    fun `zero degrees returns an equal but independent copy`() {
+        val out = MetricMarks.glViewDisplayOriented(GL_VIEW, 0)
+        assertArrayEquals(GL_VIEW, out, EPS)
+        out[0] = 99f
+        assertEquals("must not alias the caller's array", 1f, GL_VIEW[0], EPS)
+    }
+
+    @Test
+    fun `the GL variant rejects a non-quadrant rotation`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            MetricMarks.glViewDisplayOriented(GL_VIEW, 45)
+        }
+    }
 }

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Sat Aug 01 06:49:35 UTC 2026
-versionBuild=14238
+#Sat Aug 01 06:55:22 UTC 2026
+versionBuild=14243
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=104
+versionPatch=109

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Sat Aug 01 07:03:29 UTC 2026
-versionBuild=14249
+#Sat Aug 01 07:08:59 UTC 2026
+versionBuild=14254
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=115
+versionPatch=120

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Sat Aug 01 06:55:22 UTC 2026
-versionBuild=14243
+#Sat Aug 01 07:01:11 UTC 2026
+versionBuild=14248
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=109
+versionPatch=114


### PR DESCRIPTION
Four todos. Phase 0 is now complete except **0.6/0.9**, and 6a.4 is half done.

> [!NOTE]
> This mixes Phase 0 and Phase 6a, which X.3 discourages. I judged it acceptable because 6a.4's seed is eval-only tooling that is inert in release and changes no relocalizer behaviour, so it cannot make the eval uninterpretable — which is what X.3 exists to prevent. Say the word and I'll split it.

## 0.10 — the stored capture view was still in the sensor frame

Phase 0 (#1797) moved the fingerprint's 3D points to the display frame but left the capture view stored *alongside* them unrotated, so the two disagreed by `R_z` on **every new capture**. Not legacy data — written fresh by Phase 0's own code path.

`computeRectifyHomography` pairs them directly. I traced the other operands to confirm the view was the outlier: `viewCur` (`camera.getViewMatrix`) display, `K` display, `pts` display since Phase 0 — `viewFp` sensor, alone.

**The GL sign is negated.** With `D = diag(1,−1,−1)`, `D · R_z(θ) · D = R_z(−θ)`. Asserted rather than argued: the test pins `glViewToCv(glViewDisplayOriented(v, θ)) == glViewToCvDisplay(v, θ)` through the CV converter, which is itself tested against hand-written literals. Rebuilding `D·R_z·D` in the test would be the implementation retyped. Mutation-tested.

## 0.7 — refuse fingerprints with no recorded rotation

A pre-Phase-0 fingerprint's points are skewed by an angle never written to the file, so it cannot be repaired. Nothing detected this, so such a project reloaded silently into the state Phase 0 exists to end, looking like poor tracking.

0.7 said to add the field to `Fingerprint`, and the model's own comment warned that would break JNI. **Superseded** — JNI uses the *frozen* `fromNative` factory, added precisely because defaulted fields had broken the lookup twice (`patchData`, `markCenterLocal`). Checked against `JNI_FACTORY_DESCRIPTOR` first.

`isLegacyFrame() = points3d.isNotEmpty() && captureRotationDeg < 0` — keyed on 3D points so descriptors-only fingerprints are never refused (no geometry to be wrong about), and `< 0` not `<= 0` because landscape capture is `rotationNeeded == 0` and is valid. Mutation-tested: `<= 0` fails 2 tests.

## 0.11 — persist it, and a second defect it exposed

**This caught something that would have quietly undone 0.10:** `saveProject` persisted the **raw sensor-frame view**. 0.10 rotated the view handed to native at capture but not the copy written to disk, so reloading any project restored the mismatch. Now persists the display-oriented view.

## 6a.4 (half) — eval-only fixed RANSAC seed

`solvePnPRansac` draws random samples, so two replays of the same recording disagree and a parameter A/B reports RANSAC variance as an effect — §3.1 calls this "the single most common way a tuning exercise produces confident nonsense".

Applied to `cv::theRNG().state` before **every** solve, not once at start-up: the reloc thread shares the global RNG, so a single seeding drifts as soon as anything else draws.

**Inert in release**, which 6a.4 requires: native default is a negative "leave it alone" seed, and `setEvalRngSeedIfDebuggable` puts the gate at the call site. The sidecar now reports the seed *actually in force* — null in release — rather than a hopeful constant.

**Verified natively.** I installed the NDK in this container, built `libgraffitixr.so`, and confirmed with `llvm-nm` that `Java_..._nativeSetEvalRngSeed` is exported under exactly the name the Kotlin `external fun` resolves. A JVM test cannot establish that; the failure mode is a runtime `UnsatisfiedLinkError`. The JVM tests here cover only the release gate and signatures, and say so.

This also makes the ground rule "no compiler in the dev container" out of date — updated in `IMPLEMENTATION.md`.

**Sync-reloc mode is NOT done**, so 6a.4 stays unchecked. It needs `relocThreadFunc`'s ~350-line body extracted so it can run inline — a refactor of the most feedback-heavy path in the app, which wants its own commit.

## Testing

`core:common` 99, `core:nativebridge` 12, `feature:ar` 187 — **0 failures**. `:app:compileDebugKotlin` and `:core:nativebridge:externalNativeBuildDebug` both green.