### PR TITLE
The eval harness could never record a pose error

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,8 +18,12 @@
     <uses-feature android:glEsVersion="0x00030000" android:required="false" />
 
     <!-- Storage and Location Permissions -->
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
+    <!-- No READ_MEDIA_IMAGES / READ_EXTERNAL_STORAGE.
+         Every image comes from the Android photo picker (ActivityResultContracts.PickVisualMedia),
+         and project import uses ActivityResultContracts.GetContent (SAF). Both hand back a URI the
+         app already has read access to, so neither needs a broad storage grant — and Play policy
+         only permits these permissions where a system picker is technically insufficient, which
+         here it is not. -->
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -2066,13 +2066,18 @@ private fun DiagnosticOverlay(
             Spacer(Modifier.height(4.dp))
 
             Text(text = "CONFIDENCE", color = Color.Gray, fontSize = 10.sp, fontWeight = FontWeight.Bold)
-            ConfidenceProgressBar("Visible", uiState.visibleSplatConfidenceAvg)
-            ConfidenceProgressBar("Global", uiState.globalSplatConfidenceAvg)
+            // "Visible"/"Global" splat confidence removed: getConfidenceAvgs() assigns 0.0 to both
+            // unconditionally ("voxel/splat map deleted"), so both bars rendered empty forever. A
+            // progress bar pinned at zero reads as "the system is failing", not "this number no
+            // longer exists" — the same misreading the debugView `voxels=0` field invited.
 
             Spacer(Modifier.height(4.dp))
 
-            DiagnosticRow("Splats", "${uiState.splatCount}", Color.White)
-            DiagnosticRow("Immutable", "${uiState.immutableSplatCount}", if (uiState.immutableSplatCount > 0) HotPink else Color.White)
+            // "Splats" named the voxel/splat map, which was deleted; this number is now the
+            // accumulated ARCore point cloud. A label that names a subsystem the app no longer has
+            // sends the reader looking for the wrong thing — the same reason the debugView line
+            // stopped printing `voxels=`.
+            DiagnosticRow("Map points", "${uiState.splatCount}", Color.White)
 
             val sensors = uiState.sensorData
             if (sensors != null) {

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/CaptureEnvironment.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/CaptureEnvironment.kt
@@ -1,0 +1,178 @@
+package com.hereliesaz.graffitixr.common.model
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+import kotlinx.serialization.Serializable
+
+/**
+ * Everything knowable about how and where the device was held at the instant a target was captured.
+ *
+ * **Why this exists.** Until now the app tracked only the *display* rotation — `display.rotation`
+ * plus the camera's fixed `sensorOrientation`, combined into `rotationNeeded`. It had no idea which
+ * way the phone was physically pointing, which way was down, or where on earth it was. That is a
+ * problem in three separate directions:
+ *
+ *  - **The capture geometry is frozen at capture.** `PlaneMarks.backProject` runs once per target,
+ *    so whatever frame relationship held at that instant is baked into the fingerprint's 3D points
+ *    forever (`PAPER.md` §8). If a capture later turns out to be wrong, the only way to attribute it
+ *    is to know the conditions it was made under — and those conditions were not recorded.
+ *  - **`screenOrientation="fullUser"` respects the auto-rotate setting.** With rotation lock on, the
+ *    display rotation is pinned regardless of physical attitude, so `rotationNeeded` can disagree
+ *    with how the artist is actually holding the phone. Recording the device attitude alongside it
+ *    is what makes that disagreement *visible* rather than merely possible.
+ *  - **A mural is a place.** Re-opening a project at the same wall days later is the core workflow,
+ *    and a location fix plus a compass heading is the cheapest prior available for "is this the same
+ *    wall, seen from roughly the same side".
+ *
+ * **Everything is optional, and that is the design.** A device may have no magnetometer, location
+ * permission may be denied, ARCore may not have a pose yet. Every group is independently nullable so
+ * a capture never fails for want of a sensor, and a missing group reads as absent rather than as a
+ * plausible zero — the distinction this codebase has already had to relearn twice (the eval CSV's
+ * not-sampled sentinel, and a splat counter that returned a hardcoded 0).
+ */
+@Serializable
+@Parcelize
+data class CaptureEnvironment(
+    /** Wall-clock time of the capture, for correlating with logs and photographs. */
+    val capturedAtEpochMs: Long = 0L,
+    /**
+     * `SystemClock.elapsedRealtimeNanos()` at capture — monotonic, unlike [capturedAtEpochMs].
+     *
+     * Kept because sensor and location timestamps are on this clock, so it is the only base against
+     * which their staleness can be computed. Wall-clock can jump (NTP, time zones, the user); a
+     * measured "this fix was 4 s old" cannot be reconstructed from it.
+     */
+    val elapsedRealtimeNs: Long = 0L,
+
+    /** How the frame was oriented. Never null in practice — these are always computable. */
+    val frame: FrameOrientation? = null,
+    /** Physical device attitude from the motion sensors. Null when no usable sensor was present. */
+    val attitude: DeviceAttitude? = null,
+    /** ARCore's own poses at the capture frame. Null when the session had no tracking pose. */
+    val arPoses: ArPoseSnapshot? = null,
+    /** Last known location fix. Null when unavailable, denied, or never acquired. */
+    val location: LocationFix? = null,
+) : Parcelable
+
+/**
+ * The rotation bookkeeping the capture path already did, now recorded rather than recomputed.
+ *
+ * `rotationNeeded` is the angle the bitmap and intrinsics were rotated by, and — since Phase 0 — the
+ * angle the capture view matrix was rotated by to match. Storing all three inputs rather than just
+ * the result means a later reader can check the arithmetic instead of trusting it.
+ */
+@Serializable
+@Parcelize
+data class FrameOrientation(
+    /** `display.rotation * 90` — 0/90/180/270. What the *window* is doing, not the device. */
+    val displayRotationDeg: Int,
+    /** `CameraCharacteristics.SENSOR_ORIENTATION`. A fixed hardware constant, usually 90. */
+    val sensorOrientationDeg: Int,
+    /** `(sensorOrientationDeg - displayRotationDeg + 360) % 360`. */
+    val rotationNeededDeg: Int,
+    /**
+     * Whether the system auto-rotate setting was on.
+     *
+     * The one field that explains a `rotationNeededDeg` which disagrees with [DeviceAttitude]: with
+     * auto-rotate off, `screenOrientation="fullUser"` pins the window and the display rotation stops
+     * following the device. Also the precondition for `EVALUATION.md` E0b — with it off, rotating
+     * the phone does not change the experiment's independent variable at all.
+     */
+    val autoRotateEnabled: Boolean = false,
+) : Parcelable
+
+/**
+ * Physical device attitude, from the motion sensors — the data the app previously never collected.
+ *
+ * Two rotation vectors are recorded deliberately, because they fail differently. [rotationVector]
+ * fuses the magnetometer and so is absolute (its azimuth is true-ish north) but is corrupted by
+ * nearby ferrous metal and by the sort of electrical noise a building has plenty of.
+ * [gameRotationVector] omits the magnetometer: it cannot give a heading, but it is immune to that
+ * corruption. When they disagree, the magnetic environment is bad — which is itself worth knowing at
+ * a wall covered in steel reinforcement.
+ */
+@Serializable
+@Parcelize
+data class DeviceAttitude(
+    /** `TYPE_ROTATION_VECTOR` as a quaternion `[x, y, z, w]`. Empty when unavailable. */
+    val rotationVector: List<Float> = emptyList(),
+    /** Estimated heading accuracy in radians, or -1 when the sensor does not report one. */
+    val rotationVectorAccuracyRad: Float = -1f,
+    /** `TYPE_GAME_ROTATION_VECTOR` quaternion `[x, y, z, w]` — magnetometer-free. */
+    val gameRotationVector: List<Float> = emptyList(),
+    /** `TYPE_GRAVITY` in m/s², device frame. Which way is down, independent of any fusion. */
+    val gravity: List<Float> = emptyList(),
+    /** `TYPE_MAGNETIC_FIELD` in µT, device frame. */
+    val magneticFieldUt: List<Float> = emptyList(),
+    /**
+     * `SensorManager.SENSOR_STATUS_ACCURACY_*` for the magnetometer, or -1 if unknown.
+     *
+     * Recorded because `SENSOR_STATUS_UNRELIABLE` is common indoors and near rebar, and it is the
+     * difference between "the heading is wrong" and "the heading was never trustworthy".
+     */
+    val magneticAccuracy: Int = -1,
+    /** Azimuth in degrees (0 = magnetic north), or `NaN` when no absolute heading was available. */
+    val azimuthDeg: Float = Float.NaN,
+    /** Pitch in degrees, or `NaN`. */
+    val pitchDeg: Float = Float.NaN,
+    /** Roll in degrees, or `NaN`. */
+    val rollDeg: Float = Float.NaN,
+    /** Age of the newest contributing sensor sample at capture, in ms. -1 when unknown. */
+    val sampleAgeMs: Long = -1L,
+) : Parcelable
+
+/**
+ * ARCore's poses at the capture frame, all three of them, because they are three different frames
+ * and this project has already lost a week to conflating two of them.
+ *
+ * Each is `[tx, ty, tz, qx, qy, qz, qw]`, or empty when unavailable.
+ */
+@Serializable
+@Parcelize
+data class ArPoseSnapshot(
+    /**
+     * `Camera.getPose()` — the **physical** camera, "right"/"up" relative to the image readout.
+     * This is the frame the capture view matrix is built from.
+     */
+    val cameraPose: List<Float> = emptyList(),
+    /**
+     * `Camera.getDisplayOrientedPose()` — the virtual camera for rendering, relative to the
+     * *logical display orientation*. Differs from [cameraPose] by a rotation about Z of a multiple
+     * of 90°, which is exactly the `PAPER.md` §8 mismatch.
+     */
+    val displayOrientedPose: List<Float> = emptyList(),
+    /**
+     * `Frame.getAndroidSensorPose()` — the Android sensor frame. Differs from both in orientation
+     * *and* location, and is the bridge to [DeviceAttitude]: it is the only ARCore pose expressed
+     * in the frame the motion sensors report in.
+     */
+    val androidSensorPose: List<Float> = emptyList(),
+) : Parcelable
+
+/**
+ * A location fix, with the metadata needed to decide whether to believe it.
+ *
+ * [ageMs] matters more than the coordinates for this use: a fused provider will happily hand back a
+ * fix from twenty minutes and a kilometre ago, and a stale fix recorded without its age is
+ * indistinguishable from a fresh one.
+ */
+@Serializable
+@Parcelize
+data class LocationFix(
+    val latitude: Double,
+    val longitude: Double,
+    /** Metres above the WGS84 ellipsoid, or `NaN` when the provider gave none. */
+    val altitudeM: Double = Double.NaN,
+    /** Horizontal 68% confidence radius in metres, or -1 when unreported. */
+    val horizontalAccuracyM: Float = -1f,
+    /** Vertical accuracy in metres, or -1 when unreported. */
+    val verticalAccuracyM: Float = -1f,
+    /** Direction of travel in degrees, or `NaN`. Not a compass heading — see [DeviceAttitude]. */
+    val bearingDeg: Float = Float.NaN,
+    /** Ground speed in m/s, or `NaN`. */
+    val speedMps: Float = Float.NaN,
+    /** `"gps"`, `"fused"`, `"network"`, … — how the fix was obtained. */
+    val provider: String = "",
+    /** How old the fix was at capture, in ms. -1 when it could not be computed. */
+    val ageMs: Long = -1L,
+) : Parcelable

--- a/docs/research/EVALUATION.md
+++ b/docs/research/EVALUATION.md
@@ -373,6 +373,29 @@ and lock rate.
 > session spent on tip-of-tree would have produced a confident falsification of a
 > defect that had just been repaired.
 
+**Precondition — auto-rotate must be ON, or the independent variable never moves.**
+
+The app tracks the **display** rotation, not the device's physical orientation.
+There is no `OrientationEventListener` and no sensor listener anywhere in the
+codebase; `rotationNeeded` is derived entirely from `CameraCharacteristics`'
+`sensorOrientation` (a fixed hardware constant) and `display.rotation`, which
+`DisplayRotationHelper` reads from a `DisplayListener`.
+
+The manifest sets `screenOrientation="fullUser"`, which respects the user's
+auto-rotate setting. **With auto-rotate off the activity stays locked,
+`display.rotation` never changes, and `rotationNeeded` is constant however the
+phone is physically held.** E0b's method — "capture in landscape, then in
+portrait" — manipulates physical orientation, so under rotation lock both arms are
+the *same* condition. The experiment would report "identical behaviour in both
+orientations", which the **Falsifies** clause below tells the reader to interpret
+as refuting §8. It would be refuting nothing.
+
+Check the CSV rather than trusting the setting: if `captureRotationNeededDeg` is
+the same value in both arms, the condition never changed and the run is void
+regardless of what the phone was doing. That is precisely what the per-row column
+is for — the failure shows up in the data instead of being averaged into a null
+result.
+
 **Precondition — turn the Depth API OFF, or E0b does not test §8 at all.**
 `MainViewModel.onConfirmTargetCreation` branches on whether a depth buffer was
 captured, and the two branches do not share a line of geometry:

--- a/docs/research/EVALUATION.md
+++ b/docs/research/EVALUATION.md
@@ -10,6 +10,30 @@ number" produces a number nobody can defend later.
 
 ---
 
+> [!CAUTION]
+> **`errMm` was structurally `-1` in every CSV row written before 2026-08-01.** Any run
+> recorded before then measures nothing and must be discarded rather than
+> re-interpreted.
+>
+> `DriftCostProbe` only records a pose error when it is handed a ground-truth pose,
+> and `ArRenderer` gated that on
+> `slamManager.getVisibleConfidenceAvg() > markVisibleConf` with `markVisibleConf =
+> 0.5f`. `MobileGS::getConfidenceAvgs` assigns `0.0f` to both outputs
+> unconditionally — "voxel/splat map deleted" — so the comparison was `0.0 > 0.5`,
+> always false. `truthPose` was always null, so `errMm` and `errDeg` were always
+> `-1` and `marksVisible` always `false`.
+>
+> This makes **E2, E3, E4, E5, E10, E11 and E12 unrunnable as written**, not merely
+> noisy: each compares `errMm`, and there was no `errMm`. All of Phase 6a's
+> telemetry — the CSV shape guard, the reloc columns, the run-identity sidecar, the
+> fixed RANSAC seed — was feeding a file whose headline column was absent.
+>
+> The gate now keys on `RelocDiagnostics`: truth is recorded when relocalization
+> published a pose this cycle (`reject == OK`) with at least 6 inliers, matching
+> `PoseFusion`'s own bar for a usable fix. **This has not been validated on device**
+> — it is known-correct in the sense that the old gate was unconditionally false and
+> this one is not, which is a weaker claim than "the numbers are right".
+
 ## 1. The measurement problem
 
 ### 1.1 What we actually want to know

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/DeviceAttitudeProvider.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/DeviceAttitudeProvider.kt
@@ -1,0 +1,191 @@
+package com.hereliesaz.graffitixr.feature.ar
+
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager
+import android.os.SystemClock
+import com.hereliesaz.graffitixr.common.model.DeviceAttitude
+import timber.log.Timber
+
+/**
+ * Samples the device's **physical** attitude — the thing the app has never tracked.
+ *
+ * Everything orientation-related in this codebase was derived from `display.rotation`, which is a
+ * property of the *window*, not the device. With `screenOrientation="fullUser"` and auto-rotate off
+ * the two can disagree indefinitely. This closes that gap so a capture records how the phone was
+ * actually held, not merely how it was being drawn.
+ *
+ * **Design: cache continuously, snapshot instantly.** Capture happens on the GL thread inside a
+ * frame callback, so [snapshot] must not block, allocate heavily, or wait for a sensor. Listeners
+ * keep the latest value of each sensor in a plain field and [snapshot] copies them. The cost while
+ * registered is a handful of float writes per sensor event at [SensorManager.SENSOR_DELAY_UI], and
+ * nothing at all when unregistered.
+ *
+ * **Absent is not zero.** A device may lack a magnetometer, or report one that is unreliable indoors
+ * and near rebar. Every field degrades to empty/`NaN`/-1 rather than a plausible-looking value, for
+ * the reason this project has already relearned twice: a hardcoded zero reads as a measurement.
+ */
+class DeviceAttitudeProvider(context: Context) : SensorEventListener {
+
+    private val sensorManager =
+        context.getSystemService(Context.SENSOR_SERVICE) as? SensorManager
+
+    private val rotationVectorSensor = sensorManager?.getDefaultSensor(Sensor.TYPE_ROTATION_VECTOR)
+    private val gameRotationSensor =
+        sensorManager?.getDefaultSensor(Sensor.TYPE_GAME_ROTATION_VECTOR)
+    private val gravitySensor = sensorManager?.getDefaultSensor(Sensor.TYPE_GRAVITY)
+    private val magnetometer = sensorManager?.getDefaultSensor(Sensor.TYPE_MAGNETIC_FIELD)
+
+    // Latest sample per sensor. Written on the sensor thread, read on the GL thread at capture —
+    // @Volatile on the array references gives the reader a consistent view of a whole sample,
+    // because each listener publishes a NEW array rather than mutating the existing one. Mutating
+    // in place would let the reader see a half-updated vector.
+    @Volatile private var rotationVector: FloatArray? = null
+    @Volatile private var rotationVectorAccuracyRad: Float = -1f
+    @Volatile private var gameRotationVector: FloatArray? = null
+    @Volatile private var gravity: FloatArray? = null
+    @Volatile private var magneticField: FloatArray? = null
+    @Volatile private var magneticAccuracy: Int = -1
+    @Volatile private var newestSampleElapsedNs: Long = 0L
+
+    private var registered = false
+
+    /** True when the device has at least one sensor this can use. */
+    val isAvailable: Boolean
+        get() = rotationVectorSensor != null || gameRotationSensor != null ||
+            gravitySensor != null || magnetometer != null
+
+    /**
+     * Begin sampling. Safe to call repeatedly; a second call is a no-op.
+     *
+     * `SENSOR_DELAY_UI` (~60 ms) rather than `SENSOR_DELAY_GAME` or `FASTEST`: the value is read
+     * once per capture, not per frame, so a faster rate would buy nothing and cost battery on a
+     * device the artist is holding up for an hour.
+     */
+    fun start() {
+        val sm = sensorManager ?: return
+        if (registered) return
+        var any = false
+        for (s in listOfNotNull(rotationVectorSensor, gameRotationSensor, gravitySensor, magnetometer)) {
+            any = sm.registerListener(this, s, SensorManager.SENSOR_DELAY_UI) || any
+        }
+        registered = any
+        if (!any) Timber.w("DeviceAttitudeProvider: no motion sensors could be registered")
+    }
+
+    /** Stop sampling. Idempotent. Must be called when AR pauses, or the sensors stay hot. */
+    fun stop() {
+        if (!registered) return
+        sensorManager?.unregisterListener(this)
+        registered = false
+    }
+
+    override fun onSensorChanged(event: SensorEvent) {
+        // Publish a copy, never the event's own array — SensorEvent.values is reused by the
+        // framework between callbacks, so retaining it hands the reader a buffer that changes
+        // underneath them.
+        when (event.sensor.type) {
+            Sensor.TYPE_ROTATION_VECTOR -> {
+                rotationVector = event.values.copyOf()
+                // values[4], when present, is the estimated heading accuracy in radians.
+                rotationVectorAccuracyRad = if (event.values.size >= 5) event.values[4] else -1f
+            }
+            Sensor.TYPE_GAME_ROTATION_VECTOR -> gameRotationVector = event.values.copyOf()
+            Sensor.TYPE_GRAVITY -> gravity = event.values.copyOf()
+            Sensor.TYPE_MAGNETIC_FIELD -> magneticField = event.values.copyOf()
+            else -> return
+        }
+        newestSampleElapsedNs = SystemClock.elapsedRealtimeNanos()
+    }
+
+    override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) {
+        if (sensor?.type == Sensor.TYPE_MAGNETIC_FIELD) magneticAccuracy = accuracy
+    }
+
+    /**
+     * A snapshot of the latest sample from every sensor, or null when nothing has been sampled.
+     *
+     * Null rather than an all-empty record: "no attitude was available" and "attitude was available
+     * and happened to be zero" must not look the same to whoever reads the capture later.
+     */
+    fun snapshot(): DeviceAttitude? {
+        val rv = rotationVector
+        val grv = gameRotationVector
+        val g = gravity
+        val mag = magneticField
+        if (rv == null && grv == null && g == null && mag == null) return null
+
+        val euler = eulerFromRotationVector(rv)
+        val newest = newestSampleElapsedNs
+        return DeviceAttitude(
+            rotationVector = rv?.let { quaternionOf(it) } ?: emptyList(),
+            rotationVectorAccuracyRad = rotationVectorAccuracyRad,
+            gameRotationVector = grv?.let { quaternionOf(it) } ?: emptyList(),
+            gravity = g?.take(3) ?: emptyList(),
+            magneticFieldUt = mag?.take(3) ?: emptyList(),
+            magneticAccuracy = magneticAccuracy,
+            azimuthDeg = euler[0],
+            pitchDeg = euler[1],
+            rollDeg = euler[2],
+            sampleAgeMs = if (newest > 0L) {
+                (SystemClock.elapsedRealtimeNanos() - newest) / 1_000_000L
+            } else {
+                -1L
+            },
+        )
+    }
+
+    private companion object {
+
+        /**
+         * Normalize a rotation-vector sample to a full `[x, y, z, w]` quaternion.
+         *
+         * The framework's rotation vector is the first three components only on many devices;
+         * `values[3]` is the scalar when present, and must otherwise be reconstructed as
+         * `sqrt(1 - |v|²)`. Getting this wrong yields a quaternion that is silently not unit-length,
+         * which every downstream rotation then scales by.
+         */
+        fun quaternionOf(values: FloatArray): List<Float> {
+            val x = values.getOrElse(0) { 0f }
+            val y = values.getOrElse(1) { 0f }
+            val z = values.getOrElse(2) { 0f }
+            val w = if (values.size >= 4) {
+                values[3]
+            } else {
+                val t = 1f - x * x - y * y - z * z
+                if (t > 0f) kotlin.math.sqrt(t) else 0f
+            }
+            return listOf(x, y, z, w)
+        }
+
+        /**
+         * Azimuth/pitch/roll in degrees from a rotation vector, via the framework's own
+         * `getRotationMatrixFromVector` + `getOrientation`.
+         *
+         * Deliberately NOT hand-rolled from the quaternion: the framework's convention (which axis
+         * is azimuth, the sign of pitch, the remapping for the device's natural orientation) is the
+         * one every other Android consumer expects, and re-deriving it is a well-known way to ship a
+         * heading that is correct only in portrait.
+         */
+        fun eulerFromRotationVector(values: FloatArray?): FloatArray {
+            if (values == null) return floatArrayOf(Float.NaN, Float.NaN, Float.NaN)
+            return try {
+                val r = FloatArray(9)
+                SensorManager.getRotationMatrixFromVector(r, values)
+                val o = FloatArray(3)
+                SensorManager.getOrientation(r, o)
+                floatArrayOf(
+                    Math.toDegrees(o[0].toDouble()).toFloat(),
+                    Math.toDegrees(o[1].toDouble()).toFloat(),
+                    Math.toDegrees(o[2].toDouble()).toFloat(),
+                )
+            } catch (e: IllegalArgumentException) {
+                // getRotationMatrixFromVector throws on a malformed vector on some OEM builds.
+                Timber.w(e, "rotation vector -> euler failed")
+                floatArrayOf(Float.NaN, Float.NaN, Float.NaN)
+            }
+        }
+    }
+}

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -219,7 +219,14 @@ class ArRenderer(
     // Scratch holder for the mark-PnP "truth" pose read from the native anchor transform.
     private val truthPoseScratch = FloatArray(16)
     // Visible-confidence threshold above which mark-PnP is treated as truth for eval.
-    private val markVisibleConf = 0.5f
+    /**
+     * Inliers required before a relocalization is trusted as eval ground truth.
+     *
+     * Matches PoseFusion's own bar for a usable fix rather than inventing a second one: a pose good
+     * enough to move the overlay is good enough to measure against, and two different thresholds
+     * would make the CSV disagree with what the app actually did.
+     */
+    private val MIN_TRUTH_INLIERS = 6
 
     @Volatile var showAnchorBoundary: Boolean = false
     @Volatile var anchorEstablished: Boolean = false
@@ -1189,9 +1196,25 @@ class ArRenderer(
             if (frameCount % 4 == 0) {
                 driftCostProbe?.let { probe ->
                     val stageMs = slamManager.getStageTimings()
-                    // Truth = mark-PnP pose when a confident match exists; getVisibleConfidenceAvg()
-                    // gates "marks visible". Reuse the native anchor transform as the PnP-refined pose.
-                    val marksVisible = slamManager.getVisibleConfidenceAvg() > markVisibleConf
+                    // Truth = the mark-PnP pose, available only when relocalization actually
+                    // published one this cycle.
+                    //
+                    // This gate used to be `getVisibleConfidenceAvg() > markVisibleConf` (0.5f).
+                    // getConfidenceAvgs returns a HARDCODED 0.0 — "voxel/splat map deleted" — so the
+                    // comparison was `0.0 > 0.5`, always false. truthPose was therefore always null,
+                    // and EVERY eval CSV row carried errMm = -1 and marksVisible = false. The
+                    // harness's headline metric could not be populated at all, which makes every
+                    // errMm comparison in EVALUATION.md (E2's baseline, E3, E4's screening, E10,
+                    // E11, E12) unrunnable rather than merely noisy. All of Phase 6a's telemetry fed
+                    // a file whose primary column was structurally absent.
+                    //
+                    // RelocDiagnostics is the live signal: reject == OK means solvePnPRansac
+                    // published a pose this cycle, and the inlier count says how well. Read once
+                    // here and reused for the reloc columns below, so the row's truth flag and its
+                    // diagnostics describe the same relocalization rather than two samples.
+                    val relocDiag = slamManager.getRelocDiagnostics()
+                    val marksVisible = relocDiag.reject == com.hereliesaz.graffitixr.common.model
+                        .RelocReject.OK && relocDiag.inliers >= MIN_TRUTH_INLIERS
                     val truth = if (marksVisible) {
                         System.arraycopy(slamManager.getAnchorTransform(), 0, truthPoseScratch, 0, 16)
                         truthPoseScratch
@@ -1211,7 +1234,7 @@ class ArRenderer(
                         // not exist outside an eval run, and the block already allocates two
                         // FloatArrays per tick. (An earlier comment here said "four atomics", which
                         // was neither the count nor the mechanism.)
-                        reloc = slamManager.getRelocDiagnostics(),
+                        reloc = relocDiag,
                         // E0b's independent variable is the rotation that was in force AT CAPTURE,
                         // because that is the one baked into the fingerprint's 3D points. Sampling
                         // the live rotation here instead — which an earlier version of this call

--- a/feature/dashboard/src/main/java/com/hereliesaz/graffitixr/feature/dashboard/SettingsScreen.kt
+++ b/feature/dashboard/src/main/java/com/hereliesaz/graffitixr/feature/dashboard/SettingsScreen.kt
@@ -116,12 +116,6 @@ fun SettingsScreen(
         onCheckForUpdates()
     }
 
-    val storagePermissionName = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-        Manifest.permission.READ_MEDIA_IMAGES
-    } else {
-        Manifest.permission.READ_EXTERNAL_STORAGE
-    }
-
     // Permissions State — recomputed on ON_RESUME so returning from App Settings (where the user may
     // have just granted a permission via [openAppSettings]) reflects the new grant, instead of the
     // stale value a keyless remember{} would freeze at first composition.
@@ -129,14 +123,10 @@ fun SettingsScreen(
     var cameraPermission by remember {
         mutableStateOf(ContextCompat.checkSelfPermission(context, Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED)
     }
-    var storagePermission by remember {
-        mutableStateOf(ContextCompat.checkSelfPermission(context, storagePermissionName) == PackageManager.PERMISSION_GRANTED)
-    }
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
             if (event == Lifecycle.Event.ON_RESUME) {
                 cameraPermission = ContextCompat.checkSelfPermission(context, Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED
-                storagePermission = ContextCompat.checkSelfPermission(context, storagePermissionName) == PackageManager.PERMISSION_GRANTED
             }
         }
         lifecycleOwner.lifecycle.addObserver(observer)
@@ -400,7 +390,6 @@ fun SettingsScreen(
                         item {
                             SettingsSectionTitle(strings.settings.permissions)
                             PermissionItem(name = strings.settings.cameraAccess, isGranted = cameraPermission, onClick = openAppSettings, strings = strings)
-                            PermissionItem(name = strings.settings.photoAccess, isGranted = storagePermission, onClick = openAppSettings, strings = strings)
                             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                                 val notificationPermission = ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED
                                 PermissionItem(name = strings.settings.notifications, isGranted = notificationPermission, onClick = openAppSettings, strings = strings)

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Sat Aug 01 09:10:20 UTC 2026
-versionBuild=14296
+#Sat Aug 01 09:29:55 UTC 2026
+versionBuild=14299
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=162
+versionPatch=165

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Sat Aug 01 08:44:34 UTC 2026
-versionBuild=14294
+#Sat Aug 01 09:10:20 UTC 2026
+versionBuild=14296
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=160
+versionPatch=162


### PR DESCRIPTION
Found by checking the field logs you sent. The panel read `SPLATS 3668` — the previous fix working, since that was hardcoded `0` in Mural before. Checking its neighbours in the same panel found something much worse.

## `errMm` has never been recorded

`MobileGS::getConfidenceAvgs` assigns `0.0f` to **both** outputs unconditionally — *"voxel/splat map deleted"*. `ArRenderer` gated eval ground truth on:

```kotlin
marksVisible = slamManager.getVisibleConfidenceAvg() > markVisibleConf   // 0.5f
```

That is `0.0 > 0.5` — **always false**. So `truthPose` was always null, and every row `DriftCostProbe` has ever written carried `errMm = -1`, `errDeg = -1`, `marksVisible = false`.

`errMm` is the harness's headline metric. **E2 (baseline), E3, E4 (screening), E5, E10, E11 and E12 all compare it** — so they were unrunnable as written, not merely noisy. Every piece of Phase 6a telemetry — the CSV shape guard, the reloc diagnostics columns, the run-identity sidecar, and the fixed RANSAC seed I added earlier today — was feeding a file whose primary column was structurally absent.

**Any CSV recorded before this commit measures nothing and should be discarded, not re-interpreted.** `EVALUATION.md` now carries that as a CAUTION at the top.

### The fix

The gate keys on `RelocDiagnostics`: truth is recorded when relocalization actually published a pose this cycle (`reject == OK`) with at least **6 inliers**. Six matches `PoseFusion`'s own bar for a usable fix rather than inventing a second threshold — a pose good enough to move the overlay is good enough to measure against, and two bars would make the CSV disagree with what the app did.

`getRelocDiagnostics()` is now read **once** and reused for both the truth flag and the reloc columns, so a row describes one relocalization rather than two samples.

**Stated plainly: this is not validated on device.** What is established is that the old gate was unconditionally false and this one is not. Whether the resulting `errMm` is *meaningful* is a separate question, and it turns on whether `getAnchorTransform()` is a defensible truth pose while the candidate is the fused anchor — worth settling before anyone runs E2.

## Two more readouts that could only ever show one value

- **"Visible" / "Global" confidence bars** render `getConfidenceAvgs` directly, so both sat empty forever. A progress bar pinned at zero reads as *"the system is failing"*, not *"this number no longer exists"* — the same misreading the `debugView voxels=0` field invited. Removed.
- **"Splats" → "Map points."** It has counted the ARCore point cloud since the previous commit; a label naming a deleted subsystem sends the reader looking for the wrong thing.

## Confirmed working on device, from your logs and screenshots

- `debugView: feat=… planes=… pts=… fps=60` — the new format, no `voxels=`/`method=`.
- `pts` climbing 2562 → 3653, and the panel showing **3668** — the point cloud accumulates and the counter is live. It read `0` in Mural before.
- Rail order: OPEN, MODES, AR, OVERLAY, MOCKUP, TRACE, **PROJECT**, **HELP**.

## Testing

387 tests across `core:common`, `core:nativebridge`, `feature:ar`, `feature:editor` — 0 failures. `:app:compileDebugKotlin` green.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Q5WXFiVLeN4sXa9bPCSDA)_

## Summary by Sourcery

Fix eval harness pose error recording by gating ground-truth pose on relocalization diagnostics instead of a deleted splat confidence signal, and update diagnostics UI and docs to reflect the current telemetry.

Enhancements:
- Use RelocDiagnostics with a minimum inlier threshold to decide when to record truth poses and reuse the same diagnostics snapshot for both truth flag and reloc columns.
- Rename the diagnostics counter from "Splats" to "Map points" to match the ARCore point cloud it now reports and remove non-functional splat confidence bars from the overlay.

Documentation:
- Add a prominent caution to EVALUATION.md explaining that errMm was always -1 before 2026-08-01, rendering prior CSV-based evaluations invalid and documenting the new gating logic for truth pose recording.

Chores:
- Bump version metadata for the app build.