### PR TITLE
Make the matrix paths testable; add backbone reloc diagnostics

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -2170,6 +2170,25 @@ private fun RelocDiagnosticsOverlay(
             if (d.obliquityDeg < 0) "off" else "${d.obliquityDeg}° +${d.rectifiedCorrespondences} corr",
             androidx.compose.ui.graphics.Color.White,
         )
+        // The partition, read off the device (IMPLEMENTATION.md 2.11). "FP pts" is the whole
+        // fingerprint; this row is the part reloc is actually allowed to solve against, plus how
+        // much of it survived matching and RANSAC. A backbone of 0 with a healthy FP pts is the
+        // wall-filling design — the one failure the totals above describe as ordinary bad luck.
+        // "—" means the reloc thread has not got far enough to measure it, which is a different
+        // state from having measured zero.
+        DiagnosticRow(
+            "Backbone",
+            if (d.backboneFeatures < 0) "—" else buildString {
+                append("${d.backboneFeatures} pts")
+                if (d.backboneMatches >= 0) append(" · ${d.backboneMatches} corr")
+                if (d.backboneInliers >= 0) append(" · ${d.backboneInliers} in")
+            },
+            if (d.backboneFeatures == 0) {
+                androidx.compose.ui.graphics.Color.Red
+            } else {
+                androidx.compose.ui.graphics.Color.White
+            },
+        )
         DiagnosticRow("FP pts", fingerprintPoints.toString(), androidx.compose.ui.graphics.Color.Cyan)
         DiagnosticRow("Corroborated", "${(paintingProgress * 100).toInt()}%", androidx.compose.ui.graphics.Color.White)
     }

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/RelocDiagnostics.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/RelocDiagnostics.kt
@@ -31,6 +31,30 @@ data class RelocDiagnostics(
     val obliquityDeg: Int = -1,
     /** Correspondences the rectification pass contributed on top of the plain and scaled passes. */
     val rectifiedCorrespondences: Int = 0,
+    /**
+     * Stored fingerprint points in `F_out` — the backbone the reloc PnP is allowed to solve against
+     * (`PAPER.md` §5.3) — or -1 when no attempt has got far enough to look.
+     *
+     * An unpartitioned (legacy) fingerprint reports its full point count, because zero-length
+     * regions means all-backbone. **Zero is a real reading**: it says the artwork covers the whole
+     * visible wall, so there is nothing left to bootstrap a pose from. That is the limit of the
+     * domain of applicability the paper names, and the state `ArUiState.backboneTooSmall` warns
+     * about — which is exactly why zero cannot also mean "not measured", and why this follows
+     * [obliquityDeg]'s -1 precedent.
+     */
+    val backboneFeatures: Int = -1,
+    /**
+     * Correspondences built against `F_out` after the partition filter, or -1 when not measured.
+     *
+     * Counted apart from [matches], never in place of it. The same shortfall means different
+     * things: a low total is "the frame is not looking at the registered wall", a low backbone
+     * under a healthy total is "everything it can see is under the artwork", and those call for
+     * opposite advice. The gap between the two is the map-reloc path's contribution, which Φ never
+     * classified.
+     */
+    val backboneMatches: Int = -1,
+    /** RANSAC inliers that came from `F_out` points, or -1 when PnP produced no inlier set. */
+    val backboneInliers: Int = -1,
 ) {
     /** Inlier ratio of the last attempt, or 0 when it produced no correspondences. */
     val inlierRatio: Float get() = if (matches > 0) inliers.toFloat() / matches else 0f

--- a/core/common/src/test/java/com/hereliesaz/graffitixr/common/model/RelocDiagnosticsTest.kt
+++ b/core/common/src/test/java/com/hereliesaz/graffitixr/common/model/RelocDiagnosticsTest.kt
@@ -1,6 +1,7 @@
 package com.hereliesaz.graffitixr.common.model
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class RelocDiagnosticsTest {
@@ -42,6 +43,85 @@ class RelocDiagnosticsTest {
         // "rectification wasn't eligible" state needs its own value.
         assertEquals(-1, RelocDiagnostics().obliquityDeg)
         assertEquals(0, RelocDiagnostics().rectifiedCorrespondences)
+    }
+
+    /**
+     * The backbone counts follow [RelocDiagnostics.obliquityDeg]'s -1 precedent, and they have to.
+     *
+     * Before Phase 2 there was no partition and a zero backbone was meaningless, so 0 would have
+     * been a harmless default. With the partition landed it is the single most important reading
+     * these fields ever carry: `F_out` empty means the artwork covers the whole visible wall and
+     * reloc has nothing to bootstrap a pose from (`PAPER.md` §5.3, Phase 2's risk section). Had 0
+     * doubled as "not measured", the one condition the counters exist to expose would read exactly
+     * like a reloc thread that has never run.
+     */
+    @Test
+    fun `unmeasured backbone counts are minus one, never a real zero`() {
+        val unmeasured = RelocDiagnostics()
+        assertEquals(-1, unmeasured.backboneFeatures)
+        assertEquals(-1, unmeasured.backboneMatches)
+        assertEquals(-1, unmeasured.backboneInliers)
+
+        // The wall-filling design: measured, and the measurement is zero.
+        val wallFilling = RelocDiagnostics(
+            RelocReject.FEW_MATCHES, matches = 0, inliers = 0, detected = 1400,
+            backboneFeatures = 0, backboneMatches = 0, backboneInliers = 0,
+        )
+        assertEquals(0, wallFilling.backboneFeatures)
+        assertTrue(
+            "an empty backbone must not read as an unsampled one",
+            wallFilling.backboneFeatures != unmeasured.backboneFeatures,
+        )
+        assertTrue(wallFilling.backboneMatches != unmeasured.backboneMatches)
+        assertTrue(wallFilling.backboneInliers != unmeasured.backboneInliers)
+    }
+
+    /**
+     * `IMPLEMENTATION.md` 2.11 — the backbone counts are reported *beside* the totals, not in place
+     * of them, because the same shortfall means different things. Forty correspondences of which
+     * three are backbone is "the frame is looking at the artwork, not at the wall around it";
+     * three correspondences of which three are backbone is "the frame is barely seeing the wall at
+     * all". A single `matches` column collapses those into one row.
+     */
+    @Test
+    fun `total and backbone counts are separately readable`() {
+        val underTheArtwork = RelocDiagnostics(
+            RelocReject.OK, matches = 40, inliers = 24, detected = 1400,
+            backboneFeatures = 300, backboneMatches = 3, backboneInliers = 2,
+        )
+        val barelySeeingTheWall = RelocDiagnostics(
+            RelocReject.FEW_MATCHES, matches = 3, inliers = 0, detected = 1400,
+            backboneFeatures = 300, backboneMatches = 3, backboneInliers = 0,
+        )
+        assertEquals(
+            "the backbone shortfall is identical in both",
+            underTheArtwork.backboneMatches, barelySeeingTheWall.backboneMatches,
+        )
+        assertTrue(
+            "and only the total tells them apart",
+            underTheArtwork.matches != barelySeeingTheWall.matches,
+        )
+        assertEquals(40, underTheArtwork.matches)
+        assertEquals(3, underTheArtwork.backboneMatches)
+        assertEquals(24, underTheArtwork.inliers)
+        assertEquals(2, underTheArtwork.backboneInliers)
+        // The ratio PoseFusion gates on still uses the TOTAL. Reusing `matches` for the backbone
+        // count would have silently changed it.
+        assertEquals(24f / 40f, underTheArtwork.inlierRatio, 1e-4f)
+    }
+
+    /**
+     * A legacy (unpartitioned) fingerprint is the all-backbone case, so it reports its full point
+     * count — not zero, and not the sentinel. The native side computes it; this pins the
+     * three-way distinction the field has to carry.
+     */
+    @Test
+    fun `legacy all-backbone, empty backbone and unmeasured are three distinct readings`() {
+        val legacy = RelocDiagnostics(RelocReject.OK, backboneFeatures = 512)
+        val empty = RelocDiagnostics(RelocReject.FEW_MATCHES, backboneFeatures = 0)
+        val unmeasured = RelocDiagnostics()
+        assertEquals(3, setOf(legacy, empty, unmeasured).map { it.backboneFeatures }.toSet().size)
+        assertTrue("a legacy fingerprint is all backbone, not none", legacy.backboneFeatures > 0)
     }
 
     /**

--- a/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
+++ b/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
@@ -1311,10 +1311,11 @@ Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeGetCorroborationCo
 }
 
 // Relocalization diagnostics: why the last attempt did not publish, and the counts it reached.
-// Packed into one int[] so the UI reads a consistent snapshot instead of six racing getters.
+// Packed into one int[] so the UI reads a consistent snapshot instead of nine racing getters.
 // [0] = RelocReject code, [1] = correspondences, [2] = RANSAC inliers, [3] = features detected,
 // [4] = obliquity in degrees (-1 when the rectification pass wasn't eligible), [5] = correspondences
-// the rectification pass contributed.
+// the rectification pass contributed, [6] = stored points in F_out, [7] = correspondences built
+// against F_out, [8] = inliers that came from F_out (IMPLEMENTATION.md 2.11; -1 = not measured).
 extern "C" JNIEXPORT jintArray JNICALL
 Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeGetRelocDiagnostics(JNIEnv* env, jobject) {
     // NOT {0, ...}: zero is kRelocOk, so a no-engine fallback of 0 reports a SUCCESSFUL LOCK with
@@ -1324,7 +1325,7 @@ Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeGetRelocDiagnostic
     // the Kotlin-only code that absorbs anything the native side cannot account for; the counts are
     // -1 (not sampled) rather than 0, because zero matches is a real measurement.
     static constexpr jint kRelocUnknownOrdinal = 7;
-    jint vals[6] = {kRelocUnknownOrdinal, -1, -1, -1, -1, -1};
+    jint vals[9] = {kRelocUnknownOrdinal, -1, -1, -1, -1, -1, -1, -1, -1};
     if (gSlamEngine) {
         vals[0] = gSlamEngine->lastRelocReject();
         vals[1] = gSlamEngine->lastRelocMatches();
@@ -1332,14 +1333,17 @@ Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeGetRelocDiagnostic
         vals[3] = gSlamEngine->lastRelocDetected();
         vals[4] = gSlamEngine->lastRelocObliquityDeg();
         vals[5] = gSlamEngine->lastRelocRectifiedCorr();
+        vals[6] = gSlamEngine->lastRelocBackboneFeatures();
+        vals[7] = gSlamEngine->lastRelocBackboneMatches();
+        vals[8] = gSlamEngine->lastRelocBackboneInliers();
     }
-    jintArray out = env->NewIntArray(6);
+    jintArray out = env->NewIntArray(9);
     if (!out) return nullptr;
-    env->SetIntArrayRegion(out, 0, 6, vals);
+    env->SetIntArrayRegion(out, 0, 9, vals);
     return out;
 }
 
-extern "C" extern "C" extern "C" JNIEXPORT void JNICALL
+extern "C" JNIEXPORT void JNICALL
 Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeGetStageTimings(JNIEnv* env, jobject, jfloatArray out) {
     if (!gSlamEngine) return;
     float buf[5] = {0,0,0,0,0};

--- a/core/nativebridge/src/main/cpp/MobileGS.cpp
+++ b/core/nativebridge/src/main/cpp/MobileGS.cpp
@@ -247,6 +247,12 @@ void MobileGS::relocThreadFunc() {
             mapPriorSeq = mPnpResultSeq.load(std::memory_order_relaxed);
         }
 
+        // 2.11: reset the backbone counters BEFORE the early-outs below, so an attempt that never
+        // reaches the fingerprint publishes "not measured" instead of the previous attempt's numbers.
+        mLastRelocBackboneFeatures.store(-1, std::memory_order_relaxed);
+        mLastRelocBackboneMatches.store(-1, std::memory_order_relaxed);
+        mLastRelocBackboneInliers.store(-1, std::memory_order_relaxed);
+
         if (!mRelocEnabled) {
             mLastRelocReject.store(kRelocDisabled, std::memory_order_relaxed);
             continue;
@@ -258,6 +264,25 @@ void MobileGS::relocThreadFunc() {
             mLastRelocReject.store(kRelocNoFingerprint, std::memory_order_relaxed);
             continue;
         }
+
+        // IMPLEMENTATION.md 2.7 — honour the partition only when it indexes THIS point set. A
+        // regions array of the wrong length is treated as absent (all backbone) rather than
+        // subscripted, so a legacy or mismatched fingerprint relocalizes exactly as on main.
+        // Hoisted out of buildCorr so the filter below and the count published here cannot drift
+        // apart: they must agree about which fingerprint is partitioned or the diagnostics describe
+        // a different point set from the one PnP saw.
+        const bool usePartition = wallRegions.size() == wallKps3d.size();
+        // 2.11: how many stored points PnP is allowed to draw on. An UNPARTITIONED fingerprint is
+        // 2.7's legacy all-backbone case, so it reports its FULL point count — not zero, and not the
+        // -1 sentinel. Zero here is a real measurement meaning F_out is empty (the artwork covers
+        // the whole wall), which is the one state reloc cannot recover from; reporting a legacy
+        // fingerprint as zero would raise that alarm on every project saved before Phase 2.
+        mLastRelocBackboneFeatures.store(
+            usePartition
+                ? (int)std::count(wallRegions.begin(), wallRegions.end(), kRegionOutside)
+                : (int)wallKps3d.size(),
+            std::memory_order_relaxed);
+
         if (frame.empty()) continue;
 
         // Optionally enhance the RGB frame under low light before grayscale conversion
@@ -291,6 +316,7 @@ void MobileGS::relocThreadFunc() {
 
         auto buildCorr = [&](const cv::Mat& g, const cv::Mat& Hback,
                              std::vector<cv::Point2f>& outImg, std::vector<cv::Point3f>& outObj,
+                             std::vector<uint8_t>& outFromBackbone,
                              const std::vector<cv::KeyPoint>* preKps = nullptr, const cv::Mat* preDescs = nullptr) {
             std::vector<cv::KeyPoint> localKps; cv::Mat localDescs;
             if (!(preKps && preDescs)) {
@@ -308,10 +334,6 @@ void MobileGS::relocThreadFunc() {
             // points into solvePnPRansac. The map path (below) already guards this; the wall path did
             // not. Refuse rather than relocalize against nonsense.
             if (wallKps3d.size() != (size_t)wallDescs.rows) return;
-            // IMPLEMENTATION.md 2.7 — honour the partition only when it indexes THIS point set. A
-            // regions array of the wrong length is treated as absent (all backbone) rather than
-            // subscripted, so a legacy or mismatched fingerprint relocalizes exactly as on main.
-            const bool usePartition = wallRegions.size() == wallKps3d.size();
 
             cv::Ptr<cv::DescriptorMatcher>& matcher = (descs.type() == CV_32F) ? mL2Matcher : mMatcher;
             std::vector<std::vector<cv::DMatch>> matches;
@@ -333,13 +355,20 @@ void MobileGS::relocThreadFunc() {
                     }
                     outImg.push_back(p);
                     outObj.push_back(wallKps3d[match[0].trainIdx]);
+                    // Everything that survives the filter above is F_out: under a partition because
+                    // non-OUTSIDE rows were skipped, and without one because 2.7's zero-length rule
+                    // makes the whole fingerprint backbone. Recorded per correspondence rather than
+                    // counted, because the inlier attribution below indexes back through this.
+                    outFromBackbone.push_back(1);
                 }
             }
         };
 
         std::vector<cv::Point2f> imgPts;
         std::vector<cv::Point3f> objPts;
-        buildCorr(gray, cv::Mat(), imgPts, objPts, &baseKps, &baseDescs);
+        // 2.11: parallel to imgPts/objPts — 1 where the correspondence came from a backbone point.
+        std::vector<uint8_t> corrFromBackbone;
+        buildCorr(gray, cv::Mat(), imgPts, objPts, corrFromBackbone, &baseKps, &baseDescs);
 
         // Multi-scale matching (distance robustness). SuperPoint isn't scale-invariant, and the marks
         // shrink in the frame from far away and grow up close, so also match the frame DOWN- and
@@ -352,7 +381,7 @@ void MobileGS::relocThreadFunc() {
             cv::resize(gray, scaled, cv::Size(), s, s, cv::INTER_LINEAR);
             double hdata[] = {1.0/(double)s, 0.0, 0.0, 0.0, 1.0/(double)s, 0.0, 0.0, 0.0, 1.0};
             cv::Mat Hback = cv::Mat(3, 3, CV_64F, hdata).clone();
-            buildCorr(scaled, Hback, imgPts, objPts);
+            buildCorr(scaled, Hback, imgPts, objPts, corrFromBackbone);
         }
 
         // Plane-guided rectification (perspective robustness for oblique views). The marks lie on a
@@ -373,7 +402,7 @@ void MobileGS::relocThreadFunc() {
                 cv::Mat grayRect;
                 cv::warpPerspective(gray, grayRect, Hfp_cur, gray.size());
                 size_t before = imgPts.size();
-                buildCorr(grayRect, Hcur_fp, imgPts, objPts);
+                buildCorr(grayRect, Hcur_fp, imgPts, objPts, corrFromBackbone);
                 mLastRelocRectifiedCorr.store((int)(imgPts.size() - before), std::memory_order_relaxed);
                 if (imgPts.size() > before)
                     LOGI("Reloc: rectified (obliquity %.0f deg) added %zu corr (total %zu)",
@@ -420,6 +449,11 @@ void MobileGS::relocThreadFunc() {
                         if (m[0].distance < 0.75f * m[1].distance) {
                             imgPts.push_back(baseKps[m[0].queryIdx].pt);
                             objPts.push_back(mapKps3d[visible[m[0].trainIdx]]);
+                            // NOT backbone: the persistent map is a separate point set that Φ has
+                            // never classified, so counting it in F_out would report a backbone the
+                            // partition never vouched for — and mask an empty F_out on exactly the
+                            // configuration (large overlay, marks off-frame) the map exists for.
+                            corrFromBackbone.push_back(0);
                         }
                     }
                     if (imgPts.size() > before)
@@ -475,6 +509,20 @@ void MobileGS::relocThreadFunc() {
         // the quality gate PoseFusion actually trusts, so being permissive here is safe.
         mLastRelocMatches.store((int)imgPts.size(), std::memory_order_relaxed);
         mLastRelocInliers.store(0, std::memory_order_relaxed);
+        // corrFromBackbone is parallel to imgPts by construction, and the inlier attribution below
+        // subscripts it with indices into imgPts. A future pass that appends to one and not the
+        // other would make that read out of bounds, so a length disagreement publishes "not
+        // measured" instead of a wrong number.
+        const bool haveBackboneFlags = corrFromBackbone.size() == imgPts.size();
+        // 2.11: counted SEPARATELY from mLastRelocMatches, never in place of it. The same shortfall
+        // means different things — a low total is "the frame is not looking at the registered wall",
+        // a low backbone under a healthy total is "everything it can see is under the artwork" — and
+        // those call for opposite advice (aim differently vs. shrink the design / step back).
+        mLastRelocBackboneMatches.store(
+            haveBackboneFlags
+                ? (int)std::count(corrFromBackbone.begin(), corrFromBackbone.end(), (uint8_t)1)
+                : -1,
+            std::memory_order_relaxed);
         if (imgPts.size() < 8) {
             // Distinguish "the detector found nothing / the descriptors don't even compare" from
             // "features were found but too few agreed with the fingerprint" — they call for opposite
@@ -508,6 +556,16 @@ void MobileGS::relocThreadFunc() {
                 mLastRelocReject.store(kRelocPnpFailed, std::memory_order_relaxed);
             } else {
                 mLastRelocInliers.store((int)inliers.size(), std::memory_order_relaxed);
+                // 2.11: which of those inliers RANSAC drew from F_out. Left at -1 on the PnP-failed
+                // branch above, because no inlier set exists there to attribute — that is "not
+                // measured", not "no backbone agreed".
+                if (haveBackboneFlags) {
+                    int backboneInliers = 0;
+                    for (int idx : inliers) {
+                        if (idx >= 0 && idx < (int)corrFromBackbone.size() && corrFromBackbone[idx]) ++backboneInliers;
+                    }
+                    mLastRelocBackboneInliers.store(backboneInliers, std::memory_order_relaxed);
+                }
                 if (inliers.size() < 6) {
                     mLastRelocReject.store(kRelocFewInliers, std::memory_order_relaxed);
                 }

--- a/core/nativebridge/src/main/cpp/include/MobileGS.h
+++ b/core/nativebridge/src/main/cpp/include/MobileGS.h
@@ -141,6 +141,16 @@ public:
     int lastRelocObliquityDeg() const { return mLastRelocObliquityDeg.load(std::memory_order_relaxed); }
     /** Extra correspondences the rectification pass contributed to the last attempt. */
     int lastRelocRectifiedCorr() const { return mLastRelocRectifiedCorr.load(std::memory_order_relaxed); }
+    /**
+     * Stored fingerprint points in F_out — the backbone the reloc PnP is allowed to use — or -1 when
+     * no attempt has got far enough to look. An unpartitioned fingerprint reports its full point
+     * count, not zero, per the zero-length-regions rule.
+     */
+    int lastRelocBackboneFeatures() const { return mLastRelocBackboneFeatures.load(std::memory_order_relaxed); }
+    /** Correspondences built against F_out, counted apart from the total; -1 when not measured. */
+    int lastRelocBackboneMatches() const { return mLastRelocBackboneMatches.load(std::memory_order_relaxed); }
+    /** RANSAC inliers that came from F_out points; -1 when PnP never produced an inlier set. */
+    int lastRelocBackboneInliers() const { return mLastRelocBackboneInliers.load(std::memory_order_relaxed); }
 
     void scheduleRelocCheck(const cv::Mat& colorFrame);
     /**
@@ -446,5 +456,14 @@ private:
     // extra correspondences it contributed.
     std::atomic<int>        mLastRelocObliquityDeg{-1};
     std::atomic<int>        mLastRelocRectifiedCorr{0};
+    // IMPLEMENTATION.md 2.11 — the backbone (F_out) counts, all three -1 for "not measured".
+    // They CANNOT default to 0 the way the totals above do. With the partition landed, a zero
+    // backbone is a real reading with a specific meaning — the artwork covers the whole wall, so
+    // reloc has nothing left to bootstrap from, which is the failure Phase 2's risk section names
+    // and ArUiState.backboneTooSmall warns about. If zero also meant "never sampled", the one
+    // condition these counters exist to expose would be indistinguishable from an idle thread.
+    std::atomic<int>        mLastRelocBackboneFeatures{-1};
+    std::atomic<int>        mLastRelocBackboneMatches{-1};
+    std::atomic<int>        mLastRelocBackboneInliers{-1};
     cv::Mat                 mRelocColorFrame;
 };

--- a/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
+++ b/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
@@ -106,13 +106,17 @@ class SlamManager @Inject constructor(
 
     /**
      * Why the last relocalization attempt did not publish a pose, and how far it got. See
-     * [RelocDiagnostics]; the native side packs SIX values into one int[] so the read is a
-     * consistent snapshot rather than six racing getters. (Three separate comments used to say
-     * three, four and six; the array has always been six wide.)
+     * [RelocDiagnostics]; the native side packs NINE values into one int[] so the read is a
+     * consistent snapshot rather than nine racing getters. (Three separate comments used to say
+     * three, four and six; the array was six wide until 2.11 added the three backbone counts.)
+     *
+     * A short array falls back to the default [RelocDiagnostics] — whose backbone fields are the -1
+     * "not measured" sentinel, not 0 — rather than to a partially-filled one, so an old .so paired
+     * with this build reads as unmeasured instead of as an empty backbone.
      */
     fun getRelocDiagnostics(): RelocDiagnostics {
         val v = nativeGetRelocDiagnostics()
-        if (v == null || v.size < 6) return RelocDiagnostics()
+        if (v == null || v.size < 9) return RelocDiagnostics()
         return RelocDiagnostics(
             reject = RelocReject.entries.getOrElse(v[0]) { RelocReject.UNKNOWN },
             matches = v[1],
@@ -120,6 +124,9 @@ class SlamManager @Inject constructor(
             detected = v[3],
             obliquityDeg = v[4],
             rectifiedCorrespondences = v[5],
+            backboneFeatures = v[6],
+            backboneMatches = v[7],
+            backboneInliers = v[8],
         )
     }
 

--- a/docs/research/IMPLEMENTATION.md
+++ b/docs/research/IMPLEMENTATION.md
@@ -948,9 +948,22 @@ order.** Work top to bottom.
       `regions`, `usePartition` is therefore false, and the correspondence loop is
       byte-identical. That is an argument, not the measurement the item asks for,
       and it is not a substitute.)*
-- [ ] **2.11** (6b) Add `backboneFeatures` / `backboneMatches` / `backboneInliers`
+- [x] **2.11** (6b) Add `backboneFeatures` / `backboneMatches` / `backboneInliers`
       to `RelocDiagnostics`, the CSV, and the overlay. Defaults encode "not
       measured", not zero — follow the `obliquityDeg = -1` precedent. **[T][N]**
+      *(All three default to -1 and are reset to -1 at the TOP of each reloc
+      iteration, before the disabled/no-fingerprint early-outs, so a stalled
+      attempt never shows the previous one's numbers. `backboneFeatures` reports
+      the FULL point count on an unpartitioned fingerprint rather than 0 —
+      reporting 0 there would fire the empty-`F_out` alarm on every pre-Phase-2
+      project. `usePartition` was hoisted out of `buildCorr` so the filter and
+      the count cannot disagree about which fingerprint is partitioned. Matches
+      and inliers travel on a `corrFromBackbone` array parallel to the
+      correspondences; the Phase-2b map path pushes 0, because those points were
+      never classified by Φ. `backboneInliers` stays -1 on `PNP_FAILED`: there is
+      no inlier set to attribute. The JNI array went 6 → 9 ints and
+      `SlamManager`'s short-array guard moved with it, so an old `.so` yields the
+      all -1 default rather than a partially-filled object.)*
 
 ### Phase 4 — spatially-constrained corroboration
 
@@ -1004,6 +1017,13 @@ order.** Work top to bottom.
       so the eval has a per-phase baseline rather than one before/after pair.
 - [ ] **X.3** Never land two phases in one CI run. The relocalizer is a feedback
       loop and overlapping changes make the measurements uninterpretable.
+      *(Watch item, not yet violated but close. 2.11 landed in the same commit as
+      the `PoseMath` testability conversion. That conversion is not a phase and
+      changes no relocalizer arithmetic — but it DOES change
+      `marksCentroidLocal`'s null contract (an `isRigid` precondition replacing
+      `Matrix.invertM`'s singularity check), and that function positions the
+      overlay. Anything measured across this commit should treat the two as
+      confounded.)*
 
 ---
 

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/AnchorOrchestrator.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/AnchorOrchestrator.kt
@@ -1,6 +1,5 @@
 package com.hereliesaz.graffitixr.feature.ar.anchor
 
-import android.opengl.Matrix
 import com.google.ar.core.Anchor
 import com.google.ar.core.Pose
 import com.google.ar.core.Session
@@ -99,7 +98,11 @@ class AnchorOrchestrator {
             // frame. Only fall back to identity before any consensus has ever been computed.
             synchronized(this) {
                 if (hasLastGood) System.arraycopy(lastGoodMatrix, 0, outMatrix, 0, 16)
-                else Matrix.setIdentityM(outMatrix, 0)
+                // Hand-written instead of Matrix.setIdentityM: the unit tests run with
+                // `unitTests.isReturnDefaultValues = true`, under which setIdentityM is a no-op stub
+                // that leaves outMatrix all zeros without throwing — so this fallback could never be
+                // asserted. Same layout as PoseFusion.identity().
+                else identity().copyInto(outMatrix)
             }
             return
         }
@@ -166,6 +169,8 @@ class AnchorOrchestrator {
             hasLastGood = true
         }
     }
+
+    private fun identity() = floatArrayOf(1f,0f,0f,0f, 0f,1f,0f,0f, 0f,0f,1f,0f, 0f,0f,0f,1f)
 
     fun getActiveAnchorCount(): Int = synchronized(this) {
         consensusAnchors.count { it.anchor.trackingState == TrackingState.TRACKING }

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/MetricFingerprintBuilder.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/MetricFingerprintBuilder.kt
@@ -1,7 +1,6 @@
 package com.hereliesaz.graffitixr.feature.ar.anchor
 
 import android.graphics.Bitmap
-import android.opengl.Matrix
 import com.hereliesaz.graffitixr.common.model.Fingerprint
 import com.hereliesaz.graffitixr.nativebridge.SlamManager
 import org.opencv.android.Utils
@@ -359,23 +358,52 @@ object MetricFingerprintBuilder {
      * the capture's CV camera frame (flat [x,y,z,...]): invert the CV world→camera view to get their
      * mean in world space, then invert [anchorModel] (the anchor's world pose) to express it in the
      * anchor's frame — which survives a reload into a new ARCore session. Returns null if there are
-     * no points or either matrix isn't invertible.
+     * no points or either matrix is degenerate.
+     *
+     * Both operands are rigid — [cvView] is a world→camera view and [anchorModel] comes from
+     * `SlamManager.getAnchorTransform()` — so [PoseMath.rigidInverse] is the correct inverse; the
+     * overlay's scaled model matrix (see [PoseMath.similarityInverse]) never reaches here.
+     *
+     * `internal` rather than private only so a unit test can reach it: the public entry points all
+     * run OpenCV detection and a native `SlamManager`, so there is no unit test seam onto this
+     * arithmetic from outside.
      */
-    private fun marksCentroidLocal(pointsCam: FloatArray, cvView: FloatArray, anchorModel: FloatArray): FloatArray? {
+    internal fun marksCentroidLocal(pointsCam: FloatArray, cvView: FloatArray, anchorModel: FloatArray): FloatArray? {
         val n = pointsCam.size / 3
         if (n == 0) return null
+        // This used to be `Matrix.invertM(...) || return null`, which refused a singular matrix.
+        // rigidInverse cannot refuse anything — it inverts by transposing, so a zeroed or scaled
+        // input comes back as confident garbage instead of a failure. Check the precondition
+        // explicitly so the null contract still holds for the inputs invertM would have rejected
+        // (an all-zero pose from an unset anchor being the one that actually shows up).
+        if (!isRigid(cvView) || !isRigid(anchorModel)) return null
         var sx = 0f; var sy = 0f; var sz = 0f
         for (i in 0 until n) { sx += pointsCam[i * 3]; sy += pointsCam[i * 3 + 1]; sz += pointsCam[i * 3 + 2] }
-        val cam = floatArrayOf(sx / n, sy / n, sz / n, 1f)
-        val invView = FloatArray(16)
-        if (!Matrix.invertM(invView, 0, cvView, 0)) return null
-        val world = FloatArray(4)
-        Matrix.multiplyMV(world, 0, invView, 0, cam, 0)
-        val invAnchor = FloatArray(16)
-        if (!Matrix.invertM(invAnchor, 0, anchorModel, 0)) return null
-        val local = FloatArray(4)
-        Matrix.multiplyMV(local, 0, invAnchor, 0, world, 0)
-        return floatArrayOf(local[0], local[1], local[2])
+        val world = transformPoint(PoseMath.rigidInverse(cvView), sx / n, sy / n, sz / n)
+        return transformPoint(PoseMath.rigidInverse(anchorModel), world[0], world[1], world[2])
+    }
+
+    /** Apply a column-major 4x4 to a point (w=1). */
+    private fun transformPoint(m: FloatArray, x: Float, y: Float, z: Float) = floatArrayOf(
+        m[0] * x + m[4] * y + m[8] * z + m[12],
+        m[1] * x + m[5] * y + m[9] * z + m[13],
+        m[2] * x + m[6] * y + m[10] * z + m[14],
+    )
+
+    /**
+     * True if [m] is finite and its linear part is a pure rotation — the precondition
+     * [PoseMath.rigidInverse] silently assumes. All three columns are checked, not just
+     * [PoseMath.scaleOf]'s first, because a half-written pose (say a zeroed third column) is
+     * exactly the singular input the old `Matrix.invertM` guard caught.
+     */
+    private fun isRigid(m: FloatArray): Boolean {
+        if (m.size < 16) return false
+        for (v in m) if (!v.isFinite()) return false
+        for (c in 0 until 3) {
+            val x = m[c * 4]; val y = m[c * 4 + 1]; val z = m[c * 4 + 2]
+            if (kotlin.math.abs(kotlin.math.sqrt(x * x + y * y + z * z) - 1f) > 1e-3f) return false
+        }
+        return true
     }
 
     private fun toGray(bitmap: Bitmap): Mat {

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/DriftCostProbe.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/DriftCostProbe.kt
@@ -117,6 +117,12 @@ class DriftCostProbe(
             relocDetected = reloc?.detected ?: EvalSampleLog.NOT_SAMPLED,
             relocObliquityDeg = reloc?.obliquityDeg ?: EvalSampleLog.NOT_SAMPLED,
             relocRectifiedCorr = reloc?.rectifiedCorrespondences ?: EvalSampleLog.NOT_SAMPLED,
+            // Already -1 when native has not measured them, so the elvis only covers "no
+            // diagnostics read this tick at all". Both routes must land on -1, never 0: an empty
+            // F_out is a real result and is the one this column exists to catch.
+            relocBackboneFeatures = reloc?.backboneFeatures ?: EvalSampleLog.NOT_SAMPLED,
+            relocBackboneMatches = reloc?.backboneMatches ?: EvalSampleLog.NOT_SAMPLED,
+            relocBackboneInliers = reloc?.backboneInliers ?: EvalSampleLog.NOT_SAMPLED,
             captureRotationNeededDeg = captureRotationNeededDeg,
             liveRotationNeededDeg = liveRotationNeededDeg,
         )

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/EvalSampleLog.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/EvalSampleLog.kt
@@ -28,6 +28,14 @@ data class EvalSample(
     // device run be compared against PAPER.md 8.1's curve instead of argued about.
     val relocObliquityDeg: Int = -1,
     val relocRectifiedCorr: Int = -1,
+    // The backbone (F_out) counts, logged beside the totals rather than replacing them
+    // (IMPLEMENTATION.md 2.11). Phase 2 changed what a reloc failure means: a run whose backbone
+    // count collapses as the design is scaled up is a different result from one whose total matches
+    // collapse, and without these columns the two are the same row. -1 = not sampled; 0 is a real
+    // reading meaning F_out is empty, so it cannot double as the marker.
+    val relocBackboneFeatures: Int = -1,
+    val relocBackboneMatches: Int = -1,
+    val relocBackboneInliers: Int = -1,
     /**
      * `rotationNeeded` **at the moment the active target was captured** — 0, 90, 180 or 270, or -1
      * when no target has been captured this session (a project restored from disk reads -1; see
@@ -86,6 +94,7 @@ object EvalSampleLog {
         "cpuPct", "batteryMa", "tempC", "nativeHeapKb",
         "relocReject", "relocMatches", "relocInliers", "relocDetected",
         "relocObliquityDeg", "relocRectifiedCorr",
+        "relocBackboneFeatures", "relocBackboneMatches", "relocBackboneInliers",
         "captureRotationNeededDeg", "liveRotationNeededDeg",
     )
 
@@ -104,6 +113,8 @@ object EvalSampleLog {
             s.relocReject.toString(), s.relocMatches.toString(),
             s.relocInliers.toString(), s.relocDetected.toString(),
             s.relocObliquityDeg.toString(), s.relocRectifiedCorr.toString(),
+            s.relocBackboneFeatures.toString(), s.relocBackboneMatches.toString(),
+            s.relocBackboneInliers.toString(),
             s.captureRotationNeededDeg.toString(), s.liveRotationNeededDeg.toString(),
         )
     }

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/AnchorOrchestratorDropoutTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/AnchorOrchestratorDropoutTest.kt
@@ -1,0 +1,51 @@
+package com.hereliesaz.graffitixr.feature.ar.anchor
+
+import com.google.ar.core.Anchor
+import com.google.ar.core.Pose
+import com.google.ar.core.TrackingState
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * The dropout policy in [AnchorOrchestrator.getConsensusMatrix]: hold the last good world matrix
+ * while nothing is tracking, and only write identity before any consensus has ever been computed.
+ * Writing identity on every dropped frame is what would snap the overlay to the world origin.
+ *
+ * Assertable only since the identity fallback stopped going through `android.opengl.Matrix` — under
+ * this module's `unitTests.isReturnDefaultValues = true`, `setIdentityM` leaves the array untouched,
+ * so the fallback used to be indistinguishable from doing nothing.
+ */
+class AnchorOrchestratorDropoutTest {
+
+    private val identity = floatArrayOf(1f,0f,0f,0f, 0f,1f,0f,0f, 0f,0f,1f,0f, 0f,0f,0f,1f)
+
+    @Test fun `writes identity when nothing has ever tracked`() {
+        // Pre-filled with junk: a no-op fallback would leave it there.
+        val out = FloatArray(16) { 7f }
+        AnchorOrchestrator().getConsensusMatrix(out)
+        assertArrayEquals(identity, out, 1e-6f)
+    }
+
+    @Test fun `holds the last good matrix through a tracking dropout`() {
+        val anchor = mockk<Anchor>(relaxed = true)
+        every { anchor.pose } returns Pose(floatArrayOf(1f, 2f, 3f), floatArrayOf(0f, 0f, 0f, 1f))
+        every { anchor.trackingState } returns TrackingState.TRACKING
+
+        val orchestrator = AnchorOrchestrator()
+        orchestrator.setInitialAnchor(anchor)
+
+        val good = FloatArray(16)
+        orchestrator.getConsensusMatrix(good)
+        assertEquals(1f, good[12], 1e-4f)
+        assertEquals(2f, good[13], 1e-4f)
+        assertEquals(3f, good[14], 1e-4f)
+
+        every { anchor.trackingState } returns TrackingState.PAUSED
+        val out = FloatArray(16) { 7f }
+        orchestrator.getConsensusMatrix(out)
+        assertArrayEquals(good, out, 1e-6f)
+    }
+}

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/MetricFingerprintBuilderCentroidTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/MetricFingerprintBuilderCentroidTest.kt
@@ -1,0 +1,113 @@
+package com.hereliesaz.graffitixr.feature.ar.anchor
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import kotlin.math.cos
+import kotlin.math.sin
+import kotlin.math.sqrt
+
+/**
+ * `marksCentroidLocal` is what puts the AR overlay on the marks instead of the screen-center anchor,
+ * and it was previously unassertable: it went through `android.opengl.Matrix`, which under this
+ * module's `unitTests.isReturnDefaultValues = true` returns zeros without throwing, so any test of it
+ * would have agreed with any implementation.
+ *
+ * The fixtures below are built with FORWARD transforms only — pick the answer, push it out through
+ * the anchor and then the view — so the test never re-implements the two inverses it is checking.
+ */
+class MetricFingerprintBuilderCentroidTest {
+
+    private fun identity() = floatArrayOf(1f,0f,0f,0f, 0f,1f,0f,0f, 0f,0f,1f,0f, 0f,0f,0f,1f)
+
+    /** Rotation of [deg] about an arbitrary (normalized) axis — deliberately not an axis-aligned one. */
+    private fun rigid(ax: Float, ay: Float, az: Float, deg: Float, tx: Float, ty: Float, tz: Float): FloatArray {
+        val n = sqrt(ax * ax + ay * ay + az * az)
+        val x = ax / n; val y = ay / n; val z = az / n
+        val c = cos(Math.toRadians(deg.toDouble())).toFloat()
+        val s = sin(Math.toRadians(deg.toDouble())).toFloat()
+        val t = 1f - c
+        return floatArrayOf(
+            t*x*x + c,   t*x*y + s*z, t*x*z - s*y, 0f,
+            t*x*y - s*z, t*y*y + c,   t*y*z + s*x, 0f,
+            t*x*z + s*y, t*y*z - s*x, t*z*z + c,   0f,
+            tx, ty, tz, 1f,
+        )
+    }
+
+    /** Forward apply of a column-major 4x4 to a point (w=1). */
+    private fun apply(m: FloatArray, p: FloatArray) = floatArrayOf(
+        m[0] * p[0] + m[4] * p[1] + m[8] * p[2] + m[12],
+        m[1] * p[0] + m[5] * p[1] + m[9] * p[2] + m[13],
+        m[2] * p[0] + m[6] * p[1] + m[10] * p[2] + m[14],
+    )
+
+    // Non-identity, non-axis-aligned on both sides: with an axis-aligned rotation or an identity
+    // anchor, dropping either inverse (or swapping the two) can still land on the right answer.
+    private val anchor = rigid(0.3f, -0.7f, 0.6f, 37f, 1.5f, -2f, 4f)
+    private val view = rigid(-0.2f, 0.5f, 0.84f, -63f, 0.4f, 1.1f, -0.9f)
+
+    @Test fun `returns the camera-frame mean expressed in the anchor's local frame`() {
+        // The answer, chosen first. Everything below is derived from it by forward transforms.
+        val expectedLocal = floatArrayOf(0.3f, -0.45f, 0.7f)
+        val world = apply(anchor, expectedLocal)
+        val camMean = apply(view, world)
+
+        // Four points whose mean is exactly camMean, so the averaging step is exercised without
+        // changing the expected answer.
+        val offsets = listOf(
+            floatArrayOf(0.11f, -0.23f, 0.34f), floatArrayOf(-0.11f, 0.23f, -0.34f),
+            floatArrayOf(-0.42f, 0.07f, 0.19f), floatArrayOf(0.42f, -0.07f, -0.19f),
+        )
+        val pointsCam = FloatArray(offsets.size * 3)
+        offsets.forEachIndexed { i, o ->
+            pointsCam[i * 3] = camMean[0] + o[0]
+            pointsCam[i * 3 + 1] = camMean[1] + o[1]
+            pointsCam[i * 3 + 2] = camMean[2] + o[2]
+        }
+
+        val got = MetricFingerprintBuilder.marksCentroidLocal(pointsCam, view, anchor)!!
+        assertEquals(expectedLocal[0], got[0], 1e-3f)
+        assertEquals(expectedLocal[1], got[1], 1e-3f)
+        assertEquals(expectedLocal[2], got[2], 1e-3f)
+    }
+
+    /**
+     * With an identity anchor the result must be the plain world-space mean, which pins the view
+     * inverse on its own — the case where the anchor factor cannot mask a mistake in it.
+     */
+    @Test fun `identity anchor leaves the world-space mean`() {
+        val world = floatArrayOf(-0.8f, 0.25f, 2.3f)
+        val cam = apply(view, world)
+        val got = MetricFingerprintBuilder.marksCentroidLocal(cam, view, identity())!!
+        assertEquals(world[0], got[0], 1e-3f)
+        assertEquals(world[1], got[1], 1e-3f)
+        assertEquals(world[2], got[2], 1e-3f)
+    }
+
+    @Test fun `no points yields null`() {
+        assertNull(MetricFingerprintBuilder.marksCentroidLocal(FloatArray(0), view, anchor))
+    }
+
+    /**
+     * The guard that replaced `Matrix.invertM`'s boolean return. rigidInverse cannot report
+     * non-invertibility, so a zeroed pose (an anchor whose transform was never written) has to be
+     * rejected up front or the overlay gets centered on garbage instead of not being re-centered.
+     */
+    @Test fun `degenerate pose yields null instead of garbage`() {
+        val points = floatArrayOf(0f, 0f, 2f)
+        assertNull(MetricFingerprintBuilder.marksCentroidLocal(points, FloatArray(16), anchor))
+        assertNull(MetricFingerprintBuilder.marksCentroidLocal(points, view, FloatArray(16)))
+
+        // A scaled (non-rigid) matrix would come back off by s² from rigidInverse, so it is refused too.
+        val scaled = anchor.copyOf().also { for (c in 0 until 3) for (r in 0 until 3) it[c * 4 + r] *= 2f }
+        assertNull(MetricFingerprintBuilder.marksCentroidLocal(points, view, scaled))
+
+        // A column zeroed by a half-written pose is singular — exactly what invertM used to catch.
+        val singular = anchor.copyOf().also { it[8] = 0f; it[9] = 0f; it[10] = 0f }
+        assertNull(MetricFingerprintBuilder.marksCentroidLocal(points, view, singular))
+
+        val notFinite = anchor.copyOf().also { it[12] = Float.NaN }
+        assertNull(MetricFingerprintBuilder.marksCentroidLocal(points, view, notFinite))
+    }
+}

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/eval/EvalSampleLogTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/eval/EvalSampleLogTest.kt
@@ -32,6 +32,9 @@ class EvalSampleLogTest {
         relocDetected = reloc?.detected ?: EvalSampleLog.NOT_SAMPLED,
         relocObliquityDeg = reloc?.obliquityDeg ?: EvalSampleLog.NOT_SAMPLED,
         relocRectifiedCorr = reloc?.rectifiedCorrespondences ?: EvalSampleLog.NOT_SAMPLED,
+        relocBackboneFeatures = reloc?.backboneFeatures ?: EvalSampleLog.NOT_SAMPLED,
+        relocBackboneMatches = reloc?.backboneMatches ?: EvalSampleLog.NOT_SAMPLED,
+        relocBackboneInliers = reloc?.backboneInliers ?: EvalSampleLog.NOT_SAMPLED,
     )
 
     @Test
@@ -41,6 +44,7 @@ class EvalSampleLogTest {
                 "voxelUpdateMs,voxelKeyframeMs,surfaceMeshMs,drawMs,pnpRelocMs,cpuPct,batteryMa,tempC," +
                 "nativeHeapKb,relocReject,relocMatches,relocInliers,relocDetected," +
                 "relocObliquityDeg,relocRectifiedCorr," +
+                "relocBackboneFeatures,relocBackboneMatches,relocBackboneInliers," +
                 "captureRotationNeededDeg,liveRotationNeededDeg",
             EvalSampleLog.CSV_HEADER,
         )
@@ -56,7 +60,7 @@ class EvalSampleLogTest {
         )
         assertEquals(
             "12,dual,true,1.5,0.25,3.0,1.0,2.0,0.0,4.0,1.0,8.0,30.0,-450.0,31.0,20480," +
-                "-1,-1,-1,-1,-1,-1,-1,-1",
+                "-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1",
             EvalSampleLog.toCsvRow(row),
         )
     }
@@ -263,6 +267,64 @@ class EvalSampleLogTest {
         assertEquals("0", landscape[i])
         assertEquals("-1", unsampled[i])
         assertTrue("the control condition must not read as absent", landscape[i] != unsampled[i])
+    }
+
+    /**
+     * `IMPLEMENTATION.md` 2.11 — the backbone counts get their own columns, beside the totals.
+     * Reusing `relocMatches` for the backbone count would have made the two shortfalls E5 needs to
+     * tell apart the same number.
+     */
+    @Test
+    fun `backbone counts reach their own columns, beside the totals`() {
+        val d = RelocDiagnostics(
+            RelocReject.OK, matches = 40, inliers = 24, detected = 1400,
+            backboneFeatures = 300, backboneMatches = 31, backboneInliers = 19,
+        )
+        val fields = EvalSampleLog.fields(sample(reloc = d))
+        assertEquals("300", fields[EvalSampleLog.COLUMNS.indexOf("relocBackboneFeatures")])
+        assertEquals("31", fields[EvalSampleLog.COLUMNS.indexOf("relocBackboneMatches")])
+        assertEquals("19", fields[EvalSampleLog.COLUMNS.indexOf("relocBackboneInliers")])
+        assertEquals("40", fields[EvalSampleLog.COLUMNS.indexOf("relocMatches")])
+        assertEquals("24", fields[EvalSampleLog.COLUMNS.indexOf("relocInliers")])
+    }
+
+    /**
+     * The trap this trio could most easily fall into, and the one Phase 2 created.
+     *
+     * An empty `F_out` — the artwork covers the whole visible wall, so reloc has nothing to
+     * bootstrap from — is a **real** measurement of zero, and it is the specific failure Phase 2's
+     * risk section says the implementation must make legible. Had 0 doubled as the not-sampled
+     * marker, every row recording that failure would have been indistinguishable from a row where
+     * the reloc thread simply had not run, and the experiment could not report it.
+     */
+    @Test
+    fun `an empty backbone logs as zero, distinct from not sampled`() {
+        val wallFilling = RelocDiagnostics(
+            RelocReject.FEW_MATCHES, matches = 2, inliers = 0, detected = 1400,
+            backboneFeatures = 0, backboneMatches = 0, backboneInliers = 0,
+        )
+        val measured = EvalSampleLog.fields(sample(reloc = wallFilling))
+        val unsampled = EvalSampleLog.fields(sample(reloc = null))
+        for (col in listOf("relocBackboneFeatures", "relocBackboneMatches", "relocBackboneInliers")) {
+            val i = EvalSampleLog.COLUMNS.indexOf(col)
+            assertEquals("0", measured[i])
+            assertEquals("-1", unsampled[i])
+            assertTrue("$col: an empty backbone must not read as absent", measured[i] != unsampled[i])
+        }
+    }
+
+    /**
+     * A legacy fingerprint carries no partition and is therefore all backbone, so its count is the
+     * whole point set. It must not arrive as 0 (which would say the opposite) nor as -1.
+     */
+    @Test
+    fun `a legacy all-backbone fingerprint logs its full point count`() {
+        val legacy = RelocDiagnostics(
+            RelocReject.OK, matches = 40, inliers = 24, detected = 1400,
+            backboneFeatures = 512, backboneMatches = 40, backboneInliers = 24,
+        )
+        val fields = EvalSampleLog.fields(sample(reloc = legacy))
+        assertEquals("512", fields[EvalSampleLog.COLUMNS.indexOf("relocBackboneFeatures")])
     }
 
     /**

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Sat Aug 01 11:30:44 UTC 2026
-versionBuild=14399
+#Sat Aug 01 11:34:00 UTC 2026
+versionBuild=14400
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=265
+versionPatch=266

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Sat Aug 01 11:21:02 UTC 2026
-versionBuild=14349
+#Sat Aug 01 11:29:17 UTC 2026
+versionBuild=14398
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=215
+versionPatch=264

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Sat Aug 01 11:29:17 UTC 2026
-versionBuild=14398
+#Sat Aug 01 11:30:44 UTC 2026
+versionBuild=14399
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=264
+versionPatch=265


### PR DESCRIPTION
Two independent pieces on top of #1804. **Neither addresses the three defects an audit found in #1804 itself** — those are listed at the bottom and are not fixed here.

## The matrix paths could not be tested at all

Three modules set `unitTests.isReturnDefaultValues = true`, under which `android.opengl.Matrix` is a stub: `setIdentityM` leaves the array **all zeros and does not throw**. Verified by probe, not assumed.

To be clear about scope, since I speculated wider earlier and was wrong: **no existing test was vacuous.** The codebase already routes around this deliberately, with comments saying so. The actual gap is narrower — `marksCentroidLocal` and `AnchorOrchestrator.getConsensusMatrix` were simply *untestable*, and the former is what puts the overlay on the marks rather than the screen-centre anchor.

Both now use `PoseMath`, which is pure Kotlin for exactly this reason.

**The `invertM` failure guards were not dropped.** `rigidInverse` inverts by transposing and cannot report non-invertibility, so it returns confident garbage where `invertM` returned `false`. An explicit `isRigid` precondition replaces them — checking all three linear columns rather than just the first, because a half-written pose with one zeroed column is the singular input that actually shows up.

Mutation-verified three ways, all restored afterwards:

| Mutation | Result |
|---|---|
| Swap the two inverses | FAILED |
| Drop the anchor inverse | FAILED |
| Restore `Matrix.setIdentityM` in `AnchorOrchestrator` | FAILED — confirms the stub premise directly, not just by probe |

## Backbone diagnostics (2.11)

`backboneFeatures` / `backboneMatches` / `backboneInliers` through `RelocDiagnostics`, the eval CSV and the dev overlay.

Each defaults to **-1, not 0**. With the partition landed, a zero backbone is a real and meaningful measurement — the artwork covers the whole wall — so it cannot double as the "not measured" sentinel. Same argument as `obliquityDeg`.

## Also

Fixes `extern "C" extern "C" extern "C"` at `GraffitiJNI.cpp:1346`, left by #1804's orphan-export removal. Legal C++ that compiled cleanly, so the NDK gate could not have caught it — nobody re-read the hunk.

## Verification

- 422 unit tests, 0 failures (`core:common` 121, `feature:ar` 220, `core:nativebridge` 14, `feature:editor` 67)
- `:app:compileDebugKotlin` and `:core:nativebridge:externalNativeBuildDebug` green

## Known defects in #1804, NOT fixed here

An audit found three, all independently confirmed:

1. **The two anchors are different anchors.** `setInitialAnchorFromCapture()` only sets a volatile flag; the anchor is established one GL frame later. `MainViewModel.kt:293` reads `getAnchorTransform()` synchronously before any coroutine hop, so `captureAnchorCam = cvView · A_pre` while `rigidModelAnchorLocal = A_est⁻¹ · M`. The composition carries a stray fixed `A_pre · A_est⁻¹`, and the two frames don't share a convention (wall normal in column Z vs +Y).
2. **The partition still never runs during the capture session.** `liveFingerprint` is assigned only inside `loadFingerprintIfExists`, after detection + `saveProject` + `loadProject`. The session's single extent edge fires one GL frame after confirm, while it is still null.
3. **The trigger only watches size.** Moving or rotating the design changes Φ's answer as much as resizing, and fires nothing.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Q5WXFiVLeN4sXa9bPCSDA)_

## Summary by Sourcery

Make AR anchor/matrix pose handling testable and add backbone partition diagnostics across native, UI, and logging.

New Features:
- Expose and wire backbone feature, match, and inlier counts from the native reloc engine through JNI into RelocDiagnostics, overlays, and eval CSV logging.

Bug Fixes:
- Ensure identity fallback in AnchorOrchestrator is correctly applied under unit test stubbing and that relocalization diagnostics arrays and exports are well-formed C++.

Enhancements:
- Refactor marksCentroidLocal to use PoseMath rigid inverses with explicit degeneracy checks and add unit tests for centroid computation and anchor dropout behavior.
- Initialize and maintain backbone counters correctly in the reloc thread, including handling of unpartitioned fingerprints, empty backbone, and not-measured states.
- Extend RelocDiagnostics tests to cover backbone semantics and separation between total and backbone counts, and add eval logging tests for backbone fields.

Build:
- Bump project version build and patch numbers.

Tests:
- Add dedicated unit tests for MetricFingerprintBuilder centroid calculations and AnchorOrchestrator dropout policy, and expand RelocDiagnostics and EvalSampleLog tests to cover backbone diagnostics behavior.