### PR TITLE
Partition the fingerprint when the artwork lands, not at capture

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -1243,11 +1243,6 @@ class MainActivity : ComponentActivity() {
                                             // view matrix now follows (Phase 0, convention B).
                                             arUiState.targetDisplayRotation,
                                             arUiState.targetCaptureEnvironment,
-                                            // Where the artwork was at capture, for the Phase-2
-                                            // partition. Absent leaves it unpartitioned.
-                                            arUiState.targetDesignModel,
-                                            arUiState.targetDesignHalfW,
-                                            arUiState.targetDesignHalfH,
                                         )
                                     },
                                     onRetake = {

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
@@ -275,12 +275,12 @@ fun MainScreen(
                             val renderer = ArRenderer(
                                 context = ctx,
                                 slamManager = slamManager,
-                                onTargetCaptured = { bmp, cw, ch, depth, dw, dh, stride, intr, viewMat, rot, tapDist, wallPlane, environment, design ->
+                                onTargetCaptured = { bmp, cw, ch, depth, dw, dh, stride, intr, viewMat, rot, tapDist, wallPlane, environment ->
                                     arViewModel.onTargetCaptured(
                                         bmp, depth,
                                         cw, ch,
                                         dw, dh, stride,
-                                        intr, viewMat, rot, tapDist, wallPlane, environment, design
+                                        intr, viewMat, rot, tapDist, wallPlane, environment
                                     )
                                 },
                                 onTrackingUpdated = { isTracking, splatCount, immutableSplatCount, isDepthSupported, yaw, distanceMeters, relDir, isDualLens, isHardwareStereo, centerDepth, visConf, globConf ->
@@ -308,8 +308,8 @@ fun MainScreen(
                                 onFlashlightUnavailable = {
                                     arViewModel.onFlashlightUnavailable()
                                 },
-                                onDesignExtentChanged = { halfW, halfH ->
-                                    arViewModel.onDesignExtentChanged(halfW, halfH)
+                                onDesignFootprintChanged = { footprint ->
+                                    arViewModel.onDesignFootprintChanged(footprint)
                                 }
                             )
                             renderer.hideVisualization = isExporting

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainViewModel.kt
@@ -159,14 +159,6 @@ class MainViewModel @Inject constructor(
         rotationDeg: Int = 0,
         /** How and where the device was held at capture; persisted onto the project. */
         captureEnvironment: com.hereliesaz.graffitixr.common.model.CaptureEnvironment? = null,
-        /**
-         * Where the artwork sat at capture (`IMPLEMENTATION.md` 2.3): rigid world model matrix and
-         * effective, scale-included half-extents. Null/-1 leaves the fingerprint unpartitioned,
-         * which every consumer reads as all-backbone — pre-Phase-2 behaviour.
-         */
-        designModel: FloatArray? = null,
-        designHalfW: Float = -1f,
-        designHalfH: Float = -1f,
     ) {
         if (bitmap == null || intrinsics == null || viewMatrix == null) {
             // Was a bare reset: the artist confirmed a target and the capture simply vanished with no
@@ -187,16 +179,7 @@ class MainViewModel @Inject constructor(
         if (depthBuffer == null) {
             // No depth source: build the wall fingerprint from a SINGLE capture by back-projecting
             // features onto the ARCore wall plane (whose metric pose ARCore already solved).
-            handleSingleCapture(
-                bitmap, safeIntr, safeView, wallPlane, rotationDeg, captureEnvironment,
-                // Reassembled here, at the one place that consumes it, so the three loose values the
-                // UiState boundary forced never travel any further as three loose values.
-                designModel?.takeIf { it.size == 16 }?.let {
-                    com.hereliesaz.graffitixr.feature.ar.anchor.FingerprintPartition.DesignFootprint(
-                        it, designHalfW, designHalfH,
-                    )
-                },
-            )
+            handleSingleCapture(bitmap, safeIntr, safeView, wallPlane, rotationDeg, captureEnvironment)
             return
         }
         resetCaptureUi()
@@ -298,7 +281,6 @@ class MainViewModel @Inject constructor(
     private fun handleSingleCapture(
         bitmap: Bitmap, intr: FloatArray, view: FloatArray, wallPlane: FloatArray?, rotationDeg: Int,
         captureEnvironment: com.hereliesaz.graffitixr.common.model.CaptureEnvironment?,
-        design: com.hereliesaz.graffitixr.feature.ar.anchor.FingerprintPartition.DesignFootprint? = null,
     ) {
         if (wallPlane == null || wallPlane.size < 6) {
             resetCaptureUi()
@@ -329,7 +311,6 @@ class MainViewModel @Inject constructor(
             val fp = MetricFingerprintBuilder.buildSingle(
                 slamManager, bitmap, view, intr, planePoint, planeNormal, anchor,
                 rotationDeg = rotationDeg,
-                design = design,
             )
             if (fp == null) {
                 // Say WHICH way it fell short. "Not enough texture" was the same message whether the
@@ -338,16 +319,7 @@ class MainViewModel @Inject constructor(
                 val detected = MetricFingerprintBuilder.lastDetected
                 val placed = MetricFingerprintBuilder.lastPlaced
                 val need = MetricFingerprintBuilder.lastRequired
-                val backbone = MetricFingerprintBuilder.lastBackbone
                 val message = when {
-                    // IMPLEMENTATION.md 2.8. Checked FIRST: this failure has enough features and
-                    // they landed on the wall, so both of the messages below would be false. `>= 0`
-                    // rather than `> 0` — the partition ran and found zero backbone is the very case
-                    // this message is for; -1 means it never ran.
-                    backbone >= 0 && backbone < MetricFingerprintBuilder.MIN_BACKBONE ->
-                        "The artwork covers almost the whole wall in view — only $backbone features " +
-                            "sit outside it (need ${MetricFingerprintBuilder.MIN_BACKBONE}). Step " +
-                            "back so there's some bare wall around the design to lock onto."
                     detected < need ->
                         "Only $detected features on this wall (need $need). Too dark, too smooth, " +
                             "or out of focus — try a more detailed patch or more light."

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/Fingerprint.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/Fingerprint.kt
@@ -71,24 +71,33 @@ data class Fingerprint(
     val captureHalfW: Float = -1f,
     val captureHalfH: Float = -1f,
     /**
-     * The design's **rigid** model matrix at capture (column-major 4x4, 16 floats), expressed in the
-     * *same frame as [points3d]* — the capture camera frame, not world. Empty when unknown.
+     * The fingerprint **anchor's** pose expressed in the capture camera frame — `V_cv · A`, where
+     * `V_cv` is the capture's CV-convention world→camera view and `A` the anchor's world pose
+     * (column-major 4x4, 16 floats). Empty when unknown.
      *
-     * Stored so the partition can be recomputed later without it. [points3d] is a capture-frame
-     * quantity that outlives the ARCore session that produced it; the design's world pose does not.
-     * Holding the world pose here would make a reclassify after a project reload silently wrong —
-     * two frames, both plausible, no way to tell them apart from the numbers. Pre-multiplying the
-     * capture view once, at capture, removes the frame question from every later caller:
+     * This is the bridge the Phase-2 partition crosses. [points3d] are in the capture camera frame;
+     * the artwork's pose is known in world. Φ needs both in one frame, and there is no *durable*
+     * world frame to meet in — ARCore's world origin does not survive a session, and even within one
+     * it drifts and gets corrected by reloc. The anchor is the frame that does survive, which is why
+     * [markCenterLocal] is already stored relative to it.
+     *
+     * So the durable composition is
      *
      * ```
-     * inv(V·M) · p_cam  ==  inv(M) · inv(V) · p_cam  ==  inv(M) · p_world
+     * design_in_points_frame  =  captureAnchorCam · (A_live⁻¹ · M_designWorld)
      * ```
      *
-     * Rigid, not composed: the overlay's scale is folded into [captureHalfW]/[captureHalfH] instead,
-     * because `Matrix.scaleM(m, 0, s, s, 1f)` is **not** a uniform similarity and inverting it as one
-     * is wrong on the Z axis. See `Footprint`'s "scale trap".
+     * — capture-time constant on the left, live anchor-relative design pose on the right, and no
+     * world frame anywhere. Both factors are rigid, so the product is, and `Footprint`'s rigid
+     * inverse stays applicable.
+     *
+     * Stored unconditionally at capture, **including when no design is placed yet**. That case is
+     * not an edge case: target creation is what *establishes* the anchor the artwork will sit on, so
+     * on a first capture there is no artwork to partition against. Recording this now is what lets
+     * the partition be computed later, the moment the design does land, instead of the fingerprint
+     * being permanently unpartitionable.
      */
-    val captureDesignModel: List<Float> = emptyList(),
+    val captureAnchorCam: List<Float> = emptyList(),
 ) {
     init {
         // Defensive: a corrupt or truncated project file must never construct a Fingerprint whose
@@ -128,8 +137,8 @@ data class Fingerprint(
         // A 4x4 or nothing. A short list here would be read as a matrix by every consumer and index
         // past its end; a long one silently ignores whatever follows. Neither should reach a
         // reclassify from a truncated project file.
-        require(captureDesignModel.isEmpty() || captureDesignModel.size == 16) {
-            "captureDesignModel holds ${captureDesignModel.size} floats; a column-major 4x4 is 16 " +
+        require(captureAnchorCam.isEmpty() || captureAnchorCam.size == 16) {
+            "captureAnchorCam holds ${captureAnchorCam.size} floats; a column-major 4x4 is 16 " +
                 "(or empty when unknown)"
         }
     }
@@ -183,7 +192,7 @@ data class Fingerprint(
         if (!regions.contentEquals(other.regions)) return false
         if (captureHalfW != other.captureHalfW) return false
         if (captureHalfH != other.captureHalfH) return false
-        if (captureDesignModel != other.captureDesignModel) return false
+        if (captureAnchorCam != other.captureAnchorCam) return false
         return true
     }
 
@@ -200,7 +209,7 @@ data class Fingerprint(
         result = 31 * result + regions.contentHashCode()
         result = 31 * result + captureHalfW.hashCode()
         result = 31 * result + captureHalfH.hashCode()
-        result = 31 * result + captureDesignModel.hashCode()
+        result = 31 * result + captureAnchorCam.hashCode()
         return result
     }
 

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/UiState.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/UiState.kt
@@ -56,20 +56,6 @@ data class ArUiState(
     // [pointX,pointY,pointZ, normalX,normalY,normalZ] in world space. Null when the tap wasn't on a
     // qualifying (MATCH/green) plane — single-capture target creation requires one (back-projection).
     val targetWallPlane: FloatArray? = null,
-    /**
-     * Where the artwork sat at capture (`IMPLEMENTATION.md` 2.3): its **rigid** world model matrix
-     * (column-major 4x4) and its **effective**, scale-included half-extents in metres. Null/-1 when
-     * the overlay had no placement to take a footprint of, which leaves the fingerprint
-     * unpartitioned — the legacy all-backbone reading.
-     *
-     * Carried as three loose values rather than the `DesignFootprint` the builder takes, because
-     * that type lives in `feature/ar` and this module is below it in the graph. Reassembled at the
-     * one place that consumes it (`MainViewModel.handleSingleCapture`) so the loose form never
-     * spreads past this boundary.
-     */
-    val targetDesignModel: FloatArray? = null,
-    val targetDesignHalfW: Float = -1f,
-    val targetDesignHalfH: Float = -1f,
     val capturedTargetUris: List<Uri> = emptyList(),
     val capturedTargetImages: List<Bitmap> = emptyList(),
     val gpsData: GpsData? = null,
@@ -124,6 +110,16 @@ data class ArUiState(
      * locks onto a target the app appears to have loaded.
      */
     val legacyFingerprintRefused: Boolean = false,
+    /**
+     * Set when the artwork's footprint leaves too little bare wall around it for the reloc PnP to
+     * localize against (`IMPLEMENTATION.md` 2.8, `PARAMETERS.md` §4 `MIN_BACKBONE`).
+     *
+     * Raised when the partition is computed — i.e. when the artwork is placed or resized — and not
+     * at capture, because a capture is what *establishes* the anchor the artwork sits on and so has
+     * no footprint to measure. Cleared the moment a resize brings the backbone back above the floor,
+     * which is why it is recomputed on every partition rather than latched.
+     */
+    val backboneTooSmall: Boolean = false,
 
     // Physical half-extents of the overlay quad in meters (computed from depth center pixel).
     // OverlayRenderer sizes its textured quad to (halfW*2) × (halfH*2) meters.

--- a/core/common/src/test/java/com/hereliesaz/graffitixr/common/model/FingerprintPartitionPersistenceTest.kt
+++ b/core/common/src/test/java/com/hereliesaz/graffitixr/common/model/FingerprintPartitionPersistenceTest.kt
@@ -34,7 +34,7 @@ class FingerprintPartitionPersistenceTest {
         regions: ByteArray = ByteArray(0),
         halfW: Float = -1f,
         halfH: Float = -1f,
-        designModel: List<Float> = emptyList(),
+        anchorCam: List<Float> = emptyList(),
     ) = Fingerprint(
         keypoints = List(3) { KeyPoint(it.toFloat(), 2f, 7f) },
         points3d = listOf(0f, 0f, 0f, 1f, 0f, 0f, 2f, 0f, 0f),
@@ -46,7 +46,7 @@ class FingerprintPartitionPersistenceTest {
         regions = regions,
         captureHalfW = halfW,
         captureHalfH = halfH,
-        captureDesignModel = designModel,
+        captureAnchorCam = anchorCam,
     )
 
     private val identity16 = listOf(
@@ -58,16 +58,30 @@ class FingerprintPartitionPersistenceTest {
      * `assertEquals(original, decoded)` proves nothing about a field `equals` ignores.
      */
     @Test
-    fun `two fingerprints differing only in their partition are not equal`() {
+    fun `equality notices each new field on its own`() {
+        // One field at a time. A single assertNotEquals between a bare and a fully-populated
+        // fingerprint differs in four places at once, so it would still pass with three of the four
+        // missing from `equals` — and every round-trip assertion below leans on `equals`.
         val partitioned = fingerprint(byteArrayOf(INSIDE, BAND, OUTSIDE), 1f, 0.5f, identity16)
-        assertNotEquals(fingerprint(), partitioned)
         assertNotEquals(
-            "the extents are part of what the regions mean",
+            "regions: the partition itself",
+            partitioned, partitioned.copy(regions = byteArrayOf(OUTSIDE, OUTSIDE, OUTSIDE)),
+        )
+        assertNotEquals(
+            "captureHalfW: the design size the regions mean",
             partitioned, partitioned.copy(captureHalfW = 2f),
         )
         assertNotEquals(
-            "the design model is what a later reclassify replays",
-            partitioned, partitioned.copy(captureDesignModel = emptyList()),
+            "captureHalfH: likewise, and separately",
+            partitioned, partitioned.copy(captureHalfH = 2f),
+        )
+        assertNotEquals(
+            "captureAnchorCam: the frame a later partition composes through",
+            partitioned, partitioned.copy(captureAnchorCam = emptyList()),
+        )
+        assertNotEquals(
+            "captureRotationDeg: which display frame the points are in",
+            partitioned, partitioned.copy(captureRotationDeg = 180),
         )
     }
 
@@ -80,7 +94,7 @@ class FingerprintPartitionPersistenceTest {
         assertArrayEquals(byteArrayOf(INSIDE, BAND, OUTSIDE), decoded.regions)
         assertEquals(1.25f, decoded.captureHalfW, 0f)
         assertEquals(0.75f, decoded.captureHalfH, 0f)
-        assertEquals(identity16, decoded.captureDesignModel)
+        assertEquals(identity16, decoded.captureAnchorCam)
         assertFalse(decoded.isUnpartitioned())
     }
 
@@ -107,7 +121,7 @@ class FingerprintPartitionPersistenceTest {
         assertEquals(0, decoded.regions.size)
         assertEquals(-1f, decoded.captureHalfW, 0f)
         assertEquals(-1f, decoded.captureHalfH, 0f)
-        assertTrue(decoded.captureDesignModel.isEmpty())
+        assertTrue(decoded.captureAnchorCam.isEmpty())
         assertFalse("nothing to be stale against", decoded.isPartitionStale(1f, 1f))
     }
 
@@ -123,8 +137,8 @@ class FingerprintPartitionPersistenceTest {
 
     /** Same argument for the stored matrix: 16 floats or nothing, never a short prefix. */
     @Test(expected = IllegalArgumentException::class)
-    fun `a design model that is not a 4x4 is refused at construction`() {
-        fingerprint(designModel = listOf(1f, 0f, 0f))
+    fun `an anchor-cam matrix that is not a 4x4 is refused at construction`() {
+        fingerprint(anchorCam = listOf(1f, 0f, 0f))
     }
 
     /**
@@ -141,6 +155,6 @@ class FingerprintPartitionPersistenceTest {
 
         assertArrayEquals(byteArrayOf(OUTSIDE, OUTSIDE, INSIDE), decoded.fingerprint!!.regions)
         assertEquals(2f, decoded.fingerprint!!.captureHalfW, 0f)
-        assertEquals(identity16, decoded.fingerprint!!.captureDesignModel)
+        assertEquals(identity16, decoded.fingerprint!!.captureAnchorCam)
     }
 }

--- a/core/nativebridge/build.gradle.kts
+++ b/core/nativebridge/build.gradle.kts
@@ -76,3 +76,15 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach 
         jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
     }
 }
+
+// `NativeMethodAritySignatureTest` reads GraffitiJNI.cpp and SlamManager.kt as *text* at test time,
+// because the thing it checks — that a JNI entry point and its `external fun` agree on parameter
+// count — exists in neither compiled artifact. Gradle cannot infer that, so without these
+// declarations the task stays UP-TO-DATE when only the C++ changes: the exact scenario the guard
+// exists for is the one that would silently skip it. (C++ sources are not otherwise inputs to a
+// unit-test task.)
+tasks.withType<Test>().configureEach {
+    inputs.file("src/main/cpp/GraffitiJNI.cpp")
+        .withPropertyName("jniSourceForAritySignatureTest")
+        .withPathSensitivity(PathSensitivity.RELATIVE)
+}

--- a/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
+++ b/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
@@ -1339,17 +1339,7 @@ Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeGetRelocDiagnostic
     return out;
 }
 
-extern "C" JNIEXPORT void JNICALL
-Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeSetArScanMode(JNIEnv* env, jobject, jint mode) {
-    if (gSlamEngine) gSlamEngine->setArScanMode(mode);
-}
-
-extern "C" JNIEXPORT void JNICALL
-Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeSetMuralMethod(JNIEnv* env, jobject, jint method) {
-    if (gSlamEngine) gSlamEngine->setMuralMethod(method);
-}
-
-extern "C" JNIEXPORT void JNICALL
+extern "C" extern "C" extern "C" JNIEXPORT void JNICALL
 Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeGetStageTimings(JNIEnv* env, jobject, jfloatArray out) {
     if (!gSlamEngine) return;
     float buf[5] = {0,0,0,0,0};

--- a/core/nativebridge/src/main/cpp/MobileGS.cpp
+++ b/core/nativebridge/src/main/cpp/MobileGS.cpp
@@ -157,8 +157,6 @@ void MobileGS::pushFrame(const cv::Mat& depth, const cv::Mat& color, const float
 void MobileGS::clearMap() {}                            // voxel/splat map deleted
 void MobileGS::pruneByConfidence(float threshold) {}   // voxel/splat map deleted
 
-void MobileGS::setArScanMode(int mode) { mScanMode = mode; }
-void MobileGS::setMuralMethod(int method) { mMuralMethod = method; }
 void MobileGS::setParallaxMinDegrees(float deg) {}   // voxel/splat map deleted
 void MobileGS::setVoxelSize(float size) { mVoxelSize = size; }
 
@@ -1030,6 +1028,12 @@ std::vector<uint8_t> MobileGS::exportFingerprint() {
     std::lock_guard<std::mutex> lock(mMutex);
     if (mWallDescriptors.empty() || mWallKeypoints3D.empty()) return {};
 
+    // NOTE: the co-op wire format carries no Phase-2 partition, deliberately. It is a fixed,
+    // unversioned layout shared with peers that may be running an older build, so appending
+    // mWallRegions here would be read as descriptor bytes on the other end. The receiving side
+    // (alignToFingerprint) clears mWallRegions for the same reason, so a shared fingerprint is
+    // all-backbone on arrival — degraded, but correct, and the peer partitions its own once it
+    // places its own artwork. Adding a version field is what would let this change.
     uint32_t numPoints = static_cast<uint32_t>(mWallKeypoints3D.size());
     uint32_t descRows = static_cast<uint32_t>(mWallDescriptors.rows);
     uint32_t descCols = static_cast<uint32_t>(mWallDescriptors.cols);

--- a/core/nativebridge/src/main/cpp/include/MobileGS.h
+++ b/core/nativebridge/src/main/cpp/include/MobileGS.h
@@ -188,8 +188,6 @@ public:
     bool loadLowLightEnhancer(const std::vector<uchar>& onnxBytes);
     void clearMap();
     void pruneByConfidence(float threshold);
-    void setArScanMode(int mode);
-    void setMuralMethod(int method);
     void setViewportSize(int width, int height);
     // Eval: fill out[kStageCount] with average ms/stage since last reset, then reset accumulators.
     void getStageTimingsAndReset(float* out);
@@ -254,7 +252,7 @@ public:
 
     void draw(bool debugTint = false);
     // Debug perception view: draws the requested representations explicitly, regardless of
-    // mMuralMethod or mSplatsVisible. Voxels are confidence-tinted; depth-off so nothing occludes.
+    // mSplatsVisible. Voxels are confidence-tinted; depth-off so nothing occludes.
     void drawDebugLayers(bool voxels, bool mesh);
     // Voxel-method colour-mask: draws splats as a confidence-graded colour wash over the grayscale camera.
     void drawCoverage();
@@ -411,8 +409,6 @@ private:
     float mVoxelSize = 0.02f;
     std::atomic<bool> mMappingPaused{false};
     bool mSplatsVisible{false};
-    int mScanMode = 0; // 0=CLOUD, 1=MURAL
-    int mMuralMethod = 0; // 0=VOXEL_HASH, 1=SURFACE_MESH
 
     // --- Evaluation instrumentation (Sub-project A) ---
     // Accumulated wall-time per stage and a sample count, for averaging. Indexes match the Kotlin

--- a/core/nativebridge/src/test/java/com/hereliesaz/graffitixr/nativebridge/NativeMethodAritySignatureTest.kt
+++ b/core/nativebridge/src/test/java/com/hereliesaz/graffitixr/nativebridge/NativeMethodAritySignatureTest.kt
@@ -51,6 +51,18 @@ class NativeMethodAritySignatureTest {
             m.groupValues[1] to (countCppParams(m.groupValues[2]) - 2)
         }
 
+        // Orphans on the C++ side. The intersection below structurally cannot see these — a JNI
+        // entry point with no Kotlin declaration is dead export surface that nothing will ever call,
+        // and two of them survived a feature deletion here before this assertion existed. The
+        // reverse direction (Kotlin with no C++) is not checked here because it fails loudly at
+        // runtime with UnsatisfiedLinkError; a C++ orphan fails silently, forever.
+        val orphans = (cppArities.keys - kotlinArities.keys).sorted()
+        assertTrue(
+            "GraffitiJNI.cpp exports $orphans with no matching `external fun` in SlamManager.kt. " +
+                "Nothing can call them; delete the export or add the declaration.",
+            orphans.isEmpty(),
+        )
+
         val checked = kotlinArities.keys.intersect(cppArities.keys)
         assertTrue(
             "no native method names matched between the two files; one of the two regexes is wrong",

--- a/docs/research/IMPLEMENTATION.md
+++ b/docs/research/IMPLEMENTATION.md
@@ -849,87 +849,105 @@ order.** Work top to bottom.
 
 - [x] **2.1** Add `regions: ByteArray`, `captureHalfW`, `captureHalfH` to
       `Fingerprint`; empty `regions` means legacy all-backbone. **[T]**
-      *(Also `captureDesignModel` — the design's rigid pose in the POINTS' frame.
-      Without it `reclassify` cannot be called correctly after a reload: the
-      capture's world frame dies with the ARCore session, and a world-frame model
-      applied to camera-frame points produces a full, plausible, wrong partition.
-      `equals`/`hashCode` were extended to cover the new fields, without which the
-      2.9 round-trip assertion would have passed whether or not they serialized.)*
-- [x] **2.2** Add `Fingerprint.reclassify(...)` for the user-rescales-the-design
-      case; pure Kotlin over the stored points. Key the staleness check on
-      **`overlayScale`** (or the effective scaled half-extents), NOT on
-      `OverlayRenderer`'s extents — those have no user-driven call site and never
-      change. **[T]**
-      *(Wired, not merely written: `ArRenderer` fires `onDesignExtentChanged` when
-      the EFFECTIVE half-extents move past 1 mm — edge-triggered, so a resting
-      finger doesn't repartition every frame — and `ArViewModel` reclassifies the
-      retained fingerprint, re-pushes it to native, and persists it. The
-      matrix-free `reclassify(fp, halfW, halfH)` overload is what the handler
-      calls, so there is no frame for a caller to get wrong.)*
-- [x] **2.3** Thread `overlayHalfW` / `overlayHalfH` into
-      `MetricFingerprintBuilder.build` and the `PlaneMarks` single-view path.
-      *(As one `DesignFootprint` (rigid model + effective half-extents) rather than
-      two loose floats, so "no partition" reads as a deliberate `null`. Carried
-      `ArRenderer` → `ArViewModel` → `UiState` → `MainViewModel` → builder; the
-      `UiState` hop is three loose values because that module sits below
-      `feature/ar` and cannot see the type, and it is reassembled immediately.
-      Note the two-keyframe `build` overload has NO production caller and was left
-      unpartitioned rather than given a parameter nothing would pass.)*
-- [x] **2.4** Classify each surviving point via `Footprint.classify` during
-      `assemble`; populate `regions`. **[T]**
-      *(The frame trap, and the reason this was not a two-line change: the points
-      are in the capture CV camera frame and the renderer's design pose is in
-      world. `DesignFootprint.inFrameOf(view)` pre-multiplies the view once —
-      `inv(V·M)·p_cam == inv(M)·p_world` exactly, and rigid∘rigid stays rigid — so
-      Φ sees one frame, at the cost of one 4×4 multiply instead of one per
-      feature. `PoseMath.multiply`, not `android.opengl.Matrix`: the framework
-      class is a stub under a plain JVM unit test that silently returns zeros, so
-      the framework version would have been untestable AND would have classified
-      everything INSIDE. A test caught exactly that.)*
+      *(Also `captureAnchorCam` — the anchor's pose in the capture camera frame,
+      `V_cv · A`. See 2.4 for why the partition cannot be composed without it.
+      `equals`/`hashCode` were extended to every new field, without which the 2.9
+      round-trip assertion would have passed whether or not they serialized.)*
+- [x] **2.2** Add the user-rescales-the-design path; pure Kotlin over the stored
+      points. Key the staleness check on **`overlayScale`** (or the effective
+      scaled half-extents), NOT on `OverlayRenderer`'s extents. **[T]**
+      *(Landed as `FingerprintPartition.partition`, and wired: `ArRenderer` fires
+      `onDesignFootprintChanged` when the effective half-extents appear or move
+      past 1 mm; `ArViewModel` repartitions, re-pushes to native, and persists.
+      The handler cancels any in-flight job rather than queueing — a live pinch
+      fires per frame, and an older partition completing last would leave native
+      and disk describing a size the artist has already left behind.*
+      *It fires on an **unpartitioned** fingerprint as well as a stale one.
+      `isPartitionStale` is defined as false when there is no partition, so
+      gating on staleness alone would mean a fingerprint that starts
+      unpartitioned stays that way forever — which, per 2.4, is every one.)*
+- [x] **2.3** Thread the design's placement into the partition.
+      *(As one `DesignFootprint` — anchor-relative rigid pose plus effective
+      half-extents — rather than loose floats, so "no design placed" reads as a
+      deliberate `null`. NOT threaded into `MetricFingerprintBuilder`, which the
+      original text called for: see 2.4. The two-keyframe `build` overload has no
+      production caller and was left alone rather than given a parameter nothing
+      would pass.)*
+- [x] **2.4** Classify each point via `Footprint.classify`; populate `regions`. **[T]**
+      *(**This item's premise was wrong, and the first implementation inherited
+      the error.** It says to classify "during `assemble`", i.e. at capture. But
+      target creation is what **establishes the anchor the artwork sits on** —
+      `anchorEstablished` flips only after the artist confirms — so at capture
+      there is no placed design and Φ has nothing to ask about. The first cut
+      shipped exactly that: `designFootprint()` returned null on every first
+      capture, `regions` was always empty, and Phase 2 was inert on the only
+      target an artist actually paints against. An audit caught it.*
+      *So the partition runs when the artwork lands. That needs a frame that
+      survives the gap, and the world frame is not one — ARCore's origin does not
+      survive a session and drifts and gets reloc-corrected within one. The
+      anchor does survive, which is what `markCenterLocal` already relies on, so
+      the composition is*
+      *`design_in_points_frame = captureAnchorCam · (A_live⁻¹ · M_designWorld)`*
+      *— capture-time constant on the left, live anchor-relative pose on the
+      right, no world frame anywhere, both factors rigid so the product is.*
+      *`PoseMath.multiply`, not `android.opengl.Matrix`: with
+      `unitTests.isReturnDefaultValues = true` the framework class is a stub that
+      leaves matrices **all zeros without throwing** (verified by probe, not
+      assumed), so the framework version would have been untestable and would
+      have classified everything INSIDE.)*
 - [x] **2.5** Add `FingerprintPartitionTest` — synthetic straddling point set,
       expected counts per region. **[T]**
-      *(Extended with the frame reconciliation in both directions: camera-frame
-      classification must agree with world-frame, and skipping the reconciliation
-      must NOT agree — otherwise the mechanism is decorative.)*
+      *(The fixtures use a rotated+translated design pose, not the identity. With
+      an identity design the two factors commute, so the likeliest defect —
+      writing the multiply the other way round — is invisible; the first version
+      of this file used the identity and an audit passed it with the operands
+      swapped. Mutation-verified: the swap now fails four tests.)*
 - [x] **2.6** Add `regions` to `SlamManager.restoreWallFingerprintMetric`'s
       signature and JNI binding.
       *(JNI binds by SHORT NAME and does not check the descriptor, so an arity
       change on one side alone links, runs, and reads a garbage register.
-      `NativeMethodAritySignatureTest` now pins the parameter counts of every
-      `native*` method against `GraffitiJNI.cpp`; mutation-verified by adding a
-      parameter to the C++ side only, which the Kotlin compiler cannot see.)*
+      `NativeMethodAritySignatureTest` pins parameter counts for every `native*`
+      method against `GraffitiJNI.cpp` and also fails on C++ exports with no
+      Kotlin declaration — it found two, left over from an earlier feature
+      deletion, now removed along with their dead `MobileGS` setters. The test
+      reads source as text, so `GraffitiJNI.cpp` is declared a task input;
+      without that Gradle held the task UP-TO-DATE across the exact C++-only
+      change the guard exists for. Mutation-verified in both respects.)*
 - [x] **2.7** Store `mWallRegions` in `MobileGS`; filter the reloc correspondence
       build to exclude `INSIDE`. Zero-length regions → all backbone. **[N]**
-      *(Filter keeps only `OUTSIDE` — "not INSIDE" and "is OUTSIDE" differ exactly
-      on the BAND, which is the region that must be trusted by neither side.
-      `mWallRegions` is cleared at all four other sites that replace
+      *(The filter keeps only `OUTSIDE` — "not INSIDE" and "is OUTSIDE" differ
+      exactly on the BAND, the region that must be trusted by neither side.
+      `mWallRegions` is cleared at every other site that replaces
       `mWallKeypoints3D` (plain restore, co-op receive, depth-path
       `generateFingerprint`, `clearWallFingerprint`), because a partition left
       behind indexes a point set that no longer exists. Self-grow appends `BAND`
       per promoted mark so the 1:1 invariant survives without admitting an
-      unclassified feature to the backbone — 3.4 is what classifies them properly.
-      The ordinals are a wire format with no compiler checking either side, so
-      `FootprintRegionWireTest` pins the Kotlin enum against `MobileGS.h`'s
-      constants by reading the header.)*
-- [x] **2.8** Add the `F_out`-too-small capture refusal with the specific
-      "step back" message, following `MainViewModel`'s existing
-      `lastDetected/lastPlaced/lastRequired` toast pattern.
-      *(`MIN_BACKBONE = 40`, the pre-registered `PARAMETERS.md` prior. Checked
-      before anything is published to native or the overlay re-centred, so a
-      refusal leaves nothing half-built. `lastBackbone` defaults to **-1**, not 0:
-      "the design covers everything" and "nobody asked for a partition" must not
-      print the same number, and the refusal branch is ordered first because the
-      other two messages would both be false in this case.)*
+      unclassified feature to the backbone; 3.4 classifies them properly. The
+      ordinals are a wire format with nothing in either toolchain validating
+      them, so `FootprintRegionWireTest` pins the Kotlin enum against
+      `MobileGS.h` — with the header declared as a task input for the same reason
+      as 2.6. The co-op serializer deliberately does NOT carry the partition: it
+      is an unversioned wire format shared with older peers, so the receiver
+      falls back to all-backbone, which is documented at both ends.)*
+- [x] **2.8** Add the `F_out`-too-small refusal with a specific message.
+      *(`MIN_BACKBONE = 40`, the pre-registered `PARAMETERS.md` prior. Raised as
+      `ArUiState.backboneTooSmall` **when the artwork is placed or resized**, not
+      as a capture refusal — same reason as 2.4: a capture has no footprint to
+      measure. A warning rather than a refusal follows from that; by the time it
+      is knowable the target already exists, and the honest advice is "make the
+      artwork smaller or step back", not "that never worked".)*
 - [x] **2.9** Add a persistence round-trip test including the legacy-empty path. **[T]**
-      *(Asserted through `GraffitiProject` as well as `Fingerprint`, and the first
-      assertion is that equality can *tell the two apart* — a field missing from
-      `equals` makes `assertEquals(decoded, original)` prove nothing.)*
+      *(Asserted through `GraffitiProject` as well as `Fingerprint`. Equality is
+      checked one field at a time: a single comparison between a bare and a fully
+      populated fingerprint differs in five places at once and would still pass
+      with four of the five missing from `equals`.)*
 - [ ] **2.10** Verify on a replayed recording that a legacy fingerprint produces
       byte-identical inlier counts to `main`.
-      *(Blocked on hardware — needs a replayed recording, which this environment
-      cannot produce. The static argument is that a legacy fingerprint has empty
+      *(Blocked on hardware — needs a replayed recording this environment cannot
+      produce. The static argument is that a legacy fingerprint has empty
       `regions`, `usePartition` is therefore false, and the correspondence loop is
-      byte-identical; that is an argument, not the measurement the item asks for.)*
+      byte-identical. That is an argument, not the measurement the item asks for,
+      and it is not a substitute.)*
 - [ ] **2.11** (6b) Add `backboneFeatures` / `backboneMatches` / `backboneInliers`
       to `RelocDiagnostics`, the CSV, and the overlay. Defaults encode "not
       measured", not zero — follow the `obliquityDeg = -1` precedent. **[T][N]**

--- a/docs/research/PARAMETERS.md
+++ b/docs/research/PARAMETERS.md
@@ -109,22 +109,29 @@ one is still a **prior**, not a measurement: E8 is the experiment that sets them
 |---|---|---|---|---|---|
 | `DEFAULT_INNER_MARGIN` | `FingerprintPartition.kt` | `0.04` | `0.05` | guessed — a few per cent of the design's half-extent, of the order of a brush width at mural scale | E8 |
 | `DEFAULT_OUTER_MARGIN` | `FingerprintPartition.kt` | `0.10` | `0.15` | guessed — wider than inner, because overspray extends past the design and a doomed feature in `F_out` is worse than a discarded one | E8 |
-| `MIN_BACKBONE` | `MetricFingerprintBuilder.kt` | `40` | `40` | guessed — 5× the native PnP correspondence floor of 8, leaving room for the match rate | E8 |
+| `MIN_BACKBONE` | `FingerprintPartition.kt` | `40` | `40` | guessed — 5× the native PnP correspondence floor of 8, leaving room for the match rate | E8 |
 
-**The margins shipped at values this table did not predict.** Phase 1 landed
-`0.04` / `0.10` while this file said `0.05` / `0.15`; the discrepancy went
-unnoticed until Phase 2 was wired. The landed values are recorded above rather
-than the code being changed to match, because altering an already-landed phase's
-behaviour to satisfy a prior is the wrong way round — but the pre-registered
-numbers are kept in their own column so E8 can report against both. Note the
-ratio also changed: 3.0× inner as pre-registered, 2.5× as shipped.
+**The margins shipped at values this table did not predict, and the reason is not
+flattering.** They came in at `0.04` / `0.10` against a pre-registered `0.05` /
+`0.15`. There is no history to appeal to here: `Footprint.classify` takes its
+margins as required parameters with no defaults, so Phase 1 landed no values at
+all — `DEFAULT_INNER_MARGIN` / `DEFAULT_OUTER_MARGIN` were introduced by Phase 2
+itself, in `6965cef`, and simply did not match the priors sitting in this file.
+Nobody noticed until an audit checked. Both columns are kept so E8 reports
+against the pre-registered numbers rather than the ones that happened to be
+typed. Note the ratio moved too: 3.0× inner as pre-registered, 2.5× as shipped.
 
-`MIN_BACKBONE` drives the capture refusal ("the artwork covers almost the whole
-wall in view — step back so there's some bare wall around the design to lock
-onto"). Setting it too high refuses valid captures; too low ships a fingerprint
-that cannot relocalize. E8 measures both sides. It is deliberately independent of
-`MetricFingerprintBuilder`'s `minPoints` floor of 20 — those two ask different
-questions, and a capture can pass one while failing the other.
+`MIN_BACKBONE` raises `ArUiState.backboneTooSmall` ("the artwork leaves too
+little bare wall to lock onto"). Set too high it cries wolf; too low it stays
+silent on a target that cannot work. E8 measures both sides.
+
+It is checked **when the artwork is placed or resized, not at capture**. Target
+creation is what establishes the anchor the artwork sits on, so a capture has no
+footprint to measure and cannot answer the question at all — an earlier cut of
+Phase 2 put the check there and it could never fire. For the same reason it is
+independent of `MetricFingerprintBuilder`'s `minPoints` floor of 20: "did enough
+features land on the wall" and "is enough of what landed outside the artwork" are
+different questions asked at different moments.
 
 ---
 

--- a/feature/ar/build.gradle.kts
+++ b/feature/ar/build.gradle.kts
@@ -99,3 +99,14 @@ dependencies {
     testImplementation(libs.mockk)
     testImplementation(libs.kotlinx.coroutines.test)
 }
+// `FootprintRegionWireTest` reads MobileGS.h and MobileGS.cpp as *text*: the Footprint.Region
+// ordinals are a wire format shared between Kotlin and C++ with nothing in either toolchain
+// validating them against each other. Declaring the sources as inputs keeps the task from staying
+// UP-TO-DATE when only the native side moves — which is precisely when the check matters.
+tasks.withType<Test>().configureEach {
+    inputs.files(
+        rootProject.file("core/nativebridge/src/main/cpp/include/MobileGS.h"),
+        rootProject.file("core/nativebridge/src/main/cpp/MobileGS.cpp"),
+    ).withPropertyName("nativeSourcesForRegionWireTest")
+        .withPathSensitivity(PathSensitivity.RELATIVE)
+}

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -21,8 +21,10 @@ import com.google.ar.core.CameraConfig
 import com.google.ar.core.CameraConfigFilter
 import com.hereliesaz.graffitixr.common.DispatcherProvider
 import com.hereliesaz.graffitixr.common.util.imageStats
+import com.hereliesaz.graffitixr.feature.ar.anchor.FingerprintPartition
 import com.hereliesaz.graffitixr.feature.ar.anchor.MetricFingerprintBuilder
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.isActive
 import com.google.ar.core.Config
 import com.google.ar.core.Session
@@ -1509,27 +1511,49 @@ class ArViewModel @Inject constructor(
     @Volatile private var liveFingerprint: LiveFingerprint? = null
 
     /**
-     * The artist pinched the design: its footprint moved, so the stored partition now describes a
-     * shape that is no longer on the wall.
+     * Serializes the partition work and lets a newer request cancel an in-flight older one.
      *
-     * Recomputed from the stored 3D points — a pure-Kotlin pass over a few hundred points — rather
-     * than forcing a re-capture, which is the whole reason the design model is persisted in the
-     * points' own frame. A fingerprint that carries no model (legacy, depth path) is left alone by
-     * `reclassify`, so this degrades to a no-op instead of guessing a frame.
-     *
-     * Called from the GL thread; the work is dispatched off it.
+     * Both properties matter and neither is cosmetic. A pinch gesture moves the design every frame,
+     * so without cancellation this launches a coroutine per frame, each of which replaces the native
+     * fingerprint and writes the project file to disk. Without serialization those coroutines finish
+     * out of order, and the LAST write can be the partition for an intermediate size — leaving
+     * native and disk describing a design the artist has already resized past, with nothing to
+     * correct it because the renderer's own extent tracking has moved on.
      */
-    fun onDesignExtentChanged(halfW: Float, halfH: Float) {
+    private var partitionJob: Job? = null
+
+    /**
+     * The artwork was placed or resized: (re)partition the live fingerprint against where it now
+     * sits (`IMPLEMENTATION.md` 2.2/2.4).
+     *
+     * **This is where the partition actually happens**, not at capture. Target creation is what
+     * establishes the anchor the artwork will sit on, so a capture has no placed design to ask Φ
+     * about; the first time the question has an answer is here.
+     *
+     * Fires on an unpartitioned fingerprint as well as a stale one. That is the case
+     * `FingerprintPartition.partition` was written for and the one the flow above guarantees:
+     * `isPartitionStale` is defined as false when there is no partition yet, so gating on staleness
+     * alone would mean a fingerprint that starts unpartitioned stays that way forever.
+     *
+     * Called from the GL thread; all work is dispatched off it.
+     */
+    fun onDesignFootprintChanged(design: FingerprintPartition.DesignFootprint) {
         val live = liveFingerprint ?: return
-        if (!live.fingerprint.isPartitionStale(halfW, halfH)) return
-        viewModelScope.launch(Dispatchers.Default) {
+        val fp = live.fingerprint
+        if (!fp.isUnpartitioned() && !fp.isPartitionStale(design.halfW, design.halfH)) return
+        // Cancel rather than skip: the newest design size is the correct one, and an older in-flight
+        // partition can only write a size the artist has already left behind.
+        partitionJob?.cancel()
+        partitionJob = viewModelScope.launch(Dispatchers.Default) {
             val current = liveFingerprint ?: return@launch
-            val updated = com.hereliesaz.graffitixr.feature.ar.anchor.FingerprintPartition
-                .reclassify(current.fingerprint, halfW, halfH)
-            // Identity check, not equality: reclassify returns the RECEIVER when it refuses (no
-            // stored design model), and re-pushing an unchanged fingerprint would reset native's
-            // reloc state for nothing.
+            val updated = FingerprintPartition.partition(current.fingerprint, design)
+            // Identity, not equality: `partition` returns the RECEIVER when it refuses (no points, no
+            // captureAnchorCam, no usable extents), and re-pushing an unchanged fingerprint would
+            // reset native's reloc state for nothing.
             if (updated === current.fingerprint) return@launch
+            ensureActive()
+
+            val backbone = FingerprintPartition.backboneCount(updated)
             slamManager.restoreWallFingerprintMetric(
                 updated.descriptorsData, updated.descriptorsRows, updated.descriptorsCols,
                 updated.descriptorsType, updated.points3d.toFloatArray(),
@@ -1538,14 +1562,36 @@ class ArViewModel @Inject constructor(
                 regions = updated.regions,
             )
             liveFingerprint = LiveFingerprint(updated, current.anchor, current.intrinsics, current.view)
-            // Persist so the next load starts from the size the artist actually settled on. Merged
-            // through the repository transform rather than a full-object write, for the save-race
-            // reason documented on the wall-map save above.
+
+            // IMPLEMENTATION.md 2.8, relocated. The capture cannot raise this — it has no footprint
+            // to measure — so it is raised here, where the artwork's size is what made it true. A
+            // warning rather than a refusal for the same reason: by this point the target exists and
+            // the honest advice is "make the artwork smaller or step back", not "that never worked".
+            val tooSmall = backbone in 0 until FingerprintPartition.MIN_BACKBONE
+            val wasTooSmall = _uiState.value.backboneTooSmall
+            _uiState.update { it.copy(backboneTooSmall = tooSmall) }
+            // Say it, don't just record it. A `uiState` boolean that nothing reads is the same
+            // failure as an operator that nothing calls — and this codebase already had one of these
+            // sitting next to it (`legacyFingerprintRefused`, set with a KDoc claiming it was
+            // "surfaced", read by nothing). Emitted on the EDGE so a slow pinch through the
+            // threshold does not toast every frame.
+            if (tooSmall && !wasTooSmall) {
+                _feedback.tryEmit(
+                    com.hereliesaz.graffitixr.common.model.FeedbackEvent.Toast(
+                        "The artwork covers nearly all the wall in view — only $backbone tracked " +
+                            "features sit outside it. Make it smaller or step back, or the target " +
+                            "may not lock.",
+                    ),
+                )
+            }
+
+            // Persist so the next load starts from the size the artist settled on. Merged through
+            // the repository transform rather than a full-object write, for the save-race reason
+            // documented on the wall-map save above.
             projectRepository.updateProject { it.copy(fingerprint = updated) }
             Timber.i(
-                "Design resized to %.3f x %.3f m; repartitioned %d points (backbone %d)",
-                halfW, halfH, updated.points3d.size / 3,
-                com.hereliesaz.graffitixr.feature.ar.anchor.FingerprintPartition.backboneCount(updated),
+                "Design footprint %.3f x %.3f m; partitioned %d points, backbone %d",
+                design.halfW, design.halfH, updated.points3d.size / 3, backbone,
             )
         }
     }
@@ -1578,6 +1624,15 @@ class ArViewModel @Inject constructor(
                             "frame and the capture rotation was never recorded. Re-capture the target.",
                     )
                     _uiState.update { it.copy(legacyFingerprintRefused = true) }
+                    // Same argument as backboneTooSmall above: the flag's own KDoc says it is
+                    // "surfaced so the artist is told to re-capture", and until now nothing read it,
+                    // so the target silently never locked and looked like bad tracking.
+                    _feedback.tryEmit(
+                        com.hereliesaz.graffitixr.common.model.FeedbackEvent.Toast(
+                            "This project's saved target was made by an older version and its 3D " +
+                                "geometry can't be corrected. Create the target again to use it.",
+                        ),
+                    )
                     return@launch
                 }
 
@@ -2002,11 +2057,6 @@ class ArViewModel @Inject constructor(
          */
         environment: com.hereliesaz.graffitixr.common.model.CaptureEnvironment =
             com.hereliesaz.graffitixr.common.model.CaptureEnvironment(),
-        /**
-         * Where the artwork sat at capture, for the Phase-2 partition. Null leaves the fingerprint
-         * unpartitioned, which every consumer reads as all-backbone — pre-Phase-2 behaviour.
-         */
-        design: com.hereliesaz.graffitixr.feature.ar.anchor.FingerprintPartition.DesignFootprint? = null,
     ) {
         // Doodle demo: a headless capture (no tap, no review) — build the fingerprint from the
         // drawing and return before the normal capture/review flow runs. Clear the capture-request
@@ -2052,9 +2102,6 @@ class ArViewModel @Inject constructor(
                     targetIntrinsics = intrinsics,
                     targetCaptureViewMatrix = viewMatrix,
                     targetWallPlane = wallPlane,
-                    targetDesignModel = design?.rigidModel,
-                    targetDesignHalfW = design?.halfW ?: -1f,
-                    targetDesignHalfH = design?.halfH ?: -1f,
                     targetPhysicalExtent = extent,
                     isCaptureRequested = false,
                     tempCaptureBitmap = rotatedBmp,
@@ -2085,9 +2132,6 @@ class ArViewModel @Inject constructor(
                 targetIntrinsics = intrinsics,
                 targetCaptureViewMatrix = viewMatrix,
                 targetWallPlane = wallPlane,
-                targetDesignModel = design?.rigidModel,
-                targetDesignHalfW = design?.halfW ?: -1f,
-                targetDesignHalfH = design?.halfH ?: -1f,
                 targetPhysicalExtent = extent,
                 isCaptureRequested = false
             )

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/FingerprintPartition.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/FingerprintPartition.kt
@@ -39,50 +39,55 @@ object FingerprintPartition {
     const val DEFAULT_OUTER_MARGIN = 0.10f
 
     /**
-     * The design's placement at capture, in **world** space, as the renderer knows it.
+     * Minimum backbone size for a partitioned fingerprint to be able to relocalize at all
+     * (`IMPLEMENTATION.md` 2.8).
+     *
+     * `F_out` is what the reloc PnP solves from with no prior. If the artwork covers the whole
+     * visible wall there is nothing outside it and the target will never lock — `PAPER.md` states
+     * this as a limit of the domain of applicability, so the implementation's job is to say so
+     * plainly rather than let the artist discover it as mysterious tracking failure an hour in.
+     *
+     * `40` is the pre-registered `PARAMETERS.md` §4 prior: 5× the native PnP correspondence floor of
+     * 8, leaving room for the fact that only a fraction of stored features match in any one live
+     * frame. A prior, not a measurement — `EVALUATION.md` E8 sets it, and both failure modes are
+     * real: too high cries wolf, too low stays silent on a target that cannot work.
+     *
+     * Checked where the partition is computed, which is when the artwork is placed — **not** at
+     * capture. Target creation is what establishes the anchor the artwork sits on, so at capture
+     * there is no footprint and therefore no such thing as too little wall around it.
+     */
+    const val MIN_BACKBONE = 40
+
+    /**
+     * Where the artwork sits, expressed **relative to the fingerprint anchor** — `A⁻¹ · M_design` —
+     * together with its effective, scale-included half-extents in metres.
+     *
+     * **Anchor-relative, not world.** The obvious choice is the design's world pose, and it is
+     * wrong: ARCore's world origin does not survive a session, and within one it drifts and is
+     * corrected by relocalization, so a world pose recorded at one moment does not describe the same
+     * physical place at another. The anchor does survive both — it is the frame
+     * [Fingerprint.markCenterLocal] already uses for exactly this reason — so pairing it with
+     * [Fingerprint.captureAnchorCam] gives a composition with no world frame in it at all.
      *
      * One object rather than three loose parameters because the three are only meaningful together,
-     * and because "no partition" then reads as a deliberate `null` at the call site instead of three
-     * numbers somebody forgot. Absent is safe here — an unpartitioned fingerprint is the legacy
-     * all-backbone case, i.e. exactly today's behaviour — which is why the builder is allowed to
-     * default it away, unlike `rotationDeg`, where the safe value does not exist.
+     * and because "no design placed" then reads as a deliberate `null` at the call site instead of
+     * three numbers somebody forgot. Absent is safe: an unpartitioned fingerprint is the legacy
+     * all-backbone case, which is exactly the behaviour before Phase 2.
      *
-     * @param rigidModel the design's world pose **without** the overlay scale.
+     * @param rigidModelAnchorLocal the design's pose relative to the anchor, **without** the overlay
+     *   scale — that is folded into the extents instead, because `Matrix.scaleM(m, 0, s, s, 1f)`
+     *   scales X and Y but not Z and is therefore not the uniform similarity an inverse-with-scale
+     *   would assume. See `Footprint`'s "scale trap".
      * @param halfW the design's **effective** (scale-included) half-width in metres.
      */
     class DesignFootprint(
-        val rigidModel: FloatArray,
+        val rigidModelAnchorLocal: FloatArray,
         val halfW: Float,
         val halfH: Float,
     ) {
         /** True when this describes a design with real extents; a zero/negative one cannot be Φ'd. */
         val isUsable: Boolean
-            get() = rigidModel.size == 16 && halfW > 1e-6f && halfH > 1e-6f
-
-        /**
-         * The same footprint with its model expressed in a capture camera frame, given that frame's
-         * world→camera view.
-         *
-         * This is the whole frame story in one line. [Fingerprint.points3d] are camera-frame, the
-         * renderer's design pose is world-frame, and Φ requires both in one frame. Pre-multiplying
-         * the view is exact rather than approximate:
-         *
-         * ```
-         * inv(V·M) · p_cam  ==  inv(M) · inv(V) · p_cam  ==  inv(M) · p_world
-         * ```
-         *
-         * and rigid ∘ rigid stays rigid, so [Footprint.inverseOfRigid] remains applicable. Doing it
-         * this way — rather than mapping every point to world — also costs one 4x4 multiply instead
-         * of one per feature, and leaves a single matrix that can be stored for a later reclassify.
-         *
-         * [PoseMath.multiply] rather than `android.opengl.Matrix.multiplyMM`: identical arithmetic,
-         * but it runs under a plain JVM unit test. The framework version is a stub off-device, and a
-         * stubbed matrix multiply does not fail — it silently yields zeros, which invert to garbage
-         * and classify everything as INSIDE. This function's whole correctness claim is a frame
-         * reconciliation, so it has to be the kind of thing a test can actually exercise.
-         */
-        fun inFrameOf(view: FloatArray): DesignFootprint =
-            DesignFootprint(PoseMath.multiply(view, rigidModel), halfW, halfH)
+            get() = rigidModelAnchorLocal.size == 16 && halfW > 1e-6f && halfH > 1e-6f
     }
 
     /**
@@ -90,8 +95,8 @@ object FingerprintPartition {
      *
      * [points] and [designModel] must be expressed in the **same frame**, whichever that is. Φ is
      * frame-agnostic: it only ever computes `inv(designModel) · p`, so world/world and camera/camera
-     * are both correct and world/camera is silently, plausibly wrong. Use
-     * [DesignFootprint.inFrameOf] to reconcile them rather than doing it by hand at the call site.
+     * are both correct and world/camera is silently, plausibly wrong. Prefer [partition], which
+     * composes the frames for you, over reconciling them by hand at the call site.
      *
      * @param designModel the design's model matrix. Pass [composed] = true when it carries the
      *   overlay's uniform in-plane scale, in which case [halfW]/[halfH] must be the design's
@@ -127,62 +132,51 @@ object FingerprintPartition {
     }
 
     /**
-     * Recompute [Fingerprint.regions] against a new design size, returning an updated copy.
+     * Partition (or repartition) [fingerprint] against where the artwork currently sits, returning
+     * an updated copy.
      *
-     * The artist pinching the design mid-session is normal, so the response is to reclassify the
-     * stored 3D points — a cheap pure-Kotlin pass — rather than force a re-capture.
+     * This is the only entry point production should use, and it takes no matrix in the points'
+     * frame — so no caller can supply one in the wrong frame. It composes the two durable factors:
      *
-     * Returns the receiver unchanged when there is nothing to do: no points to classify. Note it
-     * does **not** short-circuit on [Fingerprint.isPartitionStale] being false, because a caller may
-     * legitimately want to partition a previously-unpartitioned (legacy) fingerprint, for which
-     * "stale" is defined as false.
+     * ```
+     * design_in_points_frame  =  fingerprint.captureAnchorCam · design.rigidModelAnchorLocal
+     * ```
      *
-     * [designModel] must be **rigid**, with the overlay scale folded into [halfW]/[halfH] — the
-     * convention `Footprint` calls preferred, and the only one that can be stored and replayed. A
-     * composed matrix has no place here: `Matrix.scaleM(m, 0, s, s, 1f)` scales X and Y but not Z,
-     * so it is not the uniform similarity [Footprint.inverseOfComposed] assumes, and the stored
-     * [Fingerprint.captureHalfW] is defined as scale-included regardless.
+     * the first frozen at capture, the second read live off the renderer, and neither expressed in
+     * a world frame that drift or a session boundary could invalidate.
+     *
+     * **This runs when the artwork lands, not (only) at capture.** Target creation is what
+     * *establishes* the anchor the artwork will sit on, so at first capture there is no design to
+     * partition against and `regions` is legitimately empty. Deferring the partition to the moment
+     * the design is placed or resized is not a fallback — it is the only point in the flow where the
+     * question Φ asks ("is this feature under the artwork?") has an answer.
+     *
+     * Returns the **receiver itself** — identity-comparable, so a caller can cheaply skip a
+     * re-push — when it cannot honestly partition: no 3D points, no [Fingerprint.captureAnchorCam]
+     * (a pre-Phase-2 or depth-path fingerprint), or a design with no usable extents. Each is a
+     * refusal rather than a guess: partitioning against an assumed frame produces a complete,
+     * plausible, wrong answer, whereas leaving it unpartitioned reproduces `main` exactly.
      */
-    fun reclassify(
+    fun partition(
         fingerprint: Fingerprint,
-        designModel: FloatArray,
-        halfW: Float,
-        halfH: Float,
+        design: DesignFootprint,
         innerMargin: Float = DEFAULT_INNER_MARGIN,
         outerMargin: Float = DEFAULT_OUTER_MARGIN,
     ): Fingerprint {
         if (fingerprint.points3d.isEmpty()) return fingerprint
-        val regions = classify(
-            fingerprint.points3d.toFloatArray(), designModel, halfW, halfH,
-            composed = false, innerMargin = innerMargin, outerMargin = outerMargin,
+        if (fingerprint.captureAnchorCam.size != 16) return fingerprint
+        if (!design.isUsable) return fingerprint
+        val designInPointFrame = PoseMath.multiply(
+            fingerprint.captureAnchorCam.toFloatArray(), design.rigidModelAnchorLocal,
         )
         return fingerprint.copy(
-            regions = regions,
-            captureHalfW = halfW,
-            captureHalfH = halfH,
-            // Keep the model that produced these bytes with them. Without it the next reclassify has
-            // to be handed a matrix again, and after a project reload there is no correct one to
-            // hand it — the capture's world frame is gone with the ARCore session.
-            captureDesignModel = designModel.toList(),
+            regions = classify(
+                fingerprint.points3d.toFloatArray(), designInPointFrame, design.halfW, design.halfH,
+                composed = false, innerMargin = innerMargin, outerMargin = outerMargin,
+            ),
+            captureHalfW = design.halfW,
+            captureHalfH = design.halfH,
         )
-    }
-
-    /**
-     * Reclassify against the design model the fingerprint already carries — the reload-safe form.
-     *
-     * This is the one a resize handler should call. It cannot be given a matrix in the wrong frame
-     * because it is not given one at all: [Fingerprint.captureDesignModel] was pre-multiplied into
-     * the capture frame at capture, which is the frame [Fingerprint.points3d] is in.
-     *
-     * Returns the receiver unchanged when there is no stored model (a pre-Phase-2 or depth-path
-     * fingerprint). That is a refusal, not a silent success: reclassifying against a guessed frame
-     * would produce a full, plausible, wrong partition, and the legacy all-backbone reading is the
-     * behaviour `main` already has.
-     */
-    fun reclassify(fingerprint: Fingerprint, halfW: Float, halfH: Float): Fingerprint {
-        val model = fingerprint.captureDesignModel
-        if (model.size != 16) return fingerprint
-        return reclassify(fingerprint, model.toFloatArray(), halfW, halfH)
     }
 
     /**

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/MetricFingerprintBuilder.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/MetricFingerprintBuilder.kt
@@ -166,47 +166,17 @@ object MetricFingerprintBuilder {
     @Volatile var lastRequired: Int = 0
         private set
 
-    /**
-     * How many of the placed points landed in the backbone set `F_out`, or -1 when the capture was
-     * not partitioned at all (no design footprint supplied — the legacy all-backbone case).
-     *
-     * -1 rather than 0 for the reason `EVALUATION.md` records twice over: 0 is a *measurement*, and
-     * "the design covers the whole wall so there is no backbone" and "nobody asked for a partition"
-     * are opposite situations that must not print the same number.
-     */
-    @Volatile var lastBackbone: Int = -1
-        private set
-
-    /**
-     * Minimum backbone size for a capture to be worth keeping (`IMPLEMENTATION.md` 2.8).
-     *
-     * `F_out` is what the reloc PnP solves from with no prior. If the design covers the whole
-     * visible wall there is nothing outside it, and the target will never lock — the paper states
-     * this as a limit of the domain of applicability, so the implementation's job is to say so at
-     * capture rather than let the artist discover it as mysterious tracking failure an hour later.
-     *
-     * `40` is the pre-registered prior from `PARAMETERS.md` §4 (`BACKBONE_MIN_FEATURES`): 5× the
-     * native PnP correspondence floor of 8, leaving room for the fact that only a fraction of stored
-     * features match in any one live frame. It is a *prior*, not a measurement — `EVALUATION.md` E8
-     * is the experiment that sets it, and both failure modes are real: too high refuses captures
-     * that would have worked, too low ships a target that can never lock.
-     *
-     * Deliberately NOT tied to `minPoints`' default of 20. The two floors ask different questions —
-     * "did enough features land on the wall at all" versus "is enough of what landed outside the
-     * artwork" — and a capture can comfortably pass the first while failing the second, which is
-     * exactly the design-covers-the-whole-wall case this exists to catch.
-     */
-    const val MIN_BACKBONE = 40
 
     /**
      * @param rotationDeg `rotationNeeded` for this capture — the angle the caller already applied
      *   to [bitmap] and to [intr]. The view is rotated to match (`IMPLEMENTATION.md` Phase 0,
      *   convention B); passing 0 while handing in rotated pixels reinstates the `PAPER.md` §8
      *   defect, which is why it has no default.
-     * @param design where the artwork sits at capture, in world space (`IMPLEMENTATION.md` 2.3/2.4).
-     *   Null — the default — leaves the fingerprint unpartitioned, which every consumer reads as
-     *   all-backbone and is byte-for-byte the behaviour before Phase 2. That is a real default, not
-     *   a shortcut: the depth path and the doodle path have no placed design to speak of.
+     *
+     * Note this does **not** take the design's placement. Target creation is what establishes the
+     * anchor the artwork will sit on, so at capture there is no placed design to partition against —
+     * see `FingerprintPartition.partition`, which runs when the artwork lands. What is recorded here
+     * is [Fingerprint.captureAnchorCam], the capture-time half of that later composition.
      */
     fun buildSingle(
         slam: SlamManager,
@@ -215,9 +185,8 @@ object MetricFingerprintBuilder {
         anchorModel: FloatArray,
         rotationDeg: Int,
         minPoints: Int = 20,
-        design: FingerprintPartition.DesignFootprint? = null,
     ): Fingerprint? {
-        lastDetected = 0; lastPlaced = 0; lastRequired = minPoints; lastBackbone = -1
+        lastDetected = 0; lastPlaced = 0; lastRequired = minPoints
         // Convention B: the bitmap and intrinsics arrived in display orientation, so the view goes
         // there too. This is the fix for PAPER.md §8 — previously `glViewToCv(glView)`, which left
         // display-frame rays intersecting a sensor-frame plane.
@@ -231,8 +200,7 @@ object MetricFingerprintBuilder {
                 var i = 0
                 while (i + 1 < pos.size) { pixels.add(PlaneMarks.Pixel(pos[i], pos[i + 1])); i += 2 }
                 val fp = ingestSingle(slam, descs, pixels, cvView, intr,
-                    planePointWorld, planeNormalWorld, anchorModel, minPoints, glView, rotationDeg,
-                    design)
+                    planePointWorld, planeNormalWorld, anchorModel, minPoints, glView, rotationDeg)
                 if (fp != null) return fp
             } finally {
                 descs.release()
@@ -251,8 +219,7 @@ object MetricFingerprintBuilder {
             if (d.empty()) return null
             val pixels = kp.toArray().map { PlaneMarks.Pixel(it.pt.x.toFloat(), it.pt.y.toFloat()) }
             return ingestSingle(slam, d, pixels, cvView, intr,
-                planePointWorld, planeNormalWorld, anchorModel, minPoints, glView, rotationDeg,
-                design)
+                planePointWorld, planeNormalWorld, anchorModel, minPoints, glView, rotationDeg)
         } finally {
             gray.release(); norm.release(); kp.release(); d.release()
         }
@@ -271,7 +238,6 @@ object MetricFingerprintBuilder {
         glView: FloatArray? = null,
         /** rotationNeeded for this capture; rotates [glView] to match the points. See 0.10. */
         rotationDeg: Int = 0,
-        design: FingerprintPartition.DesignFootprint? = null,
     ): Fingerprint? {
         val res = PlaneMarks.backProject(
             pixels, cvView, planePointWorld, planeNormalWorld,
@@ -283,25 +249,13 @@ object MetricFingerprintBuilder {
         if (res.count > lastPlaced) lastPlaced = res.count
         if (res.count < minPoints) return null
 
-        // IMPLEMENTATION.md 2.4 — tag each surviving point with its region relative to the design's
-        // projected footprint. `res.pointsCam` is in the capture CV camera frame and the renderer's
-        // design pose is in world, so the design is moved into the points' frame ONCE here rather
-        // than every point being moved into the design's; see DesignFootprint.inFrameOf for why the
-        // two are equivalent. A null or degenerate design leaves regions empty, which every consumer
-        // reads as all-backbone — Phase 2's documented rollback, reached by doing nothing.
-        val designInPointFrame = design?.takeIf { it.isUsable }?.inFrameOf(cvView)
-        val regions = designInPointFrame?.let {
-            FingerprintPartition.classify(res.pointsCam, it.rigidModel, it.halfW, it.halfH)
-        } ?: ByteArray(0)
-
-        // IMPLEMENTATION.md 2.8 — refuse a capture with no backbone to localize against. Checked
-        // before anything is published or committed, so a refusal leaves no half-built target and no
-        // stale overlay re-centering behind. lastBackbone stays -1 when unpartitioned: not measured,
-        // not zero.
-        if (regions.isNotEmpty()) {
-            lastBackbone = FingerprintPartition.backboneCount(regions)
-            if (lastBackbone < MIN_BACKBONE) return null
-        }
+        // IMPLEMENTATION.md 2.4's capture-time half: the anchor's pose in THIS frame, so the
+        // partition can be composed later without a world frame. `res.pointsCam` is in the capture
+        // CV camera frame and the design's pose will be known relative to the anchor, so
+        // `cvView · anchorModel` is the bridge between them — see Fingerprint.captureAnchorCam.
+        // Recorded unconditionally, including on a capture that establishes the anchor and therefore
+        // has no design to partition against yet.
+        val anchorCam = PoseMath.multiply(cvView, anchorModel)
 
         // Center the AR overlay on the marks (their centroid), not the screen-center anchor.
         val markCenterLocal = marksCentroidLocal(res.pointsCam, cvView, anchorModel)
@@ -341,7 +295,10 @@ object MetricFingerprintBuilder {
             // IMPLEMENTATION.md 2.6 — native filters the reloc correspondence build by these, and
             // reads a zero-length array as all-backbone, so an unpartitioned capture behaves as it
             // did before Phase 2 rather than losing its whole map.
-            regions = regions,
+            // IMPLEMENTATION.md 2.6 — no partition exists yet at capture (see above), so native
+            // gets a zero-length array and reads it as all-backbone, exactly as before Phase 2.
+            // FingerprintPartition.partition re-pushes with real regions once the artwork lands.
+            regions = ByteArray(0),
         )
         return Fingerprint(
             keypoints, res.pointsCam.toList(), bytes, rows, cols, type,
@@ -349,13 +306,9 @@ object MetricFingerprintBuilder {
             // IMPLEMENTATION.md 0.7 — record the frame these points were built in, so a reload can
             // tell a Phase-0 fingerprint from a pre-Phase-0 one instead of guessing.
             captureRotationDeg = rotationDeg,
-            // IMPLEMENTATION.md 2.4 — the partition, and the design placement that defines it. The
-            // model is stored in the POINTS' frame (see DesignFootprint.inFrameOf) so a later
-            // reclassify after a project reload has a frame it can trust.
-            regions = regions,
-            captureHalfW = designInPointFrame?.halfW ?: -1f,
-            captureHalfH = designInPointFrame?.halfH ?: -1f,
-            captureDesignModel = designInPointFrame?.rigidModel?.toList() ?: emptyList(),
+            // IMPLEMENTATION.md 2.4 — the durable bridge from these points to wherever the artwork
+            // ends up. Without it this fingerprint could never be partitioned at all.
+            captureAnchorCam = anchorCam.toList(),
         )
     }
 

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -35,7 +35,7 @@ class ArRenderer(
     private val context: Context,
     private val slamManager: SlamManager,
     // Last arg is the camera→point distance (meters) at the tapped pixel, or -1f when unavailable.
-    private val onTargetCaptured: (Bitmap, Int, Int, ByteBuffer?, Int, Int, Int, FloatArray?, FloatArray, Int, Float, FloatArray?, com.hereliesaz.graffitixr.common.model.CaptureEnvironment, com.hereliesaz.graffitixr.feature.ar.anchor.FingerprintPartition.DesignFootprint?) -> Unit,
+    private val onTargetCaptured: (Bitmap, Int, Int, ByteBuffer?, Int, Int, Int, FloatArray?, FloatArray, Int, Float, FloatArray?, com.hereliesaz.graffitixr.common.model.CaptureEnvironment) -> Unit,
     private val onTrackingUpdated: (Boolean, Int, Int, Boolean, Float, Float, Triple<Float, Float, Float>?, Boolean, Boolean, Float, Float, Float) -> Unit,
     private val onLightUpdated: (Float) -> Unit,
     private val onDiag: (String) -> Unit = {},
@@ -60,15 +60,17 @@ class ArRenderer(
     // camera config that can't drive one), so the UI can drop the toggle instead of latching a
     // light that never came on.
     private val onFlashlightUnavailable: () -> Unit = {},
-    // Fired from the GL thread when the artwork's EFFECTIVE (scale-included) half-extents change —
-    // i.e. the artist pinched the design. IMPLEMENTATION.md 2.2: the stored fingerprint's partition
-    // was computed against the old size and is now stale, so the regions get recomputed from the
-    // stored 3D points rather than the artist being made to re-capture.
+    // Fired from the GL thread when the artwork's footprint appears or changes size — the artist
+    // placed a design, or pinched one. IMPLEMENTATION.md 2.2/2.4: this is where the fingerprint
+    // actually gets partitioned, because target creation is what establishes the anchor the artwork
+    // sits on, so a capture has no footprint to partition against.
     //
-    // Edge-triggered, not per-frame: the renderer knows when the number moved and the ViewModel does
-    // not, so debouncing here costs one float compare a frame and saves a listener that would
-    // otherwise have to poll.
-    private val onDesignExtentChanged: (Float, Float) -> Unit = { _, _ -> },
+    // Edge-triggered on the EFFECTIVE (scale-included) half-extents: the renderer knows when the
+    // number moved and the ViewModel does not, so filtering here costs one float compare a frame and
+    // saves a listener that would otherwise have to poll. It is a FILTER, not a debounce — a live
+    // pinch still fires every frame, and collapsing that is the consumer's job.
+    private val onDesignFootprintChanged:
+        (com.hereliesaz.graffitixr.feature.ar.anchor.FingerprintPartition.DesignFootprint) -> Unit = {},
 ) : GLSurfaceView.Renderer {
 
     /**
@@ -454,6 +456,7 @@ class ArRenderer(
     private val DESIGN_EXTENT_EPS = 1e-3f
     private val designFootprintLock = Any()
     private val designRigidModel = FloatArray(16)
+    private val designAnchorInvScratch = FloatArray(16)
     private var designEffectiveHalfW = -1f
     private var designEffectiveHalfH = -1f
     private var designPlaced = false
@@ -579,6 +582,11 @@ class ArRenderer(
         overlayRenderer.setBorderExtent(halfW, halfH)
         // Image quad is always large so artwork is never spatially confined.
         overlayRenderer.setExtent(OverlayRenderer.QUAD_HALF_EXTENT, OverlayRenderer.QUAD_HALF_EXTENT)
+        // Re-arm the one-shot screen fit. This call OVERWRITES whatever the fit last set with a 10 m
+        // placeholder; without re-arming, the fit never restores a real size, the published design
+        // footprint stays that placeholder, and Φ swallows every feature in view — reporting zero
+        // backbone, and repartitioning the live fingerprint into one that can never relocalize.
+        quadInitialFitApplied = false
     }
 
     /**
@@ -1575,11 +1583,6 @@ class ArRenderer(
                             intrArr, mappingViewMatrix.copyOf(),
                             rotationNeeded, tapDistanceMeters,
                             wallPlane, captureEnvironment,
-                            // IMPLEMENTATION.md 2.3 — where the artwork is, so the fingerprint can
-                            // be partitioned into backbone and corroboration at the moment its
-                            // geometry is frozen. Null until the overlay has an anchor and a
-                            // texture, which leaves the capture unpartitioned (= all backbone).
-                            designFootprint(),
                         )
                     }
                 } catch (e: Exception) {
@@ -1974,19 +1977,34 @@ class ArRenderer(
             // `quadInitialFitApplied` is part of the precondition, not an optimisation. Until the
             // screen-fit above has run, the quad's extents are still QUAD_HALF_EXTENT — a 10 m
             // square placeholder chosen so artwork is never spatially confined. Publishing that as
-            // the design's size would make Φ swallow every feature in view, report a backbone of
-            // zero, and refuse every capture with "the artwork covers almost the whole wall".
+            // the design's size would make Φ swallow every feature in view and report zero backbone
+            // — "the artwork covers the whole wall" on a design the artist has only just opened.
             val placed = anchorEstablished && overlayRenderer.hasTexture && quadInitialFitApplied
             val extentMoved = placed &&
                 (kotlin.math.abs(newHalfW - designEffectiveHalfW) > DESIGN_EXTENT_EPS ||
                     kotlin.math.abs(newHalfH - designEffectiveHalfH) > DESIGN_EXTENT_EPS)
+            // Anchor-RELATIVE, not world — see FingerprintPartition.DesignFootprint. The live anchor
+            // drifts and gets corrected by reloc, so its world pose at two different moments is not
+            // the same physical place; expressing the design against it cancels that out, and the
+            // fingerprint's stored half of the composition is anchor-relative for the same reason.
+            var footprint: com.hereliesaz.graffitixr.feature.ar.anchor.FingerprintPartition.DesignFootprint? = null
             synchronized(designFootprintLock) {
-                System.arraycopy(overlayRigidScratch, 0, designRigidModel, 0, 16)
+                val invertible =
+                    android.opengl.Matrix.invertM(designAnchorInvScratch, 0, anchorMatrix, 0)
+                if (placed && invertible) {
+                    android.opengl.Matrix.multiplyMM(
+                        designRigidModel, 0, designAnchorInvScratch, 0, overlayRigidScratch, 0,
+                    )
+                }
                 designEffectiveHalfW = newHalfW
                 designEffectiveHalfH = newHalfH
-                designPlaced = placed
+                designPlaced = placed && invertible
+                if (extentMoved && designPlaced) {
+                    footprint = com.hereliesaz.graffitixr.feature.ar.anchor.FingerprintPartition
+                        .DesignFootprint(designRigidModel.copyOf(), newHalfW, newHalfH)
+                }
             }
-            if (extentMoved) onDesignExtentChanged(newHalfW, newHalfH)
+            footprint?.let(onDesignFootprintChanged)
             android.opengl.Matrix.scaleM(overlayLocalScratch, 0, overlayScale, overlayScale, 1f)
             android.opengl.Matrix.multiplyMM(
                 overlayComposedScratch, 0, overlayBaseScratch, 0, overlayLocalScratch, 0

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/OverlayRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/OverlayRenderer.kt
@@ -130,9 +130,13 @@ class OverlayRenderer(private val context: Context) : GlReleasable {
      * The artwork quad's current half-extents in metres, before the user's `overlayScale`.
      *
      * Exposed for the Phase-2 partition, which needs the design's real size on the wall to ask
-     * whether a feature sits under it. Read-only on purpose: the two [setExtent] call sites are a
-     * fixed constant and a one-shot screen-fit, and neither is user-driven — the user's resize is
-     * `overlayScale`, which lives in the model matrix.
+     * whether a feature sits under it. Read-only on purpose: neither [setExtent] call site is
+     * user-driven — the user's resize is `overlayScale`, which lives in the model matrix.
+     *
+     * The two writers are **ordered**, and the order is the trap. `ArRenderer.updateOverlayExtent`
+     * writes a fixed [QUAD_HALF_EXTENT] placeholder and can run at any time; the screen-fit that
+     * writes a real size is one-shot. So the placeholder can land *after* the fit and, unless the
+     * fit is re-armed, stick — which is exactly what `updateOverlayExtent` now does.
      */
     val extentHalfW: Float get() = halfW
     val extentHalfH: Float get() = halfH

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/FingerprintPartitionTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/FingerprintPartitionTest.kt
@@ -27,6 +27,9 @@ class FingerprintPartitionTest {
         val INSIDE = Footprint.Region.INSIDE.ordinal.toByte()
         val BAND = Footprint.Region.BAND.ordinal.toByte()
         val OUTSIDE = Footprint.Region.OUTSIDE.ordinal.toByte()
+        val IDENTITY_16 = listOf(
+            1f, 0f, 0f, 0f, 0f, 1f, 0f, 0f, 0f, 0f, 1f, 0f, 0f, 0f, 0f, 1f,
+        )
     }
 
     /** Identity model matrix: design centred on the world origin, spanning ±HALF_W by ±HALF_H. */
@@ -39,7 +42,13 @@ class FingerprintPartitionTest {
         s, 0f, 0f, 0f, 0f, s, 0f, 0f, 0f, 0f, s, 0f, 0f, 0f, 0f, 1f,
     )
 
-    private fun fp(points: List<Float>, regions: ByteArray = ByteArray(0), hw: Float = -1f, hh: Float = -1f): Fingerprint {
+    private fun fp(
+        points: List<Float>,
+        regions: ByteArray = ByteArray(0),
+        hw: Float = -1f,
+        hh: Float = -1f,
+        anchorCam: List<Float> = IDENTITY_16,
+    ): Fingerprint {
         val rows = points.size / 3
         return Fingerprint(
             keypoints = List(rows) { KeyPoint(1f, 1f, 7f) },
@@ -51,6 +60,7 @@ class FingerprintPartitionTest {
             regions = regions,
             captureHalfW = hw,
             captureHalfH = hh,
+            captureAnchorCam = anchorCam,
         )
     }
 
@@ -131,54 +141,192 @@ class FingerprintPartitionTest {
     }
 
     // -------------------------------------------------------------------------------------
-    // reclassify + the legacy reading
+    // partition + the legacy reading
     // -------------------------------------------------------------------------------------
 
-    @Test
-    fun `reclassify tags a previously unpartitioned fingerprint and records the extents`() {
-        val before = fp(listOf(0f, 0f, 0f, 5f, 0f, 0f))
-        assertTrue(before.isUnpartitioned())
-
-        val after = FingerprintPartition.reclassify(before, identity(), HALF_W, HALF_H)
-        assertFalse(after.isUnpartitioned())
-        assertEquals(2, after.regions.size)
-        assertEquals(INSIDE, after.regions[0])
-        assertEquals(OUTSIDE, after.regions[1])
-        assertEquals(HALF_W, after.captureHalfW, 1e-6f)
-        assertEquals(HALF_H, after.captureHalfH, 1e-6f)
+    /**
+     * A deliberately awkward rigid transform: 30° about Z composed with a translation, standing in
+     * for `captureAnchorCam` (the anchor's pose in the capture camera frame).
+     */
+    private fun rigid30(): FloatArray {
+        val c = kotlin.math.cos(Math.toRadians(30.0)).toFloat()
+        val sn = kotlin.math.sin(Math.toRadians(30.0)).toFloat()
+        // Written out rather than built with android.opengl.Matrix: that class is a STUB under a
+        // plain JVM unit test — `setIdentityM` leaves the array all zeros and does not throw — so
+        // building fixtures with it makes every point land at the origin and every assertion below
+        // pass for the wrong reason. Verified by probe, not assumed.
+        return floatArrayOf(
+            c, sn, 0f, 0f,
+            -sn, c, 0f, 0f,
+            0f, 0f, 1f, 0f,
+            0.3f, -1.7f, 4.0f, 1f,
+        )
     }
 
     /**
-     * Growing the design must move points from backbone into the footprint. If `reclassify` silently
-     * kept the old bytes, this would pass only by accident of the fixture — so the point chosen is
-     * one whose region genuinely changes.
+     * A design pose that is NOT the identity and NOT a pure translation.
+     *
+     * This matters more than it looks. `partition` computes `captureAnchorCam · designAnchorLocal`,
+     * and with an identity design the two operands commute — so the single most likely defect,
+     * writing the multiply the other way round, is invisible. An earlier version of this file used
+     * the identity here and passed with the operands swapped.
+     */
+    private fun designPose(): FloatArray {
+        val c = kotlin.math.cos(Math.toRadians(50.0)).toFloat()
+        val sn = kotlin.math.sin(Math.toRadians(50.0)).toFloat()
+        return floatArrayOf(
+            c, sn, 0f, 0f,
+            -sn, c, 0f, 0f,
+            0f, 0f, 1f, 0f,
+            1f, 2f, -0.5f, 1f,
+        )
+    }
+
+    private fun apply(m: FloatArray, x: Float, y: Float, z: Float) = floatArrayOf(
+        m[0] * x + m[4] * y + m[8] * z + m[12],
+        m[1] * x + m[5] * y + m[9] * z + m[13],
+        m[2] * x + m[6] * y + m[10] * z + m[14],
+    )
+
+    /**
+     * The composition `partition` rests on, checked against an independently-constructed
+     * expectation rather than by re-deriving its own arithmetic.
+     *
+     * Points are placed at known positions in the DESIGN's own frame, pushed out to the capture
+     * camera frame through the same chain the app builds them with, and the regions that come back
+     * must be the ones the design-frame positions imply. A composition applied in the wrong order,
+     * or with either factor inverted, moves the points somewhere else entirely.
      */
     @Test
-    fun `growing the design converts backbone into corroboration`() {
-        val pts = listOf(1.5f, 0f, 0f)
-        val small = FingerprintPartition.reclassify(fp(pts), identity(), HALF_W, HALF_H)
+    fun `partition composes the capture and design frames in the right order`() {
+        val anchorCam = rigid30()
+        val design = designPose()
+        // Design-frame positions: centre, exactly on the +X edge, far outside, outside via +Y.
+        val local = listOf(
+            Triple(0f, 0f, 0f),
+            Triple(HALF_W, 0f, 0f),
+            Triple(5f, 0f, 0f),
+            Triple(0.5f, 1.5f, 0f),
+        )
+        // design-local -> anchor-local -> capture camera frame.
+        val pts = ArrayList<Float>()
+        for ((x, y, z) in local) {
+            val inAnchor = apply(design, x, y, z)
+            val inCam = apply(anchorCam, inAnchor[0], inAnchor[1], inAnchor[2])
+            pts.add(inCam[0]); pts.add(inCam[1]); pts.add(inCam[2])
+        }
+
+        val out = FingerprintPartition.partition(
+            fp(pts, anchorCam = anchorCam.toList()),
+            FingerprintPartition.DesignFootprint(design, HALF_W, HALF_H),
+        )
+        assertEquals(INSIDE, out.regions[0])
+        assertEquals(BAND, out.regions[1])
+        assertEquals(OUTSIDE, out.regions[2])
+        assertEquals(OUTSIDE, out.regions[3])
+        assertEquals(HALF_W, out.captureHalfW, 1e-6f)
+        assertEquals(HALF_H, out.captureHalfH, 1e-6f)
+    }
+
+    /**
+     * The negative half. Swapping the two factors — `design · anchorCam` instead of
+     * `anchorCam · design` — must produce a different answer, or the order is untested and the test
+     * above proves only that the code runs.
+     */
+    @Test
+    fun `the two frame factors do not commute on this fixture`() {
+        val anchorCam = rigid30()
+        val design = designPose()
+        val pts = floatArrayOf(0f, 0f, 0f, 1.5f, 0.2f, 0f, 3f, 0f, 0f)
+        val right = FingerprintPartition.classify(
+            pts, PoseMath.multiply(anchorCam, design), HALF_W, HALF_H,
+        )
+        val wrong = FingerprintPartition.classify(
+            pts, PoseMath.multiply(design, anchorCam), HALF_W, HALF_H,
+        )
+        assertFalse(
+            "the fixture must distinguish the operand order, or the test above is blind to it",
+            right.contentEquals(wrong),
+        )
+    }
+
+    @Test
+    fun `partition records the design size it used, and a resize changes the answer`() {
+        val anchorCam = rigid30()
+        val design = designPose()
+        // 1.5 along the design's own +X: outside a half-width of 1.0, inside a half-width of 2.0.
+        val inAnchor = apply(design, 1.5f, 0f, 0f)
+        val inCam = apply(anchorCam, inAnchor[0], inAnchor[1], inAnchor[2])
+        val base = fp(inCam.toList(), anchorCam = anchorCam.toList())
+
+        val small = FingerprintPartition.partition(
+            base, FingerprintPartition.DesignFootprint(design, HALF_W, HALF_H),
+        )
         assertEquals(OUTSIDE, small.regions[0])
 
-        val big = FingerprintPartition.reclassify(small, identity(), 2f, 1f)
+        val big = FingerprintPartition.partition(
+            small, FingerprintPartition.DesignFootprint(design, 2f, 1f),
+        )
         assertEquals("a wider design must swallow the point", INSIDE, big.regions[0])
         assertEquals(2f, big.captureHalfW, 1e-6f)
+        assertTrue("the old size must now read as stale", small.isPartitionStale(2f, 1f))
+    }
+
+    /**
+     * Every refusal returns the RECEIVER, so a caller can skip a native re-push by identity. Each is
+     * a case where partitioning would mean guessing a frame or a size, and a guessed partition is a
+     * complete, plausible, wrong answer — whereas leaving it alone reproduces `main` exactly.
+     */
+    @Test
+    fun `partition refuses rather than guesses`() {
+        val design = FingerprintPartition.DesignFootprint(designPose(), HALF_W, HALF_H)
+
+        val noAnchorCam = fp(listOf(0f, 0f, 0f), anchorCam = emptyList())
+        assertSame("no captureAnchorCam: no frame to compose through",
+            noAnchorCam, FingerprintPartition.partition(noAnchorCam, design))
+
+        val noPoints = fp(emptyList())
+        assertSame("no points: nothing to classify",
+            noPoints, FingerprintPartition.partition(noPoints, design))
+
+        val ok = fp(listOf(0f, 0f, 0f))
+        assertSame("degenerate extents: Φ is undefined",
+            ok, FingerprintPartition.partition(
+                ok, FingerprintPartition.DesignFootprint(designPose(), 0f, 1f)))
+    }
+
+    /**
+     * The case that must work and did not in the first cut of this phase: a fingerprint captured
+     * before any artwork was placed. Target creation is what establishes the anchor the artwork sits
+     * on, so EVERY first capture is unpartitioned — and if `partition` refused those, the feature
+     * would be inert on the only target the artist actually paints against.
+     */
+    @Test
+    fun `an unpartitioned fingerprint is exactly what partition is for`() {
+        val anchorCam = rigid30()
+        val design = designPose()
+        val inAnchor = apply(design, 0f, 0f, 0f)
+        val inCam = apply(anchorCam, inAnchor[0], inAnchor[1], inAnchor[2])
+        val fresh = fp(inCam.toList(), anchorCam = anchorCam.toList())
+
+        assertTrue("a fresh capture carries no partition", fresh.isUnpartitioned())
+        assertFalse("...and is therefore never 'stale'", fresh.isPartitionStale(HALF_W, HALF_H))
+
+        val out = FingerprintPartition.partition(
+            fresh, FingerprintPartition.DesignFootprint(design, HALF_W, HALF_H),
+        )
+        assertFalse("partition must not gate on staleness", out.isUnpartitioned())
+        assertEquals(INSIDE, out.regions[0])
     }
 
     @Test
     fun `staleness tracks the recorded extents`() {
-        val f = FingerprintPartition.reclassify(fp(listOf(0f, 0f, 0f)), identity(), HALF_W, HALF_H)
+        val f = FingerprintPartition.partition(
+            fp(listOf(0f, 0f, 0f)),
+            FingerprintPartition.DesignFootprint(designPose(), HALF_W, HALF_H),
+        )
         assertFalse("same size is not stale", f.isPartitionStale(HALF_W, HALF_H))
         assertTrue("a resize is stale", f.isPartitionStale(HALF_W * 1.5f, HALF_H))
-    }
-
-    /**
-     * An unpartitioned fingerprint is never "stale" — there is nothing to recompute against, and
-     * reporting it as stale would send every legacy project through a reclassify with extents it
-     * was never built for.
-     */
-    @Test
-    fun `an unpartitioned fingerprint is never stale`() {
-        assertFalse(fp(listOf(0f, 0f, 0f)).isPartitionStale(99f, 99f))
     }
 
     /**
@@ -194,113 +342,26 @@ class FingerprintPartitionTest {
 
     @Test
     fun `backboneCount counts only OUTSIDE once partitioned`() {
-        val f = FingerprintPartition.reclassify(
-            fp(listOf(0f, 0f, 0f, 5f, 0f, 0f, HALF_W, 0f, 0f)), identity(), HALF_W, HALF_H,
+        val anchorCam = rigid30()
+        val design = designPose()
+        val pts = ArrayList<Float>()
+        for ((x, y) in listOf(0f to 0f, 5f to 0f, HALF_W to 0f)) {
+            val a = apply(design, x, y, 0f)
+            val c = apply(anchorCam, a[0], a[1], a[2])
+            pts.add(c[0]); pts.add(c[1]); pts.add(c[2])
+        }
+        val f = FingerprintPartition.partition(
+            fp(pts, anchorCam = anchorCam.toList()),
+            FingerprintPartition.DesignFootprint(design, HALF_W, HALF_H),
         )
         // inside, outside, band -> exactly one backbone point.
         assertEquals(1, FingerprintPartition.backboneCount(f))
     }
 
-    /** The 1:1 invariant is enforced by the model, so a mismatched partition cannot be constructed. */
-    @Test(expected = IllegalArgumentException::class)
-    fun `a regions array that disagrees with the point count is rejected`() {
-        fp(listOf(0f, 0f, 0f, 1f, 1f, 1f), regions = ByteArray(1))
-    }
-
-    // -------------------------------------------------------------------------------------
-    // The frame reconciliation — DesignFootprint.inFrameOf
-    // -------------------------------------------------------------------------------------
-
-    /**
-     * A deliberately awkward rigid world→camera view: a 30° rotation about Z composed with a
-     * translation, so neither the rotation nor the translation can cancel out by accident and a
-     * dropped factor changes the answer.
-     */
-    private fun view(): FloatArray {
-        // Written out rather than built with android.opengl.Matrix: that class is a stub under a
-        // plain JVM unit test and returns zeros without complaining, which would make every point
-        // land at the origin and every assertion below pass for the wrong reason.
-        val c = kotlin.math.cos(Math.toRadians(30.0)).toFloat()
-        val s = kotlin.math.sin(Math.toRadians(30.0)).toFloat()
-        return floatArrayOf(
-            c, s, 0f, 0f,
-            -s, c, 0f, 0f,
-            0f, 0f, 1f, 0f,
-            0.3f, -1.7f, 4.0f, 1f,
-        )
-    }
-
-    /** Apply a column-major 4x4 to a point, returning [x,y,z]. */
-    private fun apply(m: FloatArray, p: FloatArray): FloatArray = floatArrayOf(
-        m[0] * p[0] + m[4] * p[1] + m[8] * p[2] + m[12],
-        m[1] * p[0] + m[5] * p[1] + m[9] * p[2] + m[13],
-        m[2] * p[0] + m[6] * p[1] + m[10] * p[2] + m[14],
-    )
-
-    /**
-     * The claim `inFrameOf` rests on, checked end to end rather than by re-deriving its algebra:
-     * classifying camera-frame points against the view-premultiplied design gives the SAME bytes as
-     * classifying the corresponding world-frame points against the world design.
-     *
-     * This is the assertion that catches the bug the whole design is arranged to avoid — Φ applied
-     * across two frames. `Fingerprint.points3d` are camera-frame and the renderer's design pose is
-     * world-frame, and mixing them produces a full, plausible, entirely wrong partition.
-     */
-    @Test
-    fun `classifying in the camera frame agrees with classifying in world`() {
-        val v = view()
-        // World points chosen to land in all three regions against a design at the world origin.
-        val world = floatArrayOf(
-            0f, 0f, 0f,            // inside
-            HALF_W, 0f, 0f,        // on the edge -> band
-            5f, 0f, 0f,            // outside
-            0.5f, 1.5f, 0f,        // outside via the SHORT axis
-        )
-        val designWorld = FingerprintPartition.DesignFootprint(identity(), HALF_W, HALF_H)
-
-        val inWorld = FingerprintPartition.classify(world, designWorld.rigidModel, HALF_W, HALF_H)
-
-        // The same points, expressed in the camera frame, against the design moved into that frame.
-        val cam = FloatArray(world.size)
-        for (i in 0 until world.size / 3) {
-            val p = apply(v, floatArrayOf(world[i * 3], world[i * 3 + 1], world[i * 3 + 2]))
-            p.copyInto(cam, i * 3)
-        }
-        val designCam = designWorld.inFrameOf(v)
-        val inCam = FingerprintPartition.classify(cam, designCam.rigidModel, designCam.halfW, designCam.halfH)
-
-        assertArrayEquals("the frame must not change the partition", inWorld, inCam)
-        // ...and the fixture is not degenerate: all three regions are represented, so an
-        // everything-is-OUTSIDE bug could not produce this.
-        assertEquals(INSIDE, inWorld[0]); assertEquals(BAND, inWorld[1])
-        assertEquals(OUTSIDE, inWorld[2]); assertEquals(OUTSIDE, inWorld[3])
-    }
-
-    /**
-     * The negative half of the test above. Classifying camera-frame points against the *world*
-     * design — the mistake `inFrameOf` exists to prevent — must give a different answer, or the
-     * reconciliation is decorative and this whole mechanism could be deleted.
-     */
-    @Test
-    fun `skipping the frame reconciliation changes the answer`() {
-        val v = view()
-        val world = floatArrayOf(0f, 0f, 0f, 5f, 0f, 0f)
-        val cam = FloatArray(world.size)
-        for (i in 0 until world.size / 3) {
-            apply(v, floatArrayOf(world[i * 3], world[i * 3 + 1], world[i * 3 + 2])).copyInto(cam, i * 3)
-        }
-        val correct = FingerprintPartition.classify(
-            cam, FingerprintPartition.DesignFootprint(identity(), HALF_W, HALF_H).inFrameOf(v).rigidModel,
-            HALF_W, HALF_H,
-        )
-        val wrong = FingerprintPartition.classify(cam, identity(), HALF_W, HALF_H)
-        assertFalse("mixing frames must be detectable", correct.contentEquals(wrong))
-    }
-
     /**
      * The capture-time `F_out` floor (2.8) counts through this overload, so the distinction it draws
-     * has to be pinned: the BAND is **not** backbone. A "step back, not enough wall" refusal that
-     * counted the band would let a design covering everything but its own border pass.
+     * has to be pinned: the BAND is **not** backbone. A "not enough bare wall" warning that counted
+     * the band would stay silent on a design covering everything but its own border.
      */
     @Test
     fun `the raw backbone count excludes the band as well as the inside`() {
@@ -318,40 +379,9 @@ class FingerprintPartitionTest {
         assertTrue(FingerprintPartition.DesignFootprint(identity(), 1f, 1f).isUsable)
     }
 
-    // -------------------------------------------------------------------------------------
-    // The self-contained reclassify
-    // -------------------------------------------------------------------------------------
-
-    /**
-     * The reload-safe form: no matrix passed in, so no matrix can be passed in wrong. It must reach
-     * the same answer as the explicit form given the model the fingerprint already carries.
-     */
-    @Test
-    fun `reclassify without a matrix uses the stored design model`() {
-        val explicit = FingerprintPartition.reclassify(
-            fp(listOf(0f, 0f, 0f, 5f, 0f, 0f)), identity(), HALF_W, HALF_H,
-        )
-        assertEquals("the explicit form must store what it used", 16, explicit.captureDesignModel.size)
-
-        val implicit = FingerprintPartition.reclassify(explicit, 2f, 1f)
-        assertEquals(2f, implicit.captureHalfW, 1e-6f)
-        assertArrayEquals(
-            FingerprintPartition.reclassify(explicit, identity(), 2f, 1f).regions,
-            implicit.regions,
-        )
-    }
-
-    /**
-     * A fingerprint with no stored model must be returned untouched. Guessing a frame here would
-     * produce a complete and completely wrong partition; the legacy all-backbone reading is what
-     * `main` already does and is the safe refusal.
-     */
-    @Test
-    fun `reclassify without a matrix refuses a fingerprint that has no stored model`() {
-        val legacy = fp(listOf(0f, 0f, 0f))
-        assertTrue(legacy.captureDesignModel.isEmpty())
-        val out = FingerprintPartition.reclassify(legacy, 1f, 1f)
-        assertSame("must be the same object, not a silently-partitioned copy", legacy, out)
-        assertTrue(out.isUnpartitioned())
+    /** The 1:1 invariant is enforced by the model, so a mismatched partition cannot be constructed. */
+    @Test(expected = IllegalArgumentException::class)
+    fun `a regions array that disagrees with the point count is rejected`() {
+        fp(listOf(0f, 0f, 0f, 1f, 1f, 1f), regions = ByteArray(1))
     }
 }

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Sat Aug 01 10:18:52 UTC 2026
-versionBuild=14326
+#Sat Aug 01 10:50:38 UTC 2026
+versionBuild=14348
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=192
+versionPatch=214


### PR DESCRIPTION
Follow-up to #1803, which shipped Phase 2 with its central assumption wrong.

## The defect

`IMPLEMENTATION.md` 2.4 says to classify points "during `assemble`" — at capture. But **target creation is what establishes the anchor the artwork sits on**: `anchorEstablished` flips only after the artist confirms, one frame later. So at capture there is no placed design, Φ has nothing to ask about, and `designFootprint()` returned `null` on every first capture of every process.

The consequence: `regions` was always empty, the backbone floor could never fire, and Phase 2 was inert on the only target an artist actually paints against. Only a *second* target creation in the same process would have partitioned anything.

## The fix

The partition runs when the artwork is **placed or resized** — the first moment the question "is this feature under the artwork?" has an answer.

That needs a frame surviving the gap between the two events, and the world frame is not one: ARCore's origin does not survive a session, and within one it drifts and is corrected by relocalization. The anchor survives both — it is the frame `markCenterLocal` already relies on — so:

```
design_in_points_frame = captureAnchorCam · (A_live⁻¹ · M_designWorld)
```

A capture-time constant on the left, a live anchor-relative pose on the right, no world frame anywhere. Both factors are rigid, so the product is, and `Footprint`'s rigid inverse stays applicable.

`Fingerprint.captureAnchorCam` replaces the world-framed matrix the first cut stored. It is recorded **unconditionally**, including on the capture that has no design yet — without it, that fingerprint could never be partitioned at all.

## Other audit findings, each verified before acting

| Finding | Fix |
|---|---|
| `updateOverlayExtent` overwrites the quad extents with a 10 m placeholder and did not re-arm the one-shot screen fit, so a good fingerprint could be repartitioned into one that can never relocalize | Re-arms the fit; `OverlayRenderer` KDoc now says which writer runs last |
| The frame test used an **identity** design pose, so the two factors commuted and a reversed multiply passed | Fixtures are rotated and translated; mutation-verified that the swap fails four tests |
| The resize handler wrote to disk and pushed to native once per frame of a pinch, unordered — an older partition could land last | Cancels any in-flight job |
| `NativeMethodAritySignatureTest` and `FootprintRegionWireTest` read source as text, but their sources were not declared task inputs — Gradle held them `UP-TO-DATE` across exactly the native-only change they exist to catch | Both declared; both verified to re-run |
| The arity test could not see C++ exports with no Kotlin declaration | It now fails on them. It found two, left from an earlier feature deletion — removed with their dead `MobileGS` setters and fields |
| `backboneTooSmall` was written and never read — as was its pre-existing sibling `legacyFingerprintRefused`, whose KDoc claimed it was "surfaced" | Both now go through the feedback channel the UI already toasts, edge-triggered |

## Correction to the record

`PARAMETERS.md` §4's provenance note was **fabricated**. It claimed the margin constants shipped in Phase 1 and were left alone to avoid disturbing a landed phase. In fact `Footprint.classify` takes its margins as required parameters with no defaults; the constants were introduced by Phase 2 itself in `6965cef` and simply did not match the priors already written in that file. Corrected.

## Verification

- `:app:compileDebugKotlin` green
- 410 unit tests, 0 failures (`core:common` 118, `feature:ar` 211, `core:nativebridge` 14, `feature:editor` 67)
- `:core:nativebridge:externalNativeBuildDebug` green for `arm64-v8a` and `armeabi-v7a`; removed JNI symbols confirmed absent from the built `.so` via `llvm-nm`

**Not done:** 2.10 needs a replayed recording this environment cannot produce. The static argument — a legacy fingerprint has empty `regions`, so `usePartition` is false and the correspondence loop is byte-identical — is an argument, not the measurement the item asks for.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Q5WXFiVLeN4sXa9bPCSDA)_

## Summary by Sourcery

Partition wall fingerprints when artwork is placed or resized using an anchor-relative frame, and surface backbone and legacy-fingerprint issues to the user while tightening JNI, wire-format, and persistence safeguards.

New Features:
- Defer fingerprint partitioning to artwork placement and resize, driven by a new design footprint callback and partition coroutine in ArViewModel.
- Record the capture-time anchor-to-camera transform on fingerprints so partitions can be recomputed later without relying on a drifting world frame.
- Expose a backbone-too-small condition via ArUiState and user toasts when the artwork leaves insufficient bare wall for relocalization.

Bug Fixes:
- Fix partition frame composition by using an anchor-relative design pose and a stored captureAnchorCam, avoiding incorrect world-frame assumptions and multiply ordering errors.
- Ensure OverlayRenderer’s quad extent placeholder is corrected by re-arming the screen fit so published design size does not swallow all backbone features.
- Prevent outdated partitions from being written last during pinch gestures by cancelling in-flight repartition jobs.
- Surface legacy fingerprint refusal to the user instead of silently failing to lock, clarifying that an old target must be re-captured.
- Make NativeMethodAritySignatureTest and FootprintRegionWireTest re-run when their native sources change, and extend the arity test to catch C++ JNI exports with no Kotlin declaration.

Enhancements:
- Replace the reclassify API with a single partition entry point that composes frames internally and refuses to guess when required data is missing.
- Tighten equality and construction invariants on Fingerprint so new partition-related fields are persisted and validated correctly.
- Clarify documentation around when partitioning occurs, how MIN_BACKBONE is used, and correct the provenance of margin constants in PARAMETERS.md.

Build:
- Declare GraffitiJNI.cpp and MobileGS native sources as inputs to relevant unit-test tasks so JNI arity and region wire tests are not held UP-TO-DATE across native-only changes.

Documentation:
- Update IMPLEMENTATION.md and PARAMETERS.md to describe anchor-relative partitioning at artwork placement, the role of captureAnchorCam, the MIN_BACKBONE prior, and correct earlier misleading notes about margin constants.

Tests:
- Revise FingerprintPartition tests to use non-identity rigid transforms, explicitly check frame composition order, staleness, and refusal cases, and enforce the 1:1 point-to-region invariant.
- Strengthen persistence tests to validate each new partition-related field individually and ensure malformed anchor-camera matrices are rejected.
- Extend NativeMethodAritySignatureTest to detect JNI exports without Kotlin declarations, and FootprintRegionWireTest to treat native headers and sources as task inputs.

Chores:
- Remove unused AR scan mode and mural method JNI exports and their backing MobileGS setters, and simplify related comments.
- Increment application version metadata to reflect these changes.