### PR TITLE
Record device attitude and location at capture; drop the Play-flagged storage permissions

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -1242,6 +1242,7 @@ class MainActivity : ComponentActivity() {
                                             // and intrinsics above were already rotated by it; the
                                             // view matrix now follows (Phase 0, convention B).
                                             arUiState.targetDisplayRotation,
+                                            arUiState.targetCaptureEnvironment,
                                         )
                                     },
                                     onRetake = {

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -1243,6 +1243,11 @@ class MainActivity : ComponentActivity() {
                                             // view matrix now follows (Phase 0, convention B).
                                             arUiState.targetDisplayRotation,
                                             arUiState.targetCaptureEnvironment,
+                                            // Where the artwork was at capture, for the Phase-2
+                                            // partition. Absent leaves it unpartitioned.
+                                            arUiState.targetDesignModel,
+                                            arUiState.targetDesignHalfW,
+                                            arUiState.targetDesignHalfH,
                                         )
                                     },
                                     onRetake = {

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
@@ -275,12 +275,12 @@ fun MainScreen(
                             val renderer = ArRenderer(
                                 context = ctx,
                                 slamManager = slamManager,
-                                onTargetCaptured = { bmp, cw, ch, depth, dw, dh, stride, intr, viewMat, rot, tapDist, wallPlane, environment ->
+                                onTargetCaptured = { bmp, cw, ch, depth, dw, dh, stride, intr, viewMat, rot, tapDist, wallPlane, environment, design ->
                                     arViewModel.onTargetCaptured(
                                         bmp, depth,
                                         cw, ch,
                                         dw, dh, stride,
-                                        intr, viewMat, rot, tapDist, wallPlane, environment
+                                        intr, viewMat, rot, tapDist, wallPlane, environment, design
                                     )
                                 },
                                 onTrackingUpdated = { isTracking, splatCount, immutableSplatCount, isDepthSupported, yaw, distanceMeters, relDir, isDualLens, isHardwareStereo, centerDepth, visConf, globConf ->
@@ -307,6 +307,9 @@ fun MainScreen(
                                 },
                                 onFlashlightUnavailable = {
                                     arViewModel.onFlashlightUnavailable()
+                                },
+                                onDesignExtentChanged = { halfW, halfH ->
+                                    arViewModel.onDesignExtentChanged(halfW, halfH)
                                 }
                             )
                             renderer.hideVisualization = isExporting

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
@@ -275,12 +275,12 @@ fun MainScreen(
                             val renderer = ArRenderer(
                                 context = ctx,
                                 slamManager = slamManager,
-                                onTargetCaptured = { bmp, cw, ch, depth, dw, dh, stride, intr, viewMat, rot, tapDist, wallPlane ->
+                                onTargetCaptured = { bmp, cw, ch, depth, dw, dh, stride, intr, viewMat, rot, tapDist, wallPlane, environment ->
                                     arViewModel.onTargetCaptured(
                                         bmp, depth,
                                         cw, ch,
                                         dw, dh, stride,
-                                        intr, viewMat, rot, tapDist, wallPlane
+                                        intr, viewMat, rot, tapDist, wallPlane, environment
                                     )
                                 },
                                 onTrackingUpdated = { isTracking, splatCount, immutableSplatCount, isDepthSupported, yaw, distanceMeters, relDir, isDualLens, isHardwareStereo, centerDepth, visConf, globConf ->

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainViewModel.kt
@@ -159,6 +159,14 @@ class MainViewModel @Inject constructor(
         rotationDeg: Int = 0,
         /** How and where the device was held at capture; persisted onto the project. */
         captureEnvironment: com.hereliesaz.graffitixr.common.model.CaptureEnvironment? = null,
+        /**
+         * Where the artwork sat at capture (`IMPLEMENTATION.md` 2.3): rigid world model matrix and
+         * effective, scale-included half-extents. Null/-1 leaves the fingerprint unpartitioned,
+         * which every consumer reads as all-backbone — pre-Phase-2 behaviour.
+         */
+        designModel: FloatArray? = null,
+        designHalfW: Float = -1f,
+        designHalfH: Float = -1f,
     ) {
         if (bitmap == null || intrinsics == null || viewMatrix == null) {
             // Was a bare reset: the artist confirmed a target and the capture simply vanished with no
@@ -179,7 +187,16 @@ class MainViewModel @Inject constructor(
         if (depthBuffer == null) {
             // No depth source: build the wall fingerprint from a SINGLE capture by back-projecting
             // features onto the ARCore wall plane (whose metric pose ARCore already solved).
-            handleSingleCapture(bitmap, safeIntr, safeView, wallPlane, rotationDeg, captureEnvironment)
+            handleSingleCapture(
+                bitmap, safeIntr, safeView, wallPlane, rotationDeg, captureEnvironment,
+                // Reassembled here, at the one place that consumes it, so the three loose values the
+                // UiState boundary forced never travel any further as three loose values.
+                designModel?.takeIf { it.size == 16 }?.let {
+                    com.hereliesaz.graffitixr.feature.ar.anchor.FingerprintPartition.DesignFootprint(
+                        it, designHalfW, designHalfH,
+                    )
+                },
+            )
             return
         }
         resetCaptureUi()
@@ -281,6 +298,7 @@ class MainViewModel @Inject constructor(
     private fun handleSingleCapture(
         bitmap: Bitmap, intr: FloatArray, view: FloatArray, wallPlane: FloatArray?, rotationDeg: Int,
         captureEnvironment: com.hereliesaz.graffitixr.common.model.CaptureEnvironment?,
+        design: com.hereliesaz.graffitixr.feature.ar.anchor.FingerprintPartition.DesignFootprint? = null,
     ) {
         if (wallPlane == null || wallPlane.size < 6) {
             resetCaptureUi()
@@ -311,6 +329,7 @@ class MainViewModel @Inject constructor(
             val fp = MetricFingerprintBuilder.buildSingle(
                 slamManager, bitmap, view, intr, planePoint, planeNormal, anchor,
                 rotationDeg = rotationDeg,
+                design = design,
             )
             if (fp == null) {
                 // Say WHICH way it fell short. "Not enough texture" was the same message whether the
@@ -319,7 +338,16 @@ class MainViewModel @Inject constructor(
                 val detected = MetricFingerprintBuilder.lastDetected
                 val placed = MetricFingerprintBuilder.lastPlaced
                 val need = MetricFingerprintBuilder.lastRequired
+                val backbone = MetricFingerprintBuilder.lastBackbone
                 val message = when {
+                    // IMPLEMENTATION.md 2.8. Checked FIRST: this failure has enough features and
+                    // they landed on the wall, so both of the messages below would be false. `>= 0`
+                    // rather than `> 0` — the partition ran and found zero backbone is the very case
+                    // this message is for; -1 means it never ran.
+                    backbone >= 0 && backbone < MetricFingerprintBuilder.MIN_BACKBONE ->
+                        "The artwork covers almost the whole wall in view — only $backbone features " +
+                            "sit outside it (need ${MetricFingerprintBuilder.MIN_BACKBONE}). Step " +
+                            "back so there's some bare wall around the design to lock onto."
                     detected < need ->
                         "Only $detected features on this wall (need $need). Too dark, too smooth, " +
                             "or out of focus — try a more detailed patch or more light."

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainViewModel.kt
@@ -157,6 +157,8 @@ class MainViewModel @Inject constructor(
          * [intrinsics]. Routed to the view matrix too (IMPLEMENTATION.md Phase 0, convention B).
          */
         rotationDeg: Int = 0,
+        /** How and where the device was held at capture; persisted onto the project. */
+        captureEnvironment: com.hereliesaz.graffitixr.common.model.CaptureEnvironment? = null,
     ) {
         if (bitmap == null || intrinsics == null || viewMatrix == null) {
             // Was a bare reset: the artist confirmed a target and the capture simply vanished with no
@@ -177,7 +179,7 @@ class MainViewModel @Inject constructor(
         if (depthBuffer == null) {
             // No depth source: build the wall fingerprint from a SINGLE capture by back-projecting
             // features onto the ARCore wall plane (whose metric pose ARCore already solved).
-            handleSingleCapture(bitmap, safeIntr, safeView, wallPlane, rotationDeg)
+            handleSingleCapture(bitmap, safeIntr, safeView, wallPlane, rotationDeg, captureEnvironment)
             return
         }
         resetCaptureUi()
@@ -278,6 +280,7 @@ class MainViewModel @Inject constructor(
      */
     private fun handleSingleCapture(
         bitmap: Bitmap, intr: FloatArray, view: FloatArray, wallPlane: FloatArray?, rotationDeg: Int,
+        captureEnvironment: com.hereliesaz.graffitixr.common.model.CaptureEnvironment?,
     ) {
         if (wallPlane == null || wallPlane.size < 6) {
             resetCaptureUi()
@@ -351,6 +354,10 @@ class MainViewModel @Inject constructor(
                         MetricMarks.glViewDisplayOriented(view, rotationDeg).toList(),
                     // 0.11 — which display frame that was. -1 elsewhere means "genuinely unknown".
                     fingerprintCaptureRotationDeg = rotationDeg,
+                    // The full record of how and where the device was held at capture. The
+                    // fingerprint's geometry is frozen at that instant, so these are the conditions
+                    // any later attribution has to work from — and they exist nowhere else.
+                    captureEnvironment = captureEnvironment,
                 ),
                 targetImages = listOf(bitmap)
             )

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/Fingerprint.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/Fingerprint.kt
@@ -70,6 +70,25 @@ data class Fingerprint(
      */
     val captureHalfW: Float = -1f,
     val captureHalfH: Float = -1f,
+    /**
+     * The design's **rigid** model matrix at capture (column-major 4x4, 16 floats), expressed in the
+     * *same frame as [points3d]* — the capture camera frame, not world. Empty when unknown.
+     *
+     * Stored so the partition can be recomputed later without it. [points3d] is a capture-frame
+     * quantity that outlives the ARCore session that produced it; the design's world pose does not.
+     * Holding the world pose here would make a reclassify after a project reload silently wrong —
+     * two frames, both plausible, no way to tell them apart from the numbers. Pre-multiplying the
+     * capture view once, at capture, removes the frame question from every later caller:
+     *
+     * ```
+     * inv(V·M) · p_cam  ==  inv(M) · inv(V) · p_cam  ==  inv(M) · p_world
+     * ```
+     *
+     * Rigid, not composed: the overlay's scale is folded into [captureHalfW]/[captureHalfH] instead,
+     * because `Matrix.scaleM(m, 0, s, s, 1f)` is **not** a uniform similarity and inverting it as one
+     * is wrong on the Z axis. See `Footprint`'s "scale trap".
+     */
+    val captureDesignModel: List<Float> = emptyList(),
 ) {
     init {
         // Defensive: a corrupt or truncated project file must never construct a Fingerprint whose
@@ -105,6 +124,13 @@ data class Fingerprint(
         require(regions.isEmpty() || regions.size == points3d.size / 3) {
             "regions holds ${regions.size} tags but ${points3d.size / 3} points were supplied; " +
                 "the partition is indexed per point, so they must be 1:1 (or regions empty for legacy)"
+        }
+        // A 4x4 or nothing. A short list here would be read as a matrix by every consumer and index
+        // past its end; a long one silently ignores whatever follows. Neither should reach a
+        // reclassify from a truncated project file.
+        require(captureDesignModel.isEmpty() || captureDesignModel.size == 16) {
+            "captureDesignModel holds ${captureDesignModel.size} floats; a column-major 4x4 is 16 " +
+                "(or empty when unknown)"
         }
     }
 
@@ -149,6 +175,15 @@ data class Fingerprint(
         if (descriptorsType != other.descriptorsType) return false
         if (!patchData.contentEquals(other.patchData)) return false
         if (markCenterLocal != other.markCenterLocal) return false
+        // The Phase-0/Phase-2 fields belong here for one concrete reason: a persistence round-trip
+        // test asserts `decoded == original`, and a field missing from equals makes that assertion
+        // pass whether or not the field survived serialization. Two fingerprints differing only in
+        // which frame their points are in, or in how their points are partitioned, are not equal.
+        if (captureRotationDeg != other.captureRotationDeg) return false
+        if (!regions.contentEquals(other.regions)) return false
+        if (captureHalfW != other.captureHalfW) return false
+        if (captureHalfH != other.captureHalfH) return false
+        if (captureDesignModel != other.captureDesignModel) return false
         return true
     }
 
@@ -161,6 +196,11 @@ data class Fingerprint(
         result = 31 * result + descriptorsType
         result = 31 * result + patchData.contentHashCode()
         result = 31 * result + markCenterLocal.hashCode()
+        result = 31 * result + captureRotationDeg
+        result = 31 * result + regions.contentHashCode()
+        result = 31 * result + captureHalfW.hashCode()
+        result = 31 * result + captureHalfH.hashCode()
+        result = 31 * result + captureDesignModel.hashCode()
         return result
     }
 

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/GraffitiProject.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/GraffitiProject.kt
@@ -159,6 +159,12 @@ data class GraffitiProject(
     // inferred at load time.
     val fingerprintCaptureRotationDeg: Int = -1,
 
+    // How and where the device was held when this project's target was captured — attitude,
+    // ARCore's three poses, the frame rotations, and a location fix. Null on projects saved before
+    // the app collected any of it. See CaptureEnvironment for why each group is independently
+    // optional.
+    val captureEnvironment: CaptureEnvironment? = null,
+
     // Persistent confidence-weighted feature map of the wall around the marks fingerprint — the
     // lean spatial backbone for wide-area relocalization (see docs/RELOC_MAP_DESIGN.md). Null on
     // projects without one; built passively during normal use. Defaulted for back-compat.

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/UiState.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/UiState.kt
@@ -56,6 +56,20 @@ data class ArUiState(
     // [pointX,pointY,pointZ, normalX,normalY,normalZ] in world space. Null when the tap wasn't on a
     // qualifying (MATCH/green) plane — single-capture target creation requires one (back-projection).
     val targetWallPlane: FloatArray? = null,
+    /**
+     * Where the artwork sat at capture (`IMPLEMENTATION.md` 2.3): its **rigid** world model matrix
+     * (column-major 4x4) and its **effective**, scale-included half-extents in metres. Null/-1 when
+     * the overlay had no placement to take a footprint of, which leaves the fingerprint
+     * unpartitioned — the legacy all-backbone reading.
+     *
+     * Carried as three loose values rather than the `DesignFootprint` the builder takes, because
+     * that type lives in `feature/ar` and this module is below it in the graph. Reassembled at the
+     * one place that consumes it (`MainViewModel.handleSingleCapture`) so the loose form never
+     * spreads past this boundary.
+     */
+    val targetDesignModel: FloatArray? = null,
+    val targetDesignHalfW: Float = -1f,
+    val targetDesignHalfH: Float = -1f,
     val capturedTargetUris: List<Uri> = emptyList(),
     val capturedTargetImages: List<Bitmap> = emptyList(),
     val gpsData: GpsData? = null,

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/UiState.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/UiState.kt
@@ -96,6 +96,13 @@ data class ArUiState(
     // Store the rotation applied to the display bitmap
     val targetDisplayRotation: Int = 0,
     /**
+     * How and where the device was held when the active target was captured.
+     *
+     * Null until a capture happens this session. Persisted onto the project at save, because the
+     * conditions a fingerprint was built under are not recoverable from the fingerprint.
+     */
+    val targetCaptureEnvironment: CaptureEnvironment? = null,
+    /**
      * Set when a saved wall fingerprint was refused at load because it predates Phase 0 and its 3D
      * points are in the sensor frame with no recorded capture rotation (IMPLEMENTATION.md 0.7).
      *

--- a/core/common/src/test/java/com/hereliesaz/graffitixr/common/model/CaptureEnvironmentTest.kt
+++ b/core/common/src/test/java/com/hereliesaz/graffitixr/common/model/CaptureEnvironmentTest.kt
@@ -1,0 +1,168 @@
+package com.hereliesaz.graffitixr.common.model
+
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * `CaptureEnvironment` goes to disk inside `GraffitiProject`, so the properties that matter are the
+ * ones a saved file depends on: every group survives a round trip, every group is independently
+ * optional, and a project written before any of this existed still loads.
+ *
+ * The optionality is not incidental. A device may have no magnetometer, location may be denied,
+ * ARCore may have no pose yet — and "absent" has to stay distinguishable from "measured, and
+ * happened to be zero". This codebase has had to relearn that twice already: a splat counter that
+ * returned a hardcoded `0` and read as a real measurement, and an eval column where `0` would have
+ * collided with a genuine control condition.
+ */
+class CaptureEnvironmentTest {
+
+    private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+
+    private fun full() = CaptureEnvironment(
+        capturedAtEpochMs = 1_770_000_000_000L,
+        elapsedRealtimeNs = 987_654_321L,
+        frame = FrameOrientation(
+            displayRotationDeg = 90,
+            sensorOrientationDeg = 90,
+            rotationNeededDeg = 0,
+            autoRotateEnabled = true,
+        ),
+        attitude = DeviceAttitude(
+            rotationVector = listOf(0.1f, 0.2f, 0.3f, 0.927f),
+            rotationVectorAccuracyRad = 0.26f,
+            gameRotationVector = listOf(0.11f, 0.21f, 0.31f, 0.92f),
+            gravity = listOf(0.05f, -9.79f, 0.4f),
+            magneticFieldUt = listOf(21.5f, -3.2f, 41.0f),
+            magneticAccuracy = 3,
+            azimuthDeg = 143.5f,
+            pitchDeg = -12.25f,
+            rollDeg = 3.75f,
+            sampleAgeMs = 48L,
+        ),
+        arPoses = ArPoseSnapshot(
+            cameraPose = listOf(1f, 2f, 3f, 0f, 0f, 0f, 1f),
+            displayOrientedPose = listOf(1f, 2f, 3f, 0f, 0f, 0.707f, 0.707f),
+            androidSensorPose = listOf(1.01f, 2.02f, 3.03f, 0f, 0f, 0f, 1f),
+        ),
+        location = LocationFix(
+            latitude = 51.5072,
+            longitude = -0.1276,
+            altitudeM = 11.0,
+            horizontalAccuracyM = 4.5f,
+            verticalAccuracyM = 3.0f,
+            bearingDeg = 210.5f,
+            speedMps = 0.2f,
+            provider = "fused",
+            ageMs = 1_200L,
+        ),
+    )
+
+    @Test
+    fun `a full record survives a serialization round trip`() {
+        val decoded = json.decodeFromString<CaptureEnvironment>(json.encodeToString(full()))
+        assertEquals(full(), decoded)
+    }
+
+    /**
+     * The realistic device: no magnetometer, location denied, ARCore not yet tracking. A capture
+     * must still produce a usable record rather than failing or inventing values.
+     */
+    @Test
+    fun `a record with only frame orientation round trips`() {
+        val sparse = CaptureEnvironment(
+            capturedAtEpochMs = 1L,
+            frame = FrameOrientation(0, 90, 90),
+        )
+        val decoded = json.decodeFromString<CaptureEnvironment>(json.encodeToString(sparse))
+        assertEquals(sparse, decoded)
+        assertNull(decoded.attitude)
+        assertNull(decoded.arPoses)
+        assertNull(decoded.location)
+    }
+
+    /** Every group defaults to absent, so a capture never fails for want of a sensor. */
+    @Test
+    fun `an empty record is constructible and wholly absent`() {
+        val e = CaptureEnvironment()
+        assertNull(e.frame); assertNull(e.attitude); assertNull(e.arPoses); assertNull(e.location)
+    }
+
+    /**
+     * A project saved before any of this existed must still deserialize. `captureEnvironment` is
+     * nullable with a default for exactly this reason — the alternative is that every pre-existing
+     * project fails to load.
+     */
+    @Test
+    fun `a payload with no capture environment decodes to null`() {
+        val decoded = json.decodeFromString<Holder>("""{"name":"legacy"}""")
+        assertEquals("legacy", decoded.name)
+        assertNull(decoded.captureEnvironment)
+    }
+
+    @kotlinx.serialization.Serializable
+    data class Holder(val name: String, val captureEnvironment: CaptureEnvironment? = null)
+
+    /**
+     * Sentinels, pinned. Each says "not measured" and each is outside the range of a real reading:
+     * a magnetometer accuracy is 0..3, an age is never negative, and NaN is not a bearing.
+     */
+    @Test
+    fun `unmeasured values use sentinels that cannot be mistaken for readings`() {
+        val a = DeviceAttitude()
+        assertTrue("azimuth", a.azimuthDeg.isNaN())
+        assertTrue("pitch", a.pitchDeg.isNaN())
+        assertTrue("roll", a.rollDeg.isNaN())
+        assertEquals("magnetic accuracy is 0..3 when real", -1, a.magneticAccuracy)
+        assertEquals(-1f, a.rotationVectorAccuracyRad, 0f)
+        assertEquals(-1L, a.sampleAgeMs)
+        assertTrue("no vector is an empty list, not a zero vector", a.rotationVector.isEmpty())
+        assertTrue(a.gravity.isEmpty())
+
+        val l = LocationFix(latitude = 0.0, longitude = 0.0)
+        assertTrue("altitude", l.altitudeM.isNaN())
+        assertEquals(-1f, l.horizontalAccuracyM, 0f)
+        assertEquals(-1L, l.ageMs)
+    }
+
+    /**
+     * `(0, 0)` is a real coordinate — Null Island — so a LocationFix must never be inferred from
+     * its values. Absence is expressed by the whole object being null, which is why
+     * [CaptureEnvironment.location] is nullable rather than a fix with sentinel coordinates.
+     */
+    @Test
+    fun `a zero coordinate is a location, not an absent one`() {
+        val e = CaptureEnvironment(location = LocationFix(latitude = 0.0, longitude = 0.0))
+        assertEquals(0.0, e.location!!.latitude, 0.0)
+        assertNull("absence is the null object", CaptureEnvironment().location)
+    }
+
+    /**
+     * The field that explains a `rotationNeededDeg` disagreeing with the physical attitude, and
+     * E0b's precondition. It defaults to false — the conservative reading, since a record that
+     * predates the field cannot claim auto-rotate was on.
+     */
+    @Test
+    fun `auto-rotate defaults to false rather than assuming it was on`() {
+        assertEquals(false, FrameOrientation(0, 90, 90).autoRotateEnabled)
+    }
+
+    /** The arithmetic the capture path performs, pinned so a stored record can be re-checked. */
+    @Test
+    fun `rotationNeeded is consistent with its two inputs`() {
+        for (display in intArrayOf(0, 90, 180, 270)) {
+            val f = FrameOrientation(
+                displayRotationDeg = display,
+                sensorOrientationDeg = 90,
+                rotationNeededDeg = (90 - display + 360) % 360,
+            )
+            assertEquals(
+                "display=$display",
+                (f.sensorOrientationDeg - f.displayRotationDeg + 360) % 360,
+                f.rotationNeededDeg,
+            )
+        }
+    }
+}

--- a/core/common/src/test/java/com/hereliesaz/graffitixr/common/model/FingerprintPartitionPersistenceTest.kt
+++ b/core/common/src/test/java/com/hereliesaz/graffitixr/common/model/FingerprintPartitionPersistenceTest.kt
@@ -1,0 +1,146 @@
+package com.hereliesaz.graffitixr.common.model
+
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.opencv.core.KeyPoint
+
+/**
+ * `IMPLEMENTATION.md` **2.9** — the Phase-2 partition survives a save/load, and a project written
+ * before it existed still loads.
+ *
+ * The partition is only useful if it comes back off disk attached to the *same* points it was
+ * computed against. A `regions` array that silently failed to serialize would not throw: the
+ * fingerprint would deserialize as unpartitioned, which every consumer reads as all-backbone, so
+ * the app would keep working and would quietly have Phase 2 switched off. That is the failure this
+ * file exists to catch, and it is why the first thing asserted below is that the round trip
+ * *distinguishes* a partitioned fingerprint from an unpartitioned one at all.
+ */
+class FingerprintPartitionPersistenceTest {
+
+    private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+
+    private companion object {
+        const val INSIDE: Byte = 0
+        const val BAND: Byte = 1
+        const val OUTSIDE: Byte = 2
+    }
+
+    private fun fingerprint(
+        regions: ByteArray = ByteArray(0),
+        halfW: Float = -1f,
+        halfH: Float = -1f,
+        designModel: List<Float> = emptyList(),
+    ) = Fingerprint(
+        keypoints = List(3) { KeyPoint(it.toFloat(), 2f, 7f) },
+        points3d = listOf(0f, 0f, 0f, 1f, 0f, 0f, 2f, 0f, 0f),
+        descriptorsData = ByteArray(3 * 32) { (it % 251).toByte() },
+        descriptorsRows = 3,
+        descriptorsCols = 32,
+        descriptorsType = 0,
+        captureRotationDeg = 90,
+        regions = regions,
+        captureHalfW = halfW,
+        captureHalfH = halfH,
+        captureDesignModel = designModel,
+    )
+
+    private val identity16 = listOf(
+        1f, 0f, 0f, 0f, 0f, 1f, 0f, 0f, 0f, 0f, 1f, 0f, 0f, 0f, 0f, 1f,
+    )
+
+    /**
+     * Equality has to notice the partition, or every other assertion in this file is decorative:
+     * `assertEquals(original, decoded)` proves nothing about a field `equals` ignores.
+     */
+    @Test
+    fun `two fingerprints differing only in their partition are not equal`() {
+        val partitioned = fingerprint(byteArrayOf(INSIDE, BAND, OUTSIDE), 1f, 0.5f, identity16)
+        assertNotEquals(fingerprint(), partitioned)
+        assertNotEquals(
+            "the extents are part of what the regions mean",
+            partitioned, partitioned.copy(captureHalfW = 2f),
+        )
+        assertNotEquals(
+            "the design model is what a later reclassify replays",
+            partitioned, partitioned.copy(captureDesignModel = emptyList()),
+        )
+    }
+
+    @Test
+    fun `a partitioned fingerprint survives a round trip intact`() {
+        val original = fingerprint(byteArrayOf(INSIDE, BAND, OUTSIDE), 1.25f, 0.75f, identity16)
+        val decoded = json.decodeFromString<Fingerprint>(json.encodeToString(original))
+
+        assertEquals(original, decoded)
+        assertArrayEquals(byteArrayOf(INSIDE, BAND, OUTSIDE), decoded.regions)
+        assertEquals(1.25f, decoded.captureHalfW, 0f)
+        assertEquals(0.75f, decoded.captureHalfH, 0f)
+        assertEquals(identity16, decoded.captureDesignModel)
+        assertFalse(decoded.isUnpartitioned())
+    }
+
+    /**
+     * The legacy path, and the reading that must never invert. A pre-Phase-2 project has no
+     * `regions` key at all; it must decode to empty — "all backbone" — not fail and not default to
+     * something that would exclude the whole map from the reloc PnP.
+     */
+    @Test
+    fun `a payload written before Phase 2 decodes as unpartitioned`() {
+        val legacy = """
+            {
+              "keypoints": [{"x":1.0,"y":2.0,"size":7.0,"angle":-1.0,"response":0.0,"octave":0,"classId":-1}],
+              "points3d": [0.0, 0.0, 0.0],
+              "descriptorsData": [],
+              "descriptorsRows": 0,
+              "descriptorsCols": 0,
+              "descriptorsType": 0
+            }
+        """.trimIndent()
+        val decoded = json.decodeFromString<Fingerprint>(legacy)
+
+        assertTrue("no regions key must mean no partition", decoded.isUnpartitioned())
+        assertEquals(0, decoded.regions.size)
+        assertEquals(-1f, decoded.captureHalfW, 0f)
+        assertEquals(-1f, decoded.captureHalfH, 0f)
+        assertTrue(decoded.captureDesignModel.isEmpty())
+        assertFalse("nothing to be stale against", decoded.isPartitionStale(1f, 1f))
+    }
+
+    /**
+     * A truncated or hand-edited file must not construct a fingerprint whose partition indexes past
+     * its points. Native subscripts `mWallRegions` by point index while building reloc
+     * correspondences, so this is an out-of-bounds read, not a cosmetic inconsistency.
+     */
+    @Test(expected = IllegalArgumentException::class)
+    fun `a regions array that disagrees with the point count is refused at construction`() {
+        fingerprint(byteArrayOf(INSIDE))
+    }
+
+    /** Same argument for the stored matrix: 16 floats or nothing, never a short prefix. */
+    @Test(expected = IllegalArgumentException::class)
+    fun `a design model that is not a 4x4 is refused at construction`() {
+        fingerprint(designModel = listOf(1f, 0f, 0f))
+    }
+
+    /**
+     * `GraffitiProject` is what actually reaches disk, so the round trip is asserted through it too
+     * rather than only through the nested type. A field that serializes standalone can still be
+     * dropped by the enclosing document — for instance if the project ever stopped carrying the
+     * whole `Fingerprint` and started projecting selected columns out of it.
+     */
+    @Test
+    fun `the partition survives a round trip through the enclosing project`() {
+        val fp = fingerprint(byteArrayOf(OUTSIDE, OUTSIDE, INSIDE), 2f, 1f, identity16)
+        val project = GraffitiProject(id = "p1", name = "wall", fingerprint = fp)
+        val decoded = json.decodeFromString<GraffitiProject>(json.encodeToString(project))
+
+        assertArrayEquals(byteArrayOf(OUTSIDE, OUTSIDE, INSIDE), decoded.fingerprint!!.regions)
+        assertEquals(2f, decoded.fingerprint!!.captureHalfW, 0f)
+        assertEquals(identity16, decoded.fingerprint!!.captureDesignModel)
+    }
+}

--- a/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
+++ b/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
@@ -886,7 +886,8 @@ Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeRestoreWallFingerp
 JNIEXPORT void JNICALL
 Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeRestoreWallFingerprintMetric(
         JNIEnv* env, jobject thiz, jbyteArray descArray, jint rows, jint cols, jint type,
-        jfloatArray ptsArray, jfloatArray anchorArray, jfloatArray intrArray, jfloatArray viewArray) {
+        jfloatArray ptsArray, jfloatArray anchorArray, jfloatArray intrArray, jfloatArray viewArray,
+        jbyteArray regionsArray) {
     // Same defensive validation as the plain restore: reject a malformed/old .gxr before cv::Mat
     // wraps the descriptor blob (valid OpenCV type + 64-bit overflow-safe size check), and only pass
     // anchor/intrinsics when correctly sized (native copies a fixed 16 / 4 floats and tolerates null),
@@ -909,7 +910,24 @@ Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeRestoreWallFingerp
     jfloat* anchor = (anchorArray && env->GetArrayLength(anchorArray) == 16) ? env->GetFloatArrayElements(anchorArray, nullptr) : nullptr;
     jfloat* intr   = (intrArray && env->GetArrayLength(intrArray) == 4)    ? env->GetFloatArrayElements(intrArray, nullptr)   : nullptr;
     jfloat* view   = (viewArray && env->GetArrayLength(viewArray) == 16)   ? env->GetFloatArrayElements(viewArray, nullptr)   : nullptr;
-    gSlamEngine->restoreWallFingerprintMetric(descriptors, points3d, anchor, intr, view);
+    // Phase 2 partition: one byte per 3D point. An empty array is the legacy "all backbone" case and
+    // is passed through as empty. A NON-empty array whose length disagrees with the point count is
+    // dropped rather than truncated: native indexes it by point when building reloc correspondences,
+    // so a short array reads past the end of a vector, and a long one means the two disagree about
+    // what the map even is. Dropping degrades to all-backbone, which is safe; truncating is not.
+    std::vector<uint8_t> regions;
+    if (regionsArray) {
+        jsize regLen = env->GetArrayLength(regionsArray);
+        if (regLen > 0 && (size_t)regLen == points3d.size()) {
+            jbyte* regData = env->GetByteArrayElements(regionsArray, nullptr);
+            regions.assign((uint8_t*)regData, (uint8_t*)regData + regLen);
+            env->ReleaseByteArrayElements(regionsArray, regData, JNI_ABORT);
+        } else if (regLen > 0) {
+            LOGE("restoreWallFingerprintMetric: %d regions for %zu points - dropping partition",
+                 (int)regLen, points3d.size());
+        }
+    }
+    gSlamEngine->restoreWallFingerprintMetric(descriptors, points3d, anchor, intr, view, regions);
     env->ReleaseByteArrayElements(descArray, descData, JNI_ABORT);
     env->ReleaseFloatArrayElements(ptsArray, ptsData, JNI_ABORT);
     if (anchor) env->ReleaseFloatArrayElements(anchorArray, anchor, JNI_ABORT);

--- a/core/nativebridge/src/main/cpp/MobileGS.cpp
+++ b/core/nativebridge/src/main/cpp/MobileGS.cpp
@@ -223,6 +223,8 @@ void MobileGS::relocThreadFunc() {
 
         cv::Mat wallDescs;
         std::vector<cv::Point3f> wallKps3d;
+        // Phase 2: parallel to wallKps3d, or empty for a legacy fingerprint (= all backbone).
+        std::vector<uint8_t> wallRegions;
         cv::Mat wallPatch;
         float fpIntrinsics[4];
         bool hasFpView = false;
@@ -237,6 +239,7 @@ void MobileGS::relocThreadFunc() {
             std::lock_guard<std::mutex> lock(mMutex);
             wallDescs = mWallDescriptors.clone();
             wallKps3d = mWallKeypoints3D;
+            wallRegions = mWallRegions;
             wallPatch = mWallPatch.clone();
             memcpy(fpIntrinsics, mFingerprintIntrinsics, 4 * sizeof(float));
             hasFpView = mHasFingerprintView;
@@ -307,6 +310,10 @@ void MobileGS::relocThreadFunc() {
             // points into solvePnPRansac. The map path (below) already guards this; the wall path did
             // not. Refuse rather than relocalize against nonsense.
             if (wallKps3d.size() != (size_t)wallDescs.rows) return;
+            // IMPLEMENTATION.md 2.7 — honour the partition only when it indexes THIS point set. A
+            // regions array of the wrong length is treated as absent (all backbone) rather than
+            // subscripted, so a legacy or mismatched fingerprint relocalizes exactly as on main.
+            const bool usePartition = wallRegions.size() == wallKps3d.size();
 
             cv::Ptr<cv::DescriptorMatcher>& matcher = (descs.type() == CV_32F) ? mL2Matcher : mMatcher;
             std::vector<std::vector<cv::DMatch>> matches;
@@ -314,6 +321,12 @@ void MobileGS::relocThreadFunc() {
             for (auto& match : matches) {
                 if (match.size() < 2) continue;
                 if (match[0].distance < 0.75f * match[1].distance) {
+                    // PAPER.md §5: the reloc PnP solves the GLOBAL problem, with no prior, and must
+                    // therefore see only the backbone. Points under the artwork (INSIDE) are the
+                    // work surface — they decay as it is painted, which is exactly what makes
+                    // accuracy degrade with task progress. BAND straddles the edge and is trusted by
+                    // neither side. Corroboration against F_in happens later, once a pose exists.
+                    if (usePartition && wallRegions[match[0].trainIdx] != kRegionOutside) continue;
                     cv::Point2f p = kps[match[0].queryIdx].pt;
                     if (!Hback.empty()) {
                         std::vector<cv::Point2f> in{p}, outp;
@@ -890,6 +903,14 @@ void MobileGS::tryUpdateFingerprint(const cv::Mat& grayClean,
         for (size_t i = 0; i < take; ++i) {
             mWallKeypoints3D.push_back(newPts[i]);
             mWallDescriptors.push_back(newDescs.row((int)i));
+            // Keep the partition 1:1 with the points it indexes, or the reloc filter silently
+            // switches itself off (its length check fails) and the whole map goes back to being
+            // undifferentiated. Promoted marks are tagged BAND — trusted by NEITHER set — because
+            // nothing here has run Φ on them: admitting an unclassified feature to the backbone is
+            // precisely the corruption the band exists to prevent. IMPLEMENTATION.md 3.4 is the item
+            // that classifies promotion candidates properly; until then self-grow (default OFF)
+            // cannot enlarge F_out.
+            if (!mWallRegions.empty()) mWallRegions.push_back(kRegionBand);
         }
         // Snapshot inside the lock: these feed a log line below, and reading the containers after
         // the guard released races a concurrent restoreWallFingerprintMetric on the JNI thread.
@@ -924,13 +945,21 @@ void MobileGS::restoreWallFingerprint(const cv::Mat& d, const std::vector<cv::Po
     std::lock_guard<std::mutex> lock(mMutex);
     mWallDescriptors = d.clone();
     mWallKeypoints3D = p;
+    // This path carries no partition, and the previous fingerprint's must not survive onto it: the
+    // bytes would index a different point set entirely. Empty = all backbone, as before Phase 2.
+    mWallRegions.clear();
 }
 void MobileGS::restoreWallFingerprintMetric(const cv::Mat& d, const std::vector<cv::Point3f>& p,
                                             const float* anchorMatrix16, const float* intrinsics4,
-                                            const float* viewMatrix16) {
+                                            const float* viewMatrix16,
+                                            const std::vector<uint8_t>& regions) {
     std::lock_guard<std::mutex> lock(mMutex);
     mWallDescriptors = d.clone();
     mWallKeypoints3D = p;
+    // Belt and braces over the JNI-side length check: a partition that does not index the points it
+    // is stored beside is worse than no partition, and this is the last place it can be refused
+    // before the reloc thread subscripts it. Empty = all backbone = pre-Phase-2 behaviour.
+    mWallRegions = (regions.size() == p.size()) ? regions : std::vector<uint8_t>();
     if (anchorMatrix16) memcpy(mFingerprintAnchorMatrix, anchorMatrix16, 16 * sizeof(float));
     if (intrinsics4)    memcpy(mFingerprintIntrinsics, intrinsics4, 4 * sizeof(float));
     if (viewMatrix16) {
@@ -947,6 +976,7 @@ void MobileGS::clearWallFingerprint() {
     std::lock_guard<std::mutex> lock(mMutex);
     mWallDescriptors.release();
     mWallKeypoints3D.clear();
+    mWallRegions.clear();
     // Back to the constructed defaults, so a later project can't inherit this one's co-registration.
     static const float kIdentity16[16] = {1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1};
     memcpy(mFingerprintAnchorMatrix, kIdentity16, 16 * sizeof(float));
@@ -1070,6 +1100,10 @@ void MobileGS::alignToFingerprint(const uint8_t* data, size_t size) {
         std::lock_guard<std::mutex> lock(mMutex);
         mWallKeypoints3D = std::move(points3d);
         mWallDescriptors = descs.clone();
+        // A peer's fingerprint carries no partition, and the local one indexes a different point
+        // set. Empty = all backbone, i.e. pre-Phase-2 behaviour, which is the right default for a
+        // map whose design footprint this device never saw.
+        mWallRegions.clear();
         mRelocRequested = true; // Trigger relocalization thread to start searching
     }
     LOGI("Co-op: Received fingerprint with %u points. Relocalization triggered.", numPoints);
@@ -1391,6 +1425,9 @@ MobileGS::FingerprintData MobileGS::generateFingerprint(
         std::lock_guard<std::mutex> lock(mMutex);
         mWallDescriptors  = fd.descriptors.clone();
         mWallKeypoints3D  = std::move(pts3d);
+        // The depth path supplies no partition. Clearing rather than leaving the previous
+        // fingerprint's is not optional: those bytes index a point set that no longer exists.
+        mWallRegions.clear();
         memcpy(mFingerprintAnchorMatrix, mAnchorMatrix, 16 * sizeof(float));
         memcpy(mFingerprintIntrinsics, intr, 4 * sizeof(float));
         if (viewMat) {

--- a/core/nativebridge/src/main/cpp/include/MobileGS.h
+++ b/core/nativebridge/src/main/cpp/include/MobileGS.h
@@ -49,9 +49,15 @@ public:
     // rectification pass in relocThreadFunc. Without it computeRectifyHomography bails and oblique
     // views get no correction — which was the case for EVERY fingerprint built this way, since only
     // generateFingerprint (the depth path, disabled) ever set it.
+    //
+    // regions (optional, IMPLEMENTATION.md Phase 2) is one Footprint::Region ordinal per 3D point.
+    // The reloc correspondence build excludes INSIDE points — they sit under the artwork and decay
+    // as it is painted, so matching against them is what makes accuracy degrade with task progress.
+    // EMPTY MEANS ALL BACKBONE, reproducing pre-Phase-2 behaviour exactly for legacy fingerprints.
     void restoreWallFingerprintMetric(const cv::Mat& descriptors, const std::vector<cv::Point3f>& points3d,
                                       const float* anchorMatrix16, const float* intrinsics4,
-                                      const float* viewMatrix16 = nullptr);
+                                      const float* viewMatrix16 = nullptr,
+                                      const std::vector<uint8_t>& regions = {});
     // Drop the stored wall fingerprint (marks + co-registration). Needed because a fingerprint is
     // otherwise process-lifetime state: the restore calls above only ever REPLACE it, so a project
     // with no fingerprint of its own would keep relocalizing against whatever wall was fingerprinted
@@ -312,6 +318,18 @@ private:
 
     cv::Mat mWallDescriptors;
     std::vector<cv::Point3f> mWallKeypoints3D;
+    // IMPLEMENTATION.md Phase 2 — the footprint partition, parallel to mWallKeypoints3D. One
+    // Footprint::Region ordinal per point. EMPTY means "no partition" and is read as all-backbone,
+    // so a pre-Phase-2 fingerprint relocalizes exactly as it does on main. Always either empty or
+    // the same size as mWallKeypoints3D; the JNI layer drops a mismatched array rather than let a
+    // short one be indexed by point index.
+    std::vector<uint8_t> mWallRegions;
+    // Ordinals must match Footprint.Region's declaration order (INSIDE, BAND, OUTSIDE). Kotlin
+    // writes the byte and C++ reads it, so the two enums are a wire format with no compiler to
+    // check them; FootprintRegionWireTest pins the Kotlin side against these values.
+    static constexpr uint8_t kRegionInside = 0;
+    static constexpr uint8_t kRegionBand = 1;
+    static constexpr uint8_t kRegionOutside = 2;
     cv::Mat mArtworkDescriptors;
     std::vector<cv::Point3f> mArtworkKeypoints3D;
     std::atomic<float> mPaintingProgress{0.0f};

--- a/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
+++ b/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
@@ -151,14 +151,23 @@ class SlamManager @Inject constructor(
      * vs-frontal distortion is a homography that can be pre-cancelled before matching. Pass an empty
      * array only when the capture view genuinely isn't known (e.g. a project saved before it was
      * persisted) — then that pass is skipped rather than run against a stale frontal frame.
+     *
+     * [regions] is the Phase-2 partition: one byte per 3D point, holding a `Footprint.Region`
+     * ordinal. The reloc correspondence build excludes the points tagged `INSIDE` — they sit under
+     * the artwork and decay as it is painted. **An empty array means all-backbone**, which is
+     * exactly the behaviour before Phase 2, so a legacy fingerprint keeps relocalizing against its
+     * whole map rather than losing it. A non-empty array of the wrong length is rejected native-side
+     * rather than silently truncating, because the partition is indexed by point.
      */
     fun restoreWallFingerprintMetric(
         descriptorsData: ByteArray, rows: Int, cols: Int, type: Int,
         points3d: FloatArray, anchorMatrix: FloatArray, intrinsics: FloatArray,
         viewMatrix: FloatArray = FloatArray(0),
+        regions: ByteArray = ByteArray(0),
     ) {
         nativeRestoreWallFingerprintMetric(
             descriptorsData, rows, cols, type, points3d, anchorMatrix, intrinsics, viewMatrix,
+            regions,
         )
     }
 
@@ -635,7 +644,7 @@ class SlamManager @Inject constructor(
     private external fun nativeRestoreWallFingerprintMetric(
         descriptorsData: ByteArray, rows: Int, cols: Int, type: Int,
         points3d: FloatArray, anchorMatrix: FloatArray, intrinsics: FloatArray,
-        viewMatrix: FloatArray
+        viewMatrix: FloatArray, regions: ByteArray
     )
     private external fun nativeRestoreWallFeatureMap(
         descriptorsData: ByteArray, rows: Int, cols: Int, type: Int,

--- a/core/nativebridge/src/test/java/com/hereliesaz/graffitixr/nativebridge/NativeMethodAritySignatureTest.kt
+++ b/core/nativebridge/src/test/java/com/hereliesaz/graffitixr/nativebridge/NativeMethodAritySignatureTest.kt
@@ -1,0 +1,122 @@
+package com.hereliesaz.graffitixr.nativebridge
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * JNI resolves a non-overloaded `external fun` by its **short name** —
+ * `Java_<pkg>_<Class>_<method>` — and does **not** check the descriptor. Add a parameter on one side
+ * only and nothing fails to build, nothing fails to link, and nothing throws
+ * `UnsatisfiedLinkError`: the native function simply reads whatever happens to be in the next
+ * argument register. That is a use of uninitialised memory that presents as intermittent corruption
+ * far from its cause.
+ *
+ * This project has already paid once for trusting a name-based binding — `Fingerprint.fromNative`,
+ * where adding a field to the data class silently broke the lookup twice and `setWallFingerprint`
+ * returned null on every capture. That one is now pinned by `FingerprintJniContractTest`; the
+ * `native*` methods were not pinned by anything.
+ *
+ * So: parameter counts, both sides, from source. A count is not a full descriptor check, but it
+ * catches the failure that actually happens — a parameter added or removed on one side of the
+ * boundary. Types are still the reviewer's job.
+ */
+class NativeMethodAritySignatureTest {
+
+    @Test
+    fun `every native method declares the same parameter count on both sides`() {
+        val kotlin = File(repoRoot(), KOTLIN_SRC).readText()
+        val cpp = File(repoRoot(), CPP_SRC).readText()
+
+        val kotlinArities = Regex(
+            """private external fun (native\w+)\s*\(([^)]*)\)""",
+            RegexOption.DOT_MATCHES_ALL,
+        ).findAll(kotlin).associate { m ->
+            m.groupValues[1] to countKotlinParams(m.groupValues[2])
+        }
+
+        assertTrue(
+            "found no `private external fun native*` declarations in $KOTLIN_SRC — the regex, not " +
+                "the code, is probably what changed",
+            kotlinArities.size > 20,
+        )
+
+        val cppArities = Regex(
+            """Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_(\w+)\s*\(([^)]*)\)""",
+            RegexOption.DOT_MATCHES_ALL,
+        ).findAll(cpp).associate { m ->
+            // Every JNI entry point begins with (JNIEnv*, jobject); the Kotlin declaration has
+            // neither, so they are subtracted rather than matched.
+            m.groupValues[1] to (countCppParams(m.groupValues[2]) - 2)
+        }
+
+        val checked = kotlinArities.keys.intersect(cppArities.keys)
+        assertTrue(
+            "no native method names matched between the two files; one of the two regexes is wrong",
+            checked.size > 20,
+        )
+        for (name in checked.sorted()) {
+            assertEquals(
+                "$name: Kotlin declares ${kotlinArities[name]} parameters, GraffitiJNI.cpp takes " +
+                    "${cppArities[name]}. JNI binds by name and will not catch this at runtime.",
+                kotlinArities[name], cppArities[name],
+            )
+        }
+    }
+
+    /**
+     * The one that just changed, named explicitly so a future edit that drops `regions` from either
+     * side fails with a message about the partition rather than an anonymous arity mismatch.
+     */
+    @Test
+    fun `the metric fingerprint restore carries the Phase 2 regions array`() {
+        val kotlin = File(repoRoot(), KOTLIN_SRC).readText()
+        val cpp = File(repoRoot(), CPP_SRC).readText()
+        assertTrue(
+            "Kotlin's nativeRestoreWallFingerprintMetric no longer declares `regions`",
+            Regex("""external fun nativeRestoreWallFingerprintMetric\s*\([^)]*regions:\s*ByteArray""",
+                RegexOption.DOT_MATCHES_ALL).containsMatchIn(kotlin),
+        )
+        assertTrue(
+            "GraffitiJNI.cpp's nativeRestoreWallFingerprintMetric no longer takes regionsArray",
+            Regex("""Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeRestoreWallFingerprintMetric\s*\([^)]*jbyteArray regionsArray""",
+                RegexOption.DOT_MATCHES_ALL).containsMatchIn(cpp),
+        )
+    }
+
+    private companion object {
+        const val KOTLIN_SRC =
+            "core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt"
+        const val CPP_SRC = "core/nativebridge/src/main/cpp/GraffitiJNI.cpp"
+
+        /** Split a parameter list on top-level commas; generics/defaults don't appear in these decls. */
+        fun countKotlinParams(params: String): Int = splitTopLevel(params)
+
+        fun countCppParams(params: String): Int = splitTopLevel(params)
+
+        fun splitTopLevel(params: String): Int {
+            val body = params.trim()
+            if (body.isEmpty()) return 0
+            var depth = 0
+            var count = 1
+            for (c in body) {
+                when (c) {
+                    '<', '(', '[' -> depth++
+                    '>', ')', ']' -> depth--
+                    ',' -> if (depth == 0) count++
+                }
+            }
+            return count
+        }
+    }
+
+    private fun repoRoot(): File {
+        var dir: File? = File("").absoluteFile
+        while (dir != null) {
+            if (File(dir, KOTLIN_SRC).isFile) return dir
+            dir = dir.parentFile
+        }
+        throw AssertionError("could not locate the repo root from ${File("").absolutePath}")
+    }
+}

--- a/docs/research/IMPLEMENTATION.md
+++ b/docs/research/IMPLEMENTATION.md
@@ -847,29 +847,89 @@ order.** Work top to bottom.
 
 ### Phase 2 — partition the fingerprint
 
-- [ ] **2.1** Add `regions: ByteArray`, `captureHalfW`, `captureHalfH` to
+- [x] **2.1** Add `regions: ByteArray`, `captureHalfW`, `captureHalfH` to
       `Fingerprint`; empty `regions` means legacy all-backbone. **[T]**
-- [ ] **2.2** Add `Fingerprint.reclassify(...)` for the user-rescales-the-design
+      *(Also `captureDesignModel` — the design's rigid pose in the POINTS' frame.
+      Without it `reclassify` cannot be called correctly after a reload: the
+      capture's world frame dies with the ARCore session, and a world-frame model
+      applied to camera-frame points produces a full, plausible, wrong partition.
+      `equals`/`hashCode` were extended to cover the new fields, without which the
+      2.9 round-trip assertion would have passed whether or not they serialized.)*
+- [x] **2.2** Add `Fingerprint.reclassify(...)` for the user-rescales-the-design
       case; pure Kotlin over the stored points. Key the staleness check on
       **`overlayScale`** (or the effective scaled half-extents), NOT on
       `OverlayRenderer`'s extents — those have no user-driven call site and never
       change. **[T]**
-- [ ] **2.3** Thread `overlayHalfW` / `overlayHalfH` into
+      *(Wired, not merely written: `ArRenderer` fires `onDesignExtentChanged` when
+      the EFFECTIVE half-extents move past 1 mm — edge-triggered, so a resting
+      finger doesn't repartition every frame — and `ArViewModel` reclassifies the
+      retained fingerprint, re-pushes it to native, and persists it. The
+      matrix-free `reclassify(fp, halfW, halfH)` overload is what the handler
+      calls, so there is no frame for a caller to get wrong.)*
+- [x] **2.3** Thread `overlayHalfW` / `overlayHalfH` into
       `MetricFingerprintBuilder.build` and the `PlaneMarks` single-view path.
-- [ ] **2.4** Classify each surviving point via `Footprint.classify` during
+      *(As one `DesignFootprint` (rigid model + effective half-extents) rather than
+      two loose floats, so "no partition" reads as a deliberate `null`. Carried
+      `ArRenderer` → `ArViewModel` → `UiState` → `MainViewModel` → builder; the
+      `UiState` hop is three loose values because that module sits below
+      `feature/ar` and cannot see the type, and it is reassembled immediately.
+      Note the two-keyframe `build` overload has NO production caller and was left
+      unpartitioned rather than given a parameter nothing would pass.)*
+- [x] **2.4** Classify each surviving point via `Footprint.classify` during
       `assemble`; populate `regions`. **[T]**
-- [ ] **2.5** Add `FingerprintPartitionTest` — synthetic straddling point set,
+      *(The frame trap, and the reason this was not a two-line change: the points
+      are in the capture CV camera frame and the renderer's design pose is in
+      world. `DesignFootprint.inFrameOf(view)` pre-multiplies the view once —
+      `inv(V·M)·p_cam == inv(M)·p_world` exactly, and rigid∘rigid stays rigid — so
+      Φ sees one frame, at the cost of one 4×4 multiply instead of one per
+      feature. `PoseMath.multiply`, not `android.opengl.Matrix`: the framework
+      class is a stub under a plain JVM unit test that silently returns zeros, so
+      the framework version would have been untestable AND would have classified
+      everything INSIDE. A test caught exactly that.)*
+- [x] **2.5** Add `FingerprintPartitionTest` — synthetic straddling point set,
       expected counts per region. **[T]**
-- [ ] **2.6** Add `regions` to `SlamManager.restoreWallFingerprintMetric`'s
+      *(Extended with the frame reconciliation in both directions: camera-frame
+      classification must agree with world-frame, and skipping the reconciliation
+      must NOT agree — otherwise the mechanism is decorative.)*
+- [x] **2.6** Add `regions` to `SlamManager.restoreWallFingerprintMetric`'s
       signature and JNI binding.
-- [ ] **2.7** Store `mWallRegions` in `MobileGS`; filter the reloc correspondence
+      *(JNI binds by SHORT NAME and does not check the descriptor, so an arity
+      change on one side alone links, runs, and reads a garbage register.
+      `NativeMethodAritySignatureTest` now pins the parameter counts of every
+      `native*` method against `GraffitiJNI.cpp`; mutation-verified by adding a
+      parameter to the C++ side only, which the Kotlin compiler cannot see.)*
+- [x] **2.7** Store `mWallRegions` in `MobileGS`; filter the reloc correspondence
       build to exclude `INSIDE`. Zero-length regions → all backbone. **[N]**
-- [ ] **2.8** Add the `F_out`-too-small capture refusal with the specific
+      *(Filter keeps only `OUTSIDE` — "not INSIDE" and "is OUTSIDE" differ exactly
+      on the BAND, which is the region that must be trusted by neither side.
+      `mWallRegions` is cleared at all four other sites that replace
+      `mWallKeypoints3D` (plain restore, co-op receive, depth-path
+      `generateFingerprint`, `clearWallFingerprint`), because a partition left
+      behind indexes a point set that no longer exists. Self-grow appends `BAND`
+      per promoted mark so the 1:1 invariant survives without admitting an
+      unclassified feature to the backbone — 3.4 is what classifies them properly.
+      The ordinals are a wire format with no compiler checking either side, so
+      `FootprintRegionWireTest` pins the Kotlin enum against `MobileGS.h`'s
+      constants by reading the header.)*
+- [x] **2.8** Add the `F_out`-too-small capture refusal with the specific
       "step back" message, following `MainViewModel`'s existing
       `lastDetected/lastPlaced/lastRequired` toast pattern.
-- [ ] **2.9** Add a persistence round-trip test including the legacy-empty path. **[T]**
+      *(`MIN_BACKBONE = 40`, the pre-registered `PARAMETERS.md` prior. Checked
+      before anything is published to native or the overlay re-centred, so a
+      refusal leaves nothing half-built. `lastBackbone` defaults to **-1**, not 0:
+      "the design covers everything" and "nobody asked for a partition" must not
+      print the same number, and the refusal branch is ordered first because the
+      other two messages would both be false in this case.)*
+- [x] **2.9** Add a persistence round-trip test including the legacy-empty path. **[T]**
+      *(Asserted through `GraffitiProject` as well as `Fingerprint`, and the first
+      assertion is that equality can *tell the two apart* — a field missing from
+      `equals` makes `assertEquals(decoded, original)` prove nothing.)*
 - [ ] **2.10** Verify on a replayed recording that a legacy fingerprint produces
       byte-identical inlier counts to `main`.
+      *(Blocked on hardware — needs a replayed recording, which this environment
+      cannot produce. The static argument is that a legacy fingerprint has empty
+      `regions`, `usePartition` is therefore false, and the correspondence loop is
+      byte-identical; that is an argument, not the measurement the item asks for.)*
 - [ ] **2.11** (6b) Add `backboneFeatures` / `backboneMatches` / `backboneInliers`
       to `RelocDiagnostics`, the CSV, and the overlay. Defaults encode "not
       measured", not zero — follow the `obliquityDeg = -1` precedent. **[T][N]**

--- a/docs/research/PARAMETERS.md
+++ b/docs/research/PARAMETERS.md
@@ -100,20 +100,31 @@ to agree and nothing enforces it.
 
 ---
 
-## 4. Footprint partition — proposed
+## 4. Footprint partition — landed
 
-New, from `IMPLEMENTATION.md` Phases 1–2. No current values; the prior column is
-a starting point for the sweep, not a recommendation.
+Phases 1–2 have landed, so these now have real locations and real values. Every
+one is still a **prior**, not a measurement: E8 is the experiment that sets them.
 
-| Parameter | Prior | Reasoning for the prior | Set by |
-|---|---|---|---|
-| `FOOTPRINT_INNER_MARGIN` | `0.05` | 5% of the design's half-extent — roughly a brush-width at typical mural scale | E8 |
-| `FOOTPRINT_OUTER_MARGIN` | `0.15` | Wider than inner, because overspray extends past the design and a doomed feature in `F_out` is worse than a discarded one | E8 |
-| `BACKBONE_MIN_FEATURES` | `40` | 5× the PnP correspondence floor of 8, to leave room for the match rate | E8 |
+| Parameter | Location | Current | Prior it shipped as | Basis | Set by |
+|---|---|---|---|---|---|
+| `DEFAULT_INNER_MARGIN` | `FingerprintPartition.kt` | `0.04` | `0.05` | guessed — a few per cent of the design's half-extent, of the order of a brush width at mural scale | E8 |
+| `DEFAULT_OUTER_MARGIN` | `FingerprintPartition.kt` | `0.10` | `0.15` | guessed — wider than inner, because overspray extends past the design and a doomed feature in `F_out` is worse than a discarded one | E8 |
+| `MIN_BACKBONE` | `MetricFingerprintBuilder.kt` | `40` | `40` | guessed — 5× the native PnP correspondence floor of 8, leaving room for the match rate | E8 |
 
-`BACKBONE_MIN_FEATURES` drives the capture refusal ("step back — the target needs
-some wall around it to lock onto"). Setting it too high refuses valid captures;
-too low ships a fingerprint that cannot relocalize. E8 measures both sides.
+**The margins shipped at values this table did not predict.** Phase 1 landed
+`0.04` / `0.10` while this file said `0.05` / `0.15`; the discrepancy went
+unnoticed until Phase 2 was wired. The landed values are recorded above rather
+than the code being changed to match, because altering an already-landed phase's
+behaviour to satisfy a prior is the wrong way round — but the pre-registered
+numbers are kept in their own column so E8 can report against both. Note the
+ratio also changed: 3.0× inner as pre-registered, 2.5× as shipped.
+
+`MIN_BACKBONE` drives the capture refusal ("the artwork covers almost the whole
+wall in view — step back so there's some bare wall around the design to lock
+onto"). Setting it too high refuses valid captures; too low ships a fingerprint
+that cannot relocalize. E8 measures both sides. It is deliberately independent of
+`MetricFingerprintBuilder`'s `minPoints` floor of 20 — those two ask different
+questions, and a capture can pass one while failing the other.
 
 ---
 

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -1491,6 +1491,65 @@ class ArViewModel @Inject constructor(
         }
     }
 
+    /**
+     * The wall fingerprint currently live in native, retained so a design resize can repartition it
+     * (`IMPLEMENTATION.md` 2.2) without a round trip through the project file.
+     *
+     * Held alongside the intrinsics/anchor/view it was restored with, because a repartition has to
+     * re-push all of them — `restoreWallFingerprintMetric` REPLACES the stored fingerprint, so
+     * pushing regions alone would drop the co-registration and the rectification view with it.
+     */
+    private class LiveFingerprint(
+        val fingerprint: com.hereliesaz.graffitixr.common.model.Fingerprint,
+        val anchor: FloatArray,
+        val intrinsics: FloatArray,
+        val view: FloatArray,
+    )
+
+    @Volatile private var liveFingerprint: LiveFingerprint? = null
+
+    /**
+     * The artist pinched the design: its footprint moved, so the stored partition now describes a
+     * shape that is no longer on the wall.
+     *
+     * Recomputed from the stored 3D points — a pure-Kotlin pass over a few hundred points — rather
+     * than forcing a re-capture, which is the whole reason the design model is persisted in the
+     * points' own frame. A fingerprint that carries no model (legacy, depth path) is left alone by
+     * `reclassify`, so this degrades to a no-op instead of guessing a frame.
+     *
+     * Called from the GL thread; the work is dispatched off it.
+     */
+    fun onDesignExtentChanged(halfW: Float, halfH: Float) {
+        val live = liveFingerprint ?: return
+        if (!live.fingerprint.isPartitionStale(halfW, halfH)) return
+        viewModelScope.launch(Dispatchers.Default) {
+            val current = liveFingerprint ?: return@launch
+            val updated = com.hereliesaz.graffitixr.feature.ar.anchor.FingerprintPartition
+                .reclassify(current.fingerprint, halfW, halfH)
+            // Identity check, not equality: reclassify returns the RECEIVER when it refuses (no
+            // stored design model), and re-pushing an unchanged fingerprint would reset native's
+            // reloc state for nothing.
+            if (updated === current.fingerprint) return@launch
+            slamManager.restoreWallFingerprintMetric(
+                updated.descriptorsData, updated.descriptorsRows, updated.descriptorsCols,
+                updated.descriptorsType, updated.points3d.toFloatArray(),
+                current.anchor, current.intrinsics,
+                viewMatrix = current.view,
+                regions = updated.regions,
+            )
+            liveFingerprint = LiveFingerprint(updated, current.anchor, current.intrinsics, current.view)
+            // Persist so the next load starts from the size the artist actually settled on. Merged
+            // through the repository transform rather than a full-object write, for the save-race
+            // reason documented on the wall-map save above.
+            projectRepository.updateProject { it.copy(fingerprint = updated) }
+            Timber.i(
+                "Design resized to %.3f x %.3f m; repartitioned %d points (backbone %d)",
+                halfW, halfH, updated.points3d.size / 3,
+                com.hereliesaz.graffitixr.feature.ar.anchor.FingerprintPartition.backboneCount(updated),
+            )
+        }
+    }
+
     private fun loadFingerprintIfExists() {
         viewModelScope.launch(Dispatchers.IO) {
             val project = projectRepository.currentProject.value ?: return@launch
@@ -1537,6 +1596,17 @@ class ArViewModel @Inject constructor(
                         // skips the rectification pass rather than warping to a stale frontal frame.
                         viewMatrix = project.fingerprintViewMatrix
                             .takeIf { it.size == 16 }?.toFloatArray() ?: FloatArray(0),
+                        // IMPLEMENTATION.md 2.6 — the partition travels with the points it indexes.
+                        // Empty on a pre-Phase-2 project, which native reads as all-backbone, so the
+                        // reload relocalizes exactly as it did before the phase landed.
+                        regions = fp.regions,
+                    )
+                    // Retained for the repartition-on-resize path (2.2). Stored with exactly the
+                    // values just pushed, so a later re-push cannot drift from what native holds.
+                    liveFingerprint = LiveFingerprint(
+                        fp, anchor.toFloatArray(), intr.toFloatArray(),
+                        project.fingerprintViewMatrix.takeIf { it.size == 16 }?.toFloatArray()
+                            ?: FloatArray(0),
                     )
                 } else {
                     // Depth-path or pre-existing project: descriptors-only legacy restore.
@@ -1932,6 +2002,11 @@ class ArViewModel @Inject constructor(
          */
         environment: com.hereliesaz.graffitixr.common.model.CaptureEnvironment =
             com.hereliesaz.graffitixr.common.model.CaptureEnvironment(),
+        /**
+         * Where the artwork sat at capture, for the Phase-2 partition. Null leaves the fingerprint
+         * unpartitioned, which every consumer reads as all-backbone — pre-Phase-2 behaviour.
+         */
+        design: com.hereliesaz.graffitixr.feature.ar.anchor.FingerprintPartition.DesignFootprint? = null,
     ) {
         // Doodle demo: a headless capture (no tap, no review) — build the fingerprint from the
         // drawing and return before the normal capture/review flow runs. Clear the capture-request
@@ -1977,6 +2052,9 @@ class ArViewModel @Inject constructor(
                     targetIntrinsics = intrinsics,
                     targetCaptureViewMatrix = viewMatrix,
                     targetWallPlane = wallPlane,
+                    targetDesignModel = design?.rigidModel,
+                    targetDesignHalfW = design?.halfW ?: -1f,
+                    targetDesignHalfH = design?.halfH ?: -1f,
                     targetPhysicalExtent = extent,
                     isCaptureRequested = false,
                     tempCaptureBitmap = rotatedBmp,
@@ -2007,6 +2085,9 @@ class ArViewModel @Inject constructor(
                 targetIntrinsics = intrinsics,
                 targetCaptureViewMatrix = viewMatrix,
                 targetWallPlane = wallPlane,
+                targetDesignModel = design?.rigidModel,
+                targetDesignHalfW = design?.halfW ?: -1f,
+                targetDesignHalfH = design?.halfH ?: -1f,
                 targetPhysicalExtent = extent,
                 isCaptureRequested = false
             )

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -802,6 +802,107 @@ class ArViewModel @Inject constructor(
         Timber.w("ARDIAG onCameraStreamStalled: next AR entry will use ARCore default camera config (safe mode)")
     }
 
+    /**
+     * Physical device attitude. Created lazily so a device with no motion sensors costs nothing, and
+     * started/stopped with AR mode — sensors left registered drain a phone the artist is holding up
+     * for an hour.
+     */
+    private var attitudeProvider: DeviceAttitudeProvider? = null
+
+    /** Last known location, cached while AR is active. Null until a fix arrives or if denied. */
+    @Volatile
+    private var lastLocation: android.location.Location? = null
+    private var locationTracker: com.hereliesaz.graffitixr.common.LocationTracker? = null
+
+    /**
+     * Begin sampling attitude and location for capture records. Idempotent.
+     *
+     * Location is cached from a low-rate subscription rather than requested at capture: the capture
+     * happens on the GL thread inside a frame callback and cannot wait on a fix. A cached value with
+     * its age recorded is strictly better than a blocking call that would drop frames — and the age
+     * is what makes a stale fix visible instead of silently wrong.
+     */
+    private fun startEnvironmentSampling(context: Context) {
+        // Each source is guarded separately, and neither can stop AR mode.
+        //
+        // This is a correctness requirement, not defensiveness for its own sake: the capture record
+        // is OPTIONAL telemetry, and AR is the product. A device with no SENSOR_SERVICE, or a
+        // Play-Services location client that refuses to start (it needs a Looper, and throws
+        // "invalid null looper" without one), must degrade to recording less — never to an artist
+        // unable to enter AR. The first version of this let a location-client failure propagate out
+        // of setArMode and take the session with it.
+        try {
+            if (attitudeProvider == null) {
+                attitudeProvider = DeviceAttitudeProvider(context).also {
+                    if (!it.isAvailable) Timber.i("No motion sensors; captures will record no attitude")
+                }
+            }
+            attitudeProvider?.start()
+        } catch (t: Throwable) {
+            Timber.w(t, "attitude sampling unavailable; captures will record no attitude")
+            attitudeProvider = null
+        }
+
+        try {
+            if (locationTracker == null) {
+                locationTracker = com.hereliesaz.graffitixr.common.LocationTracker(context)
+            }
+            locationTracker?.let { tracker ->
+                if (tracker.hasPermissions()) {
+                    tracker.startLocationUpdates { loc -> lastLocation = loc }
+                } else {
+                    // Not an error: location is optional and a capture must never depend on it.
+                    Timber.i("Location permission not granted; captures will record no location")
+                }
+            }
+        } catch (t: Throwable) {
+            Timber.w(t, "location sampling unavailable; captures will record no location")
+            locationTracker = null
+        }
+    }
+
+    /**
+     * Stop sampling. Must run whenever AR stops, or the sensors and GPS stay hot.
+     *
+     * Also guarded: a teardown that throws would leave the other source registered, which is the
+     * exact leak this method exists to prevent.
+     */
+    private fun stopEnvironmentSampling() {
+        try {
+            attitudeProvider?.stop()
+        } catch (t: Throwable) {
+            Timber.w(t, "attitude sampling teardown failed")
+        }
+        try {
+            locationTracker?.stopLocationUpdates()
+        } catch (t: Throwable) {
+            Timber.w(t, "location sampling teardown failed")
+        }
+    }
+
+    /** The latest location as a serializable fix, with its age. Null when none has arrived. */
+    private fun locationFix(): com.hereliesaz.graffitixr.common.model.LocationFix? {
+        val l = lastLocation ?: return null
+        val ageMs = if (l.elapsedRealtimeNanos > 0L) {
+            (android.os.SystemClock.elapsedRealtimeNanos() - l.elapsedRealtimeNanos) / 1_000_000L
+        } else {
+            -1L
+        }
+        return com.hereliesaz.graffitixr.common.model.LocationFix(
+            latitude = l.latitude,
+            longitude = l.longitude,
+            altitudeM = if (l.hasAltitude()) l.altitude else Double.NaN,
+            horizontalAccuracyM = if (l.hasAccuracy()) l.accuracy else -1f,
+            verticalAccuracyM = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O &&
+                l.hasVerticalAccuracy()
+            ) l.verticalAccuracyMeters else -1f,
+            bearingDeg = if (l.hasBearing()) l.bearing else Float.NaN,
+            speedMps = if (l.hasSpeed()) l.speed else Float.NaN,
+            provider = l.provider ?: "",
+            ageMs = ageMs,
+        )
+    }
+
     fun setArMode(enabled: Boolean, context: Context) {
         if (enabled && !_uiState.value.isArCoreAvailable) {
             // ARCore is not supported on this device. Refuse to enter AR mode
@@ -823,6 +924,9 @@ class ArViewModel @Inject constructor(
             if (_uiState.value.trackingFailed) {
                 _uiState.update { it.copy(trackingFailed = false) }
             }
+            startEnvironmentSampling(context)
+        } else {
+            stopEnvironmentSampling()
         }
         updateSessionStateLocked(context)
     }
@@ -1549,6 +1653,11 @@ class ArViewModel @Inject constructor(
         renderer = r
         renderer?.stereoProvider = stereoProvider
         renderer?.onCameraNotFeeding = { onCameraNotFeeding() }
+        // The renderer assembles the capture record on the GL thread; these hand it the two pieces
+        // whose lifecycles live here. Lambdas rather than direct references so the renderer never
+        // touches a SensorManager or a location client it does not own.
+        renderer?.attitudeSampler = { attitudeProvider?.snapshot() }
+        renderer?.locationSampler = { locationFix() }
         renderer?.attachSession(session)
         loadCloudPointsIfExists()
     }
@@ -1816,7 +1925,13 @@ class ArViewModel @Inject constructor(
         viewMatrix: FloatArray,
         displayRotation: Int,
         tapDistanceMeters: Float,
-        wallPlane: FloatArray? = null
+        wallPlane: FloatArray? = null,
+        /**
+         * How and where the device was held at capture. Defaulted so the doodle path and tests can
+         * omit it; the real capture path always supplies one.
+         */
+        environment: com.hereliesaz.graffitixr.common.model.CaptureEnvironment =
+            com.hereliesaz.graffitixr.common.model.CaptureEnvironment(),
     ) {
         // Doodle demo: a headless capture (no tap, no review) — build the fingerprint from the
         // drawing and return before the normal capture/review flow runs. Clear the capture-request
@@ -1852,6 +1967,7 @@ class ArViewModel @Inject constructor(
                     tapMarks = it.tapMarks + com.hereliesaz.graffitixr.common.model.TapMark(tapPos.first, tapPos.second, tapDistanceMeters),
                     targetRawBitmap = bitmap,
                     targetDisplayRotation = displayRotation,
+                    targetCaptureEnvironment = environment,
                     targetDepthBuffer = depthBuffer,
                     targetDepthWidth = colorW,
                     targetDepthHeight = colorH,
@@ -1881,6 +1997,7 @@ class ArViewModel @Inject constructor(
                 annotatedCaptureBitmap = rotatedBmp.isolateMarkings(),
                 targetRawBitmap = bitmap,
                 targetDisplayRotation = displayRotation,
+                targetCaptureEnvironment = environment,
                 targetDepthBuffer = depthBuffer,
                 targetDepthWidth = colorW,
                 targetDepthHeight = colorH,
@@ -2425,6 +2542,9 @@ class ArViewModel @Inject constructor(
         coopStateJob?.cancel()
         coopStateJob = null
         collaborationManager.leaveSessionAsync()
+        // setArMode(false) is not guaranteed to run before the ViewModel dies (process death,
+        // task removal), and a registered SensorEventListener outlives it.
+        stopEnvironmentSampling()
         destroyArSession()
     }
 }

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/FingerprintPartition.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/FingerprintPartition.kt
@@ -39,10 +39,61 @@ object FingerprintPartition {
     const val DEFAULT_OUTER_MARGIN = 0.10f
 
     /**
-     * Classify [pointsCam] — a flat `[x,y,z,...]` list in the same world frame [anchorModel] is
-     * expressed in — into one region byte per point.
+     * The design's placement at capture, in **world** space, as the renderer knows it.
      *
-     * @param anchorModel the design's model matrix. Pass [composed] = true when it carries the
+     * One object rather than three loose parameters because the three are only meaningful together,
+     * and because "no partition" then reads as a deliberate `null` at the call site instead of three
+     * numbers somebody forgot. Absent is safe here — an unpartitioned fingerprint is the legacy
+     * all-backbone case, i.e. exactly today's behaviour — which is why the builder is allowed to
+     * default it away, unlike `rotationDeg`, where the safe value does not exist.
+     *
+     * @param rigidModel the design's world pose **without** the overlay scale.
+     * @param halfW the design's **effective** (scale-included) half-width in metres.
+     */
+    class DesignFootprint(
+        val rigidModel: FloatArray,
+        val halfW: Float,
+        val halfH: Float,
+    ) {
+        /** True when this describes a design with real extents; a zero/negative one cannot be Φ'd. */
+        val isUsable: Boolean
+            get() = rigidModel.size == 16 && halfW > 1e-6f && halfH > 1e-6f
+
+        /**
+         * The same footprint with its model expressed in a capture camera frame, given that frame's
+         * world→camera view.
+         *
+         * This is the whole frame story in one line. [Fingerprint.points3d] are camera-frame, the
+         * renderer's design pose is world-frame, and Φ requires both in one frame. Pre-multiplying
+         * the view is exact rather than approximate:
+         *
+         * ```
+         * inv(V·M) · p_cam  ==  inv(M) · inv(V) · p_cam  ==  inv(M) · p_world
+         * ```
+         *
+         * and rigid ∘ rigid stays rigid, so [Footprint.inverseOfRigid] remains applicable. Doing it
+         * this way — rather than mapping every point to world — also costs one 4x4 multiply instead
+         * of one per feature, and leaves a single matrix that can be stored for a later reclassify.
+         *
+         * [PoseMath.multiply] rather than `android.opengl.Matrix.multiplyMM`: identical arithmetic,
+         * but it runs under a plain JVM unit test. The framework version is a stub off-device, and a
+         * stubbed matrix multiply does not fail — it silently yields zeros, which invert to garbage
+         * and classify everything as INSIDE. This function's whole correctness claim is a frame
+         * reconciliation, so it has to be the kind of thing a test can actually exercise.
+         */
+        fun inFrameOf(view: FloatArray): DesignFootprint =
+            DesignFootprint(PoseMath.multiply(view, rigidModel), halfW, halfH)
+    }
+
+    /**
+     * Classify [points] — a flat `[x,y,z,...]` list — into one region byte per point.
+     *
+     * [points] and [designModel] must be expressed in the **same frame**, whichever that is. Φ is
+     * frame-agnostic: it only ever computes `inv(designModel) · p`, so world/world and camera/camera
+     * are both correct and world/camera is silently, plausibly wrong. Use
+     * [DesignFootprint.inFrameOf] to reconcile them rather than doing it by hand at the call site.
+     *
+     * @param designModel the design's model matrix. Pass [composed] = true when it carries the
      *   overlay's uniform in-plane scale, in which case [halfW]/[halfH] must be the design's
      *   **unscaled** half-extents; otherwise pass the **scaled** ones. Getting this pair wrong is
      *   the highest-probability bug here — both combinations compile and both produce plausible
@@ -50,26 +101,26 @@ object FingerprintPartition {
      *   boolean, and why `FingerprintPartitionTest` covers a scaled anchor explicitly.
      */
     fun classify(
-        pointsCam: FloatArray,
-        anchorModel: FloatArray,
+        points: FloatArray,
+        designModel: FloatArray,
         halfW: Float,
         halfH: Float,
         composed: Boolean = false,
         innerMargin: Float = DEFAULT_INNER_MARGIN,
         outerMargin: Float = DEFAULT_OUTER_MARGIN,
     ): ByteArray {
-        val count = pointsCam.size / 3
+        val count = points.size / 3
         if (count == 0) return ByteArray(0)
         // Hoist the inverse: Footprint.of/ofComposed each allocate a FloatArray(16) per call, and
         // ofComposed also does a sqrt to recover a scale that is constant across the capture. Over a
         // 1500-feature capture that dominates everything else this function does.
-        val inv = if (composed) Footprint.inverseOfComposed(anchorModel)
-        else Footprint.inverseOfRigid(anchorModel)
+        val inv = if (composed) Footprint.inverseOfComposed(designModel)
+        else Footprint.inverseOfRigid(designModel)
         val uv = FloatArray(2)
         val out = ByteArray(count)
         for (i in 0 until count) {
             val o = i * 3
-            Footprint.ofInverted(inv, halfW, halfH, pointsCam[o], pointsCam[o + 1], pointsCam[o + 2], uv)
+            Footprint.ofInverted(inv, halfW, halfH, points[o], points[o + 1], points[o + 2], uv)
             out[i] = Footprint.classify(uv, innerMargin, outerMargin).ordinal.toByte()
         }
         return out
@@ -85,26 +136,53 @@ object FingerprintPartition {
      * does **not** short-circuit on [Fingerprint.isPartitionStale] being false, because a caller may
      * legitimately want to partition a previously-unpartitioned (legacy) fingerprint, for which
      * "stale" is defined as false.
+     *
+     * [designModel] must be **rigid**, with the overlay scale folded into [halfW]/[halfH] — the
+     * convention `Footprint` calls preferred, and the only one that can be stored and replayed. A
+     * composed matrix has no place here: `Matrix.scaleM(m, 0, s, s, 1f)` scales X and Y but not Z,
+     * so it is not the uniform similarity [Footprint.inverseOfComposed] assumes, and the stored
+     * [Fingerprint.captureHalfW] is defined as scale-included regardless.
      */
     fun reclassify(
         fingerprint: Fingerprint,
-        anchorModel: FloatArray,
+        designModel: FloatArray,
         halfW: Float,
         halfH: Float,
-        composed: Boolean = false,
         innerMargin: Float = DEFAULT_INNER_MARGIN,
         outerMargin: Float = DEFAULT_OUTER_MARGIN,
     ): Fingerprint {
         if (fingerprint.points3d.isEmpty()) return fingerprint
         val regions = classify(
-            fingerprint.points3d.toFloatArray(), anchorModel, halfW, halfH,
-            composed, innerMargin, outerMargin,
+            fingerprint.points3d.toFloatArray(), designModel, halfW, halfH,
+            composed = false, innerMargin = innerMargin, outerMargin = outerMargin,
         )
         return fingerprint.copy(
             regions = regions,
             captureHalfW = halfW,
             captureHalfH = halfH,
+            // Keep the model that produced these bytes with them. Without it the next reclassify has
+            // to be handed a matrix again, and after a project reload there is no correct one to
+            // hand it — the capture's world frame is gone with the ARCore session.
+            captureDesignModel = designModel.toList(),
         )
+    }
+
+    /**
+     * Reclassify against the design model the fingerprint already carries — the reload-safe form.
+     *
+     * This is the one a resize handler should call. It cannot be given a matrix in the wrong frame
+     * because it is not given one at all: [Fingerprint.captureDesignModel] was pre-multiplied into
+     * the capture frame at capture, which is the frame [Fingerprint.points3d] is in.
+     *
+     * Returns the receiver unchanged when there is no stored model (a pre-Phase-2 or depth-path
+     * fingerprint). That is a refusal, not a silent success: reclassifying against a guessed frame
+     * would produce a full, plausible, wrong partition, and the legacy all-backbone reading is the
+     * behaviour `main` already has.
+     */
+    fun reclassify(fingerprint: Fingerprint, halfW: Float, halfH: Float): Fingerprint {
+        val model = fingerprint.captureDesignModel
+        if (model.size != 16) return fingerprint
+        return reclassify(fingerprint, model.toFloatArray(), halfW, halfH)
     }
 
     /**
@@ -115,7 +193,20 @@ object FingerprintPartition {
      */
     fun backboneCount(fingerprint: Fingerprint): Int {
         if (fingerprint.regions.isEmpty()) return fingerprint.points3d.size / 3
+        return backboneCount(fingerprint.regions)
+    }
+
+    /**
+     * How many of [regions] are backbone. Note this is the *raw* count and has no legacy reading —
+     * an empty array is 0 here, not "all of them", because there is no point list in scope to say
+     * how many "all" would be. Callers holding a fingerprint should use the overload above.
+     *
+     * Split out so the capture-time `F_out` floor and the diagnostic count are literally the same
+     * arithmetic. `count { it != INSIDE }` and `count { it == OUTSIDE }` differ precisely on the
+     * BAND, and having that decision written twice is how the two drift apart.
+     */
+    fun backboneCount(regions: ByteArray): Int {
         val outside = Footprint.Region.OUTSIDE.ordinal.toByte()
-        return fingerprint.regions.count { it == outside }
+        return regions.count { it == outside }
     }
 }

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/MetricFingerprintBuilder.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/MetricFingerprintBuilder.kt
@@ -167,10 +167,46 @@ object MetricFingerprintBuilder {
         private set
 
     /**
+     * How many of the placed points landed in the backbone set `F_out`, or -1 when the capture was
+     * not partitioned at all (no design footprint supplied — the legacy all-backbone case).
+     *
+     * -1 rather than 0 for the reason `EVALUATION.md` records twice over: 0 is a *measurement*, and
+     * "the design covers the whole wall so there is no backbone" and "nobody asked for a partition"
+     * are opposite situations that must not print the same number.
+     */
+    @Volatile var lastBackbone: Int = -1
+        private set
+
+    /**
+     * Minimum backbone size for a capture to be worth keeping (`IMPLEMENTATION.md` 2.8).
+     *
+     * `F_out` is what the reloc PnP solves from with no prior. If the design covers the whole
+     * visible wall there is nothing outside it, and the target will never lock — the paper states
+     * this as a limit of the domain of applicability, so the implementation's job is to say so at
+     * capture rather than let the artist discover it as mysterious tracking failure an hour later.
+     *
+     * `40` is the pre-registered prior from `PARAMETERS.md` §4 (`BACKBONE_MIN_FEATURES`): 5× the
+     * native PnP correspondence floor of 8, leaving room for the fact that only a fraction of stored
+     * features match in any one live frame. It is a *prior*, not a measurement — `EVALUATION.md` E8
+     * is the experiment that sets it, and both failure modes are real: too high refuses captures
+     * that would have worked, too low ships a target that can never lock.
+     *
+     * Deliberately NOT tied to `minPoints`' default of 20. The two floors ask different questions —
+     * "did enough features land on the wall at all" versus "is enough of what landed outside the
+     * artwork" — and a capture can comfortably pass the first while failing the second, which is
+     * exactly the design-covers-the-whole-wall case this exists to catch.
+     */
+    const val MIN_BACKBONE = 40
+
+    /**
      * @param rotationDeg `rotationNeeded` for this capture — the angle the caller already applied
      *   to [bitmap] and to [intr]. The view is rotated to match (`IMPLEMENTATION.md` Phase 0,
      *   convention B); passing 0 while handing in rotated pixels reinstates the `PAPER.md` §8
      *   defect, which is why it has no default.
+     * @param design where the artwork sits at capture, in world space (`IMPLEMENTATION.md` 2.3/2.4).
+     *   Null — the default — leaves the fingerprint unpartitioned, which every consumer reads as
+     *   all-backbone and is byte-for-byte the behaviour before Phase 2. That is a real default, not
+     *   a shortcut: the depth path and the doodle path have no placed design to speak of.
      */
     fun buildSingle(
         slam: SlamManager,
@@ -179,8 +215,9 @@ object MetricFingerprintBuilder {
         anchorModel: FloatArray,
         rotationDeg: Int,
         minPoints: Int = 20,
+        design: FingerprintPartition.DesignFootprint? = null,
     ): Fingerprint? {
-        lastDetected = 0; lastPlaced = 0; lastRequired = minPoints
+        lastDetected = 0; lastPlaced = 0; lastRequired = minPoints; lastBackbone = -1
         // Convention B: the bitmap and intrinsics arrived in display orientation, so the view goes
         // there too. This is the fix for PAPER.md §8 — previously `glViewToCv(glView)`, which left
         // display-frame rays intersecting a sensor-frame plane.
@@ -194,7 +231,8 @@ object MetricFingerprintBuilder {
                 var i = 0
                 while (i + 1 < pos.size) { pixels.add(PlaneMarks.Pixel(pos[i], pos[i + 1])); i += 2 }
                 val fp = ingestSingle(slam, descs, pixels, cvView, intr,
-                    planePointWorld, planeNormalWorld, anchorModel, minPoints, glView, rotationDeg)
+                    planePointWorld, planeNormalWorld, anchorModel, minPoints, glView, rotationDeg,
+                    design)
                 if (fp != null) return fp
             } finally {
                 descs.release()
@@ -213,7 +251,8 @@ object MetricFingerprintBuilder {
             if (d.empty()) return null
             val pixels = kp.toArray().map { PlaneMarks.Pixel(it.pt.x.toFloat(), it.pt.y.toFloat()) }
             return ingestSingle(slam, d, pixels, cvView, intr,
-                planePointWorld, planeNormalWorld, anchorModel, minPoints, glView, rotationDeg)
+                planePointWorld, planeNormalWorld, anchorModel, minPoints, glView, rotationDeg,
+                design)
         } finally {
             gray.release(); norm.release(); kp.release(); d.release()
         }
@@ -232,6 +271,7 @@ object MetricFingerprintBuilder {
         glView: FloatArray? = null,
         /** rotationNeeded for this capture; rotates [glView] to match the points. See 0.10. */
         rotationDeg: Int = 0,
+        design: FingerprintPartition.DesignFootprint? = null,
     ): Fingerprint? {
         val res = PlaneMarks.backProject(
             pixels, cvView, planePointWorld, planeNormalWorld,
@@ -242,6 +282,26 @@ object MetricFingerprintBuilder {
         if (pixels.size > lastDetected) lastDetected = pixels.size
         if (res.count > lastPlaced) lastPlaced = res.count
         if (res.count < minPoints) return null
+
+        // IMPLEMENTATION.md 2.4 — tag each surviving point with its region relative to the design's
+        // projected footprint. `res.pointsCam` is in the capture CV camera frame and the renderer's
+        // design pose is in world, so the design is moved into the points' frame ONCE here rather
+        // than every point being moved into the design's; see DesignFootprint.inFrameOf for why the
+        // two are equivalent. A null or degenerate design leaves regions empty, which every consumer
+        // reads as all-backbone — Phase 2's documented rollback, reached by doing nothing.
+        val designInPointFrame = design?.takeIf { it.isUsable }?.inFrameOf(cvView)
+        val regions = designInPointFrame?.let {
+            FingerprintPartition.classify(res.pointsCam, it.rigidModel, it.halfW, it.halfH)
+        } ?: ByteArray(0)
+
+        // IMPLEMENTATION.md 2.8 — refuse a capture with no backbone to localize against. Checked
+        // before anything is published or committed, so a refusal leaves no half-built target and no
+        // stale overlay re-centering behind. lastBackbone stays -1 when unpartitioned: not measured,
+        // not zero.
+        if (regions.isNotEmpty()) {
+            lastBackbone = FingerprintPartition.backboneCount(regions)
+            if (lastBackbone < MIN_BACKBONE) return null
+        }
 
         // Center the AR overlay on the marks (their centroid), not the screen-center anchor.
         val markCenterLocal = marksCentroidLocal(res.pointsCam, cvView, anchorModel)
@@ -278,6 +338,10 @@ object MetricFingerprintBuilder {
             bytes, rows, cols, type, res.pointsCam, anchorModel, intr,
             viewMatrix = glView?.let { MetricMarks.glViewDisplayOriented(it, rotationDeg) }
                 ?: FloatArray(0),
+            // IMPLEMENTATION.md 2.6 — native filters the reloc correspondence build by these, and
+            // reads a zero-length array as all-backbone, so an unpartitioned capture behaves as it
+            // did before Phase 2 rather than losing its whole map.
+            regions = regions,
         )
         return Fingerprint(
             keypoints, res.pointsCam.toList(), bytes, rows, cols, type,
@@ -285,6 +349,13 @@ object MetricFingerprintBuilder {
             // IMPLEMENTATION.md 0.7 — record the frame these points were built in, so a reload can
             // tell a Phase-0 fingerprint from a pre-Phase-0 one instead of guessing.
             captureRotationDeg = rotationDeg,
+            // IMPLEMENTATION.md 2.4 — the partition, and the design placement that defines it. The
+            // model is stored in the POINTS' frame (see DesignFootprint.inFrameOf) so a later
+            // reclassify after a project reload has a frame it can trust.
+            regions = regions,
+            captureHalfW = designInPointFrame?.halfW ?: -1f,
+            captureHalfH = designInPointFrame?.halfH ?: -1f,
+            captureDesignModel = designInPointFrame?.rigidModel?.toList() ?: emptyList(),
         )
     }
 

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -35,7 +35,7 @@ class ArRenderer(
     private val context: Context,
     private val slamManager: SlamManager,
     // Last arg is the camera→point distance (meters) at the tapped pixel, or -1f when unavailable.
-    private val onTargetCaptured: (Bitmap, Int, Int, ByteBuffer?, Int, Int, Int, FloatArray?, FloatArray, Int, Float, FloatArray?) -> Unit,
+    private val onTargetCaptured: (Bitmap, Int, Int, ByteBuffer?, Int, Int, Int, FloatArray?, FloatArray, Int, Float, FloatArray?, com.hereliesaz.graffitixr.common.model.CaptureEnvironment) -> Unit,
     private val onTrackingUpdated: (Boolean, Int, Int, Boolean, Float, Float, Triple<Float, Float, Float>?, Boolean, Boolean, Float, Float, Float) -> Unit,
     private val onLightUpdated: (Float) -> Unit,
     private val onDiag: (String) -> Unit = {},
@@ -216,6 +216,15 @@ class ArRenderer(
 
     // Eval (Sub-project A): null unless dev/eval mode is on. Set from ArViewModel.
     @Volatile var driftCostProbe: com.hereliesaz.graffitixr.feature.ar.eval.DriftCostProbe? = null
+
+    /**
+     * Latest physical device attitude, or null when unavailable. Supplied by the ViewModel, which
+     * owns the sensor lifecycle — the renderer only reads it, and only at capture.
+     */
+    @Volatile var attitudeSampler: (() -> com.hereliesaz.graffitixr.common.model.DeviceAttitude?)? = null
+
+    /** Latest location fix, or null. Same ownership split as [attitudeSampler]. */
+    @Volatile var locationSampler: (() -> com.hereliesaz.graffitixr.common.model.LocationFix?)? = null
     // Scratch holder for the mark-PnP "truth" pose read from the native anchor transform.
     private val truthPoseScratch = FloatArray(16)
     // Visible-confidence threshold above which mark-PnP is treated as truth for eval.
@@ -735,6 +744,40 @@ class ArRenderer(
     }
 
     /** Perception redraw rate: full normally, floored while any enabled throttle trigger is active. */
+    /**
+     * `[tx, ty, tz, qx, qy, qz, qw]` for an ARCore pose, or empty if it throws.
+     *
+     * Flattened rather than stored as a Pose because this crosses into a serializable model: a Pose
+     * is an ARCore handle, and persisting one would tie a saved project to the SDK's object graph.
+     */
+    private fun poseToList(pose: com.google.ar.core.Pose?): List<Float> = try {
+        if (pose == null) emptyList() else listOf(
+            pose.tx(), pose.ty(), pose.tz(),
+            pose.qx(), pose.qy(), pose.qz(), pose.qw(),
+        )
+    } catch (e: Exception) {
+        Timber.w(e, "pose flatten failed")
+        emptyList()
+    }
+
+    /**
+     * Whether system auto-rotate is on.
+     *
+     * Recorded at capture because it is the one setting that explains a `rotationNeeded` which
+     * disagrees with the physical attitude: `screenOrientation="fullUser"` honours it, so with
+     * auto-rotate off the window orientation stops following the device entirely. It is also the
+     * precondition for EVALUATION.md E0b — with it off, rotating the phone does not move the
+     * experiment's independent variable at all.
+     */
+    private fun isAutoRotateEnabled(): Boolean = try {
+        android.provider.Settings.System.getInt(
+            context.contentResolver,
+            android.provider.Settings.System.ACCELEROMETER_ROTATION,
+        ) == 1
+    } catch (e: Exception) {
+        false
+    }
+
     private fun effectivePerceptionFps(): Int {
         val laggy = lagThrottleEnabled && perceptionRefreshAvgMs > PERCEPTION_LAG_MS
         return if (systemThrottle || laggy) PERCEPTION_FLOOR_FPS else PERCEPTION_FULL_FPS
@@ -1455,13 +1498,35 @@ class ArRenderer(
                             }
                         }
 
+                        // Everything knowable about how and where the device was held, sampled at
+                        // the instant the geometry is frozen. backProject runs once per target, so
+                        // this is the only moment these conditions exist to be recorded — afterwards
+                        // the fingerprint carries their consequences with no record of their cause.
+                        val captureEnvironment = com.hereliesaz.graffitixr.common.model.CaptureEnvironment(
+                            capturedAtEpochMs = System.currentTimeMillis(),
+                            elapsedRealtimeNs = android.os.SystemClock.elapsedRealtimeNanos(),
+                            frame = com.hereliesaz.graffitixr.common.model.FrameOrientation(
+                                displayRotationDeg = displayDegrees,
+                                sensorOrientationDeg = sensorOrientation,
+                                rotationNeededDeg = rotationNeeded,
+                                autoRotateEnabled = isAutoRotateEnabled(),
+                            ),
+                            attitude = attitudeSampler?.invoke(),
+                            arPoses = com.hereliesaz.graffitixr.common.model.ArPoseSnapshot(
+                                cameraPose = poseToList(camera.pose),
+                                displayOrientedPose = poseToList(camera.displayOrientedPose),
+                                androidSensorPose = poseToList(frame.androidSensorPose),
+                            ),
+                            location = locationSampler?.invoke(),
+                        )
+
                         onTargetCaptured(
                             bitmap, image.width, image.height,
                             depthBuffer,
                             depthWidth, depthHeight, depthStride,
                             intrArr, mappingViewMatrix.copyOf(),
                             rotationNeeded, tapDistanceMeters,
-                            wallPlane
+                            wallPlane, captureEnvironment
                         )
                     }
                 } catch (e: Exception) {

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -35,7 +35,7 @@ class ArRenderer(
     private val context: Context,
     private val slamManager: SlamManager,
     // Last arg is the camera→point distance (meters) at the tapped pixel, or -1f when unavailable.
-    private val onTargetCaptured: (Bitmap, Int, Int, ByteBuffer?, Int, Int, Int, FloatArray?, FloatArray, Int, Float, FloatArray?, com.hereliesaz.graffitixr.common.model.CaptureEnvironment) -> Unit,
+    private val onTargetCaptured: (Bitmap, Int, Int, ByteBuffer?, Int, Int, Int, FloatArray?, FloatArray, Int, Float, FloatArray?, com.hereliesaz.graffitixr.common.model.CaptureEnvironment, com.hereliesaz.graffitixr.feature.ar.anchor.FingerprintPartition.DesignFootprint?) -> Unit,
     private val onTrackingUpdated: (Boolean, Int, Int, Boolean, Float, Float, Triple<Float, Float, Float>?, Boolean, Boolean, Float, Float, Float) -> Unit,
     private val onLightUpdated: (Float) -> Unit,
     private val onDiag: (String) -> Unit = {},
@@ -59,7 +59,16 @@ class ArRenderer(
     // Fired from the GL thread when a torch request was rejected by ARCore (no flash unit, or a
     // camera config that can't drive one), so the UI can drop the toggle instead of latching a
     // light that never came on.
-    private val onFlashlightUnavailable: () -> Unit = {}
+    private val onFlashlightUnavailable: () -> Unit = {},
+    // Fired from the GL thread when the artwork's EFFECTIVE (scale-included) half-extents change —
+    // i.e. the artist pinched the design. IMPLEMENTATION.md 2.2: the stored fingerprint's partition
+    // was computed against the old size and is now stale, so the regions get recomputed from the
+    // stored 3D points rather than the artist being made to re-capture.
+    //
+    // Edge-triggered, not per-frame: the renderer knows when the number moved and the ViewModel does
+    // not, so debouncing here costs one float compare a frame and saves a listener that would
+    // otherwise have to poll.
+    private val onDesignExtentChanged: (Float, Float) -> Unit = { _, _ -> },
 ) : GLSurfaceView.Renderer {
 
     /**
@@ -431,6 +440,45 @@ class ArRenderer(
     private val overlayBaseScratch = FloatArray(16)
     private val overlayLocalScratch = FloatArray(16)
     private val overlayComposedScratch = FloatArray(16)
+    private val overlayRigidScratch = FloatArray(16)
+
+    // Where the artwork sits, published for the capture path (IMPLEMENTATION.md 2.3/2.4).
+    //
+    // Guarded rather than @Volatile: the four values are only meaningful together, and the capture
+    // block reads them a few statements after the draw block wrote them. A torn read here would
+    // partition a whole fingerprint against half of one design's pose and half of another's, and the
+    // result would look entirely plausible. The lock is uncontended in practice — both sides are the
+    // GL thread — and costs nothing next to the frame it sits inside.
+    // A millimetre. Below this a "resize" is float noise in the composed transform, and firing on it
+    // would reclassify the whole fingerprint every frame the artist rests a finger on the screen.
+    private val DESIGN_EXTENT_EPS = 1e-3f
+    private val designFootprintLock = Any()
+    private val designRigidModel = FloatArray(16)
+    private var designEffectiveHalfW = -1f
+    private var designEffectiveHalfH = -1f
+    private var designPlaced = false
+
+    /**
+     * The design's placement as of the last drawn frame, or null when there is no placed artwork to
+     * take a footprint of.
+     *
+     * Null is the honest answer before the overlay has an anchor and a texture, and it leaves the
+     * capture unpartitioned — the legacy all-backbone reading, i.e. exactly `main`'s behaviour. The
+     * alternative, inventing an identity pose, would partition every point against a design sitting
+     * at the world origin and produce a full, confident, meaningless answer.
+     *
+     * One frame stale by construction: the capture block runs before the overlay is composed for
+     * this frame, so these are the previous frame's values. At 30–60 fps that is 16–33 ms of device
+     * motion on a shot the artist has just framed and confirmed, and it is the same transform the
+     * artist was looking at when they tapped — which is the one the partition should be against.
+     */
+    fun designFootprint(): com.hereliesaz.graffitixr.feature.ar.anchor.FingerprintPartition.DesignFootprint? =
+        synchronized(designFootprintLock) {
+            if (!designPlaced || designEffectiveHalfW <= 0f || designEffectiveHalfH <= 0f) return null
+            com.hereliesaz.graffitixr.feature.ar.anchor.FingerprintPartition.DesignFootprint(
+                designRigidModel.copyOf(), designEffectiveHalfW, designEffectiveHalfH,
+            )
+        }
     // Scratch for the 2D perspective content rotation matrix (X/Y axes).
     private val contentRotationScratch = FloatArray(16)
     private val contentRotationTemp = FloatArray(16)
@@ -1526,7 +1574,12 @@ class ArRenderer(
                             depthWidth, depthHeight, depthStride,
                             intrArr, mappingViewMatrix.copyOf(),
                             rotationNeeded, tapDistanceMeters,
-                            wallPlane, captureEnvironment
+                            wallPlane, captureEnvironment,
+                            // IMPLEMENTATION.md 2.3 — where the artwork is, so the fingerprint can
+                            // be partitioned into backbone and corroboration at the moment its
+                            // geometry is frozen. Null until the overlay has an anchor and a
+                            // texture, which leaves the capture unpartitioned (= all backbone).
+                            designFootprint(),
                         )
                     }
                 } catch (e: Exception) {
@@ -1908,6 +1961,32 @@ class ArRenderer(
             )
             // Spin the artwork in its own plane (Z-axis rotation about the wall normal).
             android.opengl.Matrix.rotateM(overlayLocalScratch, 0, overlayRotationDeg, 0f, 0f, 1f)
+            // Snapshot the design's frame BEFORE the scale goes in (IMPLEMENTATION.md 2.3/2.4). Φ
+            // needs a rigid matrix with the scale folded into the extents instead: the composed one
+            // below is scaled (s, s, 1), which is NOT the uniform similarity an inverse-with-scale
+            // would assume, and inverting it as one is wrong on Z. Taken here rather than
+            // reconstructed at capture so it cannot drift from the transform actually drawn.
+            android.opengl.Matrix.multiplyMM(
+                overlayRigidScratch, 0, overlayBaseScratch, 0, overlayLocalScratch, 0
+            )
+            val newHalfW = overlayRenderer.extentHalfW * overlayScale
+            val newHalfH = overlayRenderer.extentHalfH * overlayScale
+            // `quadInitialFitApplied` is part of the precondition, not an optimisation. Until the
+            // screen-fit above has run, the quad's extents are still QUAD_HALF_EXTENT — a 10 m
+            // square placeholder chosen so artwork is never spatially confined. Publishing that as
+            // the design's size would make Φ swallow every feature in view, report a backbone of
+            // zero, and refuse every capture with "the artwork covers almost the whole wall".
+            val placed = anchorEstablished && overlayRenderer.hasTexture && quadInitialFitApplied
+            val extentMoved = placed &&
+                (kotlin.math.abs(newHalfW - designEffectiveHalfW) > DESIGN_EXTENT_EPS ||
+                    kotlin.math.abs(newHalfH - designEffectiveHalfH) > DESIGN_EXTENT_EPS)
+            synchronized(designFootprintLock) {
+                System.arraycopy(overlayRigidScratch, 0, designRigidModel, 0, 16)
+                designEffectiveHalfW = newHalfW
+                designEffectiveHalfH = newHalfH
+                designPlaced = placed
+            }
+            if (extentMoved) onDesignExtentChanged(newHalfW, newHalfH)
             android.opengl.Matrix.scaleM(overlayLocalScratch, 0, overlayScale, overlayScale, 1f)
             android.opengl.Matrix.multiplyMM(
                 overlayComposedScratch, 0, overlayBaseScratch, 0, overlayLocalScratch, 0

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/OverlayRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/OverlayRenderer.kt
@@ -126,6 +126,17 @@ class OverlayRenderer(private val context: Context) : GlReleasable {
         hasTexture = true
     }
 
+    /**
+     * The artwork quad's current half-extents in metres, before the user's `overlayScale`.
+     *
+     * Exposed for the Phase-2 partition, which needs the design's real size on the wall to ask
+     * whether a feature sits under it. Read-only on purpose: the two [setExtent] call sites are a
+     * fixed constant and a one-shot screen-fit, and neither is user-driven — the user's resize is
+     * `overlayScale`, which lives in the model matrix.
+     */
+    val extentHalfW: Float get() = halfW
+    val extentHalfH: Float get() = halfH
+
     fun setExtent(halfW: Float, halfH: Float) {
         if (this.halfW != halfW || this.halfH != halfH) {
             this.halfW = halfW

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/FingerprintPartitionTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/FingerprintPartitionTest.kt
@@ -1,9 +1,11 @@
 package com.hereliesaz.graffitixr.feature.ar.anchor
 
 import com.hereliesaz.graffitixr.common.model.Fingerprint
+import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.opencv.core.KeyPoint
@@ -203,5 +205,153 @@ class FingerprintPartitionTest {
     @Test(expected = IllegalArgumentException::class)
     fun `a regions array that disagrees with the point count is rejected`() {
         fp(listOf(0f, 0f, 0f, 1f, 1f, 1f), regions = ByteArray(1))
+    }
+
+    // -------------------------------------------------------------------------------------
+    // The frame reconciliation — DesignFootprint.inFrameOf
+    // -------------------------------------------------------------------------------------
+
+    /**
+     * A deliberately awkward rigid world→camera view: a 30° rotation about Z composed with a
+     * translation, so neither the rotation nor the translation can cancel out by accident and a
+     * dropped factor changes the answer.
+     */
+    private fun view(): FloatArray {
+        // Written out rather than built with android.opengl.Matrix: that class is a stub under a
+        // plain JVM unit test and returns zeros without complaining, which would make every point
+        // land at the origin and every assertion below pass for the wrong reason.
+        val c = kotlin.math.cos(Math.toRadians(30.0)).toFloat()
+        val s = kotlin.math.sin(Math.toRadians(30.0)).toFloat()
+        return floatArrayOf(
+            c, s, 0f, 0f,
+            -s, c, 0f, 0f,
+            0f, 0f, 1f, 0f,
+            0.3f, -1.7f, 4.0f, 1f,
+        )
+    }
+
+    /** Apply a column-major 4x4 to a point, returning [x,y,z]. */
+    private fun apply(m: FloatArray, p: FloatArray): FloatArray = floatArrayOf(
+        m[0] * p[0] + m[4] * p[1] + m[8] * p[2] + m[12],
+        m[1] * p[0] + m[5] * p[1] + m[9] * p[2] + m[13],
+        m[2] * p[0] + m[6] * p[1] + m[10] * p[2] + m[14],
+    )
+
+    /**
+     * The claim `inFrameOf` rests on, checked end to end rather than by re-deriving its algebra:
+     * classifying camera-frame points against the view-premultiplied design gives the SAME bytes as
+     * classifying the corresponding world-frame points against the world design.
+     *
+     * This is the assertion that catches the bug the whole design is arranged to avoid — Φ applied
+     * across two frames. `Fingerprint.points3d` are camera-frame and the renderer's design pose is
+     * world-frame, and mixing them produces a full, plausible, entirely wrong partition.
+     */
+    @Test
+    fun `classifying in the camera frame agrees with classifying in world`() {
+        val v = view()
+        // World points chosen to land in all three regions against a design at the world origin.
+        val world = floatArrayOf(
+            0f, 0f, 0f,            // inside
+            HALF_W, 0f, 0f,        // on the edge -> band
+            5f, 0f, 0f,            // outside
+            0.5f, 1.5f, 0f,        // outside via the SHORT axis
+        )
+        val designWorld = FingerprintPartition.DesignFootprint(identity(), HALF_W, HALF_H)
+
+        val inWorld = FingerprintPartition.classify(world, designWorld.rigidModel, HALF_W, HALF_H)
+
+        // The same points, expressed in the camera frame, against the design moved into that frame.
+        val cam = FloatArray(world.size)
+        for (i in 0 until world.size / 3) {
+            val p = apply(v, floatArrayOf(world[i * 3], world[i * 3 + 1], world[i * 3 + 2]))
+            p.copyInto(cam, i * 3)
+        }
+        val designCam = designWorld.inFrameOf(v)
+        val inCam = FingerprintPartition.classify(cam, designCam.rigidModel, designCam.halfW, designCam.halfH)
+
+        assertArrayEquals("the frame must not change the partition", inWorld, inCam)
+        // ...and the fixture is not degenerate: all three regions are represented, so an
+        // everything-is-OUTSIDE bug could not produce this.
+        assertEquals(INSIDE, inWorld[0]); assertEquals(BAND, inWorld[1])
+        assertEquals(OUTSIDE, inWorld[2]); assertEquals(OUTSIDE, inWorld[3])
+    }
+
+    /**
+     * The negative half of the test above. Classifying camera-frame points against the *world*
+     * design — the mistake `inFrameOf` exists to prevent — must give a different answer, or the
+     * reconciliation is decorative and this whole mechanism could be deleted.
+     */
+    @Test
+    fun `skipping the frame reconciliation changes the answer`() {
+        val v = view()
+        val world = floatArrayOf(0f, 0f, 0f, 5f, 0f, 0f)
+        val cam = FloatArray(world.size)
+        for (i in 0 until world.size / 3) {
+            apply(v, floatArrayOf(world[i * 3], world[i * 3 + 1], world[i * 3 + 2])).copyInto(cam, i * 3)
+        }
+        val correct = FingerprintPartition.classify(
+            cam, FingerprintPartition.DesignFootprint(identity(), HALF_W, HALF_H).inFrameOf(v).rigidModel,
+            HALF_W, HALF_H,
+        )
+        val wrong = FingerprintPartition.classify(cam, identity(), HALF_W, HALF_H)
+        assertFalse("mixing frames must be detectable", correct.contentEquals(wrong))
+    }
+
+    /**
+     * The capture-time `F_out` floor (2.8) counts through this overload, so the distinction it draws
+     * has to be pinned: the BAND is **not** backbone. A "step back, not enough wall" refusal that
+     * counted the band would let a design covering everything but its own border pass.
+     */
+    @Test
+    fun `the raw backbone count excludes the band as well as the inside`() {
+        assertEquals(1, FingerprintPartition.backboneCount(byteArrayOf(INSIDE, BAND, OUTSIDE)))
+        assertEquals(0, FingerprintPartition.backboneCount(byteArrayOf(INSIDE, BAND, BAND)))
+        assertEquals(3, FingerprintPartition.backboneCount(byteArrayOf(OUTSIDE, OUTSIDE, OUTSIDE)))
+        assertEquals("no regions is no backbone at this level", 0, FingerprintPartition.backboneCount(ByteArray(0)))
+    }
+
+    @Test
+    fun `a design with no extents is not usable`() {
+        assertFalse(FingerprintPartition.DesignFootprint(identity(), 0f, 1f).isUsable)
+        assertFalse(FingerprintPartition.DesignFootprint(identity(), 1f, -1f).isUsable)
+        assertFalse(FingerprintPartition.DesignFootprint(FloatArray(4), 1f, 1f).isUsable)
+        assertTrue(FingerprintPartition.DesignFootprint(identity(), 1f, 1f).isUsable)
+    }
+
+    // -------------------------------------------------------------------------------------
+    // The self-contained reclassify
+    // -------------------------------------------------------------------------------------
+
+    /**
+     * The reload-safe form: no matrix passed in, so no matrix can be passed in wrong. It must reach
+     * the same answer as the explicit form given the model the fingerprint already carries.
+     */
+    @Test
+    fun `reclassify without a matrix uses the stored design model`() {
+        val explicit = FingerprintPartition.reclassify(
+            fp(listOf(0f, 0f, 0f, 5f, 0f, 0f)), identity(), HALF_W, HALF_H,
+        )
+        assertEquals("the explicit form must store what it used", 16, explicit.captureDesignModel.size)
+
+        val implicit = FingerprintPartition.reclassify(explicit, 2f, 1f)
+        assertEquals(2f, implicit.captureHalfW, 1e-6f)
+        assertArrayEquals(
+            FingerprintPartition.reclassify(explicit, identity(), 2f, 1f).regions,
+            implicit.regions,
+        )
+    }
+
+    /**
+     * A fingerprint with no stored model must be returned untouched. Guessing a frame here would
+     * produce a complete and completely wrong partition; the legacy all-backbone reading is what
+     * `main` already does and is the safe refusal.
+     */
+    @Test
+    fun `reclassify without a matrix refuses a fingerprint that has no stored model`() {
+        val legacy = fp(listOf(0f, 0f, 0f))
+        assertTrue(legacy.captureDesignModel.isEmpty())
+        val out = FingerprintPartition.reclassify(legacy, 1f, 1f)
+        assertSame("must be the same object, not a silently-partitioned copy", legacy, out)
+        assertTrue(out.isUnpartitioned())
     }
 }

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/FootprintRegionWireTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/FootprintRegionWireTest.kt
@@ -1,0 +1,85 @@
+package com.hereliesaz.graffitixr.feature.ar.anchor
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * [Footprint.Region] is a **wire format**, not an internal enum.
+ *
+ * `Fingerprint.regions` stores `Region.ordinal` as one byte per point. Kotlin writes those bytes;
+ * `MobileGS.cpp` reads them and decides which points the reloc PnP is allowed to see. Nothing in
+ * either toolchain checks that the two agree — no shared header, no generated binding, no JNI
+ * descriptor. Reorder the enum and every fingerprint in the field silently inverts: the backbone
+ * becomes the painted-over set and the target stops locking, with no error anywhere.
+ *
+ * So the agreement is pinned here, from both directions:
+ *
+ *  - the ordinals themselves, so a reorder fails a Kotlin test;
+ *  - the literal C++ constants, read out of `MobileGS.h`, so a change on that side fails too.
+ *
+ * The second assertion reads a source file, which is unusual and deliberate. The alternative is a
+ * comment saying "keep these in sync", and this codebase has already learned what those are worth.
+ */
+class FootprintRegionWireTest {
+
+    /**
+     * The ordinals, written out. Deliberately literal: deriving them from the enum would assert
+     * `ordinal == ordinal` and pass under exactly the reorder this test exists to catch.
+     */
+    @Test
+    fun `region ordinals are the persisted wire values`() {
+        assertEquals(0, Footprint.Region.INSIDE.ordinal)
+        assertEquals(1, Footprint.Region.BAND.ordinal)
+        assertEquals(2, Footprint.Region.OUTSIDE.ordinal)
+        assertEquals("no region may be added without a native counterpart", 3, Footprint.Region.entries.size)
+    }
+
+    @Test
+    fun `the native constants match the Kotlin ordinals`() {
+        val header = findRepoFile("core/nativebridge/src/main/cpp/include/MobileGS.h")
+        val text = header.readText()
+        val native = Regex("""kRegion(\w+)\s*=\s*(\d+)""").findAll(text)
+            .associate { it.groupValues[1].uppercase() to it.groupValues[2].toInt() }
+
+        assertTrue(
+            "MobileGS.h declares no kRegion* constants — did the partition filter get removed " +
+                "without this test being updated? Found: $native",
+            native.size == 3,
+        )
+        for (r in Footprint.Region.entries) {
+            assertEquals(
+                "Footprint.Region.${r.name} is ${r.ordinal} in Kotlin but ${native[r.name]} in " +
+                    "MobileGS.h; the stored bytes mean different things on the two sides",
+                r.ordinal, native[r.name],
+            )
+        }
+    }
+
+    /**
+     * The reloc filter must keep only OUTSIDE. Pinned as a literal comparison against the native
+     * constant name used in `MobileGS.cpp`, because "exclude INSIDE" and "keep only OUTSIDE" differ
+     * precisely on the BAND — the region whose whole purpose is to be trusted by neither side.
+     */
+    @Test
+    fun `the reloc filter keeps only the backbone, not merely everything that is not inside`() {
+        val src = findRepoFile("core/nativebridge/src/main/cpp/MobileGS.cpp").readText()
+        assertTrue(
+            "expected the correspondence build to skip anything that is not kRegionOutside",
+            src.contains("wallRegions[match[0].trainIdx] != kRegionOutside"),
+        )
+    }
+
+    private fun findRepoFile(relative: String): File {
+        // Test working directories differ between Gradle and IDE runs, so walk up rather than
+        // assuming one. Failing loudly here beats a silently-skipped assertion.
+        var dir: File? = File("").absoluteFile
+        while (dir != null) {
+            val f = File(dir, relative)
+            if (f.isFile) return f
+            dir = dir.parentFile
+        }
+        throw AssertionError("could not locate $relative from ${File("").absolutePath}")
+    }
+}

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Sat Aug 01 09:42:10 UTC 2026
-versionBuild=14309
+#Sat Aug 01 10:18:52 UTC 2026
+versionBuild=14326
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=175
+versionPatch=192

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Sat Aug 01 09:29:55 UTC 2026
-versionBuild=14299
+#Sat Aug 01 09:42:10 UTC 2026
+versionBuild=14309
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=165
+versionPatch=175


### PR DESCRIPTION
Two things: the Play policy blocker, and the orientation/location capture record.

## Play policy — `READ_MEDIA_IMAGES` / `READ_EXTERNAL_STORAGE` removed

Version code 14295 was flagged for requesting broad photo permissions where a system picker suffices. It does suffice — the app was **already** using the system pickers and just declaring the permissions anyway:

- every image (overlay, background, first-run) comes from `ActivityResultContracts.PickVisualMedia`, the Android photo picker, which needs no permission;
- project import uses `ActivityResultContracts.GetContent` (SAF), which also needs none.

Both hand back a URI the app already holds read access to. Nothing read media through a path requiring the grant — this was a declaration with no consumer, so removing it changes no behaviour.

**Verified against the merged manifest, not the source.** Removing a permission from `AndroidManifest.xml` proves nothing on its own: any dependency can re-introduce one via manifest merging, and the merged file is what Play reads. `processDebugMainManifest` now declares CAMERA, INTERNET, two location, two WiFi, `ACCESS_NETWORK_STATE` and the dynamic-receiver permission — and neither flagged permission.

Also removed the **"Photo library access"** row from Settings — the red marker in the field screenshots. Without the declaration it could only ever read *denied*, and tapping it opened App Settings to grant something the app no longer requests. An indicator for a permission you don't request reads as a broken install.

## The app never knew which way the phone was pointing

There was no `OrientationEventListener` and no `SensorManager` listener anywhere — only `display.rotation`, a property of the **window**. That matters in three directions:

- `backProject` runs **once** per target, so the frame relationship at that instant is baked into the fingerprint forever (§8). Attribution later needs the conditions it was made under, and those weren't recorded.
- `screenOrientation="fullUser"` honours auto-rotate, so with rotation lock on, `rotationNeeded` is pinned regardless of physical attitude. Recording both makes that disagreement **visible** rather than merely possible.
- A mural is a place. A fix plus a heading is the cheapest prior for "same wall, same side" when reopening days later.

`CaptureEnvironment` holds four independently-nullable groups:

| Group | Contents |
|---|---|
| `FrameOrientation` | display/sensor/rotationNeeded **+ whether auto-rotate was on** |
| `DeviceAttitude` | **both** rotation vectors, gravity, magnetometer + accuracy, azimuth/pitch/roll, sample age |
| `ArPoseSnapshot` | **all three** ARCore poses — camera, displayOriented, androidSensor |
| `LocationFix` | lat/lon/alt, both accuracies, bearing, speed, provider, **age** |

**Two rotation vectors on purpose.** `TYPE_ROTATION_VECTOR` fuses the magnetometer so its azimuth is absolute but corrupted near rebar; `TYPE_GAME_ROTATION_VECTOR` omits it — no heading, but immune. When they disagree the magnetic environment is bad, which at a reinforced wall is itself the finding. `magneticAccuracy` for the same reason: `SENSOR_STATUS_UNRELIABLE` is the difference between "the heading is wrong" and "it was never trustworthy".

**Location age** is recorded because a fused provider will return a fix from twenty minutes and a kilometre ago, and a stale fix without its age is indistinguishable from a fresh one.

`DeviceAttitudeProvider` caches continuously and snapshots instantly — capture runs on the GL thread inside a frame callback, so it must not block or wait. Listeners publish a **copy** of `SensorEvent.values`, since the framework reuses that array between callbacks.

### Optional telemetry cannot break AR

Both sources are guarded independently; a failure degrades to recording less, never to a stopped session. **The first version did not, and two tests caught it:** Play-Services location needs a `Looper` and throws `"invalid null looper"` without one, which propagated out of `setArMode` and took the AR session down. That was a production bug, not a test artifact — a device whose location client refuses to start would have been unable to enter AR at all.

Everything is absent-by-default (empty lists, `NaN`, `-1`), and `LocationFix` is nullable as a whole because **(0, 0) is a real coordinate**. This codebase has relearned that distinction twice already.

Gives `LocationTracker` its first caller — it has existed with zero callers, alongside `GpsData`, `SensorData` and a diagnostics row that could never render.

## Testing

**395 tests** across `core:common`, `feature:ar`, `core:nativebridge`, `feature:editor` — 0 failures, including a serialization round trip, sparse-record decode, legacy-payload decode, and sentinel pinning. `:app:compileDebugKotlin` green.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Q5WXFiVLeN4sXa9bPCSDA)_

## Summary by Sourcery

Record device orientation, AR poses, and location at capture and persist this environment metadata with wall fingerprints, while keeping AR sessions robust and lightweight.

New Features:
- Capture and persist a `CaptureEnvironment` per target, including frame orientation, device attitude, ARCore poses, and location fix.
- Expose capture environment in UI and project models so wall fingerprints carry their acquisition context.

Enhancements:
- Sample motion sensors and location only while AR mode is active, with guarded startup/teardown so failures degrade gracefully without breaking AR.
- Wire AR renderer to request attitude and location snapshots from the ViewModel at capture time instead of owning sensor lifecycles directly.
- Add tests validating `CaptureEnvironment` serialization, optionality of its groups, and sentinel handling for unmeasured values.

Tests:
- Introduce unit tests ensuring `CaptureEnvironment` and related types round-trip through JSON, handle legacy payloads, and use non-ambiguous sentinels for missing data.

Chores:
- Bump application version build and patch numbers.