### PR TITLE
Close the convention gap, and start Phase 2's partition

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -1001,12 +1001,26 @@ class MainActivity : ComponentActivity() {
                                 }
                             }
 
-                            val showPostTargetHint = arUiState.isAnchorEstablished
+                            // isAnchorEstablished means ARCore made an anchor. It says NOTHING about
+                            // whether the wall fingerprint got built, and gating the success banner
+                            // on it alone told artists a target was ready when back-projection had
+                            // produced no usable points — so the overlay could only ever drift, and
+                            // the one screen that could have explained it claimed success instead.
+                            // Gate on the thing that actually has to exist.
+                            val basePostTargetVisible = arUiState.isAnchorEstablished
                                     && editorUiState.layers.isEmpty()
                                     && !mainUiState.isCapturingTarget
                                     && editorUiState.editorMode == EditorMode.AR
                                     && !showLibrary && !showSettings
-                            if (showPostTargetHint) {
+                            val hasWallFingerprint = arUiState.wallFingerprintPoints > 0
+                            if (basePostTargetVisible && !hasWallFingerprint) {
+                                TargetIncompleteOverlay(
+                                    modifier = Modifier
+                                        .align(Alignment.BottomCenter)
+                                        .padding(bottom = 140.dp)
+                                )
+                            }
+                            if (basePostTargetVisible && hasWallFingerprint) {
                                 PostTargetInstructionOverlay(
                                     modifier = Modifier.align(Alignment.BottomCenter).padding(bottom = 96.dp)
                                 )
@@ -2243,6 +2257,47 @@ private fun ConfidenceProgressBar(label: String, progress: Float) {
             color = Cyan,
             trackColor = Color.White.copy(alpha = 0.1f)
         )
+    }
+}
+
+/**
+ * Shown when an ARCore anchor exists but the wall fingerprint does not — the state that used to
+ * render as "TARGET ESTABLISHED".
+ *
+ * This is a real and recoverable failure, not an edge case: back-projection drops any feature whose
+ * recovered depth falls outside its 0.1-10 m trust range, so a capture can find well over a thousand
+ * features and place none of them on the wall. Without a fingerprint the reloc thread has nothing to
+ * match against, every diagnostic freezes, and the overlay runs on raw VIO and drifts within
+ * seconds. Naming it is the difference between "re-capture, squarer and closer" and "this app
+ * doesn't work".
+ */
+@Composable
+private fun TargetIncompleteOverlay(modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .background(Color(0xEE1A1A1A), RoundedCornerShape(20.dp))
+            .border(2.dp, HotPink, RoundedCornerShape(20.dp))
+            .padding(horizontal = 24.dp, vertical = 20.dp)
+            .widthIn(max = 340.dp)
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(
+                text = "TARGET NOT LOCKED",
+                color = HotPink,
+                fontWeight = FontWeight.Bold,
+                fontSize = 18.sp,
+                textAlign = TextAlign.Center
+            )
+            Spacer(Modifier.height(12.dp))
+            Text(
+                text = "The anchor is placed, but no wall features were matched to it — the overlay " +
+                    "will drift. Re-capture the target: get squarer to the wall, closer, and aim at " +
+                    "a patch with more detail.",
+                color = Color.White,
+                fontSize = 14.sp,
+                textAlign = TextAlign.Center
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -1370,14 +1370,8 @@ class MainActivity : ComponentActivity() {
                                     onFeaturePointsChanged = { editorViewModel.toggleFeaturePoints() },
                                     showPlaneGrids = editorUiState.showPlaneGrids,
                                     onPlaneGridsChanged = { editorViewModel.togglePlaneGrids() },
-                                    showVoxels = editorUiState.showVoxels,
-                                    onVoxelsChanged = { editorViewModel.toggleVoxels() },
                                     showPoints = editorUiState.showPoints,
                                     onPointsChanged = { editorViewModel.togglePoints() },
-                                    showMesh = editorUiState.showMesh,
-                                    onMeshChanged = { editorViewModel.toggleMesh() },
-                                    parallaxMinDegrees = arUiState.parallaxMinDegrees,
-                                    onParallaxMinDegreesChanged = { arViewModel.setParallaxMinDegrees(it) },
                                     cameraTargetFps = arUiState.cameraTargetFps,
                                     onCameraTargetFpsChanged = { arViewModel.setCameraTargetFps(it) },
                                     throttleOnThermal = arUiState.throttleOnThermal,
@@ -1398,8 +1392,6 @@ class MainActivity : ComponentActivity() {
                                     onImperialUnitsChanged = { arViewModel.setImperialUnits(it) },
                                     backgroundColor = editorUiState.canvasBackground.toArgb(),
                                     onBackgroundColorChanged = { argb -> settingsViewModel.setBackgroundColor(argb) },
-                                    muralMethod = arUiState.muralMethod,
-                                    onMuralMethodChanged = { arViewModel.setMuralMethod(it) },
                                     onCheckForUpdates = { dashboardViewModel.checkForUpdates(BuildConfig.VERSION_NAME) },
                                     onOpenUpdatePage = { dashboardViewModel.openUpdatePage(this@MainActivity) },
                                     onResetTutorials = { settingsViewModel.resetCompletedTutorials() },
@@ -1556,34 +1548,6 @@ class MainActivity : ComponentActivity() {
             // 2. PROJECT FOLDER — directly under Open. Opening it collapses Modes (see host.modes'
             // expandWhen below); its expansion is persisted per-project via onExpandedChange so the two
             // folders coordinate reactively.
-            azRailHostItem(
-                id = "host.project",
-                text = navStrings.project,
-                color = navItemColor,
-                initiallyExpanded = railExpansion["host.project"] ?: false,
-                onExpandedChange = { editorViewModel.onRailHostExpansionChanged("host.project", it) },
-            )
-            azRailSubItem(id = "proj.new", hostId = "host.project", text = navStrings.new, color = navItemColor, shape = AzButtonShape.NONE) {
-                dashboardViewModel.onNewProjectTriggered()
-            }
-            azRailSubItem(id = "proj.save", hostId = "host.project", text = navStrings.save, color = navItemColor, shape = AzButtonShape.NONE) {
-                showSaveDialog = true
-            }
-            azRailSubItem(id = "proj.export", hostId = "host.project", text = navStrings.export, color = navItemColor, shape = AzButtonShape.NONE) {
-                // Export is mode-dispatched by the caller so it has access to the CameraX
-                // controller (Overlay stills) and a coroutine scope (AR/Overlay both suspend on
-                // asynchronous captures). This handler just tells the caller "user pressed Export".
-                onExportRequested()
-            }
-            azRailSubItem(id = "proj.load", hostId = "host.project", text = navStrings.load, color = navItemColor, shape = AzButtonShape.NONE) {
-                navController.navigate(LIBRARY_ROUTE) { launchSingleTop = true }
-            }
-            azRailSubItem(id = "proj.settings", hostId = "host.project", text = navStrings.settings, color = navItemColor, shape = AzButtonShape.NONE) {
-                showSettings = true
-            }
-
-            azDivider()
-
             // 3. MODES FOLDER — always expanded, unless the user manually collapses it or opens the
             // Project folder. expandWhen returns false while Project is open (auto-collapsing Modes) and
             // re-expands Modes on the false->true edge when Project closes; a manual collapse is respected
@@ -1714,6 +1678,35 @@ class MainActivity : ComponentActivity() {
                     editorViewModel.onToggleModeTransformLocked(EditorMode.TRACE)
                 }
             }
+
+            azDivider()
+
+            azRailHostItem(
+                id = "host.project",
+                text = navStrings.project,
+                color = navItemColor,
+                initiallyExpanded = railExpansion["host.project"] ?: false,
+                onExpandedChange = { editorViewModel.onRailHostExpansionChanged("host.project", it) },
+            )
+            azRailSubItem(id = "proj.new", hostId = "host.project", text = navStrings.new, color = navItemColor, shape = AzButtonShape.NONE) {
+                dashboardViewModel.onNewProjectTriggered()
+            }
+            azRailSubItem(id = "proj.save", hostId = "host.project", text = navStrings.save, color = navItemColor, shape = AzButtonShape.NONE) {
+                showSaveDialog = true
+            }
+            azRailSubItem(id = "proj.export", hostId = "host.project", text = navStrings.export, color = navItemColor, shape = AzButtonShape.NONE) {
+                // Export is mode-dispatched by the caller so it has access to the CameraX
+                // controller (Overlay stills) and a coroutine scope (AR/Overlay both suspend on
+                // asynchronous captures). This handler just tells the caller "user pressed Export".
+                onExportRequested()
+            }
+            azRailSubItem(id = "proj.load", hostId = "host.project", text = navStrings.load, color = navItemColor, shape = AzButtonShape.NONE) {
+                navController.navigate(LIBRARY_ROUTE) { launchSingleTop = true }
+            }
+            azRailSubItem(id = "proj.settings", hostId = "host.project", text = navStrings.settings, color = navItemColor, shape = AzButtonShape.NONE) {
+                showSettings = true
+            }
+
 
             // Help — opens AzNavRail's built-in help overlay (populated by azAdvanced(helpList=...)).
             // Registering it as azHelpRailItem is what makes the overlay reachable: the library toggles

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
@@ -340,9 +340,7 @@ fun MainScreen(
                                 // Independent in-world perception layers (Settings, default on).
                                 r.showFeaturePoints = uiState.showFeaturePoints
                                 r.showPlaneGrids = uiState.showPlaneGrids
-                                r.showVoxels = uiState.showVoxels
                                 r.showPoints = uiState.showPoints
-                                r.showMesh = uiState.showMesh
                                 // Perception throttle: system triggers (OR-ed in the VM) + the lag
                                 // trigger's enable flag (evaluated renderer-side).
                                 r.systemThrottle = arUiState.perceptionSystemThrottle

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/CameraTargetFps.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/CameraTargetFps.kt
@@ -1,0 +1,58 @@
+package com.hereliesaz.graffitixr.common.model
+
+/**
+ * The camera frame-rate choices offered in Settings.
+ *
+ * Stored as a plain `Int` rather than an enum because the value is **persisted**, and 30/60 were
+ * already on disk before the device-resolved options existed. Keeping those two as their literal
+ * frame rates means every previously-saved preference keeps meaning what it meant, with no
+ * migration; the two new options take sentinel values that cannot collide with a real frame rate.
+ *
+ * The device-resolved pair is the point of this: ARCore only exposes `TARGET_FPS_30` and
+ * `TARGET_FPS_60` as filters, so 30 and 60 are the only rates that can be *requested* by name. What
+ * a given phone actually supports is a set of `CameraConfig`s with their own `fpsRange`s, and the
+ * best of those may be neither 30 nor 60 — so [DEVICE_MAX] picks by inspecting the ranges, and
+ * [DEVICE_DEFAULT] declines to filter at all.
+ */
+object CameraTargetFps {
+
+    /** Fixed 30 fps — the historical default and the battery-pressure fallback. */
+    const val FPS_30 = 30
+
+    /** Fixed 60 fps, when the device offers a 60 config for the default camera. */
+    const val FPS_60 = 60
+
+    /**
+     * Whatever `CameraConfig` ARCore selects for itself — no filtering, no swap.
+     *
+     * Distinct from asking for 30 and happening to get it: ARCore's own choice is the
+     * broadest-compatible config it offers, and on a device where the 30 fps filter matches nothing
+     * for the default camera, this is the option that reliably works.
+     */
+    const val DEVICE_DEFAULT = 0
+
+    /**
+     * The highest frame rate the device offers for the default back camera.
+     *
+     * Chosen by the *upper bound* of each config's `fpsRange`, so a config advertising 15–60
+     * outranks a fixed 30 for a user who asked for maximum. Still capped to [FPS_30] under battery
+     * pressure when adaptive rate is on — it is the option most likely to cook the phone.
+     */
+    const val DEVICE_MAX = -1
+
+    /** Settings cycles through these in order. */
+    val CYCLE = intArrayOf(FPS_30, FPS_60, DEVICE_DEFAULT, DEVICE_MAX)
+
+    /** The next choice after [current], wrapping. Unknown values fall back to the start of [CYCLE]. */
+    fun next(current: Int): Int {
+        val i = CYCLE.indexOf(current)
+        return if (i < 0) CYCLE[0] else CYCLE[(i + 1) % CYCLE.size]
+    }
+
+    /** Display text. Sentinels get names; real rates show the number. */
+    fun label(value: Int): String = when (value) {
+        DEVICE_DEFAULT -> "Device default"
+        DEVICE_MAX -> "Device max"
+        else -> value.toString()
+    }
+}

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/Fingerprint.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/Fingerprint.kt
@@ -40,6 +40,36 @@ data class Fingerprint(
      * `-1`, which is honest: it never applied one.
      */
     val captureRotationDeg: Int = -1,
+    /**
+     * `IMPLEMENTATION.md` Phase 2 — one byte per 3D point, holding `Footprint.Region.ordinal`:
+     * the point's position relative to the design's projected footprint at capture.
+     *
+     * **Empty means legacy "all backbone"**, not "all inside". A fingerprint saved before Phase 2
+     * has no partition, and the safe reading is that every point is load-bearing — treating them as
+     * corroboration-only would exclude the entire map from the reloc PnP and the target would never
+     * lock at all. Consumers must branch on `regions.isEmpty()` rather than indexing blindly.
+     *
+     * A parallel array rather than a struct-of-arrays rewrite, matching how the descriptors (an
+     * opaque row-major blob) and the points (a flat float list) are already stored, and cheap to
+     * serialize. The invariant that it is 1:1 with the points is enforced in `init`, for the same
+     * reason the points/descriptor-rows check is: the reloc path indexes these by row, so a
+     * disagreement reads past the end of a vector rather than failing.
+     */
+    val regions: ByteArray = ByteArray(0),
+    /**
+     * The design's **effective** (scale-included) half-extents in metres at the moment [regions]
+     * was computed, or `-1` when unknown.
+     *
+     * Stored because the regions are only meaningful against the design size that produced them.
+     * Folding the overlay scale in — rather than storing raw extents and a separate scale — makes
+     * the staleness check a single float comparison per axis, and sidesteps the trap
+     * `IMPLEMENTATION.md` Phase 2 flags: `OverlayRenderer.setExtent`'s two call sites are a fixed
+     * constant and a one-shot screen-fit, **neither driven by the user**. The user's resize is
+     * `overlayScale`, which enters the model matrix, so a staleness check watching the extents alone
+     * would compare two numbers that never move.
+     */
+    val captureHalfW: Float = -1f,
+    val captureHalfH: Float = -1f,
 ) {
     init {
         // Defensive: a corrupt or truncated project file must never construct a Fingerprint whose
@@ -68,6 +98,31 @@ data class Fingerprint(
                     "the reloc path indexes points by descriptor row, so they must be 1:1"
             }
         }
+        // Same argument, third array. Native filters the reloc correspondence build by
+        // `mWallRegions[i]` for the row it just matched, so a regions array shorter than the point
+        // list indexes past the end of a vector. Empty is the legacy "no partition" case and is
+        // explicitly allowed; anything else must be exactly 1:1.
+        require(regions.isEmpty() || regions.size == points3d.size / 3) {
+            "regions holds ${regions.size} tags but ${points3d.size / 3} points were supplied; " +
+                "the partition is indexed per point, so they must be 1:1 (or regions empty for legacy)"
+        }
+    }
+
+    /** True when this fingerprint carries no partition — a pre-Phase-2 capture. See [regions]. */
+    fun isUnpartitioned(): Boolean = regions.isEmpty()
+
+    /**
+     * True when [regions] was computed against a different design size than [halfW]/[halfH].
+     *
+     * The artist pinching the design mid-session is normal, and the right response is to recompute
+     * the regions from the stored 3D points (a cheap pure-Kotlin pass) rather than force a
+     * re-capture. An unpartitioned or extent-less fingerprint is never "stale" — there is nothing to
+     * recompute against.
+     */
+    fun isPartitionStale(halfW: Float, halfH: Float, eps: Float = 1e-4f): Boolean {
+        if (regions.isEmpty() || captureHalfW < 0f || captureHalfH < 0f) return false
+        return kotlin.math.abs(captureHalfW - halfW) > eps ||
+            kotlin.math.abs(captureHalfH - halfH) > eps
     }
 
     /**

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/UiState.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/UiState.kt
@@ -224,6 +224,20 @@ data class ArUiState(
     // Diagnostic Overlay in release as well as debug — every one of these failures is otherwise
     // silent, which is why "it never works" was so hard to pin down.
     val relocDiagnostics: RelocDiagnostics = RelocDiagnostics(),
+    /**
+     * How many 3D points the live wall fingerprint holds — 0 when there is none.
+     *
+     * The direct answer to "did the target actually get built", read straight from the engine
+     * rather than inferred from [relocDiagnostics], which is stale until the reloc thread has run at
+     * least once and therefore cannot be trusted in the seconds right after a capture.
+     *
+     * Exists because "TARGET ESTABLISHED" was gated on [isAnchorEstablished] — an ARCore anchor,
+     * which says nothing about the fingerprint. A capture whose back-projection produced no usable
+     * points still lit the success banner, and the artist was told to go ahead and paint against an
+     * overlay that could only ever drift. The failure was fully diagnosable in the engine and the UI
+     * asserted the opposite.
+     */
+    val wallFingerprintPoints: Int = 0,
 )
 
 enum class CoopRole { NONE, HOST, GUEST }

--- a/core/common/src/test/java/com/hereliesaz/graffitixr/common/model/CameraTargetFpsTest.kt
+++ b/core/common/src/test/java/com/hereliesaz/graffitixr/common/model/CameraTargetFpsTest.kt
@@ -1,0 +1,62 @@
+package com.hereliesaz.graffitixr.common.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CameraTargetFpsTest {
+
+    @Test
+    fun `the cycle visits all four choices and wraps`() {
+        var v = CameraTargetFps.FPS_30
+        val seen = mutableListOf(v)
+        repeat(3) { v = CameraTargetFps.next(v); seen.add(v) }
+        assertEquals(
+            listOf(
+                CameraTargetFps.FPS_30,
+                CameraTargetFps.FPS_60,
+                CameraTargetFps.DEVICE_DEFAULT,
+                CameraTargetFps.DEVICE_MAX,
+            ),
+            seen,
+        )
+        assertEquals("must wrap", CameraTargetFps.FPS_30, CameraTargetFps.next(v))
+    }
+
+    /**
+     * The sentinels must not collide with any real frame rate, or a stored preference would change
+     * meaning. `0` and `-1` are chosen because no camera reports them.
+     */
+    @Test
+    fun `sentinels cannot be mistaken for frame rates`() {
+        assertTrue(CameraTargetFps.DEVICE_DEFAULT <= 0)
+        assertTrue(CameraTargetFps.DEVICE_MAX < 0)
+        assertTrue(CameraTargetFps.FPS_30 > 0 && CameraTargetFps.FPS_60 > 0)
+    }
+
+    /**
+     * 30 and 60 keep their literal values, which is what lets every preference saved before the
+     * device-resolved options existed keep meaning exactly what it meant. A migration here would be
+     * silent and untestable, so the encoding avoids needing one.
+     */
+    @Test
+    fun `the pre-existing values are unchanged`() {
+        assertEquals(30, CameraTargetFps.FPS_30)
+        assertEquals(60, CameraTargetFps.FPS_60)
+    }
+
+    @Test
+    fun `labels name the sentinels and print real rates`() {
+        assertEquals("30", CameraTargetFps.label(CameraTargetFps.FPS_30))
+        assertEquals("60", CameraTargetFps.label(CameraTargetFps.FPS_60))
+        assertEquals("Device default", CameraTargetFps.label(CameraTargetFps.DEVICE_DEFAULT))
+        assertEquals("Device max", CameraTargetFps.label(CameraTargetFps.DEVICE_MAX))
+    }
+
+    /** A value from a future build (or a corrupt preference) must not strand the cycle. */
+    @Test
+    fun `an unknown stored value re-enters the cycle`() {
+        assertEquals(CameraTargetFps.FPS_30, CameraTargetFps.next(120))
+        assertEquals(CameraTargetFps.FPS_30, CameraTargetFps.next(-99))
+    }
+}

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -29,6 +29,7 @@ import com.google.ar.core.Session
 import com.google.ar.core.TrackingState
 import com.google.ar.core.exceptions.CameraNotAvailableException
 import com.google.ar.core.exceptions.UnavailableException
+import com.hereliesaz.graffitixr.common.model.CameraTargetFps
 import com.hereliesaz.graffitixr.common.model.ArScanMode
 import com.hereliesaz.graffitixr.common.model.MuralMethod
 import com.hereliesaz.graffitixr.common.model.ArUiState
@@ -1080,29 +1081,56 @@ class ArViewModel @Inject constructor(
                     appendDiag("camera: SAFE MODE — ARCore default config (stream stalled previously, no fps swap)")
                     Timber.w("ARDIAG mono config: SAFE MODE default cam=${s.cameraConfig.cameraId} (forceSafeCameraConfig)")
                 } else {
-                    // Pin the camera frame rate (default 30, user-selectable 30/60). Under battery
-                    // pressure (tier ≥ medium) cap to 30fps even if 60 was chosen. Done here at session
-                    // build only — a mid-session CameraConfig swap resets tracking.
-                    val effectiveCameraFps =
-                        if (_uiState.value.adaptiveRateEnabled && _uiState.value.batteryTier >= 1) 30
+                    // Pin the camera frame rate. Four choices, two of them fixed and two resolved
+                    // from the device (CameraTargetFps): 30, 60, DEVICE_DEFAULT and DEVICE_MAX.
+                    // Under battery pressure (tier ≥ medium) cap to 30 fps whatever was chosen —
+                    // including MAX, which is the one most likely to cook the phone. Done here at
+                    // session build only: a mid-session CameraConfig swap resets tracking.
+                    val chosenFps =
+                        if (_uiState.value.adaptiveRateEnabled && _uiState.value.batteryTier >= 1)
+                            CameraTargetFps.FPS_30
                         else _uiState.value.cameraTargetFps
-                    val targetFps = if (effectiveCameraFps == 60)
-                        CameraConfig.TargetFps.TARGET_FPS_60 else CameraConfig.TargetFps.TARGET_FPS_30
                     val defaultCfg = s.cameraConfig
                     val fpsConfig = try {
-                        s.getSupportedCameraConfigs(CameraConfigFilter(s).apply {
-                            facingDirection = CameraConfig.FacingDirection.BACK
-                            this.targetFps = EnumSet.of(targetFps)
-                        }).firstOrNull { it.cameraId == defaultCfg.cameraId }
+                        when (chosenFps) {
+                            // DEVICE_DEFAULT: don't filter at all. ARCore's own choice is the
+                            // broadest-compatible config it offers, and asking for it explicitly is
+                            // different from asking for 30 and happening to get it.
+                            CameraTargetFps.DEVICE_DEFAULT -> null
+                            // DEVICE_MAX: every config for this camera, highest frame rate wins.
+                            // Compared on the range's upper bound because a config advertising
+                            // 15-60 outranks a fixed 30 for a user who asked for maximum.
+                            CameraTargetFps.DEVICE_MAX ->
+                                s.getSupportedCameraConfigs(CameraConfigFilter(s).apply {
+                                    facingDirection = CameraConfig.FacingDirection.BACK
+                                }).filter { it.cameraId == defaultCfg.cameraId }
+                                    .maxByOrNull { it.fpsRange.upper }
+                            else ->
+                                s.getSupportedCameraConfigs(CameraConfigFilter(s).apply {
+                                    facingDirection = CameraConfig.FacingDirection.BACK
+                                    this.targetFps = EnumSet.of(
+                                        if (chosenFps == CameraTargetFps.FPS_60)
+                                            CameraConfig.TargetFps.TARGET_FPS_60
+                                        else CameraConfig.TargetFps.TARGET_FPS_30,
+                                    )
+                                }).firstOrNull { it.cameraId == defaultCfg.cameraId }
+                        }
                     } catch (e: Exception) {
                         Timber.w(e, "camera fps config query failed")
                         null
                     }
                     if (fpsConfig != null) {
                         s.cameraConfig = fpsConfig
-                        appendDiag("camera fps: pinned ${_uiState.value.cameraTargetFps} (matched default cfg)")
+                        appendDiag(
+                            "camera fps: ${CameraTargetFps.label(chosenFps)} -> " +
+                                "${fpsConfig.fpsRange.lower}-${fpsConfig.fpsRange.upper}",
+                        )
+                    } else if (chosenFps == CameraTargetFps.DEVICE_DEFAULT) {
+                        appendDiag("camera fps: device default (${defaultCfg.fpsRange.upper} max) — no swap")
                     } else {
-                        appendDiag("camera fps: no ${_uiState.value.cameraTargetFps} match for default cfg — using default")
+                        appendDiag(
+                            "camera fps: no ${CameraTargetFps.label(chosenFps)} match for default cfg — using default",
+                        )
                     }
                     Timber.i("ARDIAG dual-lens: mono config cam=${s.cameraConfig.cameraId} fps=${_uiState.value.cameraTargetFps} (stereoCapable=$isStereoCapable)")
                 }

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -1547,6 +1547,9 @@ class ArViewModel @Inject constructor(
         // Read every tick (~15 Hz) rather than only on a successful lock — the whole point is to show
         // the FAILING states, which by definition never reach a success path.
         val relocDiag = slamManager.getRelocDiagnostics()
+        // Read alongside the diagnostics, not on a success path: the state this exists to expose is
+        // "the capture produced nothing", which by definition never reaches one.
+        val wallPoints = slamManager.getWallKeypointCount()
 
         val nowMs = System.currentTimeMillis()
         if (isTracking) lastTrackingTimestampMs = nowMs
@@ -1584,6 +1587,7 @@ class ArViewModel @Inject constructor(
                 isDepthApiSupported = isDepthApiSupported,
                 paintingProgress = progress,
                 relocDiagnostics = relocDiag,
+                wallFingerprintPoints = wallPoints,
                 scanPhase = newPhase,
                 ambientSectorsCovered = sectorsCovered / 3, // Keep backward compatibility for 30 degree UI units if needed
                 worldMappingProgress = mappingProgress,

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/CaptureRotation.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/CaptureRotation.kt
@@ -1,0 +1,71 @@
+package com.hereliesaz.graffitixr.feature.ar.anchor
+
+/**
+ * The display-rotation convention **at its origin** — the two transforms the capture path applies to
+ * a frame before anything geometric touches it.
+ *
+ * These lived inline in `ArRenderer`'s capture block (intrinsics) and `ArViewModel.onTargetCaptured`
+ * (bitmap), which made them untestable, and that was a real hole rather than a tidiness complaint:
+ * Phase 0's whole correctness argument is that a sensor ray `d_s` becomes `R_z(+θ)·d_s` under this
+ * pair of transforms, and **nothing in the test suite drove a pixel through the actual code**. The
+ * derivation and the tests both rested on one person's reading of these lines, so an error in that
+ * reading would have been mirrored into the tests and passed.
+ *
+ * Extracted here so `CaptureRotationTest` can close the loop end to end: project a known 3D point
+ * with sensor intrinsics, rotate the pixel the way the bitmap rotation does, unproject with the
+ * rotated intrinsics, and check the resulting ray against `R_z(+θ)` computed independently. If the
+ * convention is wrong, that test fails — which no existing test could do.
+ */
+object CaptureRotation {
+
+    /**
+     * Rotate raw sensor intrinsics into display orientation.
+     *
+     * Byte-for-byte the transform `ArRenderer` performed inline: swap the focal lengths on the
+     * quarter turns, and remap the principal point against the raw frame's dimensions.
+     *
+     * @param rawW / [rawH] the **unrotated** image dimensions (`CameraIntrinsics.imageDimensions`).
+     * @return `[fx, fy, cx, cy]` for the rotated frame.
+     */
+    fun rotateIntrinsics(
+        fx: Float, fy: Float, cx: Float, cy: Float,
+        rawW: Float, rawH: Float,
+        rotationDeg: Int,
+    ): FloatArray {
+        var rfx = fx; var rfy = fy; var rcx = cx; var rcy = cy
+        when (((rotationDeg % 360) + 360) % 360) {
+            90 -> {
+                val t = rfx; rfx = rfy; rfy = t
+                val tcx = rcx; rcx = rawH - rcy; rcy = tcx
+            }
+            180 -> {
+                rcx = rawW - rcx
+                rcy = rawH - rcy
+            }
+            270 -> {
+                val t = rfx; rfx = rfy; rfy = t
+                val tcx = rcx; rcx = rcy; rcy = rawW - tcx
+            }
+        }
+        return floatArrayOf(rfx, rfy, rcx, rcy)
+    }
+
+    /**
+     * Where a raw sensor pixel `(u, v)` lands once the bitmap has been rotated by [rotationDeg].
+     *
+     * Mirrors `android.graphics.Matrix.postRotate(deg)` followed by `Bitmap.createBitmap`, which
+     * rotates clockwise in the image's y-down coordinates and then re-offsets the result so the
+     * rotated bitmap starts at the origin. For 90° that is `(u, v) -> (rawH - v, u)`.
+     *
+     * Expressed in continuous coordinates, matching how the principal point is remapped above — the
+     * half-pixel question does not arise because both this and [rotateIntrinsics] use the same
+     * convention, and the ray they produce depends only on their difference.
+     */
+    fun rotatePixel(u: Float, v: Float, rawW: Float, rawH: Float, rotationDeg: Int): FloatArray =
+        when (((rotationDeg % 360) + 360) % 360) {
+            90 -> floatArrayOf(rawH - v, u)
+            180 -> floatArrayOf(rawW - u, rawH - v)
+            270 -> floatArrayOf(v, rawW - u)
+            else -> floatArrayOf(u, v)
+        }
+}

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/FingerprintPartition.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/FingerprintPartition.kt
@@ -1,0 +1,121 @@
+package com.hereliesaz.graffitixr.feature.ar.anchor
+
+import com.hereliesaz.graffitixr.common.model.Fingerprint
+
+/**
+ * `IMPLEMENTATION.md` **Phase 2** — tag every fingerprint point with its region relative to the
+ * design's projected footprint.
+ *
+ * This is the join between Φ ([Footprint], Phase 1) and the stored map ([Fingerprint], `core/common`).
+ * It lives in `feature/ar` and not on `Fingerprint` itself because the module graph runs
+ * `feature/ar → core/common`: the data model cannot see [Footprint]. So `Fingerprint` carries the
+ * bytes and the invariants, and the geometry that produces them lives here.
+ *
+ * **What the partition is for**, from `PAPER.md` §5: the backbone `F_out` sits outside the design
+ * and survives the whole job, so it is what the reloc PnP localizes against with no prior. The
+ * corroboration set `F_in` sits inside the design — it is the work surface, it decays as the artist
+ * paints, and it is only ever consulted *after* a pose exists. Mixing them is what makes accuracy
+ * degrade with task progress, which is the failure the whole programme is about.
+ *
+ * The [Footprint.Region.BAND] straddling the edge goes into neither set. That is deliberate and is
+ * the easiest part of this to skip: features within a hair of the boundary are exactly the ones
+ * whose classification flips as the artist paints out to the edge, and a *misclassified* feature is
+ * worse than a discarded one — a doomed feature admitted to the backbone corrupts the thing the
+ * backbone exists to be.
+ */
+object FingerprintPartition {
+
+    /**
+     * Default margins, as fractions of the design's half-extent, in normalized design coordinates.
+     *
+     * Asymmetric on purpose. The inner margin only has to exclude points whose *measured* position
+     * is uncertain; the outer one additionally absorbs the artist overshooting the design's edge,
+     * which they routinely do and which would silently convert backbone into painted-over.
+     *
+     * These are starting values, not tuned ones — `EVALUATION.md` E8 is the experiment that sets
+     * them, and `PARAMETERS.md` is where they are recorded.
+     */
+    const val DEFAULT_INNER_MARGIN = 0.04f
+    const val DEFAULT_OUTER_MARGIN = 0.10f
+
+    /**
+     * Classify [pointsCam] — a flat `[x,y,z,...]` list in the same world frame [anchorModel] is
+     * expressed in — into one region byte per point.
+     *
+     * @param anchorModel the design's model matrix. Pass [composed] = true when it carries the
+     *   overlay's uniform in-plane scale, in which case [halfW]/[halfH] must be the design's
+     *   **unscaled** half-extents; otherwise pass the **scaled** ones. Getting this pair wrong is
+     *   the highest-probability bug here — both combinations compile and both produce plausible
+     *   numbers — which is why `Footprint` exposes them as two named entry points rather than a
+     *   boolean, and why `FingerprintPartitionTest` covers a scaled anchor explicitly.
+     */
+    fun classify(
+        pointsCam: FloatArray,
+        anchorModel: FloatArray,
+        halfW: Float,
+        halfH: Float,
+        composed: Boolean = false,
+        innerMargin: Float = DEFAULT_INNER_MARGIN,
+        outerMargin: Float = DEFAULT_OUTER_MARGIN,
+    ): ByteArray {
+        val count = pointsCam.size / 3
+        if (count == 0) return ByteArray(0)
+        // Hoist the inverse: Footprint.of/ofComposed each allocate a FloatArray(16) per call, and
+        // ofComposed also does a sqrt to recover a scale that is constant across the capture. Over a
+        // 1500-feature capture that dominates everything else this function does.
+        val inv = if (composed) Footprint.inverseOfComposed(anchorModel)
+        else Footprint.inverseOfRigid(anchorModel)
+        val uv = FloatArray(2)
+        val out = ByteArray(count)
+        for (i in 0 until count) {
+            val o = i * 3
+            Footprint.ofInverted(inv, halfW, halfH, pointsCam[o], pointsCam[o + 1], pointsCam[o + 2], uv)
+            out[i] = Footprint.classify(uv, innerMargin, outerMargin).ordinal.toByte()
+        }
+        return out
+    }
+
+    /**
+     * Recompute [Fingerprint.regions] against a new design size, returning an updated copy.
+     *
+     * The artist pinching the design mid-session is normal, so the response is to reclassify the
+     * stored 3D points — a cheap pure-Kotlin pass — rather than force a re-capture.
+     *
+     * Returns the receiver unchanged when there is nothing to do: no points to classify. Note it
+     * does **not** short-circuit on [Fingerprint.isPartitionStale] being false, because a caller may
+     * legitimately want to partition a previously-unpartitioned (legacy) fingerprint, for which
+     * "stale" is defined as false.
+     */
+    fun reclassify(
+        fingerprint: Fingerprint,
+        anchorModel: FloatArray,
+        halfW: Float,
+        halfH: Float,
+        composed: Boolean = false,
+        innerMargin: Float = DEFAULT_INNER_MARGIN,
+        outerMargin: Float = DEFAULT_OUTER_MARGIN,
+    ): Fingerprint {
+        if (fingerprint.points3d.isEmpty()) return fingerprint
+        val regions = classify(
+            fingerprint.points3d.toFloatArray(), anchorModel, halfW, halfH,
+            composed, innerMargin, outerMargin,
+        )
+        return fingerprint.copy(
+            regions = regions,
+            captureHalfW = halfW,
+            captureHalfH = halfH,
+        )
+    }
+
+    /**
+     * How many points fall in the backbone set `F_out`.
+     *
+     * An **unpartitioned** fingerprint counts as all-backbone, matching the legacy reading in
+     * [Fingerprint.regions] — a pre-Phase-2 map must keep relocalizing, not be excluded wholesale.
+     */
+    fun backboneCount(fingerprint: Fingerprint): Int {
+        if (fingerprint.regions.isEmpty()) return fingerprint.points3d.size / 3
+        val outside = Footprint.Region.OUTSIDE.ordinal.toByte()
+        return fingerprint.regions.count { it == outside }
+    }
+}

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -161,9 +161,7 @@ class ArRenderer(
     // suppressed during target capture. Each governs one layer of "what the AR is seeing".
     @Volatile var showFeaturePoints: Boolean = true  // ARCore tracker landmarks (yellow dots)
     @Volatile var showPlaneGrids: Boolean = true      // detected planes as metric grids
-    @Volatile var showVoxels: Boolean = true          // SLAM voxel splats (confidence-tinted)
     @Volatile var showPoints: Boolean = true          // accumulated sparse point cloud
-    @Volatile var showMesh: Boolean = true            // persistent surface mesh
 
     // --- Throttled perception (FBO-cached) -----------------------------------------------------
     // World-locked perception is redrawn into an offscreen buffer only when the pose moves or the
@@ -688,7 +686,11 @@ class ArRenderer(
             planeRenderer.drawPlanes(activeSession, viewMatrix, projMatrix, camera.pose, gridMode = true)
         }
         // Diagnostic perception view: ALL active layers of what the AR is seeing.
-        val anyLayerOn = showFeaturePoints || showPlaneGrids || showVoxels || showPoints || showMesh
+        // showVoxels/showMesh are NOT consulted: the voxel/splat map and SurfaceMesh were deleted, so
+        // neither draws anything, and including them here meant two toggles that render nothing could
+        // still switch on the container for the three that do. Only the layers that actually draw
+        // decide whether the perception view is worth composing.
+        val anyLayerOn = showFeaturePoints || showPlaneGrids || showPoints
         // Show the perception mask (feature points / voxels) on the LIVE camera during scanning —
         // including while aiming a target. The captured frame is the raw camera image (GL overlays
         // aren't baked in), so the mask belongs here, not painted onto the frozen target preview.

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -1339,30 +1339,21 @@ class ArRenderer(
                             }
                         }
 
-                        var fx = intrinsics.focalLength[0]
-                        var fy = intrinsics.focalLength[1]
-                        var cx = intrinsics.principalPoint[0]
-                        var cy = intrinsics.principalPoint[1]
+                        val fx = intrinsics.focalLength[0]
+                        val fy = intrinsics.focalLength[1]
+                        val cx = intrinsics.principalPoint[0]
+                        val cy = intrinsics.principalPoint[1]
                         val dims = intrinsics.imageDimensions
                         val rawW = dims[0].toFloat()
                         val rawH = dims[1].toFloat()
 
-                        when (rotationNeeded) {
-                            90 -> {
-                                val t_fx = fx; fx = fy; fy = t_fx
-                                val t_cx = cx; cx = rawH - cy; cy = t_cx
-                            }
-                            180 -> {
-                                cx = rawW - cx
-                                cy = rawH - cy
-                            }
-                            270 -> {
-                                val t_fx = fx; fx = fy; fy = t_fx
-                                val t_cx = cx; cx = cy; cy = rawW - t_cx
-                            }
-                        }
-
-                        val intrArr = floatArrayOf(fx, fy, cx, cy)
+                        // Extracted to CaptureRotation so the convention is testable AT ITS ORIGIN.
+                        // Phase 0's correctness argument is that this transform, paired with the
+                        // bitmap rotation, turns a sensor ray into R_z(+rotationNeeded) * itself —
+                        // and while it lived inline here nothing could drive a pixel through it, so
+                        // the derivation and the tests both rested on one reading of these lines.
+                        val intrArr = com.hereliesaz.graffitixr.feature.ar.anchor.CaptureRotation
+                            .rotateIntrinsics(fx, fy, cx, cy, rawW, rawH, rotationNeeded)
 
                         // Camera→point distance at the tapped pixel (Sub-project C). Map the tap from
                         // view pixels to the depth image via ARCore's rotation/crop-aware transform,

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/CaptureRotationTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/CaptureRotationTest.kt
@@ -1,0 +1,168 @@
+package com.hereliesaz.graffitixr.feature.ar.anchor
+
+import kotlin.math.abs
+import kotlin.math.cos
+import kotlin.math.sin
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The test Phase 0 shipped without, and the gap the audit named: **nothing drove a pixel through the
+ * actual capture code.**
+ *
+ * Phase 0's entire correctness argument is one claim — that the capture path's bitmap rotation and
+ * intrinsics rotation together turn a sensor-frame camera ray `d_s` into `R_z(+rotationNeeded)·d_s`,
+ * and therefore that `MetricMarks.glViewToCvDisplay` must pre-multiply by `R_z(+θ)`. Every test
+ * written for it asserted properties *of the converter*, taking that claim as given. So a
+ * misreading of `ArRenderer`'s intrinsics branches or `ArViewModel`'s `postRotate` would have been
+ * mirrored into the converter, into the tests, and into the paper, and every one of them would have
+ * agreed with the others while being wrong together.
+ *
+ * This closes the loop, end to end and in the only direction that can fail independently:
+ *
+ *  1. take a known 3D point in the **sensor** camera frame;
+ *  2. project it with the **raw sensor** intrinsics — plain pinhole, no rotation anywhere;
+ *  3. move that pixel the way the **bitmap rotation** moves it ([CaptureRotation.rotatePixel]);
+ *  4. unproject with the **rotated** intrinsics that `ArRenderer` actually builds
+ *     ([CaptureRotation.rotateIntrinsics], now the shipped code path);
+ *  5. compare the resulting ray against `R_z(+θ)·d_s`, with `R_z` written out here from
+ *     `cos`/`sin` — **not** taken from `MetricMarks.rotateZ`, which is the thing under test.
+ *
+ * If the convention is backwards, step 5 disagrees and this fails. No other test in the suite can
+ * say that.
+ */
+class CaptureRotationTest {
+
+    private companion object {
+        // A deliberately non-square raw sensor frame with an OFF-CENTRE principal point and
+        // DIFFERENT focal lengths. Every one of those matters: a square frame hides an axis swap, a
+        // centred principal point hides the `rawH - cy` remap, and equal focals hide the fx/fy swap
+        // entirely — which is the single most likely thing to get wrong here.
+        const val RAW_W = 1920f
+        const val RAW_H = 1080f
+        const val FX = 1400f
+        const val FY = 1310f
+        const val CX = 950f      // not RAW_W/2
+        const val CY = 520f      // not RAW_H/2
+        const val EPS = 1e-3f
+    }
+
+    /** Pinhole projection in the sensor frame. No rotation involved anywhere. */
+    private fun projectSensor(x: Float, y: Float, z: Float) =
+        floatArrayOf(x / z * FX + CX, y / z * FY + CY)
+
+    /** `R_z(deg)` applied to a 3-vector, written from trig so it shares nothing with the impl. */
+    private fun rzApply(deg: Int, v: FloatArray): FloatArray {
+        val a = Math.toRadians(deg.toDouble())
+        val c = cos(a).toFloat()
+        val s = sin(a).toFloat()
+        return floatArrayOf(c * v[0] - s * v[1], s * v[0] + c * v[1], v[2])
+    }
+
+    /** Direction cosines, so two rays are comparable regardless of scale. */
+    private fun normalize(v: FloatArray): FloatArray {
+        val n = kotlin.math.sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2])
+        return floatArrayOf(v[0] / n, v[1] / n, v[2] / n)
+    }
+
+    /**
+     * The whole claim, at every quadrant and over a spread of points including strongly off-axis
+     * ones — where a wrong sign is largest and a centred point would show nothing.
+     */
+    @Test
+    fun `the capture path rotates a sensor ray by exactly R_z of plus rotationNeeded`() {
+        val points = listOf(
+            floatArrayOf(0.4f, 0.25f, 2f),
+            floatArrayOf(-0.6f, 0.1f, 1.5f),
+            floatArrayOf(0.15f, -0.5f, 3f),
+            floatArrayOf(-0.35f, -0.3f, 2.5f),
+            floatArrayOf(0f, 0f, 2f),          // on-axis: must be invariant
+        )
+        for (deg in intArrayOf(0, 90, 180, 270)) {
+            val r = CaptureRotation.rotateIntrinsics(FX, FY, CX, CY, RAW_W, RAW_H, deg)
+            for (p in points) {
+                // The sensor-frame ray, straight from the point.
+                val dSensor = normalize(floatArrayOf(p[0] / p[2], p[1] / p[2], 1f))
+
+                // ...and the ray the capture path actually produces for the same physical point.
+                val px = projectSensor(p[0], p[1], p[2])
+                val rot = CaptureRotation.rotatePixel(px[0], px[1], RAW_W, RAW_H, deg)
+                val dDisplay = normalize(
+                    floatArrayOf((rot[0] - r[2]) / r[0], (rot[1] - r[3]) / r[1], 1f),
+                )
+
+                val expected = normalize(rzApply(deg, dSensor))
+                for (i in 0..2) {
+                    assertEquals(
+                        "deg=$deg point=${p.toList()} component $i: " +
+                            "capture path gave ${dDisplay.toList()}, R_z(+$deg) predicts ${expected.toList()}",
+                        expected[i], dDisplay[i], EPS,
+                    )
+                }
+            }
+        }
+    }
+
+    /**
+     * The negative control. If the convention were `R_z(−θ)` — the sign this could most plausibly
+     * have been — the quarter turns would disagree measurably. Without this, a test that somehow
+     * compared a vector with itself would still pass.
+     */
+    @Test
+    fun `the opposite sign is measurably wrong at the quarter turns`() {
+        val p = floatArrayOf(0.4f, 0.25f, 2f)
+        for (deg in intArrayOf(90, 270)) {
+            val r = CaptureRotation.rotateIntrinsics(FX, FY, CX, CY, RAW_W, RAW_H, deg)
+            val px = projectSensor(p[0], p[1], p[2])
+            val rot = CaptureRotation.rotatePixel(px[0], px[1], RAW_W, RAW_H, deg)
+            val actual = normalize(
+                floatArrayOf((rot[0] - r[2]) / r[0], (rot[1] - r[3]) / r[1], 1f),
+            )
+            val wrong = normalize(rzApply(-deg, normalize(floatArrayOf(p[0] / p[2], p[1] / p[2], 1f))))
+            val gap = (0..2).maxOf { abs(actual[it] - wrong[it]) }
+            assertTrue("R_z(-$deg) must NOT match the capture path; gap was $gap", gap > 0.05f)
+        }
+    }
+
+    /** Zero rotation must be the identity in both halves, or every landscape capture is skewed. */
+    @Test
+    fun `zero rotation leaves intrinsics and pixels untouched`() {
+        val r = CaptureRotation.rotateIntrinsics(FX, FY, CX, CY, RAW_W, RAW_H, 0)
+        assertEquals(FX, r[0], 0f); assertEquals(FY, r[1], 0f)
+        assertEquals(CX, r[2], 0f); assertEquals(CY, r[3], 0f)
+        val px = CaptureRotation.rotatePixel(123f, 456f, RAW_W, RAW_H, 0)
+        assertEquals(123f, px[0], 0f); assertEquals(456f, px[1], 0f)
+    }
+
+    /**
+     * The quarter turns swap the focal lengths and the half-turn does not. `FX != FY` here on
+     * purpose — with equal focals this assertion is vacuous, and equal focals are exactly what a
+     * lazy fixture would use.
+     */
+    @Test
+    fun `quarter turns swap the focal lengths, the half turn does not`() {
+        for (deg in intArrayOf(90, 270)) {
+            val r = CaptureRotation.rotateIntrinsics(FX, FY, CX, CY, RAW_W, RAW_H, deg)
+            assertEquals("deg=$deg", FY, r[0], 0f)
+            assertEquals("deg=$deg", FX, r[1], 0f)
+        }
+        val half = CaptureRotation.rotateIntrinsics(FX, FY, CX, CY, RAW_W, RAW_H, 180)
+        assertEquals(FX, half[0], 0f)
+        assertEquals(FY, half[1], 0f)
+    }
+
+    /** Four quarter turns of a pixel return it to where it started. */
+    @Test
+    fun `four quarter turns return a pixel to itself`() {
+        var u = 700f; var v = 300f
+        var w = RAW_W; var h = RAW_H
+        repeat(4) {
+            val p = CaptureRotation.rotatePixel(u, v, w, h, 90)
+            u = p[0]; v = p[1]
+            val t = w; w = h; h = t      // the frame's dimensions swap with each quarter turn
+        }
+        assertEquals(700f, u, EPS)
+        assertEquals(300f, v, EPS)
+    }
+}

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/FingerprintPartitionTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/FingerprintPartitionTest.kt
@@ -1,0 +1,207 @@
+package com.hereliesaz.graffitixr.feature.ar.anchor
+
+import com.hereliesaz.graffitixr.common.model.Fingerprint
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.opencv.core.KeyPoint
+
+/**
+ * `IMPLEMENTATION.md` **2.5** — the partition, on a synthetic straddling point set.
+ *
+ * The design sits in the XY plane at the world origin, so the expected region of each test point is
+ * obvious by inspection and the assertions are not re-derivations of `Footprint`'s own arithmetic.
+ * That matters here more than usual: the whole value of this file is catching a Φ applied the wrong
+ * way round, and a test that computed its expectation with the same inverse would pass under
+ * exactly that bug.
+ */
+class FingerprintPartitionTest {
+
+    private companion object {
+        const val HALF_W = 1.0f
+        const val HALF_H = 0.5f
+        val INSIDE = Footprint.Region.INSIDE.ordinal.toByte()
+        val BAND = Footprint.Region.BAND.ordinal.toByte()
+        val OUTSIDE = Footprint.Region.OUTSIDE.ordinal.toByte()
+    }
+
+    /** Identity model matrix: design centred on the world origin, spanning ±HALF_W by ±HALF_H. */
+    private fun identity() = floatArrayOf(
+        1f, 0f, 0f, 0f, 0f, 1f, 0f, 0f, 0f, 0f, 1f, 0f, 0f, 0f, 0f, 1f,
+    )
+
+    /** Uniform in-plane scale `s`, as the composed overlay transform carries it. */
+    private fun scaled(s: Float) = floatArrayOf(
+        s, 0f, 0f, 0f, 0f, s, 0f, 0f, 0f, 0f, s, 0f, 0f, 0f, 0f, 1f,
+    )
+
+    private fun fp(points: List<Float>, regions: ByteArray = ByteArray(0), hw: Float = -1f, hh: Float = -1f): Fingerprint {
+        val rows = points.size / 3
+        return Fingerprint(
+            keypoints = List(rows) { KeyPoint(1f, 1f, 7f) },
+            points3d = points,
+            descriptorsData = ByteArray(rows * 32),
+            descriptorsRows = rows,
+            descriptorsCols = 32,
+            descriptorsType = 0,
+            regions = regions,
+            captureHalfW = hw,
+            captureHalfH = hh,
+        )
+    }
+
+    @Test
+    fun `a point at the design centre is inside`() {
+        val r = FingerprintPartition.classify(floatArrayOf(0f, 0f, 0f), identity(), HALF_W, HALF_H)
+        assertEquals(INSIDE, r[0])
+    }
+
+    @Test
+    fun `a point far beyond the design is outside`() {
+        val r = FingerprintPartition.classify(floatArrayOf(5f, 0f, 0f), identity(), HALF_W, HALF_H)
+        assertEquals(OUTSIDE, r[0])
+    }
+
+    /**
+     * Exactly on the edge. This is the point the BAND exists for — its classification is the one
+     * that flips as the artist paints out to the boundary, and admitting it to the backbone would
+     * corrupt the set that is supposed to survive the whole job.
+     */
+    @Test
+    fun `a point on the design edge lands in the band, not the backbone`() {
+        val r = FingerprintPartition.classify(floatArrayOf(HALF_W, 0f, 0f), identity(), HALF_W, HALF_H)
+        assertEquals("edge point must not be backbone", BAND, r[0])
+        assertNotEquals(OUTSIDE, r[0])
+    }
+
+    /**
+     * The non-square case. `HALF_W != HALF_H`, so a point that is inside along X and outside along Y
+     * catches a Φ that normalized by the wrong axis — which a square design would hide completely.
+     */
+    @Test
+    fun `non-square extents are normalized per axis`() {
+        // x = 0.5 is well inside (half-width 1.0); y = 1.5 is well outside (half-height 0.5).
+        val r = FingerprintPartition.classify(floatArrayOf(0.5f, 1.5f, 0f), identity(), HALF_W, HALF_H)
+        assertEquals(OUTSIDE, r[0])
+        // ...and the transpose is inside, which it would not be if the axes were swapped.
+        val r2 = FingerprintPartition.classify(floatArrayOf(0.5f, 0.1f, 0f), identity(), HALF_W, HALF_H)
+        assertEquals(INSIDE, r2[0])
+    }
+
+    /**
+     * The highest-probability bug in the phase, per `IMPLEMENTATION.md`: a scaled anchor with the
+     * wrong extents convention. Both combinations compile and both produce plausible numbers.
+     *
+     * With a 2× composed scale and UNSCALED extents, the design covers ±2.0 in world X. A point at
+     * x = 1.5 is therefore INSIDE — whereas treating the same matrix as rigid would call it OUTSIDE.
+     */
+    @Test
+    fun `a composed scale widens the footprint`() {
+        val p = floatArrayOf(1.5f, 0f, 0f)
+        val composed = FingerprintPartition.classify(p, scaled(2f), HALF_W, HALF_H, composed = true)
+        assertEquals("2x scale must swallow x=1.5", INSIDE, composed[0])
+
+        val asRigid = FingerprintPartition.classify(p, identity(), HALF_W, HALF_H, composed = false)
+        assertEquals("unscaled design must not reach x=1.5", OUTSIDE, asRigid[0])
+        assertNotEquals(
+            "the two conventions must be distinguishable, or the flag is decorative",
+            composed[0], asRigid[0],
+        )
+    }
+
+    @Test
+    fun `classification is one byte per point, in order`() {
+        val pts = floatArrayOf(
+            0f, 0f, 0f,     // inside
+            5f, 0f, 0f,     // outside
+            0.1f, 0f, 0f,   // inside
+        )
+        val r = FingerprintPartition.classify(pts, identity(), HALF_W, HALF_H)
+        assertEquals(3, r.size)
+        assertEquals(INSIDE, r[0]); assertEquals(OUTSIDE, r[1]); assertEquals(INSIDE, r[2])
+    }
+
+    @Test
+    fun `an empty point set yields an empty partition`() {
+        assertEquals(0, FingerprintPartition.classify(FloatArray(0), identity(), HALF_W, HALF_H).size)
+    }
+
+    // -------------------------------------------------------------------------------------
+    // reclassify + the legacy reading
+    // -------------------------------------------------------------------------------------
+
+    @Test
+    fun `reclassify tags a previously unpartitioned fingerprint and records the extents`() {
+        val before = fp(listOf(0f, 0f, 0f, 5f, 0f, 0f))
+        assertTrue(before.isUnpartitioned())
+
+        val after = FingerprintPartition.reclassify(before, identity(), HALF_W, HALF_H)
+        assertFalse(after.isUnpartitioned())
+        assertEquals(2, after.regions.size)
+        assertEquals(INSIDE, after.regions[0])
+        assertEquals(OUTSIDE, after.regions[1])
+        assertEquals(HALF_W, after.captureHalfW, 1e-6f)
+        assertEquals(HALF_H, after.captureHalfH, 1e-6f)
+    }
+
+    /**
+     * Growing the design must move points from backbone into the footprint. If `reclassify` silently
+     * kept the old bytes, this would pass only by accident of the fixture — so the point chosen is
+     * one whose region genuinely changes.
+     */
+    @Test
+    fun `growing the design converts backbone into corroboration`() {
+        val pts = listOf(1.5f, 0f, 0f)
+        val small = FingerprintPartition.reclassify(fp(pts), identity(), HALF_W, HALF_H)
+        assertEquals(OUTSIDE, small.regions[0])
+
+        val big = FingerprintPartition.reclassify(small, identity(), 2f, 1f)
+        assertEquals("a wider design must swallow the point", INSIDE, big.regions[0])
+        assertEquals(2f, big.captureHalfW, 1e-6f)
+    }
+
+    @Test
+    fun `staleness tracks the recorded extents`() {
+        val f = FingerprintPartition.reclassify(fp(listOf(0f, 0f, 0f)), identity(), HALF_W, HALF_H)
+        assertFalse("same size is not stale", f.isPartitionStale(HALF_W, HALF_H))
+        assertTrue("a resize is stale", f.isPartitionStale(HALF_W * 1.5f, HALF_H))
+    }
+
+    /**
+     * An unpartitioned fingerprint is never "stale" — there is nothing to recompute against, and
+     * reporting it as stale would send every legacy project through a reclassify with extents it
+     * was never built for.
+     */
+    @Test
+    fun `an unpartitioned fingerprint is never stale`() {
+        assertFalse(fp(listOf(0f, 0f, 0f)).isPartitionStale(99f, 99f))
+    }
+
+    /**
+     * The legacy reading, and the one that must not be inverted: **empty regions mean all-backbone**.
+     * Reading it as all-inside would exclude a pre-Phase-2 map from the reloc PnP entirely and the
+     * target would simply never lock — a total failure that looks like bad tracking.
+     */
+    @Test
+    fun `an unpartitioned fingerprint counts as all backbone`() {
+        val legacy = fp(listOf(0f, 0f, 0f, 5f, 0f, 0f, 9f, 9f, 0f))
+        assertEquals(3, FingerprintPartition.backboneCount(legacy))
+    }
+
+    @Test
+    fun `backboneCount counts only OUTSIDE once partitioned`() {
+        val f = FingerprintPartition.reclassify(
+            fp(listOf(0f, 0f, 0f, 5f, 0f, 0f, HALF_W, 0f, 0f)), identity(), HALF_W, HALF_H,
+        )
+        // inside, outside, band -> exactly one backbone point.
+        assertEquals(1, FingerprintPartition.backboneCount(f))
+    }
+
+    /** The 1:1 invariant is enforced by the model, so a mismatched partition cannot be constructed. */
+    @Test(expected = IllegalArgumentException::class)
+    fun `a regions array that disagrees with the point count is rejected`() {
+        fp(listOf(0f, 0f, 0f, 1f, 1f, 1f), regions = ByteArray(1))
+    }
+}

--- a/feature/dashboard/src/main/java/com/hereliesaz/graffitixr/feature/dashboard/SettingsScreen.kt
+++ b/feature/dashboard/src/main/java/com/hereliesaz/graffitixr/feature/dashboard/SettingsScreen.kt
@@ -83,14 +83,8 @@ fun SettingsScreen(
     onFeaturePointsChanged: () -> Unit,
     showPlaneGrids: Boolean,
     onPlaneGridsChanged: () -> Unit,
-    showVoxels: Boolean,
-    onVoxelsChanged: () -> Unit,
     showPoints: Boolean,
     onPointsChanged: () -> Unit,
-    showMesh: Boolean,
-    onMeshChanged: () -> Unit,
-    parallaxMinDegrees: Float,
-    onParallaxMinDegreesChanged: (Float) -> Unit,
     cameraTargetFps: Int,
     onCameraTargetFpsChanged: (Int) -> Unit,
     throttleOnThermal: Boolean,
@@ -111,8 +105,6 @@ fun SettingsScreen(
     onImperialUnitsChanged: (Boolean) -> Unit,
     backgroundColor: Int,
     onBackgroundColorChanged: (Int) -> Unit,
-    muralMethod: MuralMethod,
-    onMuralMethodChanged: (MuralMethod) -> Unit,
     onCheckForUpdates: () -> Unit,
     onOpenUpdatePage: () -> Unit,
     onResetTutorials: () -> Unit,
@@ -267,39 +259,19 @@ fun SettingsScreen(
                                 modifier = Modifier.clickable { onPlaneGridsChanged() }
                             )
                             SettingsItem(
-                                label = strings.settings.layerVoxels,
-                                value = if (showVoxels) strings.settings.on else strings.settings.off,
-                                modifier = Modifier.clickable { onVoxelsChanged() }
-                            )
-                            SettingsItem(
                                 label = strings.settings.layerPoints,
                                 value = if (showPoints) strings.settings.on else strings.settings.off,
                                 modifier = Modifier.clickable { onPointsChanged() }
                             )
                             SettingsItem(
-                                label = strings.settings.layerMesh,
-                                value = if (showMesh) strings.settings.on else strings.settings.off,
-                                modifier = Modifier.clickable { onMeshChanged() }
-                            )
-                            Column(modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)) {
-                                Row(
-                                    modifier = Modifier.fillMaxWidth(),
-                                    horizontalArrangement = Arrangement.SpaceBetween
-                                ) {
-                                    Text(text = strings.settings.parallaxThreshold, fontWeight = FontWeight.Medium)
-                                    Text(text = "${"%.1f".format(parallaxMinDegrees)}°", color = Color.Gray)
-                                }
-                                Slider(
-                                    value = parallaxMinDegrees,
-                                    onValueChange = onParallaxMinDegreesChanged,
-                                    valueRange = 1f..15f
-                                )
-                            }
-                            SettingsItem(
                                 label = strings.settings.cameraFps,
-                                value = "$cameraTargetFps",
+                                value = com.hereliesaz.graffitixr.common.model.CameraTargetFps
+                                    .label(cameraTargetFps),
                                 modifier = Modifier.clickable {
-                                    onCameraTargetFpsChanged(if (cameraTargetFps == 30) 60 else 30)
+                                    onCameraTargetFpsChanged(
+                                        com.hereliesaz.graffitixr.common.model.CameraTargetFps
+                                            .next(cameraTargetFps),
+                                    )
                                 }
                             )
                             // Perception throttle triggers: each drops perception 60→30 fps to save
@@ -344,20 +316,6 @@ fun SettingsScreen(
                                 modifier = Modifier.clickable { onArScanModeChanged(nextMode) }
                             )
 
-                            if (arScanMode == ArScanMode.MURAL) {
-                                val methods = MuralMethod.entries
-                                val nextMethod = methods[(muralMethod.ordinal + 1) % methods.size]
-                                val muralMethodValue = when (muralMethod) {
-                                    MuralMethod.VOXEL_HASH -> strings.settings.voxelHash
-                                    MuralMethod.SURFACE_MESH -> strings.settings.surfaceMesh
-                                    MuralMethod.CLOUD_OFFSET -> strings.settings.cloudOffset
-                                }
-                                SettingsItem(
-                                    label = strings.settings.muralMethod,
-                                    value = muralMethodValue,
-                                    modifier = Modifier.clickable { onMuralMethodChanged(nextMethod) }
-                                )
-                            }
                             SettingsItem(
                                 label = strings.settings.anchorBoundary,
                                 value = if (showAnchorBoundary) strings.settings.on else strings.settings.off,

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Sat Aug 01 07:35:48 UTC 2026
-versionBuild=14265
+#Sat Aug 01 07:44:08 UTC 2026
+versionBuild=14273
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=131
+versionPatch=139

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Sat Aug 01 07:08:59 UTC 2026
-versionBuild=14254
+#Sat Aug 01 07:31:32 UTC 2026
+versionBuild=14261
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=120
+versionPatch=127

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Sat Aug 01 07:31:32 UTC 2026
-versionBuild=14261
+#Sat Aug 01 07:35:48 UTC 2026
+versionBuild=14265
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=127
+versionPatch=131


### PR DESCRIPTION
Two things. The first is the one that matters.

## The test Phase 0 shipped without

The audit named this gap and I did not close it: **nothing in the suite drove a pixel through the actual capture code.**

Phase 0's whole correctness argument is one claim — that the bitmap rotation and the intrinsics rotation together turn a sensor ray `d_s` into `R_z(+rotationNeeded)·d_s`. Every test written for it asserted properties *of the converter*, taking that claim as given. So a misreading of `ArRenderer`'s intrinsics branches would have been mirrored into the converter, the tests, and the paper — and all three would have agreed with each other while being wrong together. Mutation-testing the converter proves nothing against that; it only proves the converter matches my model of the code.

`CaptureRotation` extracts the two transforms from where they were inline (`ArRenderer`'s capture block, `ArViewModel.onTargetCaptured`), and **`ArRenderer` now calls it**, so the tested code is the shipped code rather than a copy.

`CaptureRotationTest` closes the loop in the only direction that can fail independently:

1. take a known 3D point in the **sensor** frame
2. project it with **raw sensor** intrinsics — plain pinhole, no rotation
3. move the pixel the way the **bitmap rotation** moves it
4. unproject with the **rotated** intrinsics `ArRenderer` actually builds
5. compare against `R_z(+θ)` written out from `cos`/`sin` — deliberately **not** from `MetricMarks.rotateZ`, which is the thing under test

Passes at all four quadrants over five points including strongly off-axis ones, with a negative control asserting `R_z(−θ)` is measurably wrong at the quarter turns.

The fixture uses a non-square frame, an off-centre principal point and **different focal lengths** on purpose: a square frame hides an axis swap, a centred principal point hides the `rawH − cy` remap, and equal focals hide the `fx`/`fy` swap entirely — the likeliest thing to get wrong.

**So Phase 0's direction is now verified against the real code, not against my reading of it.** That was the last place the convention rested on prose.

## Phase 2, partially — 2.1, 2.2, 2.4, 2.5

`Fingerprint` gains `regions` (one `Footprint.Region` byte per 3D point) plus the effective half-extents they were computed against. The 1:1 invariant is enforced in `init` for the same reason the points/descriptor-rows check is: native indexes these per row, so a disagreement reads past the end of a vector rather than failing.

**Empty regions mean legacy all-backbone, not all-inside.** Reading it the other way would exclude a pre-Phase-2 map from the reloc PnP entirely and the target would never lock — a total failure that looks like bad tracking. A test pins it.

`FingerprintPartition` holds the geometry, in `feature/ar` rather than on `Fingerprint`, because the module graph runs `feature/ar → core/common` and the data model cannot see `Footprint`. It hoists the inverse out of the per-feature loop — one `FloatArray(16)` per capture instead of 1500.

Staleness keys on the stored **effective** half-extents, following the trap `IMPLEMENTATION.md` flags: `OverlayRenderer.setExtent`'s two call sites are a fixed constant and a one-shot screen-fit, *neither user-driven*. The user's resize is `overlayScale`, which enters the model matrix — so a check watching the extents alone would compare two numbers that never move.

`FingerprintPartitionTest` covers the scaled-anchor case explicitly, which the plan calls the highest-probability bug in the phase because both conventions compile and both produce plausible numbers.

**Still open in Phase 2:** 2.3 (thread extents into the builder), 2.6–2.8 (native regions, reloc filtering, the `F_out`-too-small refusal), 2.9–2.11.

## Testing

`core:common` 99, `feature:ar` 206 — **0 failures**. `:app:compileDebugKotlin` green.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Q5WXFiVLeN4sXa9bPCSDA)_

## Summary by Sourcery

Verify the capture rotation convention against the real capture path and introduce Phase 2 fingerprint partition metadata and logic.

New Features:
- Add per-point region tags and captured design half-extents to fingerprints to support Phase 2 partitioning.
- Provide utilities to classify fingerprint points into regions, reclassify against new extents, and count backbone points.

Bug Fixes:
- Ensure the capture path’s bitmap and intrinsics rotations together implement the intended +θ display-rotation convention by testing against the shipped code.

Enhancements:
- Extract capture rotation logic into a dedicated component used by ArRenderer so the convention is testable at its origin.
- Hoist footprint inverse computation out of the per-feature loop when partitioning to reduce per-capture overhead.

Build:
- Increment build and patch versions.

Tests:
- Add CaptureRotation tests that drive pixels through the actual capture pipeline and validate rotation direction, quadrant behavior, and edge cases.
- Add FingerprintPartition tests covering region classification, scaled anchors, legacy unpartitioned fingerprints, staleness detection, and backbone counting invariants.