### PR TITLE
Fix the Phase 2 partition: four rounds of defects, and the tests that would have caught them

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainViewModel.kt
@@ -288,11 +288,11 @@ class MainViewModel @Inject constructor(
             return
         }
         resetCaptureUi()
-        // Snapshot BEFORE the coroutine, and before the renderer can act on the establishment
-        // request the caller just made. Waiting for an establishment newer than this is what makes a
-        // re-capture correct: the flag-shaped version of this was permanently satisfied after the
-        // first capture, so every later one resolved instantly against the previous anchor.
-        val anchorGenBefore = slamManager.anchorGeneration.value
+        // Taken by setInitialAnchorFromCapture at the instant it raised the request, which is the
+        // only point where it does not race the GL thread's establishment. Waiting for a generation
+        // newer than this is what makes a RE-capture correct: a boolean "has one ever been
+        // established" is permanently true after the first, so every later capture resolved
+        // instantly against the previous anchor's pose.
         val planePoint = floatArrayOf(wallPlane[0], wallPlane[1], wallPlane[2])
         val planeNormal = floatArrayOf(wallPlane[3], wallPlane[4], wallPlane[5])
         // Clear any prior marks-centering override; the builder re-publishes it on a successful build.
@@ -307,7 +307,7 @@ class MainViewModel @Inject constructor(
             // indistinguishable from a real pose at the world origin. That identity became the
             // fingerprint's co-registration frame, `markCenterLocal`'s frame, and (since Phase 2)
             // `captureAnchorCam`, leaving the partition composed through a stray `A_est⁻¹`.
-            val anchor = slamManager.awaitAnchorTransform(anchorGenBefore)
+            val anchor = slamManager.awaitAnchorTransform(slamManager.captureAnchorGenerationBaseline)
             if (anchor == null || anchor.size != 16) {
                 withContext(Dispatchers.Main) {
                     Toast.makeText(

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainViewModel.kt
@@ -288,6 +288,11 @@ class MainViewModel @Inject constructor(
             return
         }
         resetCaptureUi()
+        // Snapshot BEFORE the coroutine, and before the renderer can act on the establishment
+        // request the caller just made. Waiting for an establishment newer than this is what makes a
+        // re-capture correct: the flag-shaped version of this was permanently satisfied after the
+        // first capture, so every later one resolved instantly against the previous anchor.
+        val anchorGenBefore = slamManager.anchorGeneration.value
         val planePoint = floatArrayOf(wallPlane[0], wallPlane[1], wallPlane[2])
         val planeNormal = floatArrayOf(wallPlane[3], wallPlane[4], wallPlane[5])
         // Clear any prior marks-centering override; the builder re-publishes it on a successful build.
@@ -302,7 +307,7 @@ class MainViewModel @Inject constructor(
             // indistinguishable from a real pose at the world origin. That identity became the
             // fingerprint's co-registration frame, `markCenterLocal`'s frame, and (since Phase 2)
             // `captureAnchorCam`, leaving the partition composed through a stray `A_est⁻¹`.
-            val anchor = slamManager.awaitAnchorTransform()
+            val anchor = slamManager.awaitAnchorTransform(anchorGenBefore)
             if (anchor == null || anchor.size != 16) {
                 withContext(Dispatchers.Main) {
                     Toast.makeText(

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainViewModel.kt
@@ -288,11 +288,6 @@ class MainViewModel @Inject constructor(
             return
         }
         resetCaptureUi()
-        // Taken by setInitialAnchorFromCapture at the instant it raised the request, which is the
-        // only point where it does not race the GL thread's establishment. Waiting for a generation
-        // newer than this is what makes a RE-capture correct: a boolean "has one ever been
-        // established" is permanently true after the first, so every later capture resolved
-        // instantly against the previous anchor's pose.
         val planePoint = floatArrayOf(wallPlane[0], wallPlane[1], wallPlane[2])
         val planeNormal = floatArrayOf(wallPlane[3], wallPlane[4], wallPlane[5])
         // Clear any prior marks-centering override; the builder re-publishes it on a successful build.
@@ -307,6 +302,11 @@ class MainViewModel @Inject constructor(
             // indistinguishable from a real pose at the world origin. That identity became the
             // fingerprint's co-registration frame, `markCenterLocal`'s frame, and (since Phase 2)
             // `captureAnchorCam`, leaving the partition composed through a stray `A_est⁻¹`.
+            // The baseline was taken by setInitialAnchorFromCapture at the instant it raised the
+            // request — the only point that does not race the GL thread's establishment. Waiting for
+            // a generation newer than it is what makes a RE-capture correct: a boolean "has one ever
+            // been established" is permanently true after the first, so every later capture resolved
+            // instantly against the previous anchor's pose.
             val anchor = slamManager.awaitAnchorTransform(slamManager.captureAnchorGenerationBaseline)
             if (anchor == null || anchor.size != 16) {
                 withContext(Dispatchers.Main) {

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainViewModel.kt
@@ -290,10 +290,30 @@ class MainViewModel @Inject constructor(
         resetCaptureUi()
         val planePoint = floatArrayOf(wallPlane[0], wallPlane[1], wallPlane[2])
         val planeNormal = floatArrayOf(wallPlane[3], wallPlane[4], wallPlane[5])
-        val anchor = slamManager.getAnchorTransform()
         // Clear any prior marks-centering override; the builder re-publishes it on a successful build.
         slamManager.overlayMarkCenterLocal = null
         viewModelScope.launch(Dispatchers.IO) {
+            // The anchor is read HERE, not on the caller's thread, and only once one exists.
+            //
+            // Target creation is what ESTABLISHES the anchor: `setInitialAnchorFromCapture` raises a
+            // flag and the renderer acts on it a frame later. Reading `getAnchorTransform()`
+            // synchronously at the call site — as this did — therefore returned the identity native
+            // is constructed with, and the identity is the worst possible wrong answer because it is
+            // indistinguishable from a real pose at the world origin. That identity became the
+            // fingerprint's co-registration frame, `markCenterLocal`'s frame, and (since Phase 2)
+            // `captureAnchorCam`, leaving the partition composed through a stray `A_est⁻¹`.
+            val anchor = slamManager.awaitAnchorTransform()
+            if (anchor == null || anchor.size != 16) {
+                withContext(Dispatchers.Main) {
+                    Toast.makeText(
+                        context,
+                        "Couldn't lock an anchor for this target — hold the phone steady on the " +
+                            "wall and try again.",
+                        Toast.LENGTH_LONG,
+                    ).show()
+                }
+                return@launch
+            }
             // A fingerprint is persisted INTO a project, so without one there is nowhere to put it.
             // This was a bare `?: return@launch`: the artist aimed, tapped, confirmed, and nothing
             // happened — no target, no error, no clue that the missing piece was a project.

--- a/core/nativebridge/build.gradle.kts
+++ b/core/nativebridge/build.gradle.kts
@@ -65,6 +65,7 @@ dependencies {
     implementation(libs.opencv)
     testImplementation(libs.junit)
     testImplementation(libs.mockk)
+    testImplementation(libs.kotlinx.coroutines.test)
 }
 
 // Pin Kotlin's JVM target to match Java (17). Without this, Kotlin defaults to a lower target

--- a/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
+++ b/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
@@ -483,7 +483,9 @@ Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeUpdateLightLevel(J
 JNIEXPORT void JNICALL
 Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeUpdateAnchorTransform(JNIEnv* env, jobject thiz, jfloatArray transform) {
     if (gSlamEngine) {
-        // updateAnchorTransform memcpy's 16 floats out of this.
+        // updateAnchorTransform memcpy's 16 floats out of this. A short or null array is dropped
+        // here — the Kotlin side must not read that as "an anchor was written", which is why the
+        // established-anchor signal is raised at establishment rather than by this setter.
         if (!transform || env->GetArrayLength(transform) < 16) return;
         jfloat* mat = env->GetFloatArrayElements(transform, nullptr);
         gSlamEngine->updateAnchorTransform(mat);

--- a/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
+++ b/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
@@ -66,62 +66,71 @@ class SlamManager @Inject constructor(
     fun getLastSplatTrace(): String = nativeGetLastSplatTrace()
 
     /**
-     * True once the renderer has ESTABLISHED the primary anchor — not merely written a pose.
+     * How many times the renderer has ESTABLISHED the primary anchor this session — not how many
+     * times an anchor pose has been written, and not merely whether one ever was.
      *
-     * The distinction is the whole point, and getting it wrong is what a first attempt at this did.
-     * `mAnchorMatrix` is constructed as the identity, but it does **not** stay that way until
-     * establishment: `refineAnchorFromBestPlane` runs every 30 frames *while the anchor is
-     * unestablished* and writes a provisional plane pose, as does the depth fallback. So a flag set
-     * by `updateAnchorTransform` flips within the first second of scanning, and a capture waiting on
-     * it would not wait at all — it would read the plane refiner's pose.
+     * Two distinctions, each of which a simpler design got wrong.
      *
-     * That is not a near-miss. The refiner builds its basis with the plane normal in **Z**, while
-     * establishment takes ARCore's `hitPose` verbatim, whose local **+Y** is the normal. The two
-     * differ by ~90° by construction, so reading one where the other is meant is a frame error, not
-     * drift.
+     * **Establishment, not any write.** `mAnchorMatrix` is constructed as the identity but does not
+     * stay that way: `refineAnchorFromBestPlane` runs every 30 frames *while the anchor is
+     * unestablished* and writes a provisional plane pose, as does the depth fallback. A flag set by
+     * `updateAnchorTransform` therefore flips within a second of scanning. Worse, the refiner builds
+     * its basis with the wall normal in **Z** while establishment takes ARCore's `hitPose`, whose
+     * normal is **+Y** — reading one where the other is meant is a ~90° frame error, not drift.
      *
-     * Hence [markAnchorEstablished], called from the one place that sets the renderer's
-     * `anchorEstablished`, rather than from the pose writer.
+     * **A counter, not a latch.** Every target confirmation re-establishes the anchor, so a boolean
+     * "has one ever been established" is permanently true after the first capture and every capture
+     * after it resolves instantly against the *previous* anchor's pose — the same off-by-an-anchor
+     * bug the flag existed to prevent. A caller snapshots this before requesting establishment and
+     * waits for it to advance.
      */
-    private val _anchorEstablished = kotlinx.coroutines.flow.MutableStateFlow(false)
-    val anchorEstablished: kotlinx.coroutines.flow.StateFlow<Boolean> = _anchorEstablished
+    private val _anchorGeneration = kotlinx.coroutines.flow.MutableStateFlow(0)
+    val anchorGeneration: kotlinx.coroutines.flow.StateFlow<Int> = _anchorGeneration
 
     fun updateAnchorTransform(transform: FloatArray) = nativeUpdateAnchorTransform(transform)
 
     /**
-     * Announce that the primary anchor now exists. Call from the renderer at the moment it sets its
-     * own `anchorEstablished`, and nowhere else — every other anchor write is provisional.
+     * Announce that the primary anchor has been (re-)established. Call from the renderer at the
+     * moment it sets its own `anchorEstablished`, and nowhere else — every other anchor write is
+     * provisional.
      */
-    fun markAnchorEstablished() { _anchorEstablished.value = true }
+    fun markAnchorEstablished() { _anchorGeneration.value = _anchorGeneration.value + 1 }
 
     /**
-     * The anchor pose, waiting up to [timeoutMs] for the anchor to be established if it is not yet.
+     * The anchor pose, waiting up to [timeoutMs] for an establishment **newer than**
+     * [sinceGeneration] — which the caller must snapshot from [anchorGeneration] before asking for
+     * one.
      *
-     * Returns null on timeout rather than a pose, because every candidate fallback here is a
-     * well-formed matrix that means the wrong thing: the identity reads as a real pose at the world
-     * origin, and the plane refiner's provisional pose is in a different frame convention entirely.
+     * Returns null on timeout rather than a pose, because every candidate fallback is a well-formed
+     * matrix that means the wrong thing: the identity reads as a real pose at the world origin, the
+     * plane refiner's provisional pose is in a different frame convention, and the previous
+     * anchor's pose is a plausible answer to a question about a different anchor.
      */
-    suspend fun awaitAnchorTransform(timeoutMs: Long = ANCHOR_WAIT_MS): FloatArray? {
-        if (!_anchorEstablished.value) {
+    suspend fun awaitAnchorTransform(
+        sinceGeneration: Int,
+        timeoutMs: Long = ANCHOR_WAIT_MS,
+    ): FloatArray? {
+        if (_anchorGeneration.value <= sinceGeneration) {
             kotlinx.coroutines.withTimeoutOrNull(timeoutMs) {
-                _anchorEstablished.first { it }
+                _anchorGeneration.first { it > sinceGeneration }
             } ?: return null
         }
         val m = nativeGetAnchorTransform()
         // Native hands back a freshly ZEROED array when the engine is gone, which passes a bare
         // size check and yields a singular matrix — strictly worse than the identity this exists to
-        // avoid. A real anchor pose has a unit-length first rotation column.
+        // avoid. A real anchor pose has a unit-length first rotation column; all three writers
+        // produce orthonormal matrices, so this rejects only genuinely broken input.
         if (m == null || m.size != 16) return null
         val c0 = kotlin.math.sqrt(m[0] * m[0] + m[1] * m[1] + m[2] * m[2])
         return if (kotlin.math.abs(c0 - 1f) < 1e-3f) m else null
     }
 
     /**
-     * Forget that the anchor was established. Call when tearing the AR session down: the ARCore
-     * session and its anchors do not survive that, so "established" must not either, or the next
-     * capture resolves instantly against the previous session's pose.
+     * Reset the establishment counter. Call when tearing the AR session down: the ARCore session and
+     * its anchors do not survive that, so a generation from the old session must not satisfy a wait
+     * in the new one.
      */
-    fun clearAnchorEstablished() { _anchorEstablished.value = false }
+    fun clearAnchorEstablished() { _anchorGeneration.value = 0 }
 
     /**
      * Centroid of the matched fingerprint marks, expressed in the FINGERPRINT ANCHOR's local frame

--- a/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
+++ b/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
@@ -87,6 +87,26 @@ class SlamManager @Inject constructor(
     private val _anchorGeneration = kotlinx.coroutines.flow.MutableStateFlow(0)
     val anchorGeneration: kotlinx.coroutines.flow.StateFlow<Int> = _anchorGeneration
 
+    /**
+     * Whether an anchor exists right now, as distinct from how many have existed.
+     *
+     * Needed because the counter must be **monotonic**. Resetting it to 0 on teardown lets it go
+     * backwards, which strands any capture already waiting for `> N`: the next establishment
+     * produces 1, which is not greater than 1, so the wait burns its whole budget and reports
+     * "couldn't lock an anchor" for what was actually a torn-down session. Advancing the generation
+     * on teardown and clearing this flag says the same thing without lying about ordering.
+     */
+    @Volatile private var hasAnchor = false
+
+    /**
+     * The anchor generation as of the moment a capture asked for a new anchor.
+     *
+     * Lives here rather than being snapshotted by the waiter because only the requester can take it
+     * without racing: the request and the establishment are on different threads, and a snapshot
+     * taken after the request can already include the establishment it was meant to precede.
+     */
+    @Volatile var captureAnchorGenerationBaseline: Int = 0
+
     fun updateAnchorTransform(transform: FloatArray) = nativeUpdateAnchorTransform(transform)
 
     /**
@@ -94,7 +114,13 @@ class SlamManager @Inject constructor(
      * moment it sets its own `anchorEstablished`, and nowhere else — every other anchor write is
      * provisional.
      */
-    fun markAnchorEstablished() { _anchorGeneration.value = _anchorGeneration.value + 1 }
+    @Synchronized
+    fun markAnchorEstablished() {
+        // Synchronized because this is a read-modify-write on the GL thread racing teardown on the
+        // main thread; @Volatile alone would let one of the two updates be lost.
+        hasAnchor = true
+        _anchorGeneration.value = _anchorGeneration.value + 1
+    }
 
     /**
      * The anchor pose, waiting up to [timeoutMs] for an establishment **newer than**
@@ -110,9 +136,9 @@ class SlamManager @Inject constructor(
         sinceGeneration: Int,
         timeoutMs: Long = ANCHOR_WAIT_MS,
     ): FloatArray? {
-        if (_anchorGeneration.value <= sinceGeneration) {
+        if (!(hasAnchor && _anchorGeneration.value > sinceGeneration)) {
             kotlinx.coroutines.withTimeoutOrNull(timeoutMs) {
-                _anchorGeneration.first { it > sinceGeneration }
+                _anchorGeneration.first { it > sinceGeneration && hasAnchor }
             } ?: return null
         }
         val m = nativeGetAnchorTransform()
@@ -126,11 +152,18 @@ class SlamManager @Inject constructor(
     }
 
     /**
-     * Reset the establishment counter. Call when tearing the AR session down: the ARCore session and
-     * its anchors do not survive that, so a generation from the old session must not satisfy a wait
-     * in the new one.
+     * Record that the anchor is gone. Call when tearing the AR session down: the ARCore session and
+     * its anchors do not survive it.
+     *
+     * Advances the generation rather than resetting it, so the counter only ever moves forwards. A
+     * reset to 0 makes old snapshots compare as *larger* than new generations — the opposite of the
+     * ordering the wait depends on — and strands any capture already inside it.
      */
-    fun clearAnchorEstablished() { _anchorGeneration.value = 0 }
+    @Synchronized
+    fun clearAnchorEstablished() {
+        hasAnchor = false
+        _anchorGeneration.value = _anchorGeneration.value + 1
+    }
 
     /**
      * Centroid of the matched fingerprint marks, expressed in the FINGERPRINT ANCHOR's local frame

--- a/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
+++ b/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
 @Singleton
@@ -64,7 +65,45 @@ class SlamManager @Inject constructor(
     fun getLastDepthTrace(): String = nativeGetLastDepthTrace()
     fun getLastSplatTrace(): String = nativeGetLastSplatTrace()
 
-    fun updateAnchorTransform(transform: FloatArray) = nativeUpdateAnchorTransform(transform)
+    /**
+     * True once an anchor pose has actually been written, as opposed to the identity the native
+     * engine starts with.
+     *
+     * `getAnchorTransform()` cannot express "no anchor yet" — `mAnchorMatrix` is constructed as the
+     * identity and stays that way until the renderer establishes one, so a caller that reads it too
+     * early gets a perfectly well-formed matrix that means nothing. That is not hypothetical: target
+     * creation *is* what establishes the anchor (`setInitialAnchorFromCapture` only raises a flag,
+     * and the renderer acts on it a frame later), so the capture path read the identity and used it
+     * as the fingerprint's co-registration frame.
+     */
+    private val _anchorEverSet = kotlinx.coroutines.flow.MutableStateFlow(false)
+    val anchorEverSet: kotlinx.coroutines.flow.StateFlow<Boolean> = _anchorEverSet
+
+    fun updateAnchorTransform(transform: FloatArray) {
+        nativeUpdateAnchorTransform(transform)
+        _anchorEverSet.value = true
+    }
+
+    /**
+     * The anchor pose, waiting up to [timeoutMs] for one to be established if none has been.
+     *
+     * Returns null on timeout rather than the identity, because the identity is exactly the wrong
+     * answer to fall back to — it is indistinguishable from a real pose at the world origin, and
+     * every frame composed through it is silently off by the anchor's true transform.
+     */
+    suspend fun awaitAnchorTransform(timeoutMs: Long = 2_000L): FloatArray? {
+        if (!_anchorEverSet.value) {
+            val arrived = kotlinx.coroutines.withTimeoutOrNull(timeoutMs) {
+                _anchorEverSet.first { it }
+            }
+            if (arrived == null) return null
+        }
+        return nativeGetAnchorTransform()
+    }
+
+    /** Forget that an anchor was ever set. Call when tearing a session down, or the next project
+     *  inherits this one's "established" answer while native has been reset under it. */
+    fun clearAnchorEverSet() { _anchorEverSet.value = false }
 
     /**
      * Centroid of the matched fingerprint marks, expressed in the FINGERPRINT ANCHOR's local frame

--- a/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
+++ b/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
@@ -66,44 +66,62 @@ class SlamManager @Inject constructor(
     fun getLastSplatTrace(): String = nativeGetLastSplatTrace()
 
     /**
-     * True once an anchor pose has actually been written, as opposed to the identity the native
-     * engine starts with.
+     * True once the renderer has ESTABLISHED the primary anchor — not merely written a pose.
      *
-     * `getAnchorTransform()` cannot express "no anchor yet" — `mAnchorMatrix` is constructed as the
-     * identity and stays that way until the renderer establishes one, so a caller that reads it too
-     * early gets a perfectly well-formed matrix that means nothing. That is not hypothetical: target
-     * creation *is* what establishes the anchor (`setInitialAnchorFromCapture` only raises a flag,
-     * and the renderer acts on it a frame later), so the capture path read the identity and used it
-     * as the fingerprint's co-registration frame.
+     * The distinction is the whole point, and getting it wrong is what a first attempt at this did.
+     * `mAnchorMatrix` is constructed as the identity, but it does **not** stay that way until
+     * establishment: `refineAnchorFromBestPlane` runs every 30 frames *while the anchor is
+     * unestablished* and writes a provisional plane pose, as does the depth fallback. So a flag set
+     * by `updateAnchorTransform` flips within the first second of scanning, and a capture waiting on
+     * it would not wait at all — it would read the plane refiner's pose.
+     *
+     * That is not a near-miss. The refiner builds its basis with the plane normal in **Z**, while
+     * establishment takes ARCore's `hitPose` verbatim, whose local **+Y** is the normal. The two
+     * differ by ~90° by construction, so reading one where the other is meant is a frame error, not
+     * drift.
+     *
+     * Hence [markAnchorEstablished], called from the one place that sets the renderer's
+     * `anchorEstablished`, rather than from the pose writer.
      */
-    private val _anchorEverSet = kotlinx.coroutines.flow.MutableStateFlow(false)
-    val anchorEverSet: kotlinx.coroutines.flow.StateFlow<Boolean> = _anchorEverSet
+    private val _anchorEstablished = kotlinx.coroutines.flow.MutableStateFlow(false)
+    val anchorEstablished: kotlinx.coroutines.flow.StateFlow<Boolean> = _anchorEstablished
 
-    fun updateAnchorTransform(transform: FloatArray) {
-        nativeUpdateAnchorTransform(transform)
-        _anchorEverSet.value = true
+    fun updateAnchorTransform(transform: FloatArray) = nativeUpdateAnchorTransform(transform)
+
+    /**
+     * Announce that the primary anchor now exists. Call from the renderer at the moment it sets its
+     * own `anchorEstablished`, and nowhere else — every other anchor write is provisional.
+     */
+    fun markAnchorEstablished() { _anchorEstablished.value = true }
+
+    /**
+     * The anchor pose, waiting up to [timeoutMs] for the anchor to be established if it is not yet.
+     *
+     * Returns null on timeout rather than a pose, because every candidate fallback here is a
+     * well-formed matrix that means the wrong thing: the identity reads as a real pose at the world
+     * origin, and the plane refiner's provisional pose is in a different frame convention entirely.
+     */
+    suspend fun awaitAnchorTransform(timeoutMs: Long = ANCHOR_WAIT_MS): FloatArray? {
+        if (!_anchorEstablished.value) {
+            kotlinx.coroutines.withTimeoutOrNull(timeoutMs) {
+                _anchorEstablished.first { it }
+            } ?: return null
+        }
+        val m = nativeGetAnchorTransform()
+        // Native hands back a freshly ZEROED array when the engine is gone, which passes a bare
+        // size check and yields a singular matrix — strictly worse than the identity this exists to
+        // avoid. A real anchor pose has a unit-length first rotation column.
+        if (m == null || m.size != 16) return null
+        val c0 = kotlin.math.sqrt(m[0] * m[0] + m[1] * m[1] + m[2] * m[2])
+        return if (kotlin.math.abs(c0 - 1f) < 1e-3f) m else null
     }
 
     /**
-     * The anchor pose, waiting up to [timeoutMs] for one to be established if none has been.
-     *
-     * Returns null on timeout rather than the identity, because the identity is exactly the wrong
-     * answer to fall back to — it is indistinguishable from a real pose at the world origin, and
-     * every frame composed through it is silently off by the anchor's true transform.
+     * Forget that the anchor was established. Call when tearing the AR session down: the ARCore
+     * session and its anchors do not survive that, so "established" must not either, or the next
+     * capture resolves instantly against the previous session's pose.
      */
-    suspend fun awaitAnchorTransform(timeoutMs: Long = 2_000L): FloatArray? {
-        if (!_anchorEverSet.value) {
-            val arrived = kotlinx.coroutines.withTimeoutOrNull(timeoutMs) {
-                _anchorEverSet.first { it }
-            }
-            if (arrived == null) return null
-        }
-        return nativeGetAnchorTransform()
-    }
-
-    /** Forget that an anchor was ever set. Call when tearing a session down, or the next project
-     *  inherits this one's "established" answer while native has been reset under it. */
-    fun clearAnchorEverSet() { _anchorEverSet.value = false }
+    fun clearAnchorEstablished() { _anchorEstablished.value = false }
 
     /**
      * Centroid of the matched fingerprint marks, expressed in the FINGERPRINT ANCHOR's local frame
@@ -744,5 +762,15 @@ class SlamManager @Inject constructor(
 
     private companion object {
         private const val TAG = "SlamManager"
+
+        /**
+         * How long a capture waits for the anchor to be established before giving up.
+         *
+         * The anchor is established on the GL frame after the artist confirms, so the realistic wait
+         * is one frame — under 35 ms at 30 fps. Two seconds is a generous ceiling for a stalled or
+         * dropped frame, not an expected duration, and timing out is a refusal rather than a
+         * fallback. Recorded in `PARAMETERS.md` §6.
+         */
+        const val ANCHOR_WAIT_MS = 2_000L
     }
 }

--- a/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
+++ b/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
@@ -112,6 +112,9 @@ class SlamManager @Inject constructor(
      */
     @Volatile private var sessionEpoch = 0
 
+    /** Readable so a requester can pin it alongside [captureAnchorGenerationBaseline]. */
+    val sessionEpochValue: Int get() = sessionEpoch
+
     /**
      * The anchor generation as of the moment a capture asked for a new anchor.
      *
@@ -120,6 +123,15 @@ class SlamManager @Inject constructor(
      * taken after the request can already include the establishment it was meant to precede.
      */
     @Volatile var captureAnchorGenerationBaseline: Int = 0
+
+    /**
+     * The session epoch as of the same instant [captureAnchorGenerationBaseline] was taken.
+     *
+     * Pinned with the baseline rather than at the start of the wait, for the same reason the
+     * baseline is: the wait begins a dispatcher hop later, and an epoch read there can already
+     * include the teardown it was meant to exclude.
+     */
+    @Volatile var captureSessionEpochBaseline: Int = 0
 
     fun updateAnchorTransform(transform: FloatArray) = nativeUpdateAnchorTransform(transform)
 
@@ -150,10 +162,12 @@ class SlamManager @Inject constructor(
     suspend fun awaitAnchorTransform(
         sinceGeneration: Int,
         timeoutMs: Long = ANCHOR_WAIT_MS,
+        sinceEpoch: Int = captureSessionEpochBaseline,
     ): FloatArray? {
-        // Pinned at entry: an anchor from a LATER session answers a different question than the one
-        // this capture asked, so the wait must expire rather than accept it.
-        val epochAtEntry = sessionEpoch
+        // An anchor from a LATER session answers a different question than the one this capture
+        // asked, so the wait must expire rather than accept it. Defaulted from the requester's
+        // pinned value, not read here — reading here is a dispatcher hop too late.
+        val epochAtEntry = sinceEpoch
         if (!(hasAnchor && _anchorGeneration.value > sinceGeneration)) {
             kotlinx.coroutines.withTimeoutOrNull(timeoutMs) {
                 _anchorGeneration.first { it > sinceGeneration && hasAnchor && sessionEpoch == epochAtEntry }

--- a/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
+++ b/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
@@ -99,6 +99,20 @@ class SlamManager @Inject constructor(
     @Volatile private var hasAnchor = false
 
     /**
+     * Bumped every time the AR session is torn down, so a wait started in one session cannot be
+     * satisfied by an anchor established in the next.
+     *
+     * The monotonic generation counter alone cannot express this. It fixed a real bug — resetting to
+     * zero stranded in-flight waits — but it also turned a fail-CLOSED outcome into a fail-OPEN one:
+     * teardown then re-entry produces a generation strictly greater than the waiter's baseline with
+     * `hasAnchor` true again, so the wait resolves and hands the new session's anchor to the old
+     * session's capture. That capture back-projects its pixels through a foreign anchor and persists
+     * a structurally valid, geometrically meaningless target. Refusing is the correct outcome, and
+     * `PARAMETERS.md` §6 already states it as the contract.
+     */
+    @Volatile private var sessionEpoch = 0
+
+    /**
      * The anchor generation as of the moment a capture asked for a new anchor.
      *
      * Lives here rather than being snapshotted by the waiter because only the requester can take it
@@ -124,8 +138,9 @@ class SlamManager @Inject constructor(
 
     /**
      * The anchor pose, waiting up to [timeoutMs] for an establishment **newer than**
-     * [sinceGeneration] — which the caller must snapshot from [anchorGeneration] before asking for
-     * one.
+     * [sinceGeneration] — which the capture path takes from [captureAnchorGenerationBaseline],
+     * recorded by the requester rather than snapshotted here, because only the requester can take it
+     * without racing the establishment it is meant to precede.
      *
      * Returns null on timeout rather than a pose, because every candidate fallback is a well-formed
      * matrix that means the wrong thing: the identity reads as a real pose at the world origin, the
@@ -136,11 +151,15 @@ class SlamManager @Inject constructor(
         sinceGeneration: Int,
         timeoutMs: Long = ANCHOR_WAIT_MS,
     ): FloatArray? {
+        // Pinned at entry: an anchor from a LATER session answers a different question than the one
+        // this capture asked, so the wait must expire rather than accept it.
+        val epochAtEntry = sessionEpoch
         if (!(hasAnchor && _anchorGeneration.value > sinceGeneration)) {
             kotlinx.coroutines.withTimeoutOrNull(timeoutMs) {
-                _anchorGeneration.first { it > sinceGeneration && hasAnchor }
+                _anchorGeneration.first { it > sinceGeneration && hasAnchor && sessionEpoch == epochAtEntry }
             } ?: return null
         }
+        if (sessionEpoch != epochAtEntry) return null
         val m = nativeGetAnchorTransform()
         // Native hands back a freshly ZEROED array when the engine is gone, which passes a bare
         // size check and yields a singular matrix — strictly worse than the identity this exists to
@@ -162,6 +181,7 @@ class SlamManager @Inject constructor(
     @Synchronized
     fun clearAnchorEstablished() {
         hasAnchor = false
+        sessionEpoch += 1
         _anchorGeneration.value = _anchorGeneration.value + 1
     }
 

--- a/core/nativebridge/src/test/java/com/hereliesaz/graffitixr/nativebridge/SlamManagerAnchorEstablishmentTest.kt
+++ b/core/nativebridge/src/test/java/com/hereliesaz/graffitixr/nativebridge/SlamManagerAnchorEstablishmentTest.kt
@@ -1,0 +1,122 @@
+package com.hereliesaz.graffitixr.nativebridge
+
+import com.hereliesaz.graffitixr.common.util.NativeLibLoader
+import com.hereliesaz.graffitixr.common.wearable.WearableManager
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * `awaitAnchorTransform` must wait for the anchor to be ESTABLISHED, not for any anchor write.
+ *
+ * The first version of this fix set the flag inside `updateAnchorTransform`. That method is what
+ * `refineAnchorFromBestPlane` calls every 30 frames *while the anchor is still unestablished*, so
+ * the flag flipped within the first second of scanning and the capture never waited at all — it
+ * read the plane refiner's provisional pose. The refiner builds its basis with the wall normal in
+ * **Z**; establishment takes ARCore's `hitPose`, whose local **+Y** is the normal. Reading one where
+ * the other is meant is a ~90° frame error by construction, and it shipped as a fix. Hence these
+ * tests pin the gate itself, not merely that a pose eventually comes back.
+ *
+ * **On the exceptions.** `libgraffitixr.so` is not on a JVM unit-test classpath, so every `external
+ * fun` throws `UnsatisfiedLinkError`. That is not noise here, it is the instrument: a call that is
+ * still waiting on the gate returns null at its timeout without ever reaching JNI, and a call that
+ * has passed the gate reaches `nativeGetAnchorTransform` and throws. The two outcomes are therefore
+ * unambiguous evidence of which side of the gate the coroutine is on.
+ *
+ * It also bounds what these tests can catch, and the bound is worth stating rather than discovering:
+ * a regression that set the flag *after* `nativeUpdateAnchorTransform` would be invisible here,
+ * because the throw gets there first. Off-device that is the whole method; on-device it is one line
+ * of it. Only an instrumented run closes that gap.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SlamManagerAnchorEstablishmentTest {
+
+    private lateinit var slamManager: SlamManager
+
+    @Before
+    fun setup() {
+        // The constructor calls NativeLibLoader.loadAll(), which throws when the .so is absent.
+        mockkObject(NativeLibLoader)
+        every { NativeLibLoader.loadAll() } returns Unit
+        slamManager = SlamManager(mockk<WearableManager>(relaxed = true))
+    }
+
+    @After
+    fun tearDown() {
+        unmockkObject(NativeLibLoader)
+    }
+
+    /** Stand-in for what the plane refiner pushes every 30 frames before the anchor exists. */
+    private fun provisionalPlanePose() = FloatArray(16) { if (it % 5 == 0) 1f else 0f }
+
+    /**
+     * The exact call the refiner makes, taken through the real public method so the gate under test
+     * is the production one. The JNI hop it ends in cannot resolve here; what matters is whether the
+     * method touched the establishment flag on its way there.
+     */
+    private fun writeProvisionalPose() {
+        try {
+            slamManager.updateAnchorTransform(provisionalPlanePose())
+        } catch (expected: UnsatisfiedLinkError) {
+            // nativeUpdateAnchorTransform is unresolvable off-device; see the class KDoc.
+        }
+    }
+
+    @Test
+    fun `a provisional pose write leaves a waiting capture waiting`() = runTest {
+        writeProvisionalPose()
+
+        assertFalse(
+            "a pose write must not count as establishment",
+            slamManager.anchorEstablished.value,
+        )
+        // Null means the wait ran its full budget and gave up. Had the write opened the gate this
+        // would have reached nativeGetAnchorTransform and thrown instead.
+        assertNull(slamManager.awaitAnchorTransform(timeoutMs = 5_000L))
+    }
+
+    @Test
+    fun `awaitAnchorTransform completes only once the anchor is established`() = runTest {
+        var outcome: Result<FloatArray?>? = null
+        val waiter = launch {
+            outcome = runCatching { slamManager.awaitAnchorTransform(timeoutMs = 60_000L) }
+        }
+        testScheduler.runCurrent()
+        assertFalse("must not resolve with no anchor at all", waiter.isCompleted)
+
+        writeProvisionalPose()
+        testScheduler.runCurrent()
+        assertFalse("must not resolve on the plane refiner's pose", waiter.isCompleted)
+
+        slamManager.markAnchorEstablished()
+        testScheduler.runCurrent()
+
+        assertTrue("establishment must release the wait", waiter.isCompleted)
+        assertTrue(
+            "the wait must have gone on to read the pose, not timed out; got $outcome",
+            outcome?.exceptionOrNull() is UnsatisfiedLinkError,
+        )
+    }
+
+    @Test
+    fun `clearAnchorEstablished makes the next capture wait again`() = runTest {
+        slamManager.markAnchorEstablished()
+        assertTrue(slamManager.anchorEstablished.value)
+
+        // AR teardown: the ARCore session and its anchors are gone, so "established" must not
+        // survive, or the next capture resolves instantly against the previous session's pose.
+        slamManager.clearAnchorEstablished()
+
+        assertNull(slamManager.awaitAnchorTransform(timeoutMs = 5_000L))
+    }
+}

--- a/core/nativebridge/src/test/java/com/hereliesaz/graffitixr/nativebridge/SlamManagerAnchorEstablishmentTest.kt
+++ b/core/nativebridge/src/test/java/com/hereliesaz/graffitixr/nativebridge/SlamManagerAnchorEstablishmentTest.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -17,15 +18,23 @@ import org.junit.Before
 import org.junit.Test
 
 /**
- * `awaitAnchorTransform` must wait for the anchor to be ESTABLISHED, not for any anchor write.
+ * `awaitAnchorTransform` must wait for an establishment NEWER than the caller's snapshot — not for
+ * any anchor write, and not merely for "one has ever happened".
+ *
+ * Two cuts of this fix were wrong in two different ways, and both are pinned below.
  *
  * The first version of this fix set the flag inside `updateAnchorTransform`. That method is what
  * `refineAnchorFromBestPlane` calls every 30 frames *while the anchor is still unestablished*, so
  * the flag flipped within the first second of scanning and the capture never waited at all — it
  * read the plane refiner's provisional pose. The refiner builds its basis with the wall normal in
  * **Z**; establishment takes ARCore's `hitPose`, whose local **+Y** is the normal. Reading one where
- * the other is meant is a ~90° frame error by construction, and it shipped as a fix. Hence these
- * tests pin the gate itself, not merely that a pose eventually comes back.
+ * the other is meant is a ~90° frame error by construction, and it shipped as a fix.
+ *
+ * The second used a boolean latch. Every target confirmation RE-establishes the anchor, so after the
+ * first capture the latch is permanently true and every later capture resolves instantly — against
+ * the previous anchor's pose, one GL frame before the new one is written. Re-capture is not exotic;
+ * the app's own legacy-fingerprint message tells the artist to create the target again. Hence a
+ * generation counter, and hence the last test here.
  *
  * **On the exceptions.** `libgraffitixr.so` is not on a JVM unit-test classpath, so every `external
  * fun` throws `UnsatisfiedLinkError`. That is not noise here, it is the instrument: a call that is
@@ -76,20 +85,22 @@ class SlamManagerAnchorEstablishmentTest {
     fun `a provisional pose write leaves a waiting capture waiting`() = runTest {
         writeProvisionalPose()
 
-        assertFalse(
+        assertEquals(
             "a pose write must not count as establishment",
-            slamManager.anchorEstablished.value,
+            0, slamManager.anchorGeneration.value,
         )
         // Null means the wait ran its full budget and gave up. Had the write opened the gate this
         // would have reached nativeGetAnchorTransform and thrown instead.
-        assertNull(slamManager.awaitAnchorTransform(timeoutMs = 5_000L))
+        assertNull(slamManager.awaitAnchorTransform(sinceGeneration = 0, timeoutMs = 5_000L))
     }
 
     @Test
     fun `awaitAnchorTransform completes only once the anchor is established`() = runTest {
         var outcome: Result<FloatArray?>? = null
         val waiter = launch {
-            outcome = runCatching { slamManager.awaitAnchorTransform(timeoutMs = 60_000L) }
+            outcome = runCatching {
+                slamManager.awaitAnchorTransform(sinceGeneration = 0, timeoutMs = 60_000L)
+            }
         }
         testScheduler.runCurrent()
         assertFalse("must not resolve with no anchor at all", waiter.isCompleted)
@@ -111,12 +122,53 @@ class SlamManagerAnchorEstablishmentTest {
     @Test
     fun `clearAnchorEstablished makes the next capture wait again`() = runTest {
         slamManager.markAnchorEstablished()
-        assertTrue(slamManager.anchorEstablished.value)
+        assertEquals(1, slamManager.anchorGeneration.value)
 
-        // AR teardown: the ARCore session and its anchors are gone, so "established" must not
-        // survive, or the next capture resolves instantly against the previous session's pose.
+        // AR teardown: the ARCore session and its anchors are gone, so an establishment from the old
+        // session must not satisfy a wait in the new one.
         slamManager.clearAnchorEstablished()
 
-        assertNull(slamManager.awaitAnchorTransform(timeoutMs = 5_000L))
+        assertNull(slamManager.awaitAnchorTransform(sinceGeneration = 0, timeoutMs = 5_000L))
+    }
+
+    /**
+     * The re-capture case, and the one a boolean latch cannot express.
+     *
+     * A second capture snapshots the generation AFTER the first capture established an anchor, so
+     * "has an anchor ever been established" is already true and tells it nothing. It must keep
+     * waiting until the count advances past its own snapshot — otherwise it reads the pose of the
+     * anchor it is about to replace, and the fingerprint is co-registered to a dead frame.
+     */
+    @Test
+    fun `a second capture waits for an establishment newer than its own snapshot`() = runTest {
+        slamManager.markAnchorEstablished() // capture #1 establishes anchor #1
+        val snapshotBeforeSecondCapture = slamManager.anchorGeneration.value
+        assertEquals(1, snapshotBeforeSecondCapture)
+
+        var outcome: Result<FloatArray?>? = null
+        val waiter = launch {
+            outcome = runCatching {
+                slamManager.awaitAnchorTransform(snapshotBeforeSecondCapture, timeoutMs = 60_000L)
+            }
+        }
+        testScheduler.runCurrent()
+        assertFalse(
+            "an already-established anchor must not satisfy a later capture's wait",
+            waiter.isCompleted,
+        )
+
+        // A provisional write in between must not release it either.
+        writeProvisionalPose()
+        testScheduler.runCurrent()
+        assertFalse("a pose write is still not an establishment", waiter.isCompleted)
+
+        slamManager.markAnchorEstablished() // capture #2 establishes anchor #2
+        testScheduler.runCurrent()
+
+        assertTrue("the NEW establishment must release the wait", waiter.isCompleted)
+        assertTrue(
+            "the wait must have gone on to read the pose, not timed out; got $outcome",
+            outcome?.exceptionOrNull() is UnsatisfiedLinkError,
+        )
     }
 }

--- a/core/nativebridge/src/test/java/com/hereliesaz/graffitixr/nativebridge/SlamManagerAnchorEstablishmentTest.kt
+++ b/core/nativebridge/src/test/java/com/hereliesaz/graffitixr/nativebridge/SlamManagerAnchorEstablishmentTest.kt
@@ -119,6 +119,46 @@ class SlamManagerAnchorEstablishmentTest {
         )
     }
 
+    /**
+     * **The session boundary**, and the case the monotonic counter opened up.
+     *
+     * Resetting the counter to zero on teardown stranded in-flight waits, so it became monotonic —
+     * which fixed that and silently turned a fail-CLOSED outcome into a fail-OPEN one: teardown then
+     * re-entry yields a generation strictly greater than the waiter's baseline with an anchor
+     * present again, so the wait resolved and handed the NEW session's anchor to the OLD session's
+     * capture. That capture back-projects its pixels through a foreign anchor and persists a
+     * structurally valid, geometrically meaningless target.
+     *
+     * Refusing is the contract (`PARAMETERS.md` §6: "timing out REFUSES rather than falling back").
+     */
+    @Test
+    fun `an anchor from a later session cannot satisfy an earlier session's wait`() = runTest {
+        slamManager.markAnchorEstablished()
+        val baseline = slamManager.anchorGeneration.value
+
+        var outcome: Result<FloatArray?>? = null
+        val waiter = launch {
+            outcome = runCatching { slamManager.awaitAnchorTransform(baseline, timeoutMs = 60_000L) }
+        }
+        testScheduler.runCurrent()
+        assertFalse(waiter.isCompleted)
+
+        slamManager.clearAnchorEstablished()  // AR teardown
+        slamManager.markAnchorEstablished()   // a new session establishes its own anchor
+        testScheduler.runCurrent()
+        testScheduler.advanceUntilIdle()
+
+        assertTrue("the wait must end rather than hang", waiter.isCompleted)
+        assertNull(
+            "a later session's anchor answers a different question; the capture must be refused",
+            outcome?.getOrNull(),
+        )
+        assertFalse(
+            "and it must refuse by returning null, not by reaching JNI; got $outcome",
+            outcome?.exceptionOrNull() is UnsatisfiedLinkError,
+        )
+    }
+
     @Test
     fun `clearAnchorEstablished makes the next capture wait again`() = runTest {
         slamManager.markAnchorEstablished()

--- a/docs/research/PARAMETERS.md
+++ b/docs/research/PARAMETERS.md
@@ -166,15 +166,25 @@ if repartition cost or missed repartitions ever show up in a run, start here.
 | `DESIGN_EXTENT_EPS` | `ArRenderer.kt` | `1e-3` m | guessed — a millimetre of effective half-extent; below this a "resize" is float noise in the compose chain |
 | `DESIGN_PAN_EPS_M` | `ArRenderer.kt` | `1e-3` m | guessed — likewise for in-plane pan |
 | `DESIGN_ROT_EPS_DEG` | `ArRenderer.kt` | `0.1`° | guessed — a tenth of a degree of in-plane spin |
-| `ANCHOR_WAIT_MS` | `SlamManager.kt` | `2000` ms | derived — the anchor is established on the GL frame after confirm (&lt;35 ms at 30 fps); this is a stall ceiling, not an expected duration, and timing out REFUSES rather than falling back |
+| `ANCHOR_WAIT_MS` | `SlamManager.kt` | `2000` ms | derived — the anchor is established on the GL frame after confirm (under 35 ms at 30 fps); this is a stall ceiling, not an expected duration, and timing out REFUSES rather than falling back |
 
-**The repartition trigger reads the artist's inputs, not the composed pose**, and
-that is a correctness requirement rather than a tuning choice. `anchorMatrix` is
-the *fused* pose, re-corrected every frame, and
-`anchorMatrix⁻¹ · overlayRigid` carries `R_anchorᵀ` — so any threshold on that
-product fires on drift with the phone sitting still. Pan, spin and the extents
-are drift-immune. An earlier cut keyed on the composed matrix at `1e-3` per
-element (~0.057°) and would have repartitioned continuously.
+**The repartition trigger reads the artist's gesture inputs only**, and that is a
+correctness requirement rather than a tuning choice. `anchorMatrix` is the
+*fused* pose, re-corrected every frame, and `anchorMatrix⁻¹ · overlayRigid`
+carries `R_anchorᵀ` — so any threshold on that product fires on drift with the
+phone sitting still. Two successive cuts got this wrong: the first keyed on the
+composed matrix (~0.057° at `1e-3` per element), the second added the
+marks-centering offset, which is `X_world · (R_anchor · markCenterLocal)` and is
+drift-coupled at `DESIGN_PAN_EPS_M / |markCenterLocal|` — the same 0.057° at a
+one-metre lever arm. Only `overlayPanX/Y`, `overlayRotationDeg` and the extents
+are genuinely immune, because they are set from gestures and nothing else.
+
+**The thresholds compare against the last PUBLISH, not the last frame.** Advancing
+the remembered values on a frame that reported no movement makes a slow drag
+invisible: 15 cm over 3 s is 0.08 mm per frame, under threshold every frame, and
+the delta never accumulates. That cut shipped too, and it is the more dangerous
+failure of the two — a trigger that fires too often wastes work, one that never
+fires leaves Φ answering against a design that has left.
 
 
 

--- a/docs/research/PARAMETERS.md
+++ b/docs/research/PARAMETERS.md
@@ -163,9 +163,9 @@ if repartition cost or missed repartitions ever show up in a run, start here.
 
 | Parameter | Location | Current | Basis |
 |---|---|---|---|
-| `DESIGN_EXTENT_EPS` | `ArRenderer.kt` | `1e-3` m | guessed — a millimetre of effective half-extent; below this a "resize" is float noise in the compose chain |
-| `DESIGN_PAN_EPS_M` | `ArRenderer.kt` | `1e-3` m | guessed — likewise for in-plane pan |
-| `DESIGN_ROT_EPS_DEG` | `ArRenderer.kt` | `0.1`° | guessed — a tenth of a degree of in-plane spin |
+| `DEFAULT_EXTENT_EPS_M` | `DesignMoveDetector.kt` | `1e-3` m | guessed — a millimetre of effective half-extent; below this a "resize" is float noise in the compose chain |
+| `DEFAULT_PAN_EPS_M` | `DesignMoveDetector.kt` | `1e-3` m | guessed — likewise for in-plane pan |
+| `DEFAULT_ROT_EPS_DEG` | `DesignMoveDetector.kt` | `0.1`° | guessed — a tenth of a degree of in-plane spin |
 | `ANCHOR_WAIT_MS` | `SlamManager.kt` | `2000` ms | derived — the anchor is established on the GL frame after confirm (under 35 ms at 30 fps); this is a stall ceiling, not an expected duration, and timing out REFUSES rather than falling back |
 
 **The repartition trigger reads the artist's gesture inputs only**, and that is a
@@ -175,14 +175,25 @@ carries `R_anchorᵀ` — so any threshold on that product fires on drift with t
 phone sitting still. Two successive cuts got this wrong: the first keyed on the
 composed matrix (~0.057° at `1e-3` per element), the second added the
 marks-centering offset, which is `X_world · (R_anchor · markCenterLocal)` and is
-drift-coupled at `DESIGN_PAN_EPS_M / |markCenterLocal|` — the same 0.057° at a
-one-metre lever arm. Only `overlayPanX/Y`, `overlayRotationDeg` and the extents
-are genuinely immune, because they are set from gestures and nothing else.
+drift-coupled at `DEFAULT_PAN_EPS_M / |markCenterLocal|` — the same 0.057° at a
+one-metre lever arm.
+
+`overlayPanX/Y` and `overlayRotationDeg` are gestures, so they are immune. The
+extents are `extentHalfW * overlayScale`, and only the scale is a gesture —
+`extentHalfW` comes from a screen fit. They are safe for a different reason,
+worth stating precisely in a parameter set whose history is a drift-immunity
+argument being wrong twice: the fit is **one-shot per arming**, so the extents
+are a step function rather than a per-frame signal.
+
+Removing the marks offset also removed the only input that moved when a
+**re-capture** replaced the anchor, which silently stopped the footprint being
+republished on exactly the path that most needs it. The anchor generation — a
+discrete counter, compared exactly with no threshold — carries that signal now.
 
 **The thresholds compare against the last PUBLISH, not the last frame.** Advancing
 the remembered values on a frame that reported no movement makes a slow drag
-invisible: 15 cm over 3 s is 0.08 mm per frame, under threshold every frame, and
-the delta never accumulates. That cut shipped too, and it is the more dangerous
+invisible: 15 cm over 3 s at 60 fps is 0.83 mm per frame, under the 1 mm
+threshold on every frame, and the delta never accumulates. That cut shipped too, and it is the more dangerous
 failure of the two — a trigger that fires too often wastes work, one that never
 fires leaves Φ answering against a design that has left.
 

--- a/docs/research/PARAMETERS.md
+++ b/docs/research/PARAMETERS.md
@@ -168,8 +168,9 @@ if repartition cost or missed repartitions ever show up in a run, start here.
 | `DEFAULT_ROT_EPS_DEG` | `DesignMoveDetector.kt` | `0.1`° | guessed — a tenth of a degree of in-plane spin |
 | `ANCHOR_WAIT_MS` | `SlamManager.kt` | `2000` ms | derived — the anchor is established on the GL frame after confirm (under 35 ms at 30 fps); this is a stall ceiling, not an expected duration, and timing out REFUSES rather than falling back |
 
-**The repartition trigger reads the artist's gesture inputs only**, and that is a
-correctness requirement rather than a tuning choice. `anchorMatrix` is the
+**The repartition trigger's *thresholded* inputs are the artist's gestures only**,
+and that is a correctness requirement rather than a tuning choice. (It also reads
+the anchor generation, which is discrete and compared exactly — see below.) `anchorMatrix` is the
 *fused* pose, re-corrected every frame, and `anchorMatrix⁻¹ · overlayRigid`
 carries `R_anchorᵀ` — so any threshold on that product fires on drift with the
 phone sitting still. Two successive cuts got this wrong: the first keyed on the

--- a/docs/research/PARAMETERS.md
+++ b/docs/research/PARAMETERS.md
@@ -156,6 +156,28 @@ P2 is falsified.
 
 ## 6. Rendering and interaction — set, not swept
 
+Three of these gate the Phase-2 repartition, which costs a classify pass, a
+native fingerprint replace and a project write each time it fires. They are
+guesses with stated reasoning, not measurements, and no experiment sets them —
+if repartition cost or missed repartitions ever show up in a run, start here.
+
+| Parameter | Location | Current | Basis |
+|---|---|---|---|
+| `DESIGN_EXTENT_EPS` | `ArRenderer.kt` | `1e-3` m | guessed — a millimetre of effective half-extent; below this a "resize" is float noise in the compose chain |
+| `DESIGN_PAN_EPS_M` | `ArRenderer.kt` | `1e-3` m | guessed — likewise for in-plane pan |
+| `DESIGN_ROT_EPS_DEG` | `ArRenderer.kt` | `0.1`° | guessed — a tenth of a degree of in-plane spin |
+| `ANCHOR_WAIT_MS` | `SlamManager.kt` | `2000` ms | derived — the anchor is established on the GL frame after confirm (&lt;35 ms at 30 fps); this is a stall ceiling, not an expected duration, and timing out REFUSES rather than falling back |
+
+**The repartition trigger reads the artist's inputs, not the composed pose**, and
+that is a correctness requirement rather than a tuning choice. `anchorMatrix` is
+the *fused* pose, re-corrected every frame, and
+`anchorMatrix⁻¹ · overlayRigid` carries `R_anchorᵀ` — so any threshold on that
+product fires on drift with the phone sitting still. Pan, spin and the extents
+are drift-immune. An earlier cut keyed on the composed matrix at `1e-3` per
+element (~0.057°) and would have repartitioned continuously.
+
+
+
 Listed for completeness. These are UX constants with no bearing on
 relocalization accuracy; they are here so a future session does not mistake them
 for tuning targets.

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -959,9 +959,7 @@ class ArViewModel @Inject constructor(
         // The partition's in-memory state belongs to the session that built it: the retained design
         // footprint is expressed relative to an anchor that is about to stop existing.
         latestDesignFootprint = null
-        lastPartitionedPose = null
-        liveFingerprint = null
-        restoredFingerprint = null
+        dropLoadedFingerprintState()
         // Cancel any in-flight session update (including a running stereo probe) so it stops pumping
         // the camera and releases the session mutex before cleanup tries to acquire it.
         sessionUpdateJob?.cancel()
@@ -1734,6 +1732,26 @@ class ArViewModel @Inject constructor(
      */
     @Volatile private var restoredFingerprint: com.hereliesaz.graffitixr.common.model.Fingerprint? = null
 
+    /**
+     * Forget everything that describes a fingerprint loaded into native.
+     *
+     * Every path that leaves native holding no usable map must call this, and there are three of
+     * them: no fingerprint at all, a pre-Phase-0 fingerprint that is refused, and session teardown.
+     * They were fixed one at a time and the refusal path was missed, which is why this is a function
+     * rather than three copies of the same three assignments.
+     *
+     * `restoredFingerprint` left set means switching BACK to the project that owned it hits the
+     * suppression guard and never re-pushes — native empty, Kotlin believing otherwise, reloc dead
+     * for the rest of the process and looking exactly like bad tracking. `liveFingerprint` left set
+     * is worse: a design move partitions the PREVIOUS project's map and `updateProject` writes it
+     * into the current project's file.
+     */
+    private fun dropLoadedFingerprintState() {
+        restoredFingerprint = null
+        liveFingerprint = null
+        lastPartitionedPose = null
+    }
+
     private fun loadFingerprintIfExists() {
         viewModelScope.launch(Dispatchers.IO) {
             val project = projectRepository.currentProject.value ?: return@launch
@@ -1779,6 +1797,12 @@ class ArViewModel @Inject constructor(
                                 "geometry can't be corrected. Create the target again to use it.",
                         ),
                     )
+                    // Refusing is a no-map outcome, so it must drop the caches exactly as the
+                    // no-fingerprint branch below does. Leaving them meant a design move would
+                    // partition the PREVIOUS project's map and `updateProject` would write it into
+                    // THIS project's file — the same leak that branch was fixed for, sitting
+                    // untouched sixty lines above it.
+                    dropLoadedFingerprintState()
                     return@launch
                 }
 
@@ -1848,17 +1872,7 @@ class ArViewModel @Inject constructor(
                 // aid and must not register anything beyond that flow.
                 slamManager.clearWallFingerprint()
                 slamManager.overlayMarkCenterLocal = null
-                // Native now holds nothing, so neither cache may keep claiming it does.
-                //
-                // `restoredFingerprint` left set means switching BACK to the project that owned it
-                // hits the suppression guard and never re-pushes — native empty, Kotlin believing
-                // otherwise, reloc silently dead for the rest of the process and looking exactly
-                // like bad tracking. `liveFingerprint` left set is worse: a design move would
-                // partition the PREVIOUS project's map and `updateProject` would write it into this
-                // project's file.
-                restoredFingerprint = null
-                liveFingerprint = null
-                lastPartitionedPose = null
+                dropLoadedFingerprintState()
             }
             // Restore the persistent wall feature map (Phase 2a: stored in native; matched in Phase 2b).
             // Independent of the marks fingerprint above and co-registered to the same anchor. Null on
@@ -2445,6 +2459,12 @@ class ArViewModel @Inject constructor(
     }
 
     fun setInitialAnchorFromCapture() {
+        // Snapshot BEFORE raising the flag, and publish it, because this is the only point at which
+        // "the generation before the anchor this capture asked for" is knowable. A caller that takes
+        // its own snapshot afterwards races the GL thread: if establishment lands first, the
+        // snapshot is already the NEW generation, the wait can never be satisfied, and a capture
+        // that succeeded is discarded with "couldn't lock an anchor".
+        slamManager.captureAnchorGenerationBaseline = slamManager.anchorGeneration.value
         renderer?.pendingAnchorEstablishment = true
     }
 

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -954,12 +954,13 @@ class ArViewModel @Inject constructor(
         // "an anchor has been established" must not either — otherwise the next capture's
         // `awaitAnchorTransform` returns immediately with the previous session's pose, which is the
         // identity-shaped bug it was written to prevent, wearing different numbers.
-        slamManager.clearAnchorEverSet()
+        slamManager.clearAnchorEstablished()
         // The partition's in-memory state belongs to the session that built it: the retained design
         // footprint is expressed relative to an anchor that is about to stop existing.
         latestDesignFootprint = null
         lastPartitionedPose = null
         liveFingerprint = null
+        restoredFingerprint = null
         // Cancel any in-flight session update (including a running stereo probe) so it stops pumping
         // the camera and releases the session mutex before cleanup tries to acquire it.
         sessionUpdateJob?.cancel()
@@ -1521,16 +1522,22 @@ class ArViewModel @Inject constructor(
     @Volatile private var liveFingerprint: LiveFingerprint? = null
 
     /**
-     * Serializes the partition work and lets a newer request cancel an in-flight older one.
+     * Lets a newer partition request cancel an in-flight older one.
      *
-     * Both properties matter and neither is cosmetic. A pinch gesture moves the design every frame,
-     * so without cancellation this launches a coroutine per frame, each of which replaces the native
-     * fingerprint and writes the project file to disk. Without serialization those coroutines finish
-     * out of order, and the LAST write can be the partition for an intermediate size — leaving
-     * native and disk describing a design the artist has already resized past, with nothing to
-     * correct it because the renderer's own extent tracking has moved on.
+     * **It does not serialize them, and an earlier version of this comment claimed it did.**
+     * `cancel()` does not join, `Dispatchers.Default` is multi-threaded, and the body runs a pure
+     * classify loop and a blocking JNI call with no cancellation point between them — so a cancelled
+     * job can still finish its native push. What cancellation buys is that the newest design wins
+     * the *common* case, which matters because a drag moves the design every frame and each firing
+     * costs a repartition, a native replace and a project write.
+     *
+     * The real protection against an out-of-order write is the idempotence check in the job body:
+     * a partition that computes the same regions and extents makes no write at all.
      */
-    private var partitionJob: Job? = null
+    // @Volatile because this stopped being single-threaded: the GL thread reaches it through
+    // onDesignFootprintChanged and the IO dispatcher through partitionLiveFingerprintIfNeeded. A
+    // torn read-modify-write here drops a cancel and lets two partition jobs run into native at once.
+    @Volatile private var partitionJob: Job? = null
 
     /**
      * The most recent design footprint the renderer published, or null before the artwork is placed.
@@ -1616,6 +1623,25 @@ class ArViewModel @Inject constructor(
             // captureAnchorCam, no usable extents), and re-pushing an unchanged fingerprint would
             // reset native's reloc state for nothing.
             if (updated === current.fingerprint) return@launch
+            // Idempotence, and it is load-bearing rather than an optimisation.
+            //
+            // `partition` returns a fresh copy whenever it CAN partition, so the identity check above
+            // only catches refusals. Without this second check, `loadFingerprintIfExists` →
+            // partition → `updateProject` → a new `currentProject` emission →
+            // `loadFingerprintIfExists` again is a cycle: every project load paid for two partitions,
+            // two native fingerprint replaces (each resetting reloc state) and two full project
+            // writes. It terminated only because `Fingerprint.equals` compares `regions` by content
+            // and `MutableStateFlow` conflates equal values — an accident of an override written for
+            // a serialization test, one non-value-equal field away from an unbounded write loop.
+            if (updated.regions.contentEquals(current.fingerprint.regions) &&
+                updated.captureHalfW == current.fingerprint.captureHalfW &&
+                updated.captureHalfH == current.fingerprint.captureHalfH
+            ) {
+                // Still record the pose: the partition is genuinely up to date for it, and not
+                // recording it would re-enter here on every subsequent frame of a drag.
+                lastPartitionedPose = design.rigidModelAnchorLocal.copyOf()
+                return@launch
+            }
             ensureActive()
 
             val backbone = FingerprintPartition.backboneCount(updated)
@@ -1628,6 +1654,9 @@ class ArViewModel @Inject constructor(
             )
             liveFingerprint = LiveFingerprint(updated, current.anchor, current.intrinsics, current.view)
             lastPartitionedPose = design.rigidModelAnchorLocal.copyOf()
+            // Native now holds exactly this, so the reload our own updateProject is about to trigger
+            // must not push it again.
+            restoredFingerprint = updated
 
             // IMPLEMENTATION.md 2.8, relocated. The capture cannot raise this — it has no footprint
             // to measure — so it is raised here, where the artwork's size is what made it true. A
@@ -1662,10 +1691,28 @@ class ArViewModel @Inject constructor(
         }
     }
 
+    /**
+     * The fingerprint currently pushed to native, for suppressing redundant restores.
+     *
+     * `loadFingerprintIfExists` runs on EVERY `currentProject` emission, and the partition itself
+     * writes the project — so a partition triggers a reload, which would re-push the identical
+     * fingerprint and reset native's reloc state for nothing. Any other writer of `currentProject`
+     * (`saveWallFeatureMap`, for one) dragged the same cost behind it.
+     */
+    @Volatile private var restoredFingerprint: com.hereliesaz.graffitixr.common.model.Fingerprint? = null
+
     private fun loadFingerprintIfExists() {
         viewModelScope.launch(Dispatchers.IO) {
             val project = projectRepository.currentProject.value ?: return@launch
             val fp = project.fingerprint
+            // Value equality, and it is exactly the right comparison: two fingerprints that agree on
+            // points, descriptors, frame and partition ARE the same map, whichever object holds them.
+            if (fp != null && fp == restoredFingerprint) {
+                // Still let the partition re-evaluate — the design may have moved while this
+                // emission was in flight — but do not touch native.
+                partitionLiveFingerprintIfNeeded()
+                return@launch
+            }
             if (fp != null) {
                 val intr = project.fingerprintIntrinsics
                 val anchor = project.fingerprintAnchor
@@ -1729,10 +1776,15 @@ class ArViewModel @Inject constructor(
                         project.fingerprintViewMatrix.takeIf { it.size == 16 }?.toFloatArray()
                             ?: FloatArray(0),
                     )
+                    restoredFingerprint = fp
                     // The fingerprint just became available. If the artwork is already placed — which
                     // it is on every project load, and on every capture session by the time the
                     // save/load round trip finishes — partition it now rather than waiting for a
                     // footprint edge that has already been and gone.
+                    //
+                    // `lastPartitionedPose` is cleared because this is a DIFFERENT fingerprint from
+                    // whatever was partitioned before (the guard above returned early otherwise), so
+                    // the remembered pose describes a map that is no longer loaded.
                     lastPartitionedPose = null
                     partitionLiveFingerprintIfNeeded()
                 } else {

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -48,6 +48,7 @@ import com.hereliesaz.graffitixr.nativebridge.depth.StereoDepthProvider
 import com.hereliesaz.graffitixr.domain.repository.SettingsRepository
 import com.hereliesaz.graffitixr.data.ProjectManager
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -1525,19 +1526,23 @@ class ArViewModel @Inject constructor(
      * Lets a newer partition request cancel an in-flight older one.
      *
      * **It does not serialize them, and an earlier version of this comment claimed it did.**
-     * `cancel()` does not join, `Dispatchers.Default` is multi-threaded, and the body runs a pure
-     * classify loop and a blocking JNI call with no cancellation point between them — so a cancelled
-     * job can still finish its native push. What cancellation buys is that the newest design wins
-     * the *common* case, which matters because a drag moves the design every frame and each firing
-     * costs a repartition, a native replace and a project write.
+     * `cancel()` does not join and `Dispatchers.Default` is multi-threaded, so a cancelled job can
+     * still finish. There IS an `ensureActive()` between the classify pass and the native push, so
+     * the common cancellation lands there — but nothing checks between that call and
+     * `restoreWallFingerprintMetric`, so a cancel arriving in that window still completes its push.
+     * What cancellation buys is that the newest design wins the usual case, which matters because a
+     * drag fires every frame and each firing costs a repartition, a native replace and a write.
      *
      * The real protection against an out-of-order write is the idempotence check in the job body:
      * a partition that computes the same regions and extents makes no write at all.
      */
-    // @Volatile because this stopped being single-threaded: the GL thread reaches it through
-    // onDesignFootprintChanged and the IO dispatcher through partitionLiveFingerprintIfNeeded. A
-    // torn read-modify-write here drops a cancel and lets two partition jobs run into native at once.
-    @Volatile private var partitionJob: Job? = null
+    // AtomicReference, not @Volatile. This stopped being single-threaded when partition-on-arrival
+    // landed: the GL thread reaches it through onDesignFootprintChanged and the IO dispatcher
+    // through partitionLiveFingerprintIfNeeded. @Volatile gives visibility but NOT atomicity, so a
+    // plain `cancel(); assign` still interleaves into "both threads cancel the same job, one
+    // assignment is lost, and the orphan runs to completion alongside its replacement" — two jobs
+    // pushing into native at once, which is precisely what the swap exists to prevent.
+    private val partitionJob = java.util.concurrent.atomic.AtomicReference<Job?>(null)
 
     /**
      * The most recent design footprint the renderer published, or null before the artwork is placed.
@@ -1560,7 +1565,43 @@ class ArViewModel @Inject constructor(
      */
     @Volatile private var lastPartitionedPose: FloatArray? = null
 
-    /** Element-wise, with the same millimetre/milliradian threshold the renderer's edge uses. */
+    /**
+     * Raise or clear the "artwork leaves too little bare wall" warning, and toast on the rising edge.
+     *
+     * Extracted so the fresh-partition and already-up-to-date paths share one implementation: they
+     * diverged once, and the reload path — where a project reopens already in that state and the
+     * artist has no memory of being told — was the half that lost the message.
+     *
+     * Edge-triggered so a slow pinch through the threshold does not toast every frame. Saying it at
+     * all matters: a `uiState` boolean nothing reads is the same failure as an operator nothing
+     * calls, and its neighbour `legacyFingerprintRefused` shipped exactly that way, with a KDoc
+     * claiming it was "surfaced".
+     */
+    private fun publishBackboneWarning(backbone: Int) {
+        val tooSmall = backbone in 0 until FingerprintPartition.MIN_BACKBONE
+        val wasTooSmall = _uiState.value.backboneTooSmall
+        _uiState.update { it.copy(backboneTooSmall = tooSmall) }
+        if (tooSmall && !wasTooSmall) {
+            _feedback.tryEmit(
+                com.hereliesaz.graffitixr.common.model.FeedbackEvent.Toast(
+                    "The artwork covers nearly all the wall in view — only $backbone tracked " +
+                        "features sit outside it. Make it smaller or step back, or the target " +
+                        "may not lock.",
+                ),
+            )
+        }
+    }
+
+    /**
+     * Element-wise, at a millimetre.
+     *
+     * Note this DOES walk the anchor-relative model matrix, which carries `R_anchorᵀ` and is
+     * therefore drift-coupled — the very property that made the renderer's old trigger misfire. It
+     * is harmless only because it never sees an unpublished value: every footprint reaching here was
+     * one the renderer already decided to emit, so this compares a published pose against a copy of
+     * a published pose. If it ever gains a caller that feeds it live per-frame poses, it becomes the
+     * same bug.
+     */
     private fun poseDiffers(pose: FloatArray, previous: FloatArray?): Boolean {
         if (previous == null || previous.size != pose.size) return true
         for (i in pose.indices) if (kotlin.math.abs(pose[i] - previous[i]) > 1e-3f) return true
@@ -1615,8 +1656,9 @@ class ArViewModel @Inject constructor(
         if (!needsPartition) return
         // Cancel rather than skip: the newest design size is the correct one, and an older in-flight
         // partition can only write a size the artist has already left behind.
-        partitionJob?.cancel()
-        partitionJob = viewModelScope.launch(Dispatchers.Default) {
+        // LAZY so the job exists to be stored before it can run: started only after getAndSet has
+        // published it, so a job can never be cancelled by a successor that has not yet seen it.
+        val next = viewModelScope.launch(Dispatchers.Default, start = CoroutineStart.LAZY) {
             val current = liveFingerprint ?: return@launch
             val updated = FingerprintPartition.partition(current.fingerprint, design)
             // Identity, not equality: `partition` returns the RECEIVER when it refuses (no points, no
@@ -1640,6 +1682,11 @@ class ArViewModel @Inject constructor(
                 // Still record the pose: the partition is genuinely up to date for it, and not
                 // recording it would re-enter here on every subsequent frame of a drag.
                 lastPartitionedPose = design.rigidModelAnchorLocal.copyOf()
+                // ...and still raise the warning. Skipping it here lost the "artwork covers nearly
+                // all the wall" message on the RELOAD path — a project saved in that state reopened
+                // silently, which is the one case where the artist has no memory of being told.
+                // The partition is unchanged, not absent; its backbone count is just as real.
+                publishBackboneWarning(FingerprintPartition.backboneCount(updated))
                 return@launch
             }
             ensureActive()
@@ -1662,23 +1709,7 @@ class ArViewModel @Inject constructor(
             // to measure — so it is raised here, where the artwork's size is what made it true. A
             // warning rather than a refusal for the same reason: by this point the target exists and
             // the honest advice is "make the artwork smaller or step back", not "that never worked".
-            val tooSmall = backbone in 0 until FingerprintPartition.MIN_BACKBONE
-            val wasTooSmall = _uiState.value.backboneTooSmall
-            _uiState.update { it.copy(backboneTooSmall = tooSmall) }
-            // Say it, don't just record it. A `uiState` boolean that nothing reads is the same
-            // failure as an operator that nothing calls — and this codebase already had one of these
-            // sitting next to it (`legacyFingerprintRefused`, set with a KDoc claiming it was
-            // "surfaced", read by nothing). Emitted on the EDGE so a slow pinch through the
-            // threshold does not toast every frame.
-            if (tooSmall && !wasTooSmall) {
-                _feedback.tryEmit(
-                    com.hereliesaz.graffitixr.common.model.FeedbackEvent.Toast(
-                        "The artwork covers nearly all the wall in view — only $backbone tracked " +
-                            "features sit outside it. Make it smaller or step back, or the target " +
-                            "may not lock.",
-                    ),
-                )
-            }
+            publishBackboneWarning(backbone)
 
             // Persist so the next load starts from the size the artist settled on. Merged through
             // the repository transform rather than a full-object write, for the save-race reason
@@ -1689,6 +1720,8 @@ class ArViewModel @Inject constructor(
                 design.halfW, design.halfH, updated.points3d.size / 3, backbone,
             )
         }
+        partitionJob.getAndSet(next)?.cancel()
+        next.start()
     }
 
     /**
@@ -1815,6 +1848,17 @@ class ArViewModel @Inject constructor(
                 // aid and must not register anything beyond that flow.
                 slamManager.clearWallFingerprint()
                 slamManager.overlayMarkCenterLocal = null
+                // Native now holds nothing, so neither cache may keep claiming it does.
+                //
+                // `restoredFingerprint` left set means switching BACK to the project that owned it
+                // hits the suppression guard and never re-pushes — native empty, Kotlin believing
+                // otherwise, reloc silently dead for the rest of the process and looking exactly
+                // like bad tracking. `liveFingerprint` left set is worse: a design move would
+                // partition the PREVIOUS project's map and `updateProject` would write it into this
+                // project's file.
+                restoredFingerprint = null
+                liveFingerprint = null
+                lastPartitionedPose = null
             }
             // Restore the persistent wall feature map (Phase 2a: stored in native; matched in Phase 2b).
             // Independent of the marks fingerprint above and co-registered to the same anchor. Null on

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -950,6 +950,16 @@ class ArViewModel @Inject constructor(
         // Drop the marks-centering override so a later AR re-entry (or a different project) doesn't
         // center the overlay on a stale target's marks before a new one is built/restored.
         slamManager.overlayMarkCenterLocal = null
+        // Same argument, for the anchor. The ARCore session and its anchors do not survive this, so
+        // "an anchor has been established" must not either — otherwise the next capture's
+        // `awaitAnchorTransform` returns immediately with the previous session's pose, which is the
+        // identity-shaped bug it was written to prevent, wearing different numbers.
+        slamManager.clearAnchorEverSet()
+        // The partition's in-memory state belongs to the session that built it: the retained design
+        // footprint is expressed relative to an anchor that is about to stop existing.
+        latestDesignFootprint = null
+        lastPartitionedPose = null
+        liveFingerprint = null
         // Cancel any in-flight session update (including a running stereo probe) so it stops pumping
         // the camera and releases the session mutex before cleanup tries to acquire it.
         sessionUpdateJob?.cancel()

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -947,6 +947,16 @@ class ArViewModel @Inject constructor(
     fun exitArMode() {
         isInArMode = false
         isDestroying = true
+        // Stop the GL thread FIRST, before any of the state below is cleared.
+        //
+        // `onDrawFrame` returns immediately on this flag, and until it is set the renderer keeps
+        // running full frames — `anchorEstablished` is a one-way latch, so `placed` stays true right
+        // through teardown. `clearAnchorEstablished()` two lines down advances the anchor
+        // generation, which the move detector reads as a change, so the renderer would publish a
+        // footprint and `onDesignFootprintChanged` would write `latestDesignFootprint` straight back
+        // after the line below nulls it. The next session would then partition its fingerprint
+        // against the DEAD session's design pose. Ordering is the whole fix.
+        renderer?.isDestroying = true
         lastMappingPausedCmd = null
         // Drop the marks-centering override so a later AR re-entry (or a different project) doesn't
         // center the overlay on a stale target's marks before a new one is built/restored.
@@ -959,7 +969,7 @@ class ArViewModel @Inject constructor(
         // The partition's in-memory state belongs to the session that built it: the retained design
         // footprint is expressed relative to an anchor that is about to stop existing.
         latestDesignFootprint = null
-        dropLoadedFingerprintState()
+        dropPartitionState()
         // Cancel any in-flight session update (including a running stereo probe) so it stops pumping
         // the camera and releases the session mutex before cleanup tries to acquire it.
         sessionUpdateJob?.cancel()
@@ -1733,23 +1743,38 @@ class ArViewModel @Inject constructor(
     @Volatile private var restoredFingerprint: com.hereliesaz.graffitixr.common.model.Fingerprint? = null
 
     /**
-     * Forget everything that describes a fingerprint loaded into native.
+     * Forget the Kotlin-side state describing a partitionable fingerprint.
      *
-     * Every path that leaves native holding no usable map must call this, and there are three of
-     * them: no fingerprint at all, a pre-Phase-0 fingerprint that is refused, and session teardown.
-     * They were fixed one at a time and the refusal path was missed, which is why this is a function
-     * rather than three copies of the same three assignments.
+     * `liveFingerprint` left set is the dangerous one: a design move partitions the PREVIOUS
+     * project's map and `updateProject` writes it into the CURRENT project's file. `restoredFingerprint`
+     * left set arms the suppression guard, so switching back never re-pushes — native holding one
+     * thing, Kotlin believing another, reloc dead for the process and looking like bad tracking.
      *
-     * `restoredFingerprint` left set means switching BACK to the project that owned it hits the
-     * suppression guard and never re-pushes — native empty, Kotlin believing otherwise, reloc dead
-     * for the rest of the process and looking exactly like bad tracking. `liveFingerprint` left set
-     * is worse: a design move partitions the PREVIOUS project's map and `updateProject` writes it
-     * into the current project's file.
+     * Call this from any path that leaves no partitionable map loaded, *including* one that leaves a
+     * descriptors-only map in native. [dropLoadedFingerprint] is the stronger form for paths that
+     * must also empty native.
      */
-    private fun dropLoadedFingerprintState() {
+    private fun dropPartitionState() {
         restoredFingerprint = null
         liveFingerprint = null
         lastPartitionedPose = null
+    }
+
+    /**
+     * Leave nothing loaded, in native or in Kotlin: no fingerprint, no marks centre, no partition
+     * state.
+     *
+     * This exists because the alternative kept failing. The branches of `loadFingerprintIfExists`
+     * were fixed one at a time — no-fingerprint first, then the legacy refusal, and each time a
+     * sibling was missed. The refusal branch got the Kotlin half and not `clearWallFingerprint`, so
+     * a project whose target was refused went on relocalizing against the PREVIOUS project's wall
+     * and centring its overlay on the previous project's marks. Bundling the three operations means
+     * a future branch cannot get one and forget the others.
+     */
+    private fun dropLoadedFingerprint() {
+        slamManager.clearWallFingerprint()
+        slamManager.overlayMarkCenterLocal = null
+        dropPartitionState()
     }
 
     private fun loadFingerprintIfExists() {
@@ -1797,12 +1822,11 @@ class ArViewModel @Inject constructor(
                                 "geometry can't be corrected. Create the target again to use it.",
                         ),
                     )
-                    // Refusing is a no-map outcome, so it must drop the caches exactly as the
-                    // no-fingerprint branch below does. Leaving them meant a design move would
-                    // partition the PREVIOUS project's map and `updateProject` would write it into
-                    // THIS project's file — the same leak that branch was fixed for, sitting
-                    // untouched sixty lines above it.
-                    dropLoadedFingerprintState()
+                    // Refusing means this project has no usable map, so nothing may be left loaded
+                    // — in Kotlin OR in native. An earlier cut dropped only the Kotlin caches, so a
+                    // refused project kept relocalizing against the PREVIOUS project's wall and
+                    // centring its overlay on that project's marks.
+                    dropLoadedFingerprint()
                     return@launch
                 }
 
@@ -1853,6 +1877,13 @@ class ArViewModel @Inject constructor(
                         fp.descriptorsType,
                         fp.points3d.toFloatArray()
                     )
+                    // Native now holds THIS project's map, so it must not be cleared — but the map
+                    // carries no co-registration and cannot be partitioned, so every Kotlin cache
+                    // describing a partitionable fingerprint has to go. Missing this was the fourth
+                    // instance of the same leak: `liveFingerprint` kept describing the PREVIOUS
+                    // project while native held this one, and a design move wrote the previous
+                    // project's partitioned map into this project's file.
+                    dropPartitionState()
                 }
                 // Restore the distortion-head canonical patch so the head works after reload, not only
                 // in the capture session. 256x256 raw gray (= sqrt(len)); inert if absent/head unloaded.
@@ -1870,9 +1901,7 @@ class ArViewModel @Inject constructor(
                 // an un-fingerprinted project silently relocalizes against a previous target — most
                 // visibly the marks built during first-run onboarding, which are a throwaway teaching
                 // aid and must not register anything beyond that flow.
-                slamManager.clearWallFingerprint()
-                slamManager.overlayMarkCenterLocal = null
-                dropLoadedFingerprintState()
+                dropLoadedFingerprint()
             }
             // Restore the persistent wall feature map (Phase 2a: stored in native; matched in Phase 2b).
             // Independent of the marks fingerprint above and co-registered to the same anchor. Null on

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -970,6 +970,12 @@ class ArViewModel @Inject constructor(
         // footprint is expressed relative to an anchor that is about to stop existing.
         latestDesignFootprint = null
         dropPartitionState()
+        // The UI's copy of "an anchor exists" is a separate latch, set true in
+        // onPrimaryAnchorEstablished and — until this line — never set false anywhere in the
+        // repository. Left standing it made the NEXT session pause splat mapping on its first
+        // tracking frame (updateAutoMapping gates on it) and report scanPhase COMPLETE on a session
+        // that never scanned. Sixth field to be cleared in one place and not its sibling.
+        _uiState.update { it.copy(isAnchorEstablished = false, backboneTooSmall = false) }
         // Cancel any in-flight session update (including a running stereo probe) so it stops pumping
         // the camera and releases the session mutex before cleanup tries to acquire it.
         sessionUpdateJob?.cancel()
@@ -1649,6 +1655,11 @@ class ArViewModel @Inject constructor(
         // two independent events and neither reliably comes second, so whichever is later has to be
         // able to start the work. Holding only a callback made this a one-shot that the capture
         // session always lost.
+        // Refuse anything arriving after teardown began. The renderer re-checks its own
+        // `isDestroying` before calling, but the two flags are set on different threads and this is
+        // the assignment that matters: it is what teardown nulls two lines after clearing the
+        // anchor, and a late frame re-arming it is the sixth-audit defect in one line.
+        if (isDestroying) return
         latestDesignFootprint = design
         val live = liveFingerprint ?: return
         val fp = live.fingerprint
@@ -1666,6 +1677,11 @@ class ArViewModel @Inject constructor(
         // partition can only write a size the artist has already left behind.
         // LAZY so the job exists to be stored before it can run: started only after getAndSet has
         // published it, so a job can never be cancelled by a successor that has not yet seen it.
+        // Captured at launch, checked before every write. `updateProject` applies to whatever is
+        // current WHEN IT RUNS, not when it was queued, so a project switch during the partition
+        // (a classify pass plus a blocking native replace) would write this fingerprint into the
+        // wrong project's file and leave native holding the wrong map.
+        val forProjectId = loadedFingerprint?.projectId
         val next = viewModelScope.launch(Dispatchers.Default, start = CoroutineStart.LAZY) {
             val current = liveFingerprint ?: return@launch
             val updated = FingerprintPartition.partition(current.fingerprint, design)
@@ -1673,6 +1689,8 @@ class ArViewModel @Inject constructor(
             // captureAnchorCam, no usable extents), and re-pushing an unchanged fingerprint would
             // reset native's reloc state for nothing.
             if (updated === current.fingerprint) return@launch
+            // The project may have changed while this ran; everything below writes.
+            if (loadedFingerprint?.projectId != forProjectId) return@launch
             // Idempotence, and it is load-bearing rather than an optimisation.
             //
             // `partition` returns a fresh copy whenever it CAN partition, so the identity check above
@@ -1710,8 +1728,8 @@ class ArViewModel @Inject constructor(
             liveFingerprint = LiveFingerprint(updated, current.anchor, current.intrinsics, current.view)
             lastPartitionedPose = design.rigidModelAnchorLocal.copyOf()
             // Native now holds exactly this, so the reload our own updateProject is about to trigger
-            // must not push it again.
-            restoredFingerprint = updated
+            // must recognise it and not push it again.
+            forProjectId?.let { loadedFingerprint = LoadedFingerprint(it, updated) }
 
             // IMPLEMENTATION.md 2.8, relocated. The capture cannot raise this — it has no footprint
             // to measure — so it is raised here, where the artwork's size is what made it true. A
@@ -1732,30 +1750,18 @@ class ArViewModel @Inject constructor(
         next.start()
     }
 
-    /**
-     * The fingerprint currently pushed to native, for suppressing redundant restores.
-     *
-     * `loadFingerprintIfExists` runs on EVERY `currentProject` emission, and the partition itself
-     * writes the project — so a partition triggers a reload, which would re-push the identical
-     * fingerprint and reset native's reloc state for nothing. Any other writer of `currentProject`
-     * (`saveWallFeatureMap`, for one) dragged the same cost behind it.
-     */
-    @Volatile private var restoredFingerprint: com.hereliesaz.graffitixr.common.model.Fingerprint? = null
 
     /**
      * Forget the Kotlin-side state describing a partitionable fingerprint.
      *
      * `liveFingerprint` left set is the dangerous one: a design move partitions the PREVIOUS
-     * project's map and `updateProject` writes it into the CURRENT project's file. `restoredFingerprint`
-     * left set arms the suppression guard, so switching back never re-pushes — native holding one
-     * thing, Kotlin believing another, reloc dead for the process and looking like bad tracking.
+     * project's map and `updateProject` writes it into the CURRENT project's file.
      *
      * Call this from any path that leaves no partitionable map loaded, *including* one that leaves a
      * descriptors-only map in native. [dropLoadedFingerprint] is the stronger form for paths that
      * must also empty native.
      */
     private fun dropPartitionState() {
-        restoredFingerprint = null
         liveFingerprint = null
         lastPartitionedPose = null
     }
@@ -1777,135 +1783,161 @@ class ArViewModel @Inject constructor(
         dropPartitionState()
     }
 
+    /**
+     * What is currently loaded into native, and which project it belongs to.
+     *
+     * The project id is the part that matters. Six consecutive audits found the same defect —
+     * state belonging to project A surviving into project B — each in a different branch, each
+     * found immediately after the previous one was patched. Naming the clearing operations was not
+     * enough, because the bug is not "a branch forgot to clear"; it is that nothing tied the loaded
+     * state to the project it described, so every new branch was a fresh chance to forget.
+     *
+     * With the pair stored together, a project switch is a value change rather than a sequence of
+     * assignments somebody has to remember, and the partition job can refuse to write a fingerprint
+     * into a project it was not computed for.
+     */
+    private data class LoadedFingerprint(
+        val projectId: String,
+        val fingerprint: com.hereliesaz.graffitixr.common.model.Fingerprint?,
+    )
+
+    @Volatile private var loadedFingerprint: LoadedFingerprint? = null
+
+    /**
+     * Restore (or clear) the wall fingerprint for the current project.
+     *
+     * **Single exit, and every state write in one place.** There are no early returns past the
+     * idempotence check: the branches decide an OUTCOME and the tail applies it. That shape is the
+     * actual fix for this function's history — the wall-feature-map block below used to be skipped
+     * by the refusal branch's `return`, so a refused project kept the previous project's map in
+     * native and then SAVED it into the refused project's file on teardown. Two branches, one
+     * `return`, and the sixth instance of the same family.
+     */
     private fun loadFingerprintIfExists() {
         viewModelScope.launch(Dispatchers.IO) {
             val project = projectRepository.currentProject.value ?: return@launch
             val fp = project.fingerprint
-            // Value equality, and it is exactly the right comparison: two fingerprints that agree on
-            // points, descriptors, frame and partition ARE the same map, whichever object holds them.
-            if (fp != null && fp == restoredFingerprint) {
-                // Still let the partition re-evaluate — the design may have moved while this
-                // emission was in flight — but do not touch native.
+            val incoming = LoadedFingerprint(project.id, fp)
+            val current = loadedFingerprint
+
+            // Nothing about the map changed: re-evaluate the partition (the design may have moved
+            // while this emission was in flight) and touch native not at all. This guard is what
+            // keeps `loadFingerprintIfExists` — which runs on EVERY currentProject emission,
+            // including the ones the partition itself causes — from re-pushing and, on the refusal
+            // path, from re-wiping native's artwork registration every time a layer is saved.
+            if (current == incoming) {
                 partitionLiveFingerprintIfNeeded()
                 return@launch
             }
-            if (fp != null) {
-                val intr = project.fingerprintIntrinsics
-                val anchor = project.fingerprintAnchor
+            // A different project — and `current != null` is load-bearing, not defensive. On the
+            // FIRST load of a session there is no previous project, and the footprint present is the
+            // one the renderer just published for the artwork now on screen; nulling it there wipes
+            // exactly the value the partition is about to need. (Caught by
+            // `ArViewModelTest.loading an unpartitioned fingerprint partitions it and writes exactly
+            // once`, which is why that test exists.)
+            if (current != null && current.projectId != project.id) latestDesignFootprint = null
 
-                // IMPLEMENTATION.md 0.7 — refuse a pre-Phase-0 metric fingerprint instead of
-                // relocalizing against it.
-                //
-                // Its 3D points were back-projected with display-rotated pixels and intrinsics but a
-                // SENSOR-frame view (PAPER.md §8), so they are skewed by an angle that was never
-                // recorded and cannot be recovered from the file. Restoring it would put the app in
-                // the exact state Phase 0 exists to end, silently, on a wall the artist has already
-                // painted — and the failure would look like poor tracking rather than stale data.
-                //
-                // The check keys on the PROJECT field, not the Fingerprint's, because a project
-                // saved before 0.11 has no rotation on either. Descriptors-only fingerprints are
-                // untouched: with no 3D points there is no frame to be wrong about, which is what
-                // `isLegacyFrame()` encodes.
-                val legacyFrame = fp.isLegacyFrame() && project.fingerprintCaptureRotationDeg < 0
-                if (legacyFrame && intr.size >= 4 && anchor.size == 16) {
-                    Timber.w(
-                        "Refusing a pre-Phase-0 wall fingerprint: its 3D points are in the sensor " +
-                            "frame and the capture rotation was never recorded. Re-capture the target.",
-                    )
-                    _uiState.update { it.copy(legacyFingerprintRefused = true) }
-                    // Same argument as backboneTooSmall above: the flag's own KDoc says it is
-                    // "surfaced so the artist is told to re-capture", and until now nothing read it,
-                    // so the target silently never locked and looked like bad tracking.
-                    _feedback.tryEmit(
-                        com.hereliesaz.graffitixr.common.model.FeedbackEvent.Toast(
-                            "This project's saved target was made by an older version and its 3D " +
-                                "geometry can't be corrected. Create the target again to use it.",
-                        ),
-                    )
-                    // Refusing means this project has no usable map, so nothing may be left loaded
-                    // — in Kotlin OR in native. An earlier cut dropped only the Kotlin caches, so a
-                    // refused project kept relocalizing against the PREVIOUS project's wall and
-                    // centring its overlay on that project's marks.
+            val intr = project.fingerprintIntrinsics
+            val anchor = project.fingerprintAnchor
+            // IMPLEMENTATION.md 0.7 — refuse a pre-Phase-0 metric fingerprint instead of
+            // relocalizing against it.
+            //
+            // Its 3D points were back-projected with display-rotated pixels and intrinsics but a
+            // SENSOR-frame view (PAPER.md §8), so they are skewed by an angle that was never
+            // recorded and cannot be recovered from the file. Restoring it would put the app in the
+            // exact state Phase 0 exists to end, silently, on a wall the artist has already painted
+            // — and the failure would look like poor tracking rather than stale data.
+            //
+            // Keys on the PROJECT field, not the Fingerprint's, because a project saved before 0.11
+            // has no rotation on either. Descriptors-only fingerprints are untouched: with no 3D
+            // points there is no frame to be wrong about, which is what `isLegacyFrame()` encodes.
+            val hasCoRegistration = intr.size >= 4 && anchor.size == 16
+            val legacyFrame = fp != null && fp.isLegacyFrame() &&
+                project.fingerprintCaptureRotationDeg < 0 && hasCoRegistration
+
+            when {
+                fp == null || legacyFrame -> {
+                    if (legacyFrame) {
+                        Timber.w(
+                            "Refusing a pre-Phase-0 wall fingerprint: its 3D points are in the " +
+                                "sensor frame and the capture rotation was never recorded.",
+                        )
+                        _uiState.update { it.copy(legacyFingerprintRefused = true) }
+                        // Surfaced, not merely recorded: the flag's own KDoc said it was, and until
+                        // recently nothing read it, so the target silently never locked and looked
+                        // like bad tracking.
+                        _feedback.tryEmit(
+                            com.hereliesaz.graffitixr.common.model.FeedbackEvent.Toast(
+                                "This project's saved target was made by an older version and its " +
+                                    "3D geometry can't be corrected. Create the target again to use it.",
+                            ),
+                        )
+                    }
+                    // Nothing usable for this project, so nothing may be left loaded — in Kotlin or
+                    // in native. Reached once per project change, not once per emission, which is
+                    // what the idempotence guard above buys: `clearWallFingerprint` also drops the
+                    // artwork descriptors and painting progress, and running it on every emission
+                    // would wipe the registration `updatePaintingGuide` established for the project
+                    // currently open.
                     dropLoadedFingerprint()
-                    return@launch
                 }
 
-                if (intr.size >= 4 && anchor.size == 16) {
+                hasCoRegistration -> {
                     // Metric fingerprint: replay the true capture intrinsics + anchor so PnP reloc
                     // matches the live capture instead of using a default-intrinsics guess.
+                    val view = project.fingerprintViewMatrix
+                        .takeIf { it.size == 16 }?.toFloatArray() ?: FloatArray(0)
                     slamManager.restoreWallFingerprintMetric(
-                        fp.descriptorsData,
-                        fp.descriptorsRows,
-                        fp.descriptorsCols,
-                        fp.descriptorsType,
-                        fp.points3d.toFloatArray(),
-                        anchor.toFloatArray(),
-                        intr.toFloatArray(),
+                        fp.descriptorsData, fp.descriptorsRows, fp.descriptorsCols,
+                        fp.descriptorsType, fp.points3d.toFloatArray(),
+                        anchor.toFloatArray(), intr.toFloatArray(),
                         // Empty on projects saved before the capture view was persisted; native then
                         // skips the rectification pass rather than warping to a stale frontal frame.
-                        viewMatrix = project.fingerprintViewMatrix
-                            .takeIf { it.size == 16 }?.toFloatArray() ?: FloatArray(0),
+                        viewMatrix = view,
                         // IMPLEMENTATION.md 2.6 — the partition travels with the points it indexes.
                         // Empty on a pre-Phase-2 project, which native reads as all-backbone, so the
                         // reload relocalizes exactly as it did before the phase landed.
                         regions = fp.regions,
                     )
-                    // Retained for the repartition-on-resize path (2.2). Stored with exactly the
-                    // values just pushed, so a later re-push cannot drift from what native holds.
-                    liveFingerprint = LiveFingerprint(
-                        fp, anchor.toFloatArray(), intr.toFloatArray(),
-                        project.fingerprintViewMatrix.takeIf { it.size == 16 }?.toFloatArray()
-                            ?: FloatArray(0),
-                    )
-                    restoredFingerprint = fp
-                    // The fingerprint just became available. If the artwork is already placed — which
-                    // it is on every project load, and on every capture session by the time the
-                    // save/load round trip finishes — partition it now rather than waiting for a
-                    // footprint edge that has already been and gone.
-                    //
-                    // `lastPartitionedPose` is cleared because this is a DIFFERENT fingerprint from
-                    // whatever was partitioned before (the guard above returned early otherwise), so
-                    // the remembered pose describes a map that is no longer loaded.
+                    // Retained for the repartition path (2.2), with exactly the values just pushed
+                    // so a later re-push cannot drift from what native holds.
+                    liveFingerprint = LiveFingerprint(fp, anchor.toFloatArray(), intr.toFloatArray(), view)
+                    // A different fingerprint from whatever was partitioned before, so the
+                    // remembered pose describes a map that is no longer loaded.
                     lastPartitionedPose = null
-                    partitionLiveFingerprintIfNeeded()
-                } else {
+                }
+
+                else -> {
                     // Depth-path or pre-existing project: descriptors-only legacy restore.
                     slamManager.restoreWallFingerprint(
-                        fp.descriptorsData,
-                        fp.descriptorsRows,
-                        fp.descriptorsCols,
-                        fp.descriptorsType,
-                        fp.points3d.toFloatArray()
+                        fp.descriptorsData, fp.descriptorsRows, fp.descriptorsCols,
+                        fp.descriptorsType, fp.points3d.toFloatArray(),
                     )
-                    // Native now holds THIS project's map, so it must not be cleared — but the map
-                    // carries no co-registration and cannot be partitioned, so every Kotlin cache
-                    // describing a partitionable fingerprint has to go. Missing this was the fourth
-                    // instance of the same leak: `liveFingerprint` kept describing the PREVIOUS
-                    // project while native held this one, and a design move wrote the previous
-                    // project's partitioned map into this project's file.
+                    // Native holds THIS project's map, so it must not be cleared — but the map has
+                    // no co-registration and cannot be partitioned, so every cache describing a
+                    // partitionable fingerprint has to go.
                     dropPartitionState()
                 }
-                // Restore the distortion-head canonical patch so the head works after reload, not only
-                // in the capture session. 256x256 raw gray (= sqrt(len)); inert if absent/head unloaded.
+            }
+
+            if (fp != null && !legacyFrame) {
+                // Restore the distortion-head canonical patch so the head works after reload, not
+                // only in the capture session. 256x256 raw gray (= sqrt(len)); inert if absent.
                 if (fp.patchData.isNotEmpty()) {
-                    val s = kotlin.math.sqrt(fp.patchData.size.toDouble()).toInt()
-                    if (s * s == fp.patchData.size) slamManager.setWallPatchBytes(fp.patchData, s)
+                    val side = kotlin.math.sqrt(fp.patchData.size.toDouble()).toInt()
+                    if (side * side == fp.patchData.size) slamManager.setWallPatchBytes(fp.patchData, side)
                 }
-                // Re-publish the marks centroid (anchor-local) so the overlay re-centers on the marks
-                // after reload, even though the builder doesn't run on a restored fingerprint.
+                // Re-publish the marks centroid (anchor-local) so the overlay re-centers on the
+                // marks after reload, even though the builder doesn't run on a restored fingerprint.
                 slamManager.overlayMarkCenterLocal =
                     if (fp.markCenterLocal.size >= 3) fp.markCenterLocal.toFloatArray() else null
-            } else {
-                // No fingerprint on this project: drop whatever is left in native from earlier in the
-                // session. The restore calls only ever REPLACE the stored fingerprint, so without this
-                // an un-fingerprinted project silently relocalizes against a previous target — most
-                // visibly the marks built during first-run onboarding, which are a throwaway teaching
-                // aid and must not register anything beyond that flow.
-                dropLoadedFingerprint()
             }
-            // Restore the persistent wall feature map (Phase 2a: stored in native; matched in Phase 2b).
-            // Independent of the marks fingerprint above and co-registered to the same anchor. Null on
-            // every current project until the passive builder (Phase 3) starts producing one.
+
+            loadedFingerprint = incoming
+            // Only after the state above is consistent, because this can launch a partition that
+            // reads it.
+            if (fp != null && !legacyFrame && hasCoRegistration) partitionLiveFingerprintIfNeeded()
+
             val map = project.wallFeatureMap
             if (map != null && map.pointCount > 0) {
                 slamManager.restoreWallFeatureMap(map)
@@ -2494,6 +2526,7 @@ class ArViewModel @Inject constructor(
         // snapshot is already the NEW generation, the wait can never be satisfied, and a capture
         // that succeeded is discarded with "couldn't lock an anchor".
         slamManager.captureAnchorGenerationBaseline = slamManager.anchorGeneration.value
+        slamManager.captureSessionEpochBaseline = slamManager.sessionEpochValue
         renderer?.pendingAnchorEstablishment = true
     }
 

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -1523,6 +1523,46 @@ class ArViewModel @Inject constructor(
     private var partitionJob: Job? = null
 
     /**
+     * The most recent design footprint the renderer published, or null before the artwork is placed.
+     *
+     * Kept because the two events that make a partition possible — the artwork being placed, and the
+     * fingerprint becoming live — race, and the losing order was the common one. In a capture
+     * session the fingerprint arrives only after detection, `saveProject` and `loadProject`, long
+     * after the single footprint edge that follows confirmation; with only the callback, that
+     * session's fingerprint was never partitioned at all.
+     */
+    @Volatile private var latestDesignFootprint: FingerprintPartition.DesignFootprint? = null
+
+    /**
+     * The design pose the live partition was last computed against, or null when none has been.
+     *
+     * In memory rather than on the `Fingerprint`: the stored `captureHalfW`/`captureHalfH` already
+     * answer "was this partitioned against a different SIZE", and adding a persisted pose would mean
+     * a fourth parallel field to keep consistent for a question that only matters within a session.
+     * Null after a reload forces exactly one partition, which is what should happen there regardless.
+     */
+    @Volatile private var lastPartitionedPose: FloatArray? = null
+
+    /** Element-wise, with the same millimetre/milliradian threshold the renderer's edge uses. */
+    private fun poseDiffers(pose: FloatArray, previous: FloatArray?): Boolean {
+        if (previous == null || previous.size != pose.size) return true
+        for (i in pose.indices) if (kotlin.math.abs(pose[i] - previous[i]) > 1e-3f) return true
+        return false
+    }
+
+    /**
+     * Partition the live fingerprint against the last known design footprint, if both exist and the
+     * partition is missing or stale.
+     *
+     * The pull half of the pair above: called when the FINGERPRINT arrives, where
+     * [onDesignFootprintChanged] is called when the FOOTPRINT moves.
+     */
+    private fun partitionLiveFingerprintIfNeeded() {
+        val design = latestDesignFootprint ?: return
+        onDesignFootprintChanged(design)
+    }
+
+    /**
      * The artwork was placed or resized: (re)partition the live fingerprint against where it now
      * sits (`IMPLEMENTATION.md` 2.2/2.4).
      *
@@ -1538,9 +1578,24 @@ class ArViewModel @Inject constructor(
      * Called from the GL thread; all work is dispatched off it.
      */
     fun onDesignFootprintChanged(design: FingerprintPartition.DesignFootprint) {
+        // Retained so the partition can also be driven the OTHER way round — see
+        // [partitionLiveFingerprintIfNeeded]. The footprint edge and the fingerprint's arrival are
+        // two independent events and neither reliably comes second, so whichever is later has to be
+        // able to start the work. Holding only a callback made this a one-shot that the capture
+        // session always lost.
+        latestDesignFootprint = design
         val live = liveFingerprint ?: return
         val fp = live.fingerprint
-        if (!fp.isUnpartitioned() && !fp.isPartitionStale(design.halfW, design.halfH)) return
+        // Three ways this is worth doing, and the third is the one a size-only check misses.
+        // `Fingerprint.isPartitionStale` compares extents, because extents are what it stores — so
+        // a design the artist DRAGGED across the wall is not "stale" by that measure while being
+        // completely wrong by Φ's. The pose it was last partitioned against is therefore tracked
+        // here, in memory, rather than persisted: after a reload `lastPartitionedPose` is null,
+        // which forces one partition, and that is the correct answer anyway.
+        val needsPartition = fp.isUnpartitioned() ||
+            fp.isPartitionStale(design.halfW, design.halfH) ||
+            poseDiffers(design.rigidModelAnchorLocal, lastPartitionedPose)
+        if (!needsPartition) return
         // Cancel rather than skip: the newest design size is the correct one, and an older in-flight
         // partition can only write a size the artist has already left behind.
         partitionJob?.cancel()
@@ -1562,6 +1617,7 @@ class ArViewModel @Inject constructor(
                 regions = updated.regions,
             )
             liveFingerprint = LiveFingerprint(updated, current.anchor, current.intrinsics, current.view)
+            lastPartitionedPose = design.rigidModelAnchorLocal.copyOf()
 
             // IMPLEMENTATION.md 2.8, relocated. The capture cannot raise this — it has no footprint
             // to measure — so it is raised here, where the artwork's size is what made it true. A
@@ -1663,6 +1719,12 @@ class ArViewModel @Inject constructor(
                         project.fingerprintViewMatrix.takeIf { it.size == 16 }?.toFloatArray()
                             ?: FloatArray(0),
                     )
+                    // The fingerprint just became available. If the artwork is already placed — which
+                    // it is on every project load, and on every capture session by the time the
+                    // save/load round trip finishes — partition it now rather than waiting for a
+                    // footprint edge that has already been and gone.
+                    lastPartitionedPose = null
+                    partitionLiveFingerprintIfNeeded()
                 } else {
                     // Depth-path or pre-existing project: descriptors-only legacy restore.
                     slamManager.restoreWallFingerprint(

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/DesignMoveDetector.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/DesignMoveDetector.kt
@@ -1,0 +1,80 @@
+package com.hereliesaz.graffitixr.feature.ar.anchor
+
+import kotlin.math.abs
+
+/**
+ * Decides when the artist has moved or resized the artwork enough to be worth repartitioning the
+ * fingerprint (`IMPLEMENTATION.md` 2.2).
+ *
+ * Extracted from `ArRenderer` for one reason: this logic has now been wrong twice, in two different
+ * ways, and both times it was unreachable from a test because it lived inside a `GLSurfaceView`
+ * frame callback. Here it is ordinary Kotlin with no Android dependency, so the two failures below
+ * are pinned by `DesignMoveDetectorTest` rather than by a comment asking the reader to be careful.
+ *
+ * ## The two failures
+ *
+ * **It compares against the last PUBLISH, not the last frame.** Advancing the remembered values on a
+ * frame that reported no movement makes a slow drag invisible: 15 cm over three seconds is 0.08 mm
+ * per frame at 60 fps, under any sane threshold on every single frame, so the delta never
+ * accumulates and the design ends up 15 cm from the footprint Φ was computed against. Fast drags
+ * fired and the careful final placement did not — the worst possible split, since the last thing an
+ * artist does before painting is nudge the design into position.
+ *
+ * **Its inputs must be drift-immune.** The obvious candidates are not. The composed model matrix
+ * carries `R_anchorᵀ`, and so does the marks-centering offset (`X_world · (R_anchor · markLocal)`);
+ * `anchorMatrix` is the *fused* pose, re-blended on every reloc snap, so a threshold on either fires
+ * with the phone sitting still. Only quantities set from gestures qualify — pan, spin, and the
+ * overlay extents. Two successive attempts at this shipped a drift-coupled input.
+ */
+class DesignMoveDetector(
+    private val panEpsM: Float = DEFAULT_PAN_EPS_M,
+    private val rotEpsDeg: Float = DEFAULT_ROT_EPS_DEG,
+    private val extentEpsM: Float = DEFAULT_EXTENT_EPS_M,
+) {
+    // NaN until the first publish, so the first call always reports movement — which is correct:
+    // there is no previously-published footprint for the partition to already match.
+    private var panX = Float.NaN
+    private var panY = Float.NaN
+    private var rotDeg = Float.NaN
+    private var halfW = Float.NaN
+    private var halfH = Float.NaN
+
+    /**
+     * True when [panX]/[panY] (metres), [rotDeg] (degrees) or the effective half-extents (metres)
+     * have moved past their thresholds **since the last call that returned true**.
+     *
+     * Records the new values only when it returns true. That asymmetry is the whole point: see the
+     * class docs for what recording unconditionally does to a slow drag.
+     */
+    fun moved(panX: Float, panY: Float, rotDeg: Float, halfW: Float, halfH: Float): Boolean {
+        val moved = !(abs(panX - this.panX) <= panEpsM &&
+            abs(panY - this.panY) <= panEpsM &&
+            abs(rotDeg - this.rotDeg) <= rotEpsDeg &&
+            abs(halfW - this.halfW) <= extentEpsM &&
+            abs(halfH - this.halfH) <= extentEpsM)
+        if (moved) {
+            this.panX = panX; this.panY = panY; this.rotDeg = rotDeg
+            this.halfW = halfW; this.halfH = halfH
+        }
+        return moved
+    }
+
+    /** Forget the last publish, so the next call reports movement. For session teardown. */
+    fun reset() {
+        panX = Float.NaN; panY = Float.NaN; rotDeg = Float.NaN
+        halfW = Float.NaN; halfH = Float.NaN
+    }
+
+    companion object {
+        /**
+         * A millimetre of pan or extent, and a tenth of a degree of spin. Below these a "change" is
+         * float noise in the compose chain, and firing on it repartitions the fingerprint, replaces
+         * the native map and rewrites the project file every frame the artist rests a finger on the
+         * screen. Guesses with stated reasoning, recorded in `PARAMETERS.md` §6; no experiment sets
+         * them, so if repartition cost or missed repartitions ever show up in a run, start here.
+         */
+        const val DEFAULT_PAN_EPS_M = 1e-3f
+        const val DEFAULT_ROT_EPS_DEG = 0.1f
+        const val DEFAULT_EXTENT_EPS_M = 1e-3f
+    }
+}

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/DesignMoveDetector.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/DesignMoveDetector.kt
@@ -34,8 +34,10 @@ import kotlin.math.abs
  * **And it must react to the anchor being REPLACED.** Removing the marks offset removed the only
  * input that moved when a re-capture established a new anchor — so the trigger went quiet on
  * exactly the path that most needs it, and the new fingerprint got partitioned against the previous
- * anchor's design pose. [anchorGeneration] restores that as a discrete counter: it changes once per
- * establishment and never otherwise, so it carries the signal with none of the drift.
+ * anchor's design pose. [anchorGeneration] restores that as a discrete counter, carrying the signal
+ * with none of the drift. Note it also advances on session TEARDOWN, not only on establishment — so
+ * the renderer must be stopped before teardown clears the partition state, or this fires on the way
+ * down and republishes a footprint belonging to the session being destroyed.
  */
 class DesignMoveDetector(
     private val panEpsM: Float = DEFAULT_PAN_EPS_M,

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/DesignMoveDetector.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/DesignMoveDetector.kt
@@ -14,8 +14,8 @@ import kotlin.math.abs
  * ## The two failures
  *
  * **It compares against the last PUBLISH, not the last frame.** Advancing the remembered values on a
- * frame that reported no movement makes a slow drag invisible: 15 cm over three seconds is 0.08 mm
- * per frame at 60 fps, under any sane threshold on every single frame, so the delta never
+ * frame that reported no movement makes a slow drag invisible: 15 cm over three seconds is 0.83 mm
+ * per frame at 60 fps, under the 1 mm threshold on every single frame, so the delta never
  * accumulates and the design ends up 15 cm from the footprint Φ was computed against. Fast drags
  * fired and the careful final placement did not — the worst possible split, since the last thing an
  * artist does before painting is nudge the design into position.
@@ -23,8 +23,19 @@ import kotlin.math.abs
  * **Its inputs must be drift-immune.** The obvious candidates are not. The composed model matrix
  * carries `R_anchorᵀ`, and so does the marks-centering offset (`X_world · (R_anchor · markLocal)`);
  * `anchorMatrix` is the *fused* pose, re-blended on every reloc snap, so a threshold on either fires
- * with the phone sitting still. Only quantities set from gestures qualify — pan, spin, and the
- * overlay extents. Two successive attempts at this shipped a drift-coupled input.
+ * with the phone sitting still. Two successive attempts at this shipped a drift-coupled input.
+ *
+ * Pan and spin are set from gestures. The extents are `extentHalfW * overlayScale`, of which only
+ * the scale is a gesture — `extentHalfW` comes from a screen fit — but the fit is one-shot per
+ * arming rather than per frame, so it is a step function, not a drift signal. That is the actual
+ * reason it is safe, and it is worth stating precisely in a class whose whole history is a
+ * drift-immunity argument being wrong.
+ *
+ * **And it must react to the anchor being REPLACED.** Removing the marks offset removed the only
+ * input that moved when a re-capture established a new anchor — so the trigger went quiet on
+ * exactly the path that most needs it, and the new fingerprint got partitioned against the previous
+ * anchor's design pose. [anchorGeneration] restores that as a discrete counter: it changes once per
+ * establishment and never otherwise, so it carries the signal with none of the drift.
  */
 class DesignMoveDetector(
     private val panEpsM: Float = DEFAULT_PAN_EPS_M,
@@ -38,31 +49,46 @@ class DesignMoveDetector(
     private var rotDeg = Float.NaN
     private var halfW = Float.NaN
     private var halfH = Float.NaN
+    // -1 rather than 0: 0 is a real generation (no anchor established yet), so it cannot double as
+    // "nothing published". Same argument as every other sentinel in this codebase.
+    private var anchorGeneration = -1
 
     /**
      * True when [panX]/[panY] (metres), [rotDeg] (degrees) or the effective half-extents (metres)
-     * have moved past their thresholds **since the last call that returned true**.
+     * have moved past their thresholds **since the last call that returned true**, or when
+     * [anchorGeneration] differs at all — an anchor replacement changes the design's anchor-relative
+     * pose outright, so there is no threshold to apply.
      *
      * Records the new values only when it returns true. That asymmetry is the whole point: see the
      * class docs for what recording unconditionally does to a slow drag.
      */
-    fun moved(panX: Float, panY: Float, rotDeg: Float, halfW: Float, halfH: Float): Boolean {
-        val moved = !(abs(panX - this.panX) <= panEpsM &&
-            abs(panY - this.panY) <= panEpsM &&
-            abs(rotDeg - this.rotDeg) <= rotEpsDeg &&
-            abs(halfW - this.halfW) <= extentEpsM &&
-            abs(halfH - this.halfH) <= extentEpsM)
+    fun moved(
+        panX: Float,
+        panY: Float,
+        rotDeg: Float,
+        halfW: Float,
+        halfH: Float,
+        anchorGeneration: Int,
+    ): Boolean {
+        val moved = anchorGeneration != this.anchorGeneration ||
+            !(abs(panX - this.panX) <= panEpsM &&
+                abs(panY - this.panY) <= panEpsM &&
+                abs(rotDeg - this.rotDeg) <= rotEpsDeg &&
+                abs(halfW - this.halfW) <= extentEpsM &&
+                abs(halfH - this.halfH) <= extentEpsM)
         if (moved) {
             this.panX = panX; this.panY = panY; this.rotDeg = rotDeg
             this.halfW = halfW; this.halfH = halfH
+            this.anchorGeneration = anchorGeneration
         }
         return moved
     }
 
-    /** Forget the last publish, so the next call reports movement. For session teardown. */
+    /** Forget the last publish, so the next call reports movement. */
     fun reset() {
         panX = Float.NaN; panY = Float.NaN; rotDeg = Float.NaN
         halfW = Float.NaN; halfH = Float.NaN
+        anchorGeneration = -1
     }
 
     companion object {

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -1970,19 +1970,16 @@ class ArRenderer(
             // the design's size would make Φ swallow every feature in view and report zero backbone
             // — "the artwork covers the whole wall" on a design the artist has only just opened.
             val placed = anchorEstablished && overlayRenderer.hasTexture && quadInitialFitApplied
-            // Size OR pose. Φ asks where a feature sits relative to the artwork, and panning or
-            // spinning the design changes that answer exactly as much as resizing it does — the
-            // artist drags the artwork across the wall far more often than they pinch it. Watching
-            // the extents alone left every one of those moves silently unpartitioned, against a
-            // footprint the artwork had left.
-            // Size AND placement, in one detector. Φ asks where a feature sits relative to the
-            // artwork, and dragging or spinning the design changes that answer as much as resizing
-            // does — artists drag far more often than they pinch.
-            // Forget the last publish whenever the design is not placed, so the first placed frame
-            // afterwards always republishes rather than comparing against a footprint from before
-            // the gap. Note this is a weak guard on its own: `anchorEstablished` is a one-way latch,
-            // so `placed` does not drop on a re-capture — the anchor generation below is what
-            // carries that case.
+            // Size, placement, and which anchor the placement is relative to — one detector.
+            //
+            // Φ asks where a feature sits relative to the artwork, so dragging or spinning it
+            // changes the answer as much as resizing does, and artists drag far more often than they
+            // pinch. The anchor generation is in there because a re-capture REPLACES the anchor the
+            // design pose is expressed against, and nothing else in the list moves on that path.
+            //
+            // The reset is a weak guard on its own — `anchorEstablished` is a one-way latch, so
+            // `placed` does not drop on a re-capture — but it keeps the remembered values from
+            // surviving a gap where the design was not placed at all.
             if (!placed) designMoveDetector.reset()
             val designMoved = placed && designMoveDetector.moved(
                 overlayPanX, overlayPanY, overlayRotationDeg, newHalfW, newHalfH,

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -452,10 +452,9 @@ class ArRenderer(
     // together, so a future reader from another thread inherits the guarantee rather than having to
     // rediscover the need for it; uncontended, it costs nothing.
 
-    // A millimetre of extent or pan, and a tenth of a degree of spin. Below these a "change" is
-    // float noise in the compose chain, and firing on it would repartition the fingerprint and
-    // rewrite the project file every frame the artist rests a finger on the screen. Recorded in
-    // `PARAMETERS.md` §6.
+    // Guards the design pose while it is composed and copied out. GL-thread-only on both sides now
+    // that the capture-path reader is gone, so it states an invariant more than it contends: the
+    // pose and the extents handed to onDesignFootprintChanged must come from the same frame.
     private val designFootprintLock = Any()
     private val designRigidModel = FloatArray(16)
     private val designAnchorInvScratch = FloatArray(16)
@@ -466,8 +465,6 @@ class ArRenderer(
     private val designMoveDetector =
         com.hereliesaz.graffitixr.feature.ar.anchor.DesignMoveDetector()
 
-    private var designEffectiveHalfW = -1f
-    private var designEffectiveHalfH = -1f
     private var designPlaced = false
 
     // Scratch for the 2D perspective content rotation matrix (X/Y axes).
@@ -1981,8 +1978,15 @@ class ArRenderer(
             // Size AND placement, in one detector. Φ asks where a feature sits relative to the
             // artwork, and dragging or spinning the design changes that answer as much as resizing
             // does — artists drag far more often than they pinch.
+            // Forget the last publish whenever the design is not placed, so the first placed frame
+            // afterwards always republishes rather than comparing against a footprint from before
+            // the gap. Note this is a weak guard on its own: `anchorEstablished` is a one-way latch,
+            // so `placed` does not drop on a re-capture — the anchor generation below is what
+            // carries that case.
+            if (!placed) designMoveDetector.reset()
             val designMoved = placed && designMoveDetector.moved(
                 overlayPanX, overlayPanY, overlayRotationDeg, newHalfW, newHalfH,
+                slamManager.anchorGeneration.value,
             )
             // Anchor-RELATIVE, not world — see FingerprintPartition.DesignFootprint. The live anchor
             // drifts and is corrected by reloc, so its world pose at two moments is not the same
@@ -2009,8 +2013,6 @@ class ArRenderer(
                         designRigidModel, 0, designAnchorInvScratch, 0, overlayRigidScratch, 0,
                     )
                 }
-                designEffectiveHalfW = newHalfW
-                designEffectiveHalfH = newHalfH
                 designPlaced = placed && invertible
                 if (designPlaced && designMoved) {
                     footprint = com.hereliesaz.graffitixr.feature.ar.anchor.FingerprintPartition

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -454,9 +454,28 @@ class ArRenderer(
     // A millimetre. Below this a "resize" is float noise in the composed transform, and firing on it
     // would reclassify the whole fingerprint every frame the artist rests a finger on the screen.
     private val DESIGN_EXTENT_EPS = 1e-3f
+    private val DESIGN_POSE_EPS = 1e-3f
     private val designFootprintLock = Any()
     private val designRigidModel = FloatArray(16)
     private val designAnchorInvScratch = FloatArray(16)
+    private val designPoseScratch = FloatArray(16)
+
+    /**
+     * True when the freshly-computed design pose differs from the published one by more than a
+     * millimetre of translation or the rotational equivalent.
+     *
+     * A flat element-wise comparison, which is the right test here precisely because it is crude: it
+     * catches translation, in-plane spin and the wall-frame re-orthonormalisation alike, and every
+     * one of those changes what Φ answers. The rotation columns are unit-length, so an element
+     * threshold of 1e-3 is roughly a milliradian — comfortably below anything a hand does and
+     * comfortably above float noise in the compose chain.
+     */
+    private fun designPoseMoved(): Boolean {
+        for (i in 0 until 16) {
+            if (kotlin.math.abs(designPoseScratch[i] - designRigidModel[i]) > DESIGN_POSE_EPS) return true
+        }
+        return false
+    }
     private var designEffectiveHalfW = -1f
     private var designEffectiveHalfH = -1f
     private var designPlaced = false
@@ -1980,6 +1999,11 @@ class ArRenderer(
             // the design's size would make Φ swallow every feature in view and report zero backbone
             // — "the artwork covers the whole wall" on a design the artist has only just opened.
             val placed = anchorEstablished && overlayRenderer.hasTexture && quadInitialFitApplied
+            // Size OR pose. Φ asks where a feature sits relative to the artwork, and panning or
+            // spinning the design changes that answer exactly as much as resizing it does — the
+            // artist drags the artwork across the wall far more often than they pinch it. Watching
+            // the extents alone left every one of those moves silently unpartitioned, against a
+            // footprint the artwork had left.
             val extentMoved = placed &&
                 (kotlin.math.abs(newHalfW - designEffectiveHalfW) > DESIGN_EXTENT_EPS ||
                     kotlin.math.abs(newHalfH - designEffectiveHalfH) > DESIGN_EXTENT_EPS)
@@ -1993,13 +2017,20 @@ class ArRenderer(
                     android.opengl.Matrix.invertM(designAnchorInvScratch, 0, anchorMatrix, 0)
                 if (placed && invertible) {
                     android.opengl.Matrix.multiplyMM(
-                        designRigidModel, 0, designAnchorInvScratch, 0, overlayRigidScratch, 0,
+                        designPoseScratch, 0, designAnchorInvScratch, 0, overlayRigidScratch, 0,
                     )
+                }
+                // Compared BEFORE designRigidModel is overwritten below, and only against the model
+                // that was actually published — comparing against the scratch would compare a value
+                // with itself.
+                val poseMoved = placed && invertible && designPoseMoved()
+                if (placed && invertible) {
+                    System.arraycopy(designPoseScratch, 0, designRigidModel, 0, 16)
                 }
                 designEffectiveHalfW = newHalfW
                 designEffectiveHalfH = newHalfH
                 designPlaced = placed && invertible
-                if (extentMoved && designPlaced) {
+                if (designPlaced && (extentMoved || poseMoved)) {
                     footprint = com.hereliesaz.graffitixr.feature.ar.anchor.FingerprintPartition
                         .DesignFootprint(designRigidModel.copyOf(), newHalfW, newHalfH)
                 }

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -444,47 +444,28 @@ class ArRenderer(
     private val overlayComposedScratch = FloatArray(16)
     private val overlayRigidScratch = FloatArray(16)
 
-    // Where the artwork sits, published for the capture path (IMPLEMENTATION.md 2.3/2.4).
+    // Where the artwork sits (IMPLEMENTATION.md 2.3/2.4), assembled here and handed out through
+    // onDesignFootprintChanged.
     //
-    // Guarded rather than @Volatile: the four values are only meaningful together, and the capture
-    // block reads them a few statements after the draw block wrote them. A torn read here would
-    // partition a whole fingerprint against half of one design's pose and half of another's, and the
-    // result would look entirely plausible. The lock is uncontended in practice — both sides are the
-    // GL thread — and costs nothing next to the frame it sits inside.
-    // A millimetre. Below this a "resize" is float noise in the composed transform, and firing on it
-    // would reclassify the whole fingerprint every frame the artist rests a finger on the screen.
-    // A millimetre of pan, and a tenth of a degree of spin. Below these a "move" is float noise in
-    // the compose chain, and firing on it would repartition the fingerprint and write the project
-    // file every frame the artist rests a finger on the screen. Recorded in `PARAMETERS.md` §6.
-    private val DESIGN_EXTENT_EPS = 1e-3f
-    private val DESIGN_PAN_EPS_M = 1e-3f
-    private val DESIGN_ROT_EPS_DEG = 0.1f
+    // The lock is now GL-thread-only on both sides: the capture-path reader it originally guarded
+    // went with `designFootprint()`. It is kept because the four values are only meaningful
+    // together, so a future reader from another thread inherits the guarantee rather than having to
+    // rediscover the need for it; uncontended, it costs nothing.
+
+    // A millimetre of extent or pan, and a tenth of a degree of spin. Below these a "change" is
+    // float noise in the compose chain, and firing on it would repartition the fingerprint and
+    // rewrite the project file every frame the artist rests a finger on the screen. Recorded in
+    // `PARAMETERS.md` §6.
     private val designFootprintLock = Any()
     private val designRigidModel = FloatArray(16)
     private val designAnchorInvScratch = FloatArray(16)
 
-    // Last in-plane design transform the footprint was published for: pan X/Y in metres and spin in
-    // degrees. NaN until the first publish, so the first comparison always reports movement.
-    private var lastDesignPanX = Float.NaN
-    private var lastDesignPanY = Float.NaN
-    private var lastDesignRotDeg = Float.NaN
+    // Extracted so the two rules it has to obey — compare against the last PUBLISH not the last
+    // frame, and take only drift-immune inputs — are pinned by tests instead of comments. Each was
+    // violated once here, and neither was reachable from a test while it lived inside onDrawFrame.
+    private val designMoveDetector =
+        com.hereliesaz.graffitixr.feature.ar.anchor.DesignMoveDetector()
 
-    /**
-     * True when the artist's in-plane placement of the design has moved since the last publish.
-     *
-     * Deliberately reads the USER's inputs rather than the composed model matrix. Every quantity
-     * here is drift-immune: pan and spin are set from gestures, and the marks-centering offset is
-     * recomputed from the anchor-local mark centroid, so none of them moves when ARCore corrects the
-     * anchor underneath. Also updates the remembered values, so the caller must invoke it exactly
-     * once per frame.
-     */
-    private fun designLocalMoved(panX: Float, panY: Float, rotDeg: Float): Boolean {
-        val moved = !(kotlin.math.abs(panX - lastDesignPanX) <= DESIGN_PAN_EPS_M &&
-            kotlin.math.abs(panY - lastDesignPanY) <= DESIGN_PAN_EPS_M &&
-            kotlin.math.abs(rotDeg - lastDesignRotDeg) <= DESIGN_ROT_EPS_DEG)
-        lastDesignPanX = panX; lastDesignPanY = panY; lastDesignRotDeg = rotDeg
-        return moved
-    }
     private var designEffectiveHalfW = -1f
     private var designEffectiveHalfH = -1f
     private var designPlaced = false
@@ -1997,9 +1978,12 @@ class ArRenderer(
             // artist drags the artwork across the wall far more often than they pinch it. Watching
             // the extents alone left every one of those moves silently unpartitioned, against a
             // footprint the artwork had left.
-            val extentMoved = placed &&
-                (kotlin.math.abs(newHalfW - designEffectiveHalfW) > DESIGN_EXTENT_EPS ||
-                    kotlin.math.abs(newHalfH - designEffectiveHalfH) > DESIGN_EXTENT_EPS)
+            // Size AND placement, in one detector. Φ asks where a feature sits relative to the
+            // artwork, and dragging or spinning the design changes that answer as much as resizing
+            // does — artists drag far more often than they pinch.
+            val designMoved = placed && designMoveDetector.moved(
+                overlayPanX, overlayPanY, overlayRotationDeg, newHalfW, newHalfH,
+            )
             // Anchor-RELATIVE, not world — see FingerprintPartition.DesignFootprint. The live anchor
             // drifts and is corrected by reloc, so its world pose at two moments is not the same
             // physical place, and pairing this with the fingerprint's capture-time anchor pose is
@@ -2012,7 +1996,10 @@ class ArRenderer(
             // the anchor's orientation estimate does. That is a real residual and it is why the
             // repartition trigger below reads the artist's inputs instead of this matrix. For Φ
             // itself the residual is tolerable: a fraction of a degree moves a design edge by
-            // millimetres, well inside the BAND the partition already discards.
+            // millimetres. Note that is an argument about SMALL corrections, and PoseFusion also
+            // performs cold snaps that are not small — a 3° relock at a one-metre lever arm moves an
+            // edge ~5 cm, past DEFAULT_INNER_MARGIN. Nothing bounds that today; E8 is where the
+            // margins and this interaction get measured rather than asserted.
             var footprint: com.hereliesaz.graffitixr.feature.ar.anchor.FingerprintPartition.DesignFootprint? = null
             synchronized(designFootprintLock) {
                 val invertible =
@@ -2022,25 +2009,10 @@ class ArRenderer(
                         designRigidModel, 0, designAnchorInvScratch, 0, overlayRigidScratch, 0,
                     )
                 }
-                // Compared against the USER's in-plane transform, not against the composed pose.
-                //
-                // The composed one looks like the obvious choice and is a trap: overlayBaseScratch
-                // copies anchorMatrix's translation but OVERWRITES its rotation with a world-fixed
-                // frame, so `anchorMatrix⁻¹ · overlayRigid` cancels the translation and *injects*
-                // R_anchorᵀ. anchorMatrix is the FUSED pose, re-corrected every frame, so a
-                // 1e-3 element threshold on that product fires on drift with the phone sitting
-                // still — replacing a drift-immune trigger with a drift-coupled one and paying a
-                // repartition, a native re-push and a project write each time.
-                //
-                // Pan, spin and the marks-centering offset are what the artist actually controls,
-                // and they are drift-immune for the same reason the extents are.
-                val poseMoved = placed && designLocalMoved(
-                    markOffsetX + overlayPanX, markOffsetY + overlayPanY, overlayRotationDeg,
-                )
                 designEffectiveHalfW = newHalfW
                 designEffectiveHalfH = newHalfH
                 designPlaced = placed && invertible
-                if (designPlaced && (extentMoved || poseMoved)) {
+                if (designPlaced && designMoved) {
                     footprint = com.hereliesaz.graffitixr.feature.ar.anchor.FingerprintPartition
                         .DesignFootprint(designRigidModel.copyOf(), newHalfW, newHalfH)
                 }

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -2016,7 +2016,14 @@ class ArRenderer(
                         .DesignFootprint(designRigidModel.copyOf(), newHalfW, newHalfH)
                 }
             }
-            footprint?.let(onDesignFootprintChanged)
+            // Re-checked here, not only at the top of the frame. `isDestroying` is set by
+            // `exitArMode` on the main thread, but a frame that entered the body before that can sit
+            // inside `session.update()` for a whole camera period and arrive here afterwards — with
+            // the anchor generation already bumped by teardown, so `designMoved` is unconditionally
+            // true. Publishing then re-arms `latestDesignFootprint` immediately after teardown nulls
+            // it, and the next session partitions against the dead session's design pose. The
+            // top-of-frame check cannot cover this; only a second one can.
+            if (!isDestroying) footprint?.let(onDesignFootprintChanged)
             android.opengl.Matrix.scaleM(overlayLocalScratch, 0, overlayScale, overlayScale, 1f)
             android.opengl.Matrix.multiplyMM(
                 overlayComposedScratch, 0, overlayBaseScratch, 0, overlayLocalScratch, 0

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -453,54 +453,42 @@ class ArRenderer(
     // GL thread — and costs nothing next to the frame it sits inside.
     // A millimetre. Below this a "resize" is float noise in the composed transform, and firing on it
     // would reclassify the whole fingerprint every frame the artist rests a finger on the screen.
+    // A millimetre of pan, and a tenth of a degree of spin. Below these a "move" is float noise in
+    // the compose chain, and firing on it would repartition the fingerprint and write the project
+    // file every frame the artist rests a finger on the screen. Recorded in `PARAMETERS.md` §6.
     private val DESIGN_EXTENT_EPS = 1e-3f
-    private val DESIGN_POSE_EPS = 1e-3f
+    private val DESIGN_PAN_EPS_M = 1e-3f
+    private val DESIGN_ROT_EPS_DEG = 0.1f
     private val designFootprintLock = Any()
     private val designRigidModel = FloatArray(16)
     private val designAnchorInvScratch = FloatArray(16)
-    private val designPoseScratch = FloatArray(16)
+
+    // Last in-plane design transform the footprint was published for: pan X/Y in metres and spin in
+    // degrees. NaN until the first publish, so the first comparison always reports movement.
+    private var lastDesignPanX = Float.NaN
+    private var lastDesignPanY = Float.NaN
+    private var lastDesignRotDeg = Float.NaN
 
     /**
-     * True when the freshly-computed design pose differs from the published one by more than a
-     * millimetre of translation or the rotational equivalent.
+     * True when the artist's in-plane placement of the design has moved since the last publish.
      *
-     * A flat element-wise comparison, which is the right test here precisely because it is crude: it
-     * catches translation, in-plane spin and the wall-frame re-orthonormalisation alike, and every
-     * one of those changes what Φ answers. The rotation columns are unit-length, so an element
-     * threshold of 1e-3 is roughly a milliradian — comfortably below anything a hand does and
-     * comfortably above float noise in the compose chain.
+     * Deliberately reads the USER's inputs rather than the composed model matrix. Every quantity
+     * here is drift-immune: pan and spin are set from gestures, and the marks-centering offset is
+     * recomputed from the anchor-local mark centroid, so none of them moves when ARCore corrects the
+     * anchor underneath. Also updates the remembered values, so the caller must invoke it exactly
+     * once per frame.
      */
-    private fun designPoseMoved(): Boolean {
-        for (i in 0 until 16) {
-            if (kotlin.math.abs(designPoseScratch[i] - designRigidModel[i]) > DESIGN_POSE_EPS) return true
-        }
-        return false
+    private fun designLocalMoved(panX: Float, panY: Float, rotDeg: Float): Boolean {
+        val moved = !(kotlin.math.abs(panX - lastDesignPanX) <= DESIGN_PAN_EPS_M &&
+            kotlin.math.abs(panY - lastDesignPanY) <= DESIGN_PAN_EPS_M &&
+            kotlin.math.abs(rotDeg - lastDesignRotDeg) <= DESIGN_ROT_EPS_DEG)
+        lastDesignPanX = panX; lastDesignPanY = panY; lastDesignRotDeg = rotDeg
+        return moved
     }
     private var designEffectiveHalfW = -1f
     private var designEffectiveHalfH = -1f
     private var designPlaced = false
 
-    /**
-     * The design's placement as of the last drawn frame, or null when there is no placed artwork to
-     * take a footprint of.
-     *
-     * Null is the honest answer before the overlay has an anchor and a texture, and it leaves the
-     * capture unpartitioned — the legacy all-backbone reading, i.e. exactly `main`'s behaviour. The
-     * alternative, inventing an identity pose, would partition every point against a design sitting
-     * at the world origin and produce a full, confident, meaningless answer.
-     *
-     * One frame stale by construction: the capture block runs before the overlay is composed for
-     * this frame, so these are the previous frame's values. At 30–60 fps that is 16–33 ms of device
-     * motion on a shot the artist has just framed and confirmed, and it is the same transform the
-     * artist was looking at when they tapped — which is the one the partition should be against.
-     */
-    fun designFootprint(): com.hereliesaz.graffitixr.feature.ar.anchor.FingerprintPartition.DesignFootprint? =
-        synchronized(designFootprintLock) {
-            if (!designPlaced || designEffectiveHalfW <= 0f || designEffectiveHalfH <= 0f) return null
-            com.hereliesaz.graffitixr.feature.ar.anchor.FingerprintPartition.DesignFootprint(
-                designRigidModel.copyOf(), designEffectiveHalfW, designEffectiveHalfH,
-            )
-        }
     // Scratch for the 2D perspective content rotation matrix (X/Y axes).
     private val contentRotationScratch = FloatArray(16)
     private val contentRotationTemp = FloatArray(16)
@@ -1147,6 +1135,11 @@ class ArRenderer(
                     }
                     setPrimaryAnchor(anchor) // non-null: the fallback branch always creates one
                     anchorEstablished = true
+                    // Announce it beyond the GL thread. This is the ONLY anchor write that counts as
+                    // establishment — the plane refiner and the depth fallback both write poses
+                    // before this point, in a different frame convention, and a capture that
+                    // resolved against one of those would be co-registered ~90° out.
+                    slamManager.markAnchorEstablished()
                     hideVisualization = true
                     onAnchorEstablished()
 
@@ -2008,25 +2001,42 @@ class ArRenderer(
                 (kotlin.math.abs(newHalfW - designEffectiveHalfW) > DESIGN_EXTENT_EPS ||
                     kotlin.math.abs(newHalfH - designEffectiveHalfH) > DESIGN_EXTENT_EPS)
             // Anchor-RELATIVE, not world — see FingerprintPartition.DesignFootprint. The live anchor
-            // drifts and gets corrected by reloc, so its world pose at two different moments is not
-            // the same physical place; expressing the design against it cancels that out, and the
-            // fingerprint's stored half of the composition is anchor-relative for the same reason.
+            // drifts and is corrected by reloc, so its world pose at two moments is not the same
+            // physical place, and pairing this with the fingerprint's capture-time anchor pose is
+            // what makes the two ends comparable at all.
+            //
+            // It cancels the anchor's TRANSLATION exactly: overlayBaseScratch takes its translation
+            // from anchorMatrix, so that factor divides out. It does NOT cancel the rotation —
+            // overlayBaseScratch overwrites the anchor's 3x3 with a world-fixed frame built from the
+            // captured surface normal and world-up, so this product carries R_anchorᵀ and moves when
+            // the anchor's orientation estimate does. That is a real residual and it is why the
+            // repartition trigger below reads the artist's inputs instead of this matrix. For Φ
+            // itself the residual is tolerable: a fraction of a degree moves a design edge by
+            // millimetres, well inside the BAND the partition already discards.
             var footprint: com.hereliesaz.graffitixr.feature.ar.anchor.FingerprintPartition.DesignFootprint? = null
             synchronized(designFootprintLock) {
                 val invertible =
                     android.opengl.Matrix.invertM(designAnchorInvScratch, 0, anchorMatrix, 0)
                 if (placed && invertible) {
                     android.opengl.Matrix.multiplyMM(
-                        designPoseScratch, 0, designAnchorInvScratch, 0, overlayRigidScratch, 0,
+                        designRigidModel, 0, designAnchorInvScratch, 0, overlayRigidScratch, 0,
                     )
                 }
-                // Compared BEFORE designRigidModel is overwritten below, and only against the model
-                // that was actually published — comparing against the scratch would compare a value
-                // with itself.
-                val poseMoved = placed && invertible && designPoseMoved()
-                if (placed && invertible) {
-                    System.arraycopy(designPoseScratch, 0, designRigidModel, 0, 16)
-                }
+                // Compared against the USER's in-plane transform, not against the composed pose.
+                //
+                // The composed one looks like the obvious choice and is a trap: overlayBaseScratch
+                // copies anchorMatrix's translation but OVERWRITES its rotation with a world-fixed
+                // frame, so `anchorMatrix⁻¹ · overlayRigid` cancels the translation and *injects*
+                // R_anchorᵀ. anchorMatrix is the FUSED pose, re-corrected every frame, so a
+                // 1e-3 element threshold on that product fires on drift with the phone sitting
+                // still — replacing a drift-immune trigger with a drift-coupled one and paying a
+                // repartition, a native re-push and a project write each time.
+                //
+                // Pan, spin and the marks-centering offset are what the artist actually controls,
+                // and they are drift-immune for the same reason the extents are.
+                val poseMoved = placed && designLocalMoved(
+                    markOffsetX + overlayPanX, markOffsetY + overlayPanY, overlayRotationDeg,
+                )
                 designEffectiveHalfW = newHalfW
                 designEffectiveHalfH = newHalfH
                 designPlaced = placed && invertible

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/ArViewModelTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/ArViewModelTest.kt
@@ -16,6 +16,8 @@ import android.graphics.Matrix
 import android.graphics.Paint
 import com.hereliesaz.graffitixr.common.util.isolateMarkings
 import com.hereliesaz.graffitixr.common.util.NativeLibLoader
+import com.hereliesaz.graffitixr.feature.ar.anchor.FingerprintPartition
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
@@ -434,6 +436,142 @@ class ArViewModelTest {
         testDispatcher.scheduler.runCurrent()
 
         assertFalse(viewModel.uiState.value.doodleLocked)
+    }
+
+    // ==================== Fingerprint load / partition cascade ====================
+
+    /**
+     * A fingerprint whose points straddle a 0.5 x 0.5 m design placed at the anchor: three under it,
+     * three well outside. The absolute positions only have to survive Φ's classification; what the
+     * tests below care about is that the partition is non-trivial, so an "already partitioned"
+     * fixture cannot be confused with an empty one.
+     */
+    private val fixturePoints = listOf(
+        0f, 0f, 0f, 0.1f, 0.1f, 0f, -0.2f, 0.05f, 0f,
+        1.0f, 0f, 0f, 0f, -1.2f, 0f, -0.9f, 0.8f, 0f,
+    )
+
+    private val fixtureFootprint = FingerprintPartition.DesignFootprint(
+        rigidModelAnchorLocal = identityMatrix(),
+        halfW = 0.5f,
+        halfH = 0.5f,
+    )
+
+    /** Unpartitioned: `regions` empty, extents unknown. The state a fresh capture is saved in. */
+    private fun unpartitionedFingerprint() = com.hereliesaz.graffitixr.common.model.Fingerprint(
+        keypoints = emptyList(),
+        points3d = fixturePoints,
+        descriptorsData = ByteArray(fixturePoints.size / 3 * 32),
+        descriptorsRows = fixturePoints.size / 3,
+        descriptorsCols = 32,
+        descriptorsType = 0,
+        // Non-negative so `isLegacyFrame` is false and the pre-Phase-0 refusal doesn't short-circuit
+        // the restore this test is measuring.
+        captureRotationDeg = 0,
+        captureAnchorCam = identityMatrix().toList(),
+    )
+
+    private fun projectWith(fp: com.hereliesaz.graffitixr.common.model.Fingerprint) =
+        com.hereliesaz.graffitixr.common.model.GraffitiProject(
+            id = "partition-fixture",
+            fingerprint = fp,
+            // The metric restore is gated on both being present; without them the load takes the
+            // descriptors-only legacy branch and never reaches the partition at all.
+            fingerprintIntrinsics = listOf(500f, 500f, 320f, 240f),
+            fingerprintAnchor = identityMatrix().toList(),
+            fingerprintCaptureRotationDeg = 0,
+        )
+
+    private fun identityMatrix() = floatArrayOf(
+        1f, 0f, 0f, 0f, 0f, 1f, 0f, 0f, 0f, 0f, 1f, 0f, 0f, 0f, 0f, 1f,
+    )
+
+    /**
+     * `loadFingerprintIfExists` and the partition both run off the test dispatcher — IO and Default
+     * respectively — so the sequence load → partition → (possible) write only completes on real
+     * threads. Interleave scheduler drains with real pauses until it has.
+     */
+    private fun settle(rounds: Int = 6, pauseMs: Long = 150L) {
+        repeat(rounds) {
+            testDispatcher.scheduler.advanceUntilIdle()
+            Thread.sleep(pauseMs)
+        }
+        testDispatcher.scheduler.advanceUntilIdle()
+    }
+
+    private fun viewModelOn(projects: MutableStateFlow<com.hereliesaz.graffitixr.common.model.GraffitiProject?>): ArViewModel {
+        every { projectRepository.currentProject } returns projects
+        return ArViewModel(
+            slamManager, stereoProvider, projectRepository, settingsRepository, projectManager,
+            collaborationManager, wearableManager, context, testDispatchers,
+        )
+    }
+
+    /**
+     * Loading an already-correctly-partitioned fingerprint must push it to native once and write
+     * nothing.
+     *
+     * `loadFingerprintIfExists` runs on EVERY `currentProject` emission and the partition itself
+     * calls `updateProject`, so a partition that writes on load is a cycle: load → partition →
+     * write → emission → load. Before the idempotence check in `onDesignFootprintChanged` that is
+     * exactly what happened — two partitions, two `restoreWallFingerprintMetric` calls (each
+     * resetting native's reloc state) and two full project writes per load. It terminated only
+     * because `Fingerprint.equals` compares `regions` by content and `MutableStateFlow` conflates
+     * equal values, which is an accident of an override written for a serialization test: one
+     * non-value-equal field added to `Fingerprint` turns it into an unbounded write loop.
+     *
+     * The stored regions come from `FingerprintPartition.partition` itself rather than a literal, so
+     * the fixture cannot drift away from what the implementation would compute.
+     */
+    @Test
+    fun `loading an already-partitioned fingerprint pushes once and writes nothing`() = runTest {
+        val stored = FingerprintPartition.partition(unpartitionedFingerprint(), fixtureFootprint)
+        assertNotEquals(
+            "fixture must actually be partitioned, or this test proves nothing",
+            0, stored.regions.size,
+        )
+        val projects = MutableStateFlow<com.hereliesaz.graffitixr.common.model.GraffitiProject?>(null)
+        val vm = viewModelOn(projects)
+        // The footprint edge fires before the fingerprint arrives — the ordering a project load
+        // always has, since the artwork is placed from the saved project.
+        vm.onDesignFootprintChanged(fixtureFootprint)
+
+        projects.value = projectWith(stored)
+        settle()
+
+        verify(exactly = 1) {
+            slamManager.restoreWallFingerprintMetric(
+                any(), any(), any(), any(), any(), any(), any(), any(), any(),
+            )
+        }
+        coVerify(exactly = 0) { projectRepository.updateProject(any<com.hereliesaz.graffitixr.common.model.GraffitiProject>()) }
+        coVerify(exactly = 0) {
+            projectRepository.updateProject(any<(com.hereliesaz.graffitixr.common.model.GraffitiProject) -> com.hereliesaz.graffitixr.common.model.GraffitiProject>())
+        }
+    }
+
+    /**
+     * The other half, without which the test above would also pass if partitioning were broken
+     * outright: an UNpartitioned fingerprint must be partitioned and persisted — once.
+     */
+    @Test
+    fun `loading an unpartitioned fingerprint partitions it and writes exactly once`() = runTest {
+        val projects = MutableStateFlow<com.hereliesaz.graffitixr.common.model.GraffitiProject?>(null)
+        val vm = viewModelOn(projects)
+        vm.onDesignFootprintChanged(fixtureFootprint)
+
+        projects.value = projectWith(unpartitionedFingerprint())
+        settle()
+
+        coVerify(exactly = 1) {
+            projectRepository.updateProject(any<(com.hereliesaz.graffitixr.common.model.GraffitiProject) -> com.hereliesaz.graffitixr.common.model.GraffitiProject>())
+        }
+        // The restore on load, plus the one that hands native the freshly partitioned regions.
+        verify(exactly = 2) {
+            slamManager.restoreWallFingerprintMetric(
+                any(), any(), any(), any(), any(), any(), any(), any(), any(),
+            )
+        }
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/DesignMoveDetectorTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/DesignMoveDetectorTest.kt
@@ -1,0 +1,121 @@
+package com.hereliesaz.graffitixr.feature.ar.anchor
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The repartition trigger, pinned. This logic shipped wrong twice, in two different ways, and both
+ * times it was unreachable from a test because it lived inside a `GLSurfaceView` frame callback —
+ * so the tests below are the reason it was extracted at all.
+ *
+ * The failure that matters most is the slow drag. A trigger that fires too often wastes work; one
+ * that never fires leaves Φ classifying the fingerprint against a design that has physically moved
+ * away, and the artist gets a target that will not lock with no indication why.
+ */
+class DesignMoveDetectorTest {
+
+    private companion object {
+        const val W = 1.0f
+        const val H = 0.5f
+    }
+
+    private fun detector() = DesignMoveDetector()
+
+    /** No previous publish exists, so there is nothing for the partition to already match. */
+    @Test
+    fun `the first call always reports movement`() {
+        assertTrue(detector().moved(0f, 0f, 0f, W, H))
+    }
+
+    @Test
+    fun `a repeat of the published values reports nothing`() {
+        val d = detector()
+        assertTrue(d.moved(0.2f, 0.3f, 15f, W, H))
+        assertFalse(d.moved(0.2f, 0.3f, 15f, W, H))
+        assertFalse("still nothing on a third identical frame", d.moved(0.2f, 0.3f, 15f, W, H))
+    }
+
+    /**
+     * **The slow drag.** 15 cm over three seconds at 60 fps is 0.083 mm per frame — under the 1 mm
+     * threshold on every single frame. If the detector advanced its remembered values on frames that
+     * reported no movement, the delta would never accumulate and this would never fire, leaving the
+     * partition 15 cm out. Fast drags fired and the careful final placement did not, which is the
+     * worst possible split: nudging the design into position is the last thing an artist does.
+     */
+    @Test
+    fun `a drag slower than the threshold per frame still eventually fires`() {
+        val d = detector()
+        assertTrue(d.moved(0f, 0f, 0f, W, H))
+
+        val perFrame = 0.000083f // 15 cm / (3 s x 60 fps)
+        var x = 0f
+        var fired = false
+        repeat(180) {
+            x += perFrame
+            if (d.moved(x, 0f, 0f, W, H)) fired = true
+        }
+        assertTrue("a 15 cm drag must repartition, however slowly it is made", fired)
+        assertTrue("...and it must have travelled the full distance", x > 0.014f)
+    }
+
+    /** The same argument for a slow rotation: a 4° alignment tweak over two seconds. */
+    @Test
+    fun `a rotation slower than the threshold per frame still eventually fires`() {
+        val d = detector()
+        assertTrue(d.moved(0f, 0f, 0f, W, H))
+
+        var deg = 0f
+        var fired = false
+        repeat(120) {
+            deg += 4f / 120f // 0.033 deg/frame, under the 0.1 deg threshold
+            if (d.moved(0f, 0f, deg, W, H)) fired = true
+        }
+        assertTrue("a 4 degree tweak must repartition", fired)
+    }
+
+    /**
+     * The counterpart: genuine stillness must stay quiet. Float noise at a tenth of the threshold
+     * must not fire, or a resting finger repartitions the fingerprint, replaces the native map and
+     * rewrites the project file every frame.
+     */
+    @Test
+    fun `noise below the threshold never fires, however many frames pass`() {
+        val d = detector()
+        assertTrue(d.moved(0.5f, 0.5f, 10f, W, H))
+
+        var fired = false
+        repeat(600) { i ->
+            // Alternating jitter, so it cannot accumulate into a real move.
+            val j = if (i % 2 == 0) 1e-4f else -1e-4f
+            if (d.moved(0.5f + j, 0.5f + j, 10f + j, W, H)) fired = true
+        }
+        assertFalse("jitter must not be mistaken for a drag", fired)
+    }
+
+    /** Each axis on its own, so a detector that ignored one would not hide behind the others. */
+    @Test
+    fun `every tracked quantity fires independently`() {
+        for ((name, call) in listOf<Pair<String, (DesignMoveDetector) -> Boolean>>(
+            "panX" to { d -> d.moved(1f, 0f, 0f, W, H) },
+            "panY" to { d -> d.moved(0f, 1f, 0f, W, H) },
+            "rotation" to { d -> d.moved(0f, 0f, 30f, W, H) },
+            "halfW" to { d -> d.moved(0f, 0f, 0f, W * 2, H) },
+            "halfH" to { d -> d.moved(0f, 0f, 0f, W, H * 2) },
+        )) {
+            val d = detector()
+            assertTrue(d.moved(0f, 0f, 0f, W, H))
+            assertTrue("$name must be tracked", call(d))
+        }
+    }
+
+    /** Teardown forgets the session's last publish, so the next one is treated as the first. */
+    @Test
+    fun `reset makes the next call report movement again`() {
+        val d = detector()
+        assertTrue(d.moved(0.2f, 0.3f, 15f, W, H))
+        assertFalse(d.moved(0.2f, 0.3f, 15f, W, H))
+        d.reset()
+        assertTrue("after teardown there is no published footprint to match", d.moved(0.2f, 0.3f, 15f, W, H))
+    }
+}

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/DesignMoveDetectorTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/DesignMoveDetectorTest.kt
@@ -18,6 +18,8 @@ class DesignMoveDetectorTest {
     private companion object {
         const val W = 1.0f
         const val H = 0.5f
+        /** A fixed anchor generation, so these cases exercise the thresholds and not the counter. */
+        const val GEN = 7
     }
 
     private fun detector() = DesignMoveDetector()
@@ -25,19 +27,19 @@ class DesignMoveDetectorTest {
     /** No previous publish exists, so there is nothing for the partition to already match. */
     @Test
     fun `the first call always reports movement`() {
-        assertTrue(detector().moved(0f, 0f, 0f, W, H))
+        assertTrue(detector().moved(0f, 0f, 0f, W, H, GEN))
     }
 
     @Test
     fun `a repeat of the published values reports nothing`() {
         val d = detector()
-        assertTrue(d.moved(0.2f, 0.3f, 15f, W, H))
-        assertFalse(d.moved(0.2f, 0.3f, 15f, W, H))
-        assertFalse("still nothing on a third identical frame", d.moved(0.2f, 0.3f, 15f, W, H))
+        assertTrue(d.moved(0.2f, 0.3f, 15f, W, H, GEN))
+        assertFalse(d.moved(0.2f, 0.3f, 15f, W, H, GEN))
+        assertFalse("still nothing on a third identical frame", d.moved(0.2f, 0.3f, 15f, W, H, GEN))
     }
 
     /**
-     * **The slow drag.** 15 cm over three seconds at 60 fps is 0.083 mm per frame — under the 1 mm
+     * **The slow drag.** 15 cm over three seconds at 60 fps is 0.83 mm per frame — under the 1 mm
      * threshold on every single frame. If the detector advanced its remembered values on frames that
      * reported no movement, the delta would never accumulate and this would never fire, leaving the
      * partition 15 cm out. Fast drags fired and the careful final placement did not, which is the
@@ -46,30 +48,30 @@ class DesignMoveDetectorTest {
     @Test
     fun `a drag slower than the threshold per frame still eventually fires`() {
         val d = detector()
-        assertTrue(d.moved(0f, 0f, 0f, W, H))
+        assertTrue(d.moved(0f, 0f, 0f, W, H, GEN))
 
-        val perFrame = 0.000083f // 15 cm / (3 s x 60 fps)
+        val perFrame = 0.000833f // 15 cm / (3 s x 60 fps) = 0.83 mm, just under the 1 mm threshold
         var x = 0f
         var fired = false
         repeat(180) {
             x += perFrame
-            if (d.moved(x, 0f, 0f, W, H)) fired = true
+            if (d.moved(x, 0f, 0f, W, H, GEN)) fired = true
         }
         assertTrue("a 15 cm drag must repartition, however slowly it is made", fired)
-        assertTrue("...and it must have travelled the full distance", x > 0.014f)
+        assertTrue("...and it must have travelled the full 15 cm", x > 0.149f)
     }
 
     /** The same argument for a slow rotation: a 4° alignment tweak over two seconds. */
     @Test
     fun `a rotation slower than the threshold per frame still eventually fires`() {
         val d = detector()
-        assertTrue(d.moved(0f, 0f, 0f, W, H))
+        assertTrue(d.moved(0f, 0f, 0f, W, H, GEN))
 
         var deg = 0f
         var fired = false
         repeat(120) {
             deg += 4f / 120f // 0.033 deg/frame, under the 0.1 deg threshold
-            if (d.moved(0f, 0f, deg, W, H)) fired = true
+            if (d.moved(0f, 0f, deg, W, H, GEN)) fired = true
         }
         assertTrue("a 4 degree tweak must repartition", fired)
     }
@@ -82,13 +84,13 @@ class DesignMoveDetectorTest {
     @Test
     fun `noise below the threshold never fires, however many frames pass`() {
         val d = detector()
-        assertTrue(d.moved(0.5f, 0.5f, 10f, W, H))
+        assertTrue(d.moved(0.5f, 0.5f, 10f, W, H, GEN))
 
         var fired = false
         repeat(600) { i ->
             // Alternating jitter, so it cannot accumulate into a real move.
             val j = if (i % 2 == 0) 1e-4f else -1e-4f
-            if (d.moved(0.5f + j, 0.5f + j, 10f + j, W, H)) fired = true
+            if (d.moved(0.5f + j, 0.5f + j, 10f + j, W, H, GEN)) fired = true
         }
         assertFalse("jitter must not be mistaken for a drag", fired)
     }
@@ -97,25 +99,51 @@ class DesignMoveDetectorTest {
     @Test
     fun `every tracked quantity fires independently`() {
         for ((name, call) in listOf<Pair<String, (DesignMoveDetector) -> Boolean>>(
-            "panX" to { d -> d.moved(1f, 0f, 0f, W, H) },
-            "panY" to { d -> d.moved(0f, 1f, 0f, W, H) },
-            "rotation" to { d -> d.moved(0f, 0f, 30f, W, H) },
-            "halfW" to { d -> d.moved(0f, 0f, 0f, W * 2, H) },
-            "halfH" to { d -> d.moved(0f, 0f, 0f, W, H * 2) },
+            "panX" to { d -> d.moved(1f, 0f, 0f, W, H, GEN) },
+            "panY" to { d -> d.moved(0f, 1f, 0f, W, H, GEN) },
+            "rotation" to { d -> d.moved(0f, 0f, 30f, W, H, GEN) },
+            "halfW" to { d -> d.moved(0f, 0f, 0f, W * 2, H, GEN) },
+            "halfH" to { d -> d.moved(0f, 0f, 0f, W, H * 2, GEN) },
         )) {
             val d = detector()
-            assertTrue(d.moved(0f, 0f, 0f, W, H))
+            assertTrue(d.moved(0f, 0f, 0f, W, H, GEN))
             assertTrue("$name must be tracked", call(d))
         }
+    }
+
+    /**
+     * **The re-capture.** A new target replaces the anchor the design's pose is expressed relative
+     * to, so the footprint must be republished even though the artist has touched nothing.
+     *
+     * This is the case an earlier cut lost. It removed the marks-centering offset — correctly, that
+     * input was drift-coupled — and with it the only quantity that moved when the anchor changed.
+     * Nothing else in the list does: pan, spin and scale are gestures a capture does not touch, and
+     * the extents come from a one-shot fit. `anchorEstablished` is a one-way latch, so `placed` does
+     * not drop either. The trigger simply went quiet, and the NEW fingerprint was partitioned
+     * against the DEAD anchor's design frame.
+     *
+     * No threshold applies: an anchor replacement is discrete, so any change at all must fire.
+     */
+    @Test
+    fun `a new anchor generation republishes even when nothing else moved`() {
+        val d = detector()
+        assertTrue(d.moved(0.2f, 0.3f, 15f, W, H, GEN))
+        assertFalse("nothing has changed yet", d.moved(0.2f, 0.3f, 15f, W, H, GEN))
+
+        assertTrue(
+            "a re-capture replaces the anchor, so the footprint is stale however still the artist held",
+            d.moved(0.2f, 0.3f, 15f, W, H, GEN + 1),
+        )
+        assertFalse("...and settles again on the new anchor", d.moved(0.2f, 0.3f, 15f, W, H, GEN + 1))
     }
 
     /** Teardown forgets the session's last publish, so the next one is treated as the first. */
     @Test
     fun `reset makes the next call report movement again`() {
         val d = detector()
-        assertTrue(d.moved(0.2f, 0.3f, 15f, W, H))
-        assertFalse(d.moved(0.2f, 0.3f, 15f, W, H))
+        assertTrue(d.moved(0.2f, 0.3f, 15f, W, H, GEN))
+        assertFalse(d.moved(0.2f, 0.3f, 15f, W, H, GEN))
         d.reset()
-        assertTrue("after teardown there is no published footprint to match", d.moved(0.2f, 0.3f, 15f, W, H))
+        assertTrue("after teardown there is no published footprint to match", d.moved(0.2f, 0.3f, 15f, W, H, GEN))
     }
 }

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Sat Aug 01 18:59:24 UTC 2026
-versionBuild=14453
+#Sat Aug 01 19:14:57 UTC 2026
+versionBuild=14457
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=319
+versionPatch=323

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Sat Aug 01 13:32:13 UTC 2026
-versionBuild=14405
+#Sat Aug 01 13:36:47 UTC 2026
+versionBuild=14407
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=271
+versionPatch=273

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Sat Aug 01 13:36:47 UTC 2026
-versionBuild=14407
+#Sat Aug 01 13:38:10 UTC 2026
+versionBuild=14408
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=273
+versionPatch=274

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Sat Aug 01 14:16:06 UTC 2026
-versionBuild=14438
+#Sat Aug 01 14:33:36 UTC 2026
+versionBuild=14445
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=304
+versionPatch=311

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Sat Aug 01 13:38:10 UTC 2026
-versionBuild=14408
+#Sat Aug 01 13:53:10 UTC 2026
+versionBuild=14416
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=274
+versionPatch=282

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Sat Aug 01 14:33:36 UTC 2026
-versionBuild=14445
+#Sat Aug 01 14:49:55 UTC 2026
+versionBuild=14452
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=311
+versionPatch=318

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Sat Aug 01 11:34:00 UTC 2026
-versionBuild=14400
+#Sat Aug 01 13:32:13 UTC 2026
+versionBuild=14405
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=266
+versionPatch=271

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Sat Aug 01 13:53:10 UTC 2026
-versionBuild=14416
+#Sat Aug 01 14:03:48 UTC 2026
+versionBuild=14426
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=282
+versionPatch=292

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Sat Aug 01 14:03:48 UTC 2026
-versionBuild=14426
+#Sat Aug 01 14:16:06 UTC 2026
+versionBuild=14438
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=292
+versionPatch=304


### PR DESCRIPTION
**Draft, deliberately.** A fifth audit is running against the tip commit. This branch has been through four rounds of adversarial audit and every round found real defects — including two rounds where the *fix* was broken. Do not merge on my say-so.

## What this fixes

Phase 2 merged in #1804/#1805 with a partition that did not work. Four rounds of audit later, these were the actual defects:

### Round 1 — the partition never ran on the capture that matters
`IMPLEMENTATION.md` 2.4 says classify at capture, but **target creation is what establishes the anchor the artwork sits on**. At capture there is no placed design, so `designFootprint()` returned `null` on every first capture of every process. Partitioning now happens when the artwork lands, composed through the anchor rather than a world frame that does not survive a session:

```
design_in_points_frame = captureAnchorCam · (A_live⁻¹ · M_designWorld)
```

### Round 2 — the anchor read returned a pose from a different frame
`refineAnchorFromBestPlane` writes an anchor pose every 30 frames *while the anchor is unestablished*, so keying a flag on `updateAnchorTransform` meant the capture never waited. It read the plane refiner's pose — whose wall normal is in **Z** where establishment puts it in **+Y**. A ~90° frame error. Now keyed on `markAnchorEstablished()`, called from the one line that establishes.

### Round 3 — a slow drag never repartitioned at all
The move detector advanced its remembered values every frame, so it compared against the previous *frame* rather than the last *publish*. A 15 cm drag over 3 s is 0.83 mm/frame — under threshold on every frame, delta never accumulates, never fires. Fast drags worked; the careful final placement did not.

Also still drift-coupled: the marks offset is `X_world · (R_anchor · markCenterLocal)`, and `anchorMatrix` is the fused pose.

### Round 4 — re-capture went silent, and a leak was half-fixed
Removing the marks offset was right, but it was the only input that moved when a re-capture *replaced* the anchor. Nothing else does — `anchorEstablished` is assigned `true` at one line and never `false`, so `placed` never drops either. The anchor generation now carries that signal.

And the `liveFingerprint` leak fixed in round 3 was fixed in one branch of two: the pre-Phase-0 refusal returns sixty lines earlier, before any clearing, so a design move would partition the previous project's map and write it into the current project's file.

## Structural changes, not just patches

- **`DesignMoveDetector`** — extracted because this logic was wrong twice and neither failure was reachable from a test while it lived inside a frame callback. Now pinned by 8 tests including both slow-motion cases and the re-capture case.
- **`dropLoadedFingerprintState()`** — one function for all three no-map paths, because they were fixed one at a time and one was missed.
- **`SlamManager.anchorGeneration`** — monotonic counter plus `hasAnchor`, because a boolean latch cannot express "established since I asked" and a reset-to-zero strands an in-flight wait.

## Tests

Every new test is mutation-verified:

| Test | Mutation that fails it |
|---|---|
| Re-entrant cascade | Remove the idempotence check → `2 matching calls, needs exactly 1` |
| Establishment timing | Move the flag into `updateAnchorTransform` → 2 tests fail |
| Re-capture waits | Revert to latch semantics → fails |
| Slow drag | Restore the unconditional advance → 2 tests fail |
| Anchor generation | Drop it from the comparison → fails |

430 tests, 0 failures. `:app:compileDebugKotlin` and `:core:nativebridge:externalNativeBuildDebug` green.

## Known limits

- **A mutation the tests cannot catch:** setting the establishment flag *after* the native call is invisible off-device, because `UnsatisfiedLinkError` fires first. On-device that line runs. Stated in the test's KDoc.
- **2.10 is not done** — it needs a replayed recording this environment cannot produce.
- **The commits show as Unverified.** The signing key in this environment is a zero-byte file with no private key; author and committer emails are correct. Not fixable from here.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Q5WXFiVLeN4sXa9bPCSDA)_

## Summary by Sourcery

Make Phase 2 fingerprint partitioning and anchor establishment robust across captures, reloads, session teardown, and slow user gestures.

Bug Fixes:
- Reset anchor and fingerprint partition state on AR session teardown and legacy fingerprint refusal to avoid leaking maps between projects.
- Ensure fingerprint partitioning runs when either the artwork footprint moves or a fingerprint is (re)loaded, and prevent redundant native restores and project writes.
- Drive anchor establishment from a monotonic generation counter and await a fresh anchor pose per capture instead of using latch semantics or provisional plane poses.
- Wait asynchronously for a valid anchor transform when creating targets, showing a user-facing error if no anchor can be locked in time.

Enhancements:
- Extract design movement detection into a dedicated, drift-immune detector keyed to published gesture inputs and anchor generation, and reuse it to drive repartitioning.
- Introduce pose-change tracking for the last partitioned design and in-memory caching of the currently restored fingerprint to keep native and Kotlin fingerprint state consistent.
- Refine backbone warning publication into a shared helper that handles both fresh partitions and reloads without spamming toasts.
- Add anchor generation tracking and validation in SlamManager, including safeguards around broken or zeroed native anchor matrices.

Build:
- Add kotlinx-coroutines-test as a nativebridge test dependency to support new coroutine-based SlamManager tests.

Documentation:
- Document repartitioning thresholds, anchor wait timeout, and their rationale in PARAMETERS.md as part of the Phase 2 rendering/interaction parameters.

Tests:
- Add unit tests around fingerprint load/partition cascades to verify correct native restores and single project writes for both partitioned and unpartitioned fingerprints.
- Add SlamManager anchor establishment tests to pin correct generation-based waiting semantics and differentiate provisional pose writes from real anchor establishment.
- Add DesignMoveDetector tests to cover slow drags, slow rotations, noise rejection, per-axis movement, re-capture handling via anchor generation, and reset behavior.