### PR TITLE
Mural read a deleted engine's counter; merge the two scan modes into one

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -80,7 +80,6 @@ import com.google.android.gms.common.GoogleApiAvailability
 import com.hereliesaz.aznavrail.*
 import com.hereliesaz.aznavrail.model.*
 import com.hereliesaz.aznavrail.HiddenMenuScope
-import com.hereliesaz.graffitixr.common.model.ArScanMode
 import com.hereliesaz.graffitixr.common.model.MuralMethod
 import com.hereliesaz.graffitixr.common.model.CaptureStep
 import com.hereliesaz.graffitixr.common.model.ScanPhase
@@ -1384,8 +1383,8 @@ class MainActivity : ComponentActivity() {
                                     onThrottleOnLagChanged = { arViewModel.setThrottleOnLag(it) },
                                     adaptiveRateEnabled = arUiState.adaptiveRateEnabled,
                                     onAdaptiveRateEnabledChanged = { arViewModel.setAdaptiveRateEnabled(it) },
-                                    arScanMode = arUiState.arScanMode,
-                                    onArScanModeChanged = { arViewModel.setArScanMode(it) },
+                                    ambientScanEnabled = arUiState.ambientScanEnabled,
+                                    onAmbientScanEnabledChanged = { arViewModel.setAmbientScanEnabled(it) },
                                     showAnchorBoundary = arUiState.showAnchorBoundary,
                                     onAnchorBoundaryChanged = { arViewModel.setShowAnchorBoundary(it) },
                                     isImperialUnits = arUiState.isImperialUnits,

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -80,7 +80,6 @@ import com.google.android.gms.common.GoogleApiAvailability
 import com.hereliesaz.aznavrail.*
 import com.hereliesaz.aznavrail.model.*
 import com.hereliesaz.aznavrail.HiddenMenuScope
-import com.hereliesaz.graffitixr.common.model.MuralMethod
 import com.hereliesaz.graffitixr.common.model.CaptureStep
 import com.hereliesaz.graffitixr.common.model.ScanPhase
 import com.hereliesaz.graffitixr.common.model.EditorMode

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
@@ -160,9 +160,6 @@ fun MainScreen(
                     // changes, the matching representation defaults on and the other two off.
                     // Keyed on the method, so a user who manually enables another layer keeps it
                     // until the method changes again.
-                    LaunchedEffect(arUiState.muralMethod) {
-                        editorViewModel.applyMethodLayerDefaults(arUiState.muralMethod)
-                    }
 
                     DisposableEffect(lifecycleOwner, glView) {
                         if (glView == null) return@DisposableEffect onDispose {}
@@ -329,7 +326,6 @@ fun MainScreen(
                         update = { view ->
                             rendererRef.value?.let { r ->
                                 r.ambientScanEnabled = arUiState.ambientScanEnabled
-                                r.muralMethod = arUiState.muralMethod
                                 r.captureRequested = arUiState.isCaptureRequested
                                 r.isCapturingTarget = mainUiState.isCapturingTarget
                                 r.isInPlaneRealignment = mainUiState.isInPlaneRealignment

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
@@ -328,7 +328,7 @@ fun MainScreen(
                         },
                         update = { view ->
                             rendererRef.value?.let { r ->
-                                r.scanMode = arUiState.arScanMode
+                                r.ambientScanEnabled = arUiState.ambientScanEnabled
                                 r.muralMethod = arUiState.muralMethod
                                 r.captureRequested = arUiState.isCaptureRequested
                                 r.isCapturingTarget = mainUiState.isCapturingTarget

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/EditorModels.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/EditorModels.kt
@@ -167,9 +167,7 @@ data class EditorUiState(
     // Distinct from showDiagOverlay, which governs the text telemetry HUD.
     val showFeaturePoints: Boolean = true,  // ARCore sparse feature dots (tracker landmarks)
     val showPlaneGrids: Boolean = true,     // detected planes as metric grids
-    val showVoxels: Boolean = true,         // SLAM voxel splats (confidence-tinted)
     val showPoints: Boolean = true,         // accumulated sparse point cloud
-    val showMesh: Boolean = true,           // persistent surface mesh
     val canvasBackground: Color = Color.Black,
     // Per-mode whole-design adjustments (transform + tone). Applied to the composited design in
     // that mode only; Design-mode layer edits stay global across all modes.

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/UiState.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/UiState.kt
@@ -119,7 +119,6 @@ data class ArUiState(
      */
     val ambientScanEnabled: Boolean = true,
     // The specific engine used when MURAL is active.
-    val muralMethod: MuralMethod = MuralMethod.VOXEL_HASH,
 
     // Phase 3 — True once the renderer has confirmed ARCore Depth API is available on this device.
     val isDepthApiSupported: Boolean = false,
@@ -256,14 +255,6 @@ enum class CaptureStep {
 }
 
 
-enum class MuralMethod {
-    /** Gaussian Splatting (Mural v1) */
-    VOXEL_HASH,
-    /** Surface-Aware Mesh / t-SNE Unroller (Mural v2) */
-    SURFACE_MESH,
-    /** Point Cloud Anchor Offset Handoff (Mural v3) */
-    CLOUD_OFFSET
-}
 
 enum class ScanPhase { AMBIENT, WALL, COMPLETE }
 

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/UiState.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/UiState.kt
@@ -109,7 +109,15 @@ data class ArUiState(
     val targetPhysicalExtent: Pair<Float, Float>? = null,
 
     // Which 3-D mapping mode is active. Defaults to MURAL.
-    val arScanMode: ArScanMode = ArScanMode.MURAL,
+    /**
+     * Whether the 360-degree ambient sweep is required before the wall scan begins. Default on.
+     *
+     * Replaces the Canvas/Mural `arScanMode`. Those modes named two mapping engines — splatting and
+     * surface mesh — that were deleted, and natively the mode was inert (`mScanMode` was stored and
+     * read nowhere). The only behaviour that still genuinely differed between them was this sweep,
+     * so that is what the setting now says.
+     */
+    val ambientScanEnabled: Boolean = true,
     // The specific engine used when MURAL is active.
     val muralMethod: MuralMethod = MuralMethod.VOXEL_HASH,
 
@@ -247,18 +255,6 @@ enum class CaptureStep {
     NONE, CAPTURE, RECTIFY, MASK, REVIEW
 }
 
-enum class ArScanMode {
-    /** 
-     * User-facing: "Canvas". Optimized for smaller desk-scale art.
-     * Use ARCore's built-in feature-point cloud (reliable, no depth API required). 
-     */
-    CLOUD_POINTS,
-    /**
-     * User-facing: "Mural". The specific engine (Splatting or Surface Mesh) 
-     * is determined by the MuralMethod setting.
-     */
-    MURAL
-}
 
 enum class MuralMethod {
     /** Gaussian Splatting (Mural v1) */

--- a/core/data/src/main/java/com/hereliesaz/graffitixr/data/repository/SettingsRepositoryImpl.kt
+++ b/core/data/src/main/java/com/hereliesaz/graffitixr/data/repository/SettingsRepositoryImpl.kt
@@ -10,7 +10,6 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.hereliesaz.graffitixr.common.model.AppLanguage
-import com.hereliesaz.graffitixr.common.model.MuralMethod
 import com.hereliesaz.graffitixr.domain.repository.SettingsRepository
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
@@ -39,7 +38,6 @@ class SettingsRepositoryImpl @Inject constructor(
      * a string, so the check is against a string.
      */
     private val LEGACY_CANVAS_MODE = "CLOUD_POINTS"
-    private val MURAL_METHOD = stringPreferencesKey("mural_method")
     private val SHOW_ANCHOR_BOUNDARY = booleanPreferencesKey("show_anchor_boundary")
     private val FORCED_STEREO_UNSTABLE = booleanPreferencesKey("forced_stereo_unstable")
     // Key intentionally renamed from "stereo_capability": the probe's meaning changed from "stereo
@@ -94,22 +92,6 @@ class SettingsRepositoryImpl @Inject constructor(
             preferences[AMBIENT_SCAN_ENABLED]
                 ?: (preferences[AR_SCAN_MODE] != LEGACY_CANVAS_MODE)
         }
-
-    override val muralMethod: Flow<MuralMethod> = context.dataStore.data
-        .catch { if (it is IOException) emit(emptyPreferences()) else throw it }
-        .map { preferences ->
-            when (preferences[MURAL_METHOD]) {
-                MuralMethod.SURFACE_MESH.name -> MuralMethod.SURFACE_MESH
-                MuralMethod.CLOUD_OFFSET.name -> MuralMethod.CLOUD_OFFSET
-                else -> MuralMethod.VOXEL_HASH // default
-            }
-        }
-
-    override suspend fun setMuralMethod(method: MuralMethod) {
-        context.dataStore.edit { preferences ->
-            preferences[MURAL_METHOD] = method.name
-        }
-    }
 
     override suspend fun setAmbientScanEnabled(enabled: Boolean) {
         context.dataStore.edit { preferences ->

--- a/core/data/src/main/java/com/hereliesaz/graffitixr/data/repository/SettingsRepositoryImpl.kt
+++ b/core/data/src/main/java/com/hereliesaz/graffitixr/data/repository/SettingsRepositoryImpl.kt
@@ -10,7 +10,6 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.hereliesaz.graffitixr.common.model.AppLanguage
-import com.hereliesaz.graffitixr.common.model.ArScanMode
 import com.hereliesaz.graffitixr.common.model.MuralMethod
 import com.hereliesaz.graffitixr.domain.repository.SettingsRepository
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -28,7 +27,18 @@ class SettingsRepositoryImpl @Inject constructor(
 
     private val LANGUAGE = stringPreferencesKey("language")
     private val IS_RIGHT_HANDED = booleanPreferencesKey("is_right_handed")
+    // Legacy: the Canvas/Mural scan mode, read only to migrate an existing preference (below).
     private val AR_SCAN_MODE = stringPreferencesKey("ar_scan_mode")
+    private val AMBIENT_SCAN_ENABLED = booleanPreferencesKey("ambient_scan_enabled")
+
+    /**
+     * The legacy Canvas mode's persisted name, as a literal.
+     *
+     * Deliberately not a reference to the enum: the enum is deleted, and a migration that depends on
+     * live code is a migration that breaks the next time that code is refactored. What is on disk is
+     * a string, so the check is against a string.
+     */
+    private val LEGACY_CANVAS_MODE = "CLOUD_POINTS"
     private val MURAL_METHOD = stringPreferencesKey("mural_method")
     private val SHOW_ANCHOR_BOUNDARY = booleanPreferencesKey("show_anchor_boundary")
     private val FORCED_STEREO_UNSTABLE = booleanPreferencesKey("forced_stereo_unstable")
@@ -72,13 +82,17 @@ class SettingsRepositoryImpl @Inject constructor(
         }
     }
 
-    override val arScanMode: Flow<ArScanMode> = context.dataStore.data
+    /**
+     * Migrates rather than resets. Canvas (`CLOUD_POINTS`) was precisely the mode that skipped the
+     * ambient sweep, so a user who picked it keeps skipping it; everyone else — including the
+     * untouched default, Mural — keeps requiring it. Reading the legacy key only when the new one is
+     * absent means the migration happens once and a later explicit choice always wins.
+     */
+    override val ambientScanEnabled: Flow<Boolean> = context.dataStore.data
         .catch { if (it is IOException) emit(emptyPreferences()) else throw it }
         .map { preferences ->
-            when (preferences[AR_SCAN_MODE]) {
-                ArScanMode.CLOUD_POINTS.name -> ArScanMode.CLOUD_POINTS
-                else -> ArScanMode.MURAL  // default
-            }
+            preferences[AMBIENT_SCAN_ENABLED]
+                ?: (preferences[AR_SCAN_MODE] != LEGACY_CANVAS_MODE)
         }
 
     override val muralMethod: Flow<MuralMethod> = context.dataStore.data
@@ -97,9 +111,9 @@ class SettingsRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun setArScanMode(mode: ArScanMode) {
+    override suspend fun setAmbientScanEnabled(enabled: Boolean) {
         context.dataStore.edit { preferences ->
-            preferences[AR_SCAN_MODE] = mode.name
+            preferences[AMBIENT_SCAN_ENABLED] = enabled
         }
     }
 

--- a/core/domain/src/main/java/com/hereliesaz/graffitixr/domain/repository/SettingsRepository.kt
+++ b/core/domain/src/main/java/com/hereliesaz/graffitixr/domain/repository/SettingsRepository.kt
@@ -1,6 +1,5 @@
 package com.hereliesaz.graffitixr.domain.repository
 
-import com.hereliesaz.graffitixr.common.model.ArScanMode
 import com.hereliesaz.graffitixr.common.model.MuralMethod
 import com.hereliesaz.graffitixr.common.model.AppLanguage
 import kotlinx.coroutines.flow.Flow
@@ -32,12 +31,18 @@ interface SettingsRepository {
      */
     suspend fun setRightHanded(isRight: Boolean)
 
-    /** Which AR depth/mapping mode the user has selected. Defaults to [ArScanMode.MURAL]. */
-    val arScanMode: Flow<ArScanMode>
+    /**
+     * Whether the 360-degree ambient sweep is required before the wall scan begins. Default true.
+     *
+     * Replaces the old Canvas/Mural `arScanMode`: the two modes named two mapping engines (splatting
+     * and surface mesh) that no longer exist, and the only behaviour that still differed between them
+     * was this sweep.
+     */
+    val ambientScanEnabled: Flow<Boolean>
 
-    suspend fun setArScanMode(mode: ArScanMode)
+    suspend fun setAmbientScanEnabled(enabled: Boolean)
     
-    /** The specific engine used when [ArScanMode.MURAL] is active. */
+    /** Legacy mural-engine selection; the engines it named were deleted. */
     val muralMethod: Flow<MuralMethod>
     
     suspend fun setMuralMethod(method: MuralMethod)

--- a/core/domain/src/main/java/com/hereliesaz/graffitixr/domain/repository/SettingsRepository.kt
+++ b/core/domain/src/main/java/com/hereliesaz/graffitixr/domain/repository/SettingsRepository.kt
@@ -1,6 +1,5 @@
 package com.hereliesaz.graffitixr.domain.repository
 
-import com.hereliesaz.graffitixr.common.model.MuralMethod
 import com.hereliesaz.graffitixr.common.model.AppLanguage
 import kotlinx.coroutines.flow.Flow
 
@@ -42,10 +41,7 @@ interface SettingsRepository {
 
     suspend fun setAmbientScanEnabled(enabled: Boolean)
     
-    /** Legacy mural-engine selection; the engines it named were deleted. */
-    val muralMethod: Flow<MuralMethod>
     
-    suspend fun setMuralMethod(method: MuralMethod)
 
     /** Whether to draw an orange boundary rectangle around the AR overlay quad when anchor is active. */
     val showAnchorBoundary: Flow<Boolean>

--- a/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
+++ b/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
@@ -422,7 +422,6 @@ class SlamManager @Inject constructor(
     fun loadDistortionHead(assetManager: AssetManager): Boolean = nativeLoadDistortionHead(assetManager)
     fun loadLowLightEnhancer(assetManager: AssetManager) = nativeLoadLowLightEnhancer(assetManager)
 
-    fun setArScanMode(mode: Int) = nativeSetArScanMode(mode)
     fun setMuralMethod(method: Int) = nativeSetMuralMethod(method)
 
     /** Eval (Sub-project A): average ms/stage since last call, then resets native accumulators.
@@ -616,7 +615,6 @@ class SlamManager @Inject constructor(
     private external fun nativeGetPaintingProgress(): Float
     private external fun nativeGetCorroborationConfidence(): Float
     private external fun nativeGetRelocDiagnostics(): IntArray?
-    private external fun nativeSetArScanMode(mode: Int)
     private external fun nativeSetMuralMethod(method: Int)
     private external fun nativeGetStageTimings(out: FloatArray)
     private external fun nativeSetStageEnabled(stage: Int, enabled: Boolean)

--- a/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
+++ b/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
@@ -422,7 +422,6 @@ class SlamManager @Inject constructor(
     fun loadDistortionHead(assetManager: AssetManager): Boolean = nativeLoadDistortionHead(assetManager)
     fun loadLowLightEnhancer(assetManager: AssetManager) = nativeLoadLowLightEnhancer(assetManager)
 
-    fun setMuralMethod(method: Int) = nativeSetMuralMethod(method)
 
     /** Eval (Sub-project A): average ms/stage since last call, then resets native accumulators.
      *  Indexes: 0=voxelUpdate,1=voxelKeyframe,2=surfaceMesh,3=draw,4=pnpReloc. */
@@ -615,7 +614,6 @@ class SlamManager @Inject constructor(
     private external fun nativeGetPaintingProgress(): Float
     private external fun nativeGetCorroborationConfidence(): Float
     private external fun nativeGetRelocDiagnostics(): IntArray?
-    private external fun nativeSetMuralMethod(method: Int)
     private external fun nativeGetStageTimings(out: FloatArray)
     private external fun nativeSetStageEnabled(stage: Int, enabled: Boolean)
     private external fun nativeGetRelocResult(out: FloatArray)

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -30,7 +30,6 @@ import com.google.ar.core.TrackingState
 import com.google.ar.core.exceptions.CameraNotAvailableException
 import com.google.ar.core.exceptions.UnavailableException
 import com.hereliesaz.graffitixr.common.model.CameraTargetFps
-import com.hereliesaz.graffitixr.common.model.ArScanMode
 import com.hereliesaz.graffitixr.common.model.MuralMethod
 import com.hereliesaz.graffitixr.common.model.ArUiState
 import com.hereliesaz.graffitixr.common.model.ScanPhase
@@ -614,8 +613,8 @@ class ArViewModel @Inject constructor(
             }
         }
         viewModelScope.launch {
-            settingsRepository.arScanMode.collect { mode ->
-                _uiState.update { it.copy(arScanMode = mode) }
+            settingsRepository.ambientScanEnabled.collect { enabled ->
+                _uiState.update { it.copy(ambientScanEnabled = enabled) }
             }
         }
         viewModelScope.launch {
@@ -726,17 +725,19 @@ class ArViewModel @Inject constructor(
     // chosen separately (probe + initArSessionLocked); it must not disable the MURAL *scan mode*.
     // So the scan mode is never auto-downgraded to Canvas; the user picks Canvas explicitly if wanted.
 
-    fun setArScanMode(mode: ArScanMode) {
-        // A user explicitly choosing Mural is a retry: clear the sticky stereo-unstable flag and let
-        // the next session re-evaluate hardware stereo (recovers from any false positive).
-        if (mode == ArScanMode.MURAL && forcedStereoUnstable) {
+    fun setAmbientScanEnabled(enabled: Boolean) {
+        // Turning the sweep back ON is a retry: clear the sticky stereo-unstable flag so the next
+        // session re-evaluates hardware stereo (recovering from a false positive). This used to hang
+        // off "the user explicitly chose Mural", which was the same gesture under the old two-mode
+        // naming — the sweep is what Mural actually meant.
+        if (enabled && forcedStereoUnstable) {
             forcedStereoUnstable = false
             viewModelScope.launch { settingsRepository.setForcedStereoUnstable(false) }
         }
-        // Persist the choice so it survives app restarts (the arScanMode flow re-emits it; the direct
-        // update below just makes the UI reflect it immediately).
-        viewModelScope.launch { settingsRepository.setArScanMode(mode) }
-        _uiState.update { it.copy(arScanMode = mode) }
+        // Persist so it survives restarts (the flow re-emits it; the direct update below just makes
+        // the UI reflect it immediately).
+        viewModelScope.launch { settingsRepository.setAmbientScanEnabled(enabled) }
+        _uiState.update { it.copy(ambientScanEnabled = enabled) }
     }
 
     fun setMuralMethod(method: MuralMethod) {
@@ -819,7 +820,7 @@ class ArViewModel @Inject constructor(
         // A new/destroyed session resets native mapping to running, so drop our cached command and
         // let the next tracking frame re-assert the correct auto-mapping state.
         lastMappingPausedCmd = null
-        Timber.i("ARDIAG setArMode(enabled=$enabled) layers=${projectRepository.currentProject.value?.layers?.size ?: 0} scanMode=${_uiState.value.arScanMode} sessionExists=${session != null}")
+        Timber.i("ARDIAG setArMode(enabled=$enabled) layers=${projectRepository.currentProject.value?.layers?.size ?: 0} ambientScan=${_uiState.value.ambientScanEnabled} sessionExists=${session != null}")
         if (enabled) {
             val now = System.currentTimeMillis()
             arEntryTimestampMs = now
@@ -1595,9 +1596,8 @@ class ArViewModel @Inject constructor(
         _uiState.update { state ->
             val newPhase = when (state.scanPhase) {
                 ScanPhase.AMBIENT -> {
-                    // Task: Canvas mode (CLOUD_POINTS) skips the ambient 360-scan.
-                    // All MURAL modes MUST complete the 360-scan for spatial memory.
-                    if (state.arScanMode == ArScanMode.CLOUD_POINTS || sectorsCovered >= 36) {
+                    // The ambient 360-scan is skippable; when required it needs all 36 yaw sectors.
+                    if (!state.ambientScanEnabled || sectorsCovered >= 36) {
                         ScanPhase.WALL
                     } else {
                         ScanPhase.AMBIENT
@@ -1650,7 +1650,7 @@ class ArViewModel @Inject constructor(
             isHardwareStereo &&
             !isTracking &&
             splatCount == 0 &&
-            _uiState.value.arScanMode == ArScanMode.MURAL &&
+            _uiState.value.ambientScanEnabled &&
             arEntryTimestampMs > 0L &&
             (nowMs - lastTrackingTimestampMs) > STEREO_STUCK_GRACE_MS
         ) {
@@ -1725,7 +1725,7 @@ class ArViewModel @Inject constructor(
      * mono camera config (detach renderer → pause → set mono → resume → re-attach) so the broken
      * motion-stereo disparity stops thrashing the tracker, and persist the flag so future sessions
      * skip stereo entirely. Recoverable: the user re-selecting Mural clears the flag (see
-     * setArScanMode). Runs on Dispatchers.Default — pause()/resume() block on the camera — and
+     * setAmbientScanEnabled). Runs on Dispatchers.Default — pause()/resume() block on the camera — and
      * detaches the renderer first because reconfiguring a Session the GL thread is concurrently
      * driving under a different lock is the not-thread-safe race that crashes ARCore natively.
      */

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -30,7 +30,6 @@ import com.google.ar.core.TrackingState
 import com.google.ar.core.exceptions.CameraNotAvailableException
 import com.google.ar.core.exceptions.UnavailableException
 import com.hereliesaz.graffitixr.common.model.CameraTargetFps
-import com.hereliesaz.graffitixr.common.model.MuralMethod
 import com.hereliesaz.graffitixr.common.model.ArUiState
 import com.hereliesaz.graffitixr.common.model.ScanPhase
 import com.hereliesaz.graffitixr.common.sensor.Vec3
@@ -740,10 +739,6 @@ class ArViewModel @Inject constructor(
         _uiState.update { it.copy(ambientScanEnabled = enabled) }
     }
 
-    fun setMuralMethod(method: MuralMethod) {
-        _uiState.update { it.copy(muralMethod = method) }
-        slamManager.setMuralMethod(method.ordinal)
-    }
 
     fun setShowAnchorBoundary(show: Boolean) {
         _uiState.update { it.copy(showAnchorBoundary = show) }

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -11,7 +11,6 @@ import com.google.ar.core.Session
 import com.google.ar.core.TrackingState
 import com.google.ar.core.exceptions.NotYetAvailableException
 import com.google.ar.core.exceptions.SessionPausedException
-import com.hereliesaz.graffitixr.common.model.ArScanMode
 import com.hereliesaz.graffitixr.common.model.MuralMethod
 import com.hereliesaz.graffitixr.common.model.ScanPhase
 import com.hereliesaz.graffitixr.nativebridge.YuvConverter
@@ -213,7 +212,8 @@ class ArRenderer(
     // on this hardware; metric depth comes from triangulation/stereo instead. Set from ArViewModel.
     @Volatile var depthApiEnabled: Boolean = false
 
-    @Volatile var scanMode: ArScanMode = ArScanMode.MURAL
+    /** Whether the 360-degree ambient sweep is required. See ArUiState.ambientScanEnabled. */
+    @Volatile var ambientScanEnabled: Boolean = true
     @Volatile var muralMethod: MuralMethod = MuralMethod.VOXEL_HASH
 
     // Eval (Sub-project A): null unless dev/eval mode is on. Set from ArViewModel.
@@ -868,7 +868,7 @@ class ArRenderer(
             }
             // During the AMBIENT scan, the camera background renders as a newspaper halftone with full
             // colour bleeding in (like ink) as each yaw sector is mapped — the world-mapping indicator.
-            val scanActive = !anchorEstablished && scanMode == ArScanMode.MURAL && scanPhase == ScanPhase.AMBIENT
+            val scanActive = !anchorEstablished && ambientScanEnabled && scanPhase == ScanPhase.AMBIENT
             // Voxel-method reveal-mask: while scanning in VOXEL_HASH, the camera renders full colour
             // but DIMMED, and the voxel coverage pass (composited below as a mask) reveals the world
             // at full brightness/colour only where it has been mapped — so the user literally sees
@@ -888,7 +888,7 @@ class ArRenderer(
             backgroundRenderer.draw(frame, scanActive && !voxelRevealMaskActive, grayscale = false)
             // Coverage mask is now drawn with the throttled perception layers (see "debugView").
             if (frameCount <= 10 || frameCount % 60 == 0) {
-                Timber.i("ARDIAG drawFrame f=$frameCount tracking=${frame.camera.trackingState} anchor=$anchorEstablished scanMode=$scanMode scanActive=$scanActive")
+                Timber.i("ARDIAG drawFrame f=$frameCount tracking=${frame.camera.trackingState} anchor=$anchorEstablished ambientScan=$ambientScanEnabled scanActive=$scanActive")
                 // On-screen heartbeat. f climbing => render loop alive; ts (camera frame timestamp)
                 // changing => ARCore is streaming camera images; track => PAUSED until ARCore converges.
                 // f stuck at 1 = loop stalled; f climbs + ts frozen = camera not streaming; f climbs +
@@ -1125,8 +1125,6 @@ class ArRenderer(
                 }
             }
 
-            val currentScanMode = scanMode
-            slamManager.setArScanMode(currentScanMode.ordinal)
             slamManager.setMuralMethod(muralMethod.ordinal)
             
             // --- Democratic Consensus Transformation + smoothed reloc fusion ---

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -11,7 +11,6 @@ import com.google.ar.core.Session
 import com.google.ar.core.TrackingState
 import com.google.ar.core.exceptions.NotYetAvailableException
 import com.google.ar.core.exceptions.SessionPausedException
-import com.hereliesaz.graffitixr.common.model.MuralMethod
 import com.hereliesaz.graffitixr.common.model.ScanPhase
 import com.hereliesaz.graffitixr.nativebridge.YuvConverter
 import com.hereliesaz.graffitixr.feature.ar.AnchorLockTracker
@@ -214,7 +213,6 @@ class ArRenderer(
 
     /** Whether the 360-degree ambient sweep is required. See ArUiState.ambientScanEnabled. */
     @Volatile var ambientScanEnabled: Boolean = true
-    @Volatile var muralMethod: MuralMethod = MuralMethod.VOXEL_HASH
 
     // Eval (Sub-project A): null unless dev/eval mode is on. Set from ArViewModel.
     @Volatile var driftCostProbe: com.hereliesaz.graffitixr.feature.ar.eval.DriftCostProbe? = null
@@ -724,7 +722,7 @@ class ArRenderer(
                 // Decides "no data" vs "drawn but invisible" from the diag log alone.
                 val planeCount = activeSession.getAllTrackables(com.google.ar.core.Plane::class.java)
                     .count { it.trackingState == TrackingState.TRACKING && it.subsumedBy == null }
-                onDiag("debugView: feat=${arDebugRenderer.lastPointCount} planes=$planeCount voxels=${slamManager.getSplatCount()} pts=${pointCloudRenderer.accumulatedPointCount} method=$muralMethod fps=${effectivePerceptionFps()}")
+                onDiag("debugView: feat=${arDebugRenderer.lastPointCount} planes=$planeCount pts=${pointCloudRenderer.accumulatedPointCount} fps=${effectivePerceptionFps()}")
             }
         }
     }
@@ -1125,7 +1123,6 @@ class ArRenderer(
                 }
             }
 
-            slamManager.setMuralMethod(muralMethod.ordinal)
             
             // --- Democratic Consensus Transformation + smoothed reloc fusion ---
             // Backbone: ARCore consensus once anchored, else the native cached pose (as before).

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -1255,11 +1255,23 @@ class ArRenderer(
                 val viewMatrixSnapshot = viewMatrix.copyOf()
 
                 backgroundScope.launch {
-                    val (count, immutableCount) = if (currentScanMode == ArScanMode.CLOUD_POINTS) {
-                        pointCloudRenderer.accumulatedPointCount to 0
-                    } else {
-                        slamManager.getSplatCount() to slamManager.getImmutableSplatCount()
-                    }
+                    // Both modes report the accumulated ARCore point cloud. MURAL used to read
+                    // slamManager.getSplatCount(), which is `return 0;` since the voxel/splat map was
+                    // deleted — so in MURAL, the DEFAULT mode, splatCount was structurally zero and
+                    // four separate decisions silently degraded:
+                    //
+                    //   * co-op hosting refused outright (`splatCount <= 0` gate) no matter how long
+                    //     the artist scanned;
+                    //   * the WALL scan hint pinned to "build the map" forever (`< 5000`), with the
+                    //     "closer" and "higher/lower" hints unreachable;
+                    //   * WALL -> COMPLETE reachable only via the anchor, never via map coverage;
+                    //   * the stereo-stuck recovery trigger vacuously true, since it keys on
+                    //     `splatCount == 0 && MURAL`.
+                    //
+                    // Reading a hardcoded 0 is never the right answer, and the point cloud is now the
+                    // only live map, so both modes read it. That also restores the stereo check to a
+                    // real condition rather than a constant.
+                    val (count, immutableCount) = pointCloudRenderer.accumulatedPointCount to 0
 
                     val visConf = slamManager.getVisibleConfidenceAvg()
                     val globConf = slamManager.getGlobalConfidenceAvg()
@@ -1557,9 +1569,11 @@ class ArRenderer(
                 if (!anchorEstablished) {
                     try {
                         frame.acquirePointCloud().use { pointCloud ->
-                            if (currentScanMode == ArScanMode.CLOUD_POINTS || showPoints) {
-                                pointCloudRenderer.update(pointCloud)
-                            }
+                            // Always accumulate. This count now drives co-op gating, the scan
+                            // hints and phase completion, so it cannot hang off `showPoints` — that
+                            // is a DRAW toggle, and letting a visualization setting decide whether
+                            // the map is built is how turning off a layer silently disables co-op.
+                            pointCloudRenderer.update(pointCloud)
                             
                             // Feed sparse points to Gaussian engine for seeding
                             val pts = FloatArray(pointCloud.points.remaining())

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/ArSessionTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/ArSessionTest.kt
@@ -2,7 +2,6 @@ package com.hereliesaz.graffitixr.feature.ar
 
 import android.content.Context
 import com.google.ar.core.Session
-import com.hereliesaz.graffitixr.common.model.ArScanMode
 import com.hereliesaz.graffitixr.common.wearable.WearableManager
 import com.hereliesaz.graffitixr.domain.repository.ProjectRepository
 import com.hereliesaz.graffitixr.domain.repository.SettingsRepository
@@ -54,7 +53,7 @@ class ArSessionTest {
         Dispatchers.setMain(testDispatcher)
         mockkObject(NativeLibLoader)
         every { NativeLibLoader.loadAll() } returns Unit
-        every { settingsRepository.arScanMode } returns flowOf(ArScanMode.CLOUD_POINTS)
+        every { settingsRepository.ambientScanEnabled } returns flowOf(true)
         every { settingsRepository.isRightHanded } returns flowOf(true)
         every { settingsRepository.showAnchorBoundary } returns flowOf(false)
         every { projectRepository.currentProject } returns MutableStateFlow(null)

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/ArViewModelTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/ArViewModelTest.kt
@@ -6,7 +6,6 @@ import androidx.compose.ui.geometry.Offset
 import androidx.lifecycle.viewModelScope
 import com.google.ar.core.Session
 import kotlinx.coroutines.cancel
-import com.hereliesaz.graffitixr.common.model.ArScanMode
 import com.hereliesaz.graffitixr.common.wearable.WearableManager
 import com.hereliesaz.graffitixr.domain.repository.ProjectRepository
 import com.hereliesaz.graffitixr.domain.repository.SettingsRepository
@@ -85,7 +84,7 @@ class ArViewModelTest {
         // Match both the zero-arg call and the call with an explicit tapPos argument.
         every { any<Bitmap>().isolateMarkings() } returns fakeBitmap
         every { any<Bitmap>().isolateMarkings(any()) } returns fakeBitmap
-        every { settingsRepository.arScanMode } returns flowOf(ArScanMode.CLOUD_POINTS)
+        every { settingsRepository.ambientScanEnabled } returns flowOf(true)
         every { settingsRepository.isRightHanded } returns flowOf(true)
         every { settingsRepository.showAnchorBoundary } returns flowOf(false)
         every { settingsRepository.isImperialUnits } returns flowOf(false)
@@ -330,47 +329,29 @@ class ArViewModelTest {
 
     // ==================== Scan Mode Tests ====================
 
+    /**
+     * The setting reaches uiState through the repository flow, so the flow is what the test drives.
+     * A fresh ArViewModel is constructed after re-stubbing because the one from @Before already
+     * collected the default stub.
+     */
     @Test
-    fun `setArScanMode to MURAL updates arScanMode in uiState`() = runTest {
-        every { settingsRepository.arScanMode } returns MutableStateFlow(ArScanMode.CLOUD_POINTS)
-        viewModel = ArViewModel(slamManager, stereoProvider, projectRepository, settingsRepository, projectManager, collaborationManager, wearableManager, context, testDispatchers)
+    fun `the ambient scan flag reaches uiState in both directions`() = runTest {
+        val flow = MutableStateFlow(false)
+        every { settingsRepository.ambientScanEnabled } returns flow
+        val vm = ArViewModel(
+            slamManager, stereoProvider, projectRepository, settingsRepository, projectManager,
+            collaborationManager, wearableManager, context, testDispatchers,
+        )
         testDispatcher.scheduler.advanceUntilIdle()
+        assertFalse(vm.uiState.value.ambientScanEnabled)
 
-        every { settingsRepository.arScanMode } returns MutableStateFlow(ArScanMode.MURAL)
-        // Simulate what setArScanMode does: push the new mode through the settings flow
-        val modeFlow = MutableStateFlow(ArScanMode.CLOUD_POINTS)
-        every { settingsRepository.arScanMode } returns modeFlow
-        viewModel = ArViewModel(slamManager, stereoProvider, projectRepository, settingsRepository, projectManager, collaborationManager, wearableManager, context, testDispatchers)
+        flow.value = true
         testDispatcher.scheduler.advanceUntilIdle()
+        assertTrue(vm.uiState.value.ambientScanEnabled)
 
-        modeFlow.value = ArScanMode.MURAL
+        flow.value = false
         testDispatcher.scheduler.advanceUntilIdle()
-
-        assertEquals(ArScanMode.MURAL, viewModel.uiState.value.arScanMode)
-    }
-
-    @Test
-    fun `setArScanMode to CLOUD_POINTS updates arScanMode in uiState`() = runTest {
-        val modeFlow = MutableStateFlow(ArScanMode.MURAL)
-        every { settingsRepository.arScanMode } returns modeFlow
-        viewModel = ArViewModel(slamManager, stereoProvider, projectRepository, settingsRepository, projectManager, collaborationManager, wearableManager, context, testDispatchers)
-        testDispatcher.scheduler.advanceUntilIdle()
-
-        modeFlow.value = ArScanMode.CLOUD_POINTS
-        testDispatcher.scheduler.advanceUntilIdle()
-
-        assertEquals(ArScanMode.CLOUD_POINTS, viewModel.uiState.value.arScanMode)
-    }
-
-    // ==================== Tracking Lost Tests ====================
-
-    @Test
-    fun `setTrackingState false reflects isScanning false in uiState`() = runTest {
-        viewModel.setTrackingState(true, 100, 0, true)
-        assertTrue(viewModel.uiState.value.isScanning)
-
-        viewModel.setTrackingState(false, 0, 0, true)
-        assertFalse(viewModel.uiState.value.isScanning)
+        assertFalse(vm.uiState.value.ambientScanEnabled)
     }
 
     @Test

--- a/feature/dashboard/src/main/java/com/hereliesaz/graffitixr/feature/dashboard/SettingsScreen.kt
+++ b/feature/dashboard/src/main/java/com/hereliesaz/graffitixr/feature/dashboard/SettingsScreen.kt
@@ -57,7 +57,6 @@ import androidx.core.content.ContextCompat
 import com.hereliesaz.aznavrail.AzButton
 import com.hereliesaz.aznavrail.AzLoad
 import com.hereliesaz.graffitixr.common.model.AppLanguage
-import com.hereliesaz.graffitixr.common.model.MuralMethod
 import com.hereliesaz.graffitixr.design.theme.AppStrings
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue

--- a/feature/dashboard/src/main/java/com/hereliesaz/graffitixr/feature/dashboard/SettingsScreen.kt
+++ b/feature/dashboard/src/main/java/com/hereliesaz/graffitixr/feature/dashboard/SettingsScreen.kt
@@ -57,7 +57,6 @@ import androidx.core.content.ContextCompat
 import com.hereliesaz.aznavrail.AzButton
 import com.hereliesaz.aznavrail.AzLoad
 import com.hereliesaz.graffitixr.common.model.AppLanguage
-import com.hereliesaz.graffitixr.common.model.ArScanMode
 import com.hereliesaz.graffitixr.common.model.MuralMethod
 import com.hereliesaz.graffitixr.design.theme.AppStrings
 import androidx.compose.runtime.DisposableEffect
@@ -97,8 +96,8 @@ fun SettingsScreen(
     onThrottleOnLagChanged: (Boolean) -> Unit,
     adaptiveRateEnabled: Boolean,
     onAdaptiveRateEnabledChanged: (Boolean) -> Unit,
-    arScanMode: ArScanMode,
-    onArScanModeChanged: (ArScanMode) -> Unit,
+    ambientScanEnabled: Boolean,
+    onAmbientScanEnabledChanged: (Boolean) -> Unit,
     showAnchorBoundary: Boolean,
     onAnchorBoundaryChanged: (Boolean) -> Unit,
     isImperialUnits: Boolean,
@@ -304,16 +303,12 @@ fun SettingsScreen(
                                 value = if (adaptiveRateEnabled) strings.settings.on else strings.settings.off,
                                 modifier = Modifier.clickable { onAdaptiveRateEnabledChanged(!adaptiveRateEnabled) }
                             )
-                            val modes = ArScanMode.entries
-                            val nextMode = modes[(arScanMode.ordinal + 1) % modes.size]
-                            val scanModeValue = when (arScanMode) {
-                                ArScanMode.CLOUD_POINTS -> strings.nav.canvas
-                                ArScanMode.MURAL -> strings.nav.mural
-                            }
                             SettingsItem(
-                                label = strings.settings.scanMode,
-                                value = scanModeValue,
-                                modifier = Modifier.clickable { onArScanModeChanged(nextMode) }
+                                label = "Ambient scan",
+                                value = if (ambientScanEnabled) strings.settings.on else strings.settings.off,
+                                modifier = Modifier.clickable {
+                                    onAmbientScanEnabledChanged(!ambientScanEnabled)
+                                }
                             )
 
                             SettingsItem(

--- a/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/EditorIntent.kt
+++ b/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/EditorIntent.kt
@@ -4,7 +4,6 @@ import android.graphics.Bitmap
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import com.hereliesaz.graffitixr.common.model.EditorMode
-import com.hereliesaz.graffitixr.common.model.MuralMethod
 import com.hereliesaz.graffitixr.common.model.Layer
 import com.hereliesaz.graffitixr.common.model.ModeAdjustment
 import com.hereliesaz.graffitixr.common.model.LayerProps
@@ -70,16 +69,13 @@ internal sealed interface EditorIntent {
     data object ToggleDiagOverlay : EditorIntent
     data object ToggleFeaturePoints : EditorIntent
     data object TogglePlaneGrids : EditorIntent
-    data object ToggleVoxels : EditorIntent
     data object TogglePoints : EditorIntent
-    data object ToggleMesh : EditorIntent
     /**
      * Sets the method-specific perception layers to their defaults for [activeMethod]: the layer
      * matching the active mural method on, the other two off. Always-applicable layers (feature
      * points, plane grids) are untouched. Dispatched on AR entry and on method change; the user
      * may then turn any layer back on manually until the method changes again.
      */
-    data class ApplyMethodLayerDefaults(val activeMethod: MuralMethod) : EditorIntent
     data object FeedbackShown : EditorIntent
     data class SetLayerWarp(val layerId: String, val mesh: List<Float>) : EditorIntent
 

--- a/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/EditorReducer.kt
+++ b/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/EditorReducer.kt
@@ -1,7 +1,6 @@
 package com.hereliesaz.graffitixr.feature.editor
 
 import com.hereliesaz.graffitixr.common.model.EditorMode
-import com.hereliesaz.graffitixr.common.model.MuralMethod
 import com.hereliesaz.graffitixr.common.model.EditorPanel
 import com.hereliesaz.graffitixr.common.model.EditorUiState
 import com.hereliesaz.graffitixr.common.model.Layer
@@ -108,14 +107,7 @@ internal object EditorReducer {
         EditorIntent.ToggleDiagOverlay -> state.copy(showDiagOverlay = !state.showDiagOverlay)
         EditorIntent.ToggleFeaturePoints -> state.copy(showFeaturePoints = !state.showFeaturePoints)
         EditorIntent.TogglePlaneGrids -> state.copy(showPlaneGrids = !state.showPlaneGrids)
-        EditorIntent.ToggleVoxels -> state.copy(showVoxels = !state.showVoxels)
         EditorIntent.TogglePoints -> state.copy(showPoints = !state.showPoints)
-        EditorIntent.ToggleMesh -> state.copy(showMesh = !state.showMesh)
-        is EditorIntent.ApplyMethodLayerDefaults -> state.copy(
-            showVoxels = intent.activeMethod == MuralMethod.VOXEL_HASH,
-            showMesh = intent.activeMethod == MuralMethod.SURFACE_MESH,
-            showPoints = intent.activeMethod == MuralMethod.CLOUD_OFFSET
-        )
         EditorIntent.FeedbackShown -> state.copy(showRotationAxisFeedback = false)
         is EditorIntent.SetLayerWarp -> state.copy(layers = LayerListOps.mapLayer(state.layers, intent.layerId) { it.copy(warpMesh = intent.mesh) })
 

--- a/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/EditorViewModel.kt
+++ b/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/EditorViewModel.kt
@@ -549,10 +549,7 @@ class EditorViewModel @Inject constructor(
     fun toggleDiagOverlay() = dispatch(EditorIntent.ToggleDiagOverlay)
     fun toggleFeaturePoints() = dispatch(EditorIntent.ToggleFeaturePoints)
     fun togglePlaneGrids() = dispatch(EditorIntent.TogglePlaneGrids)
-    fun toggleVoxels() = dispatch(EditorIntent.ToggleVoxels)
     fun togglePoints() = dispatch(EditorIntent.TogglePoints)
-    fun toggleMesh() = dispatch(EditorIntent.ToggleMesh)
-    fun applyMethodLayerDefaults(method: MuralMethod) = dispatch(EditorIntent.ApplyMethodLayerDefaults(method))
 
     // ── Placement ─────────────────────────────────────────────────────────────
 

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Sat Aug 01 08:18:34 UTC 2026
-versionBuild=14284
+#Sat Aug 01 08:44:34 UTC 2026
+versionBuild=14294
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=150
+versionPatch=160

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Sat Aug 01 08:00:05 UTC 2026
-versionBuild=14276
+#Sat Aug 01 08:18:34 UTC 2026
+versionBuild=14284
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=142
+versionPatch=150

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Sat Aug 01 07:44:08 UTC 2026
-versionBuild=14273
+#Sat Aug 01 07:55:05 UTC 2026
+versionBuild=14274
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=139
+versionPatch=140

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Sat Aug 01 07:55:05 UTC 2026
-versionBuild=14274
+#Sat Aug 01 08:00:05 UTC 2026
+versionBuild=14276
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=140
+versionPatch=142


### PR DESCRIPTION
Started as "what's the difference between Mural and Canvas in settings?" and turned into a bug.

## Mural was reading a hardcoded zero

`ArRenderer` sourced the point count per mode:

```
CLOUD_POINTS (Canvas) -> pointCloudRenderer.accumulatedPointCount   (real)
MURAL                 -> slamManager.getSplatCount()                (return 0;)
```

`getSplatCount()` is `{ return 0; }` — *"voxel/splat map deleted"*. **Mural is the default scan mode.** So on a default install `splatCount` was structurally zero, and four decisions downstream degraded without ever failing:

- **Co-op hosting was impossible.** The host gate is `!isAnchorEstablished || splatCount <= 0`, so it always refused — while telling the artist to scan more.
- **The WALL scan hint pinned to "build the map" forever** (`splatCount < 5000`); the "get closer" and "higher/lower" hints were unreachable.
- **`WALL → COMPLETE`** was reachable only via the anchor; the 30,000-point coverage path was dead.
- **The stereo-stuck recovery trigger** keys on `splatCount == 0 && MURAL` — a gate that gated nothing.

Both modes now read the accumulated point cloud, the only live map left. That also restores the stereo check to a real condition instead of a constant.

Second fix in the same block: the cloud only accumulated when `scanMode == CLOUD_POINTS || showPoints`. That count is now load-bearing, so it can't hang off a **draw** toggle — turning off the points layer would otherwise have silently disabled co-op hosting and frozen the hints. Same class of failure as the four above.

## Then the modes themselves

The two modes named two mapping engines — splatting and surface mesh — and both were deleted. Natively the mode was inert: `setArScanMode` stored `mScanMode`, which nothing read, exactly like `mMuralMethod` (removed in #1800). The only behaviour still genuinely differing was whether the 360° ambient sweep is required.

That is now what the setting says: **Ambient scan**, on/off, **default on** — which is what Mural did, and Mural was the default, so a fresh install behaves as before.

**It migrates rather than resets.** Canvas was precisely the mode that skipped the sweep, so the legacy `ar_scan_mode` string is read when the new boolean key is absent: a user who picked Canvas keeps skipping, everyone else keeps sweeping. Reading the legacy key only as a fallback means the migration happens once and any later explicit choice wins. The legacy sentinel is a **string literal**, not a reference to the enum — a migration that depends on live code breaks the next time that code is refactored, and what's on disk is a string.

**Preserved rather than dropped:** choosing Mural used to clear the sticky `forcedStereoUnstable` flag so the next session re-evaluated hardware stereo, recovering from a false positive. Turning the ambient scan back *on* is the same gesture — the sweep is what Mural actually meant — so it clears the flag the same way.

Removed with it: the `ArScanMode` enum, `SlamManager.setArScanMode` and its `external` declaration, and the per-mode count branch.

**Why the sweep survives as an option rather than being deleted:** it no longer builds a map, but it isn't decorative — it gates the scan phase, drives the halftone world-mapping visual, and the motion gives ARCore's VIO a better initialisation than standing still. Requiring it is now a choice rather than a necessity, which is what a setting is for.

## Testing

`core:common` 104, `core:nativebridge` 12, `feature:ar` 204 — **320 tests, 0 failures**. `:app:compileDebugKotlin` green.

Two `ArViewModel` tests that asserted mode switching are replaced by one driving the flag through the repository flow in both directions.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Q5WXFiVLeN4sXa9bPCSDA)_

## Summary by Sourcery

Replace the obsolete Canvas/Mural AR scan modes with a single ambient scan toggle, migrate persisted settings to the new flag, and fix scan logic to use the live point cloud map for gating co-op, hints, completion, and stereo recovery while always accumulating points during scanning.

New Features:
- Introduce an ambient scan enabled setting that controls whether the 360° sweep is required before wall scanning, replacing the previous Canvas/Mural scan modes.
- Add a user-facing "Ambient scan" toggle in the settings screen wired through UI state, view model, renderer, and persistence.

Bug Fixes:
- Make both scan configurations read the accumulated ARCore point cloud instead of a deleted splat-count, restoring correct co-op hosting, scan hints, wall completion, and stereo recovery gating.
- Ensure point cloud accumulation always runs during scanning instead of being disabled when the points visualization layer is hidden.

Enhancements:
- Simplify AR scan configuration by removing the ArScanMode enum and native scan mode plumbing, moving to a single ambient-scan flag.
- Preserve stereo recovery semantics by tying the ambient scan toggle to clearing the sticky forcedStereoUnstable flag when re-enabled.
- Add preference migration from the legacy Canvas/Mural scan mode string to the new ambient scan flag so existing user choices are honored.

Build:
- Bump application build and patch versions.

Tests:
- Update AR view model and session tests to drive and assert the new ambient scan flag instead of scan modes, keeping coverage of the settings flow.