### PR TITLE
Phase 4: spatially-constrained corroboration

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -2206,6 +2206,12 @@ private fun RelocDiagnosticsOverlay(
                 append("${d.corrobMatched}/${d.corrobPredicted}")
                 val r = corroboration.searchRadiusPx
                 if (r >= 0f) append(" · r=${r.toInt()}px")
+                // The skips are shown only when there are any, because on a healthy frame the
+                // number is 0 and a permanent "· 0 skip" trains the eye to ignore the field. When
+                // it IS non-zero it is the most important thing in the row: those are predicted
+                // features the match declined to test, so the ratio to its left is understated by
+                // exactly that much and a low reading may be the radius rather than the wall.
+                if (d.corrobLoneSkips > 0) append(" · ${d.corrobLoneSkips} skip")
             },
             // Amber, not red: zero predicted is the artist looking elsewhere, which is ordinary and
             // self-correcting. Red is reserved for the states that do not fix themselves.

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -1109,6 +1109,7 @@ class MainActivity : ComponentActivity() {
                                 !showLibrary && !showSettings && !mainUiState.isCapturingTarget) {
                                 RelocDiagnosticsOverlay(
                                     diagnostics = arUiState.relocDiagnostics,
+                                    corroboration = arUiState.corroborationDiagnostics,
                                     fingerprintPoints = arUiState.evalLiveMetrics.wallCount,
                                     paintingProgress = arUiState.paintingProgress,
                                 )
@@ -2116,6 +2117,7 @@ private const val FEW_FEATURES_IN_FRAME = 100
 @Composable
 private fun RelocDiagnosticsOverlay(
     diagnostics: RelocDiagnostics,
+    corroboration: com.hereliesaz.graffitixr.common.model.CorroborationDiagnostics,
     fingerprintPoints: Int,
     paintingProgress: Float,
 ) {
@@ -2190,7 +2192,42 @@ private fun RelocDiagnosticsOverlay(
             },
         )
         DiagnosticRow("FP pts", fingerprintPoints.toString(), androidx.compose.ui.graphics.Color.Cyan)
-        DiagnosticRow("Corroborated", "${(paintingProgress * 100).toInt()}%", androidx.compose.ui.graphics.Color.White)
+        // IMPLEMENTATION.md 4.6 — the corroboration match's own numbers, which are NOT the row
+        // below. "Corrob" is instantaneous: of the design features this pose says are in view, how
+        // many the wall backs right now, and the radius the gated search used to decide. "Painted"
+        // is cumulative over the whole design and moves over hours. They were one number until
+        // Phase 4/5b split them, and this row existing separately is what makes the split visible.
+        //
+        // "—" is the gated match never having run — no design placement, or no pose this frame — and
+        // is a different state from `0/0`, which says the artist is looking away from the design.
+        DiagnosticRow(
+            "Corrob",
+            if (d.corrobPredicted < 0) "—" else buildString {
+                append("${d.corrobMatched}/${d.corrobPredicted}")
+                val r = corroboration.searchRadiusPx
+                if (r >= 0f) append(" · r=${r.toInt()}px")
+            },
+            // Amber, not red: zero predicted is the artist looking elsewhere, which is ordinary and
+            // self-correcting. Red is reserved for the states that do not fix themselves.
+            if (d.corrobPredicted == 0) {
+                androidx.compose.ui.graphics.Color(0xFFFFC107)
+            } else {
+                androidx.compose.ui.graphics.Color.White
+            },
+        )
+        // The residual the search radius' drift term is derived from — and the fastest read on
+        // whether a "locked" state is actually a good lock. A green LOCKED with a large reprojection
+        // error is a pose that solved and is wrong, which nothing else on this overlay distinguishes.
+        if (corroboration.relocReprojPx >= 0f) {
+            DiagnosticRow(
+                "Reproj",
+                String.format(java.util.Locale.US, "%.1f px", corroboration.relocReprojPx),
+                androidx.compose.ui.graphics.Color.White,
+            )
+        }
+        // Painting progress, labelled as such. It was labelled "Corroborated" while being fed
+        // paintingProgress — a name for the value one row up, on a number that is not it.
+        DiagnosticRow("Painted", "${(paintingProgress * 100).toInt()}%", androidx.compose.ui.graphics.Color.White)
     }
 }
 

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainScreen.kt
@@ -267,7 +267,30 @@ fun MainScreen(
                             compositeLayersForAr(visibleLayers, arOverlayAdj)
                         }
                         rendererRef.value?.updateOverlayBitmap(composite)
-                        arViewModel.updatePaintingGuide(composite)
+                    }
+
+                    // Split from the effect above, and NOT keyed on the tone: brightness, contrast,
+                    // saturation, opacity and invert are how the artist wants the overlay to LOOK on
+                    // screen, not what the artwork is. Registering the toned composite as the
+                    // validator meant nudging the opacity slider re-ran the detector and re-registered
+                    // the design, which resets painting progress — cheap before Phase 4, when the
+                    // published value was the current frame's ratio and reappeared on the next reloc
+                    // tick, and expensive after it, when progress accumulates over confirmed features
+                    // and has to climb back one feature at a time. A tone slider must not cost the
+                    // artist their progress bar.
+                    //
+                    // Composites a second time rather than sharing the bitmap above, because the two
+                    // now legitimately differ. Only on a layer change, which is rare — the recompose
+                    // storm this file worries about elsewhere is driven by the tone key, and that no
+                    // longer reaches here.
+                    LaunchedEffect(visibleLayers, arUiState.isAnchorEstablished) {
+                        if (!arUiState.isAnchorEstablished || visibleLayers.isEmpty()) {
+                            return@LaunchedEffect
+                        }
+                        val guide = withContext(Dispatchers.Default) {
+                            compositeLayersForAr(visibleLayers)
+                        }
+                        arViewModel.updatePaintingGuide(guide)
                     }
 
                     AndroidView(

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/RelocDiagnostics.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/RelocDiagnostics.kt
@@ -55,10 +55,48 @@ data class RelocDiagnostics(
     val backboneMatches: Int = -1,
     /** RANSAC inliers that came from `F_out` points, or -1 when PnP produced no inlier set. */
     val backboneInliers: Int = -1,
+    /**
+     * `IMPLEMENTATION.md` **4.6** — design features the current pose predicts are visible in the
+     * frame, or -1 when no *gated* corroboration attempt has run.
+     *
+     * The global fallback match deliberately does not fill this in. It measures the whole design
+     * including the parts behind the camera, so reporting its count here would put two different
+     * quantities in one column and make a Phase-4 run look comparable to a pre-Phase-4 one.
+     *
+     * **Zero is a real reading** — the artist is looking away from the design — and it is the state
+     * `4.8` exists to keep distinct from a zero [corrobMatched].
+     */
+    val corrobPredicted: Int = -1,
+    /**
+     * How many of [corrobPredicted] the wall answered for, or -1 when no gated attempt has run.
+     *
+     * `corrobMatched / corrobPredicted` is the corroboration confidence `PoseFusion` scales by;
+     * `corrobMatched` against the whole design is *not* — painting progress has its own, cumulative
+     * denominator, and conflating the two is the defect Phase 5 exists to undo.
+     */
+    val corrobMatched: Int = -1,
 ) {
     /** Inlier ratio of the last attempt, or 0 when it produced no correspondences. */
     val inlierRatio: Float get() = if (matches > 0) inliers.toFloat() / matches else 0f
 }
+
+/**
+ * `IMPLEMENTATION.md` **4.6** — the corroboration path's pixel-valued readings.
+ *
+ * Separate from [RelocDiagnostics] only because that channel is an `int[]`: rounding a sub-pixel
+ * radius to an integer to share it would destroy the reading at exactly the tight radii Phase 4 is
+ * trying to measure.
+ *
+ * @param searchRadiusPx the radius the last gated corroboration attempt used, or -1 when none has
+ *   run. Derived from `ρ`, the design's on-screen scale and the measured drift — see `SearchRadius`.
+ * @param relocReprojPx the mean reprojection error over the last lock's PnP inliers, or -1 when not
+ *   measured. **Zero cannot be the sentinel here**: a perfectly tracking pose really does report a
+ *   near-zero residual, and that is the reading this column exists to show.
+ */
+data class CorroborationDiagnostics(
+    val searchRadiusPx: Float = -1f,
+    val relocReprojPx: Float = -1f,
+)
 
 /**
  * Mirrors `MobileGS::RelocReject`, ordinal for ordinal — the native side reports an int. Ordered by

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/RelocDiagnostics.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/RelocDiagnostics.kt
@@ -75,6 +75,19 @@ data class RelocDiagnostics(
      * denominator, and conflating the two is the defect Phase 5 exists to undo.
      */
     val corrobMatched: Int = -1,
+    /**
+     * `IMPLEMENTATION.md` **4.6** — predicted-visible features the gated match **refused to test**,
+     * because their neighbourhood held a single candidate and Lowe's ratio has nothing to divide
+     * by. -1 when no gated attempt has run.
+     *
+     * This is the number that says whether the search radius is usable. A skip deflates
+     * [corrobMatched] without touching [corrobPredicted], so a radius that is too tight does not
+     * announce itself — it announces itself as a wall that has stopped corroborating, which looks
+     * exactly like an unpainted one. And the deflation is not harmless: lower confidence means a
+     * smaller correction blend in `PoseFusion`, so a too-tight radius trades false snapping for
+     * accumulated drift, which is the thing corroboration exists to prevent.
+     */
+    val corrobLoneSkips: Int = -1,
 ) {
     /** Inlier ratio of the last attempt, or 0 when it produced no correspondences. */
     val inlierRatio: Float get() = if (matches > 0) inliers.toFloat() / matches else 0f

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/UiState.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/UiState.kt
@@ -249,6 +249,16 @@ data class ArUiState(
     // silent, which is why "it never works" was so hard to pin down.
     val relocDiagnostics: RelocDiagnostics = RelocDiagnostics(),
     /**
+     * `IMPLEMENTATION.md` **4.6** — the corroboration path's pixel-valued readings, carried apart
+     * from [relocDiagnostics] only because that record is filled from an `int[]` channel.
+     *
+     * Both fields are -1 until measured. The search radius in particular is the number that tells an
+     * artist's bug report apart from a tuning problem: a radius pinned at its ceiling means the
+     * design's on-screen scale is being read wrongly, and one pinned at its floor means
+     * corroboration is being starved — two opposite faults that look identical from the outside.
+     */
+    val corroborationDiagnostics: CorroborationDiagnostics = CorroborationDiagnostics(),
+    /**
      * How many 3D points the live wall fingerprint holds — 0 when there is none.
      *
      * The direct answer to "did the target actually get built", read straight from the engine

--- a/core/common/src/test/java/com/hereliesaz/graffitixr/common/model/RelocDiagnosticsTest.kt
+++ b/core/common/src/test/java/com/hereliesaz/graffitixr/common/model/RelocDiagnosticsTest.kt
@@ -125,6 +125,53 @@ class RelocDiagnosticsTest {
     }
 
     /**
+     * `IMPLEMENTATION.md` **4.8** — the corroboration counts carry the same three-way distinction as
+     * the backbone trio, and the middle case is the one the guard exists for.
+     *
+     * -1 is "no *gated* corroboration attempt has run" — no design placement, or no pose this
+     * frame, so the global fallback match measured a different quantity and deliberately did not
+     * fill these in. Zero predicted is "the artist is looking away from the design", which is
+     * ordinary and self-correcting. Zero matched under a positive predicted is the real alarm: the
+     * design is in view and the wall backs none of it. Collapsing any two of those would hide the
+     * third.
+     */
+    @Test
+    fun `unmeasured, nothing-in-view and nothing-corroborated are three distinct readings`() {
+        val unmeasured = RelocDiagnostics()
+        assertEquals(-1, unmeasured.corrobPredicted)
+        assertEquals(-1, unmeasured.corrobMatched)
+
+        val lookingAway = RelocDiagnostics(RelocReject.OK, corrobPredicted = 0, corrobMatched = 0)
+        val inViewNoAgreement =
+            RelocDiagnostics(RelocReject.OK, corrobPredicted = 240, corrobMatched = 0)
+        assertEquals(
+            "the three states must not share a corrobPredicted value",
+            3,
+            setOf(unmeasured, lookingAway, inViewNoAgreement).map { it.corrobPredicted }.toSet().size,
+        )
+        // ...and the two zero-matched states are told apart by the denominator alone, which is the
+        // whole reason predicted is published rather than just the ratio.
+        assertEquals(lookingAway.corrobMatched, inViewNoAgreement.corrobMatched)
+        assertTrue(lookingAway.corrobPredicted != inViewNoAgreement.corrobPredicted)
+    }
+
+    /**
+     * The float channel's sentinel, which cannot be zero for a reason the int fields do not share:
+     * a perfectly tracking pose really does report a near-zero reprojection residual, and a search
+     * radius clamped to its floor is a real 4 px. Both are readings this column exists to show.
+     */
+    @Test
+    fun `corroboration float diagnostics default to minus one, and zero is a real reading`() {
+        assertEquals(-1f, CorroborationDiagnostics().searchRadiusPx, 0f)
+        assertEquals(-1f, CorroborationDiagnostics().relocReprojPx, 0f)
+        val perfectLock = CorroborationDiagnostics(searchRadiusPx = 4f, relocReprojPx = 0f)
+        assertTrue(
+            "a zero reprojection error must not be indistinguishable from not measured",
+            perfectLock != CorroborationDiagnostics(),
+        )
+    }
+
+    /**
      * The same match shortfall means opposite things depending on how much texture the frame had, so
      * the two have to be independently readable.
      */

--- a/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
+++ b/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
@@ -1319,8 +1319,10 @@ Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeGetCorroborationCo
 // the rectification pass contributed, [6] = stored points in F_out, [7] = correspondences built
 // against F_out, [8] = inliers that came from F_out (IMPLEMENTATION.md 2.11; -1 = not measured),
 // [9] = design features the current pose predicts are visible, [10] = how many of those the wall
-// answered for (IMPLEMENTATION.md 4.6; -1 until a GATED corroboration attempt has run, and 0 for
-// [9] is a real reading meaning the artist is not looking at the design).
+// answered for, [11] = how many predicted features the gated match refused to test because their
+// neighbourhood held a single candidate (IMPLEMENTATION.md 4.6; all three -1 until a GATED
+// corroboration attempt has run, and 0 for [9] is a real reading meaning the artist is not looking
+// at the design).
 extern "C" JNIEXPORT jintArray JNICALL
 Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeGetRelocDiagnostics(JNIEnv* env, jobject) {
     // NOT {0, ...}: zero is kRelocOk, so a no-engine fallback of 0 reports a SUCCESSFUL LOCK with
@@ -1330,7 +1332,7 @@ Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeGetRelocDiagnostic
     // the Kotlin-only code that absorbs anything the native side cannot account for; the counts are
     // -1 (not sampled) rather than 0, because zero matches is a real measurement.
     static constexpr jint kRelocUnknownOrdinal = 7;
-    jint vals[11] = {kRelocUnknownOrdinal, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1};
+    jint vals[12] = {kRelocUnknownOrdinal, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1};
     if (gSlamEngine) {
         vals[0] = gSlamEngine->lastRelocReject();
         vals[1] = gSlamEngine->lastRelocMatches();
@@ -1343,10 +1345,11 @@ Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeGetRelocDiagnostic
         vals[8] = gSlamEngine->lastRelocBackboneInliers();
         vals[9] = gSlamEngine->corrobPredicted();
         vals[10] = gSlamEngine->corrobMatched();
+        vals[11] = gSlamEngine->corrobLoneSkips();
     }
-    jintArray out = env->NewIntArray(11);
+    jintArray out = env->NewIntArray(12);
     if (!out) return nullptr;
-    env->SetIntArrayRegion(out, 0, 11, vals);
+    env->SetIntArrayRegion(out, 0, 12, vals);
     return out;
 }
 

--- a/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
+++ b/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
@@ -396,6 +396,22 @@ Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeSetEvalRngSeed(JNI
     if (gSlamEngine) gSlamEngine->setEvalRngSeed((long long)seed);
 }
 
+// EVALUATION.md 3.1 / IMPLEMENTATION.md 6a.4 — inline relocalization for deterministic replay.
+JNIEXPORT void JNICALL
+Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeSetEvalSyncReloc(
+        JNIEnv* env, jobject thiz, jboolean enabled, jint everyN) {
+    if (gSlamEngine) gSlamEngine->setEvalSyncReloc(enabled == JNI_TRUE, (int)everyN);
+}
+
+// The cadence ACTUALLY in force: 0 when sync mode is off, so one int carries both the flag and the
+// N. Read back rather than remembered on the Kotlin side, so the run-identity sidecar reports what
+// the engine is doing and not what the caller asked for -- with no engine there is no sync mode, and
+// a sidecar claiming otherwise would be the kind of evidence that is worse than none.
+JNIEXPORT jint JNICALL
+Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeGetEvalSyncRelocEveryN(JNIEnv* env, jobject thiz) {
+    return gSlamEngine ? (jint)gSlamEngine->evalSyncEveryN() : 0;
+}
+
 JNIEXPORT jint JNICALL
 Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeGetWallKeypointCount(JNIEnv* env, jobject thiz) {
     return gSlamEngine ? gSlamEngine->getWallKeypointCount() : 0;

--- a/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
+++ b/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
@@ -1317,7 +1317,10 @@ Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeGetCorroborationCo
 // [0] = RelocReject code, [1] = correspondences, [2] = RANSAC inliers, [3] = features detected,
 // [4] = obliquity in degrees (-1 when the rectification pass wasn't eligible), [5] = correspondences
 // the rectification pass contributed, [6] = stored points in F_out, [7] = correspondences built
-// against F_out, [8] = inliers that came from F_out (IMPLEMENTATION.md 2.11; -1 = not measured).
+// against F_out, [8] = inliers that came from F_out (IMPLEMENTATION.md 2.11; -1 = not measured),
+// [9] = design features the current pose predicts are visible, [10] = how many of those the wall
+// answered for (IMPLEMENTATION.md 4.6; -1 until a GATED corroboration attempt has run, and 0 for
+// [9] is a real reading meaning the artist is not looking at the design).
 extern "C" JNIEXPORT jintArray JNICALL
 Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeGetRelocDiagnostics(JNIEnv* env, jobject) {
     // NOT {0, ...}: zero is kRelocOk, so a no-engine fallback of 0 reports a SUCCESSFUL LOCK with
@@ -1327,7 +1330,7 @@ Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeGetRelocDiagnostic
     // the Kotlin-only code that absorbs anything the native side cannot account for; the counts are
     // -1 (not sampled) rather than 0, because zero matches is a real measurement.
     static constexpr jint kRelocUnknownOrdinal = 7;
-    jint vals[9] = {kRelocUnknownOrdinal, -1, -1, -1, -1, -1, -1, -1, -1};
+    jint vals[11] = {kRelocUnknownOrdinal, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1};
     if (gSlamEngine) {
         vals[0] = gSlamEngine->lastRelocReject();
         vals[1] = gSlamEngine->lastRelocMatches();
@@ -1338,11 +1341,49 @@ Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeGetRelocDiagnostic
         vals[6] = gSlamEngine->lastRelocBackboneFeatures();
         vals[7] = gSlamEngine->lastRelocBackboneMatches();
         vals[8] = gSlamEngine->lastRelocBackboneInliers();
+        vals[9] = gSlamEngine->corrobPredicted();
+        vals[10] = gSlamEngine->corrobMatched();
     }
-    jintArray out = env->NewIntArray(9);
+    jintArray out = env->NewIntArray(11);
     if (!out) return nullptr;
-    env->SetIntArrayRegion(out, 0, 9, vals);
+    env->SetIntArrayRegion(out, 0, 11, vals);
     return out;
+}
+
+// IMPLEMENTATION.md 4.6 — the two float diagnostics from the corroboration path, which cannot ride
+// the int[] above. Packed together for the same reason it is packed: one call, one snapshot.
+// [0] = search radius the last gated attempt used, in pixels; [1] = mean reprojection error over the
+// last lock's PnP inliers, also in pixels. Both -1 for "not measured", never 0 — a perfectly
+// tracking pose really does have a near-zero reprojection error, so zero cannot double as the
+// default.
+extern "C" JNIEXPORT jfloatArray JNICALL
+Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeGetCorroborationDiagnostics(JNIEnv* env, jobject) {
+    jfloat vals[2] = {-1.0f, -1.0f};
+    if (gSlamEngine) {
+        vals[0] = gSlamEngine->corrobSearchRadiusPx();
+        vals[1] = gSlamEngine->lastRelocReprojPx();
+    }
+    jfloatArray out = env->NewFloatArray(2);
+    if (!out) return nullptr;
+    env->SetFloatArrayRegion(out, 0, 2, vals);
+    return out;
+}
+
+// IMPLEMENTATION.md 4.5 — where the design sits, so the corroboration match can predict where each
+// of its features should appear. A null or wrong-length matrix clears the placement rather than
+// being padded: the corroboration match then falls back to its global search, which is Phase 4 off
+// and not Phase 4 guessing.
+extern "C" JNIEXPORT void JNICALL
+Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeSetDesignPlacement(
+        JNIEnv* env, jobject, jfloatArray fpFromDesign16, jfloat halfW, jfloat halfH) {
+    if (!gSlamEngine) return;
+    if (!fpFromDesign16 || env->GetArrayLength(fpFromDesign16) != 16) {
+        gSlamEngine->setDesignPlacement(nullptr, 0.0f, 0.0f);
+        return;
+    }
+    jfloat* m = env->GetFloatArrayElements(fpFromDesign16, nullptr);
+    gSlamEngine->setDesignPlacement(m, halfW, halfH);
+    env->ReleaseFloatArrayElements(fpFromDesign16, m, JNI_ABORT);
 }
 
 extern "C" JNIEXPORT void JNICALL

--- a/core/nativebridge/src/main/cpp/MobileGS.cpp
+++ b/core/nativebridge/src/main/cpp/MobileGS.cpp
@@ -1,8 +1,11 @@
 #include "include/MobileGS.h"
+#include "include/KeypointGrid.h"
+#include "include/SearchRadius.h"
 #include <jni.h>
 #include <EGL/egl.h>
 #include <algorithm>
 #include <android/log.h>
+#include <cfloat>
 #include <cstring>
 #include <vector>
 #include <fstream>
@@ -252,6 +255,11 @@ void MobileGS::relocThreadFunc() {
         mLastRelocBackboneFeatures.store(-1, std::memory_order_relaxed);
         mLastRelocBackboneMatches.store(-1, std::memory_order_relaxed);
         mLastRelocBackboneInliers.store(-1, std::memory_order_relaxed);
+        // Same rule for the reprojection residual (IMPLEMENTATION.md 4.3): it is only meaningful
+        // for the attempt that produced it, and the search radius reads it as a drift measurement.
+        // Leaving a previous lock's value in place would widen or narrow the corroboration search
+        // on the strength of a pose that is no longer the one being predicted from.
+        mLastRelocReprojPx.store(-1.0f, std::memory_order_relaxed);
 
         if (!mRelocEnabled) {
             mLastRelocReject.store(kRelocDisabled, std::memory_order_relaxed);
@@ -340,7 +348,7 @@ void MobileGS::relocThreadFunc() {
             matcher->knnMatch(descs, wallDescs, matches, 2);
             for (auto& match : matches) {
                 if (match.size() < 2) continue;
-                if (match[0].distance < 0.75f * match[1].distance) {
+                if (match[0].distance < kRelocLoweRatio * match[1].distance) {
                     // PAPER.md §5: the reloc PnP solves the GLOBAL problem, with no prior, and must
                     // therefore see only the backbone. Points under the artwork (INSIDE) are the
                     // work surface — they decay as it is painted, which is exactly what makes
@@ -446,7 +454,7 @@ void MobileGS::relocThreadFunc() {
                     size_t before = imgPts.size();
                     for (auto& m : matches) {
                         if (m.size() < 2) continue;
-                        if (m[0].distance < 0.75f * m[1].distance) {
+                        if (m[0].distance < kRelocLoweRatio * m[1].distance) {
                             imgPts.push_back(baseKps[m[0].queryIdx].pt);
                             objPts.push_back(mapKps3d[visible[m[0].trainIdx]]);
                             // NOT backbone: the persistent map is a separate point set that Φ has
@@ -594,6 +602,14 @@ void MobileGS::relocThreadFunc() {
                                 if (e < bestErr) { bestErr = e; rvecs[s].copyTo(rvec); tvecs[s].copyTo(tvec); }
                             }
                         } catch (const cv::Exception&) { /* keep RANSAC pose */ }
+                        // IMPLEMENTATION.md 4.3 — publish the MEAN, not the sum `reproj` returns.
+                        // The sum grows with the inlier count, so a better lock would report a worse
+                        // error and the corroboration search would tighten exactly when it has the
+                        // most to gain from staying put. Divided by the same set it was summed over.
+                        if (!inObj.empty()) {
+                            mLastRelocReprojPx.store((float)(bestErr / (double)inObj.size()),
+                                                     std::memory_order_relaxed);
+                        }
                     }
                     cv::Mat R;
                     cv:: Rodrigues(rvec, R);
@@ -783,7 +799,7 @@ void MobileGS::growMapFromReloc(const glm::mat4& camFromFp, const std::vector<cv
         matcher->knnMatch(descs, mMapDescriptors, matches, 2);
         for (auto& m : matches) {
             if (m.size() < 2) continue;
-            if (m[0].distance < 0.75f * m[1].distance) {
+            if (m[0].distance < kRelocLoweRatio * m[1].distance) {
                 int ti = m[0].trainIdx, qi = m[0].queryIdx;
                 if (ti >= 0 && ti < (int)mMapConfidence.size() && qi >= 0 && qi < (int)matched.size()) {
                     mMapConfidence[ti] = std::min(1.0f, mMapConfidence[ti] + 0.1f);
@@ -826,10 +842,29 @@ void MobileGS::tryUpdateFingerprint(const cv::Mat& grayClean,
                                     const std::vector<cv::KeyPoint>* preKps,
                                     const cv::Mat* preDescs) {
     cv::Mat artDescs;
+    std::vector<cv::Point2f> artPts2d;
+    int artImgW = 0, artImgH = 0;
+    long artGeneration = 0;
+    bool havePlacement = false;
+    float fpFromDesign[16];
+    float designHalfW = 0.0f, designHalfH = 0.0f;
+    float camFromFp[16];
+    float fpFx = 0.0f, fpFy = 0.0f, fpCx = 0.0f, fpCy = 0.0f;
     {
         std::lock_guard<std::mutex> lock(mMutex);
         if (mArtworkDescriptors.empty()) return;
         artDescs = mArtworkDescriptors;
+        artPts2d = mArtworkKeypoints2D;
+        artImgW = mArtworkImageW;
+        artImgH = mArtworkImageH;
+        artGeneration = mArtworkGeneration;
+        havePlacement = mHasDesignPlacement;
+        memcpy(fpFromDesign, mDesignFpFromDesign, 16 * sizeof(float));
+        designHalfW = mDesignHalfW;
+        designHalfH = mDesignHalfH;
+        memcpy(camFromFp, mPnpCamFromFpWorld, 16 * sizeof(float));
+        fpFx = mFingerprintIntrinsics[0]; fpFy = mFingerprintIntrinsics[1];
+        fpCx = mFingerprintIntrinsics[2]; fpCy = mFingerprintIntrinsics[3];
     }
     if (grayClean.empty()) return;
 
@@ -851,34 +886,201 @@ void MobileGS::tryUpdateFingerprint(const cv::Mat& grayClean,
     const cv::Mat& descs = reuse ? *preDescs : localDescs;
     if (descs.empty() || descs.type() != artDescs.type()) return;
 
-    cv::Ptr<cv::DescriptorMatcher>& matcher = (descs.type() == CV_32F) ? mL2Matcher : mMatcher;
-    std::vector<std::vector<cv::DMatch>> matches;
-    matcher->knnMatch(descs, artDescs, matches, 2);
+    // IMPLEMENTATION.md 4.5 — is the SPATIALLY-CONSTRAINED match available for this frame?
+    //
+    // Four things have to hold, and each missing one is a refusal rather than a guess:
+    //  - the design's placement on the wall, pushed from Kotlin (setDesignPlacement);
+    //  - a pose for THIS frame. mLastRelocReject is written by the attempt that just ran, a few
+    //    lines above the call into here, so kRelocOk means mPnpCamFromFpWorld describes this frame
+    //    and not some earlier lock. Predicting from a stale pose is precisely the failure the phase
+    //    warns about, and it fails silently — the search looks in a confidently wrong place;
+    //  - the artwork's 2D positions, one per descriptor row. A length mismatch means the two fell
+    //    out of step and every prediction after that point would be another feature's;
+    //  - the intrinsics the fingerprint's 3D was built with, which the reloc PnP also uses.
+    //
+    // When any of them is missing this falls back to the global knnMatch below, which is exactly
+    // pre-Phase-4 behaviour.
+    const bool gated =
+        havePlacement &&
+        mLastRelocReject.load(std::memory_order_relaxed) == kRelocOk &&
+        (int)artPts2d.size() == artDescs.rows &&
+        artImgW > 0 && artImgH > 0 && fpFx > 0.0f && fpFy > 0.0f;
 
     std::vector<char> hit(artDescs.rows, 0);
     std::vector<int> validQuery;   // clean keypoints that corroborate the artwork (self-grow candidates)
     int matched = 0;
-    for (auto& m : matches) {
-        if (m.size() < 2) continue;
-        if (m[0].distance < 0.75f * m[1].distance) {
-            int a = m[0].trainIdx;
-            if (a >= 0 && a < (int)hit.size() && !hit[a]) { hit[a] = 1; matched++; }
-            validQuery.push_back(m[0].queryIdx);
+    int predicted = -1;            // -1 = no gated attempt ran; 0 is a real reading
+    float radiusPx = -1.0f;
+
+    if (gated) {
+        // camera_from_design = camera_from_fingerprintWorld * fingerprintWorld_from_design. Both are
+        // column-major, which is glm's layout, so make_mat4 is a reinterpretation and not a
+        // transpose. The right-hand factor is the SAME composition Phi is classified with — see
+        // setDesignPlacement — deliberately, so the two cannot disagree about where the design is.
+        const glm::mat4 camFromDesign = glm::make_mat4(camFromFp) * glm::make_mat4(fpFromDesign);
+        // Distance to the wall along the view axis: the design origin's depth in the camera frame.
+        // OpenCV convention (+Z forward), because that matrix came out of solvePnP.
+        const float wallDistM = camFromDesign[3][2];
+        const float focalPx = 0.5f * (fpFx + fpFy);
+        // poseErrMm is unconditionally "not measured" here and that is not an oversight: the only
+        // producer is DriftCostProbe, which needs a ground-truth pose and returns its own -1 sentinel
+        // without one. The reprojection residual below is the drift signal that exists on this path.
+        radiusPx = searchradius::pixels(
+            searchradius::kRho, designHalfW, designHalfH, wallDistM, focalPx,
+            /*poseErrMm=*/searchradius::kNotMeasured,
+            /*reprojErrPx=*/mLastRelocReprojPx.load(std::memory_order_relaxed));
+
+        KeypointGrid grid;
+        grid.build(kps, radiusPx);
+
+        // Descriptor distance, computed directly rather than through a matcher: the query here is
+        // "these few candidates", and building a per-feature cv::Mat to hand to knnMatch would cost
+        // more than the comparison. L2 for SuperPoint (CV_32F), Hamming for ORB — the same pairing
+        // mL2Matcher/mMatcher encode, and the type equality was checked above.
+        const bool isFloat = descs.type() == CV_32F;
+        const int dcols = descs.cols;
+        auto descDistance = [&](int q, int a) -> float {
+            if (isFloat) {
+                const float* pq = descs.ptr<float>(q);
+                const float* pa = artDescs.ptr<float>(a);
+                float acc = 0.0f;
+                for (int k = 0; k < dcols; ++k) { const float d = pq[k] - pa[k]; acc += d * d; }
+                return std::sqrt(acc);
+            }
+            const uchar* pq = descs.ptr<uchar>(q);
+            const uchar* pa = artDescs.ptr<uchar>(a);
+            int acc = 0;
+            for (int k = 0; k < dcols; ++k) acc += __builtin_popcount((unsigned)(pq[k] ^ pa[k]));
+            return (float)acc;
+        };
+
+        const float frameW = (float)grayClean.cols;
+        const float frameH = (float)grayClean.rows;
+        std::vector<int> cand;
+        predicted = 0;
+        int loneCandidateSkips = 0;
+        for (int a = 0; a < artDescs.rows; ++a) {
+            const cv::Point2f& ap = artPts2d[(size_t)a];
+            // Composite pixel -> design-plane metres. The overlay quad spans [-halfW, halfW] x
+            // [-halfH, halfH] with the texture stretched across it and V flipped (OverlayRenderer
+            // writes `1 - v` alongside `y = -halfH + v * 2 * halfH`), so image row 0 is +halfH. The
+            // mapping is parametric in the composite's size, which is why it needs no aspect
+            // agreement between the bitmap and the quad.
+            const float lx = designHalfW * (2.0f * ap.x / (float)artImgW - 1.0f);
+            const float ly = designHalfH * (1.0f - 2.0f * ap.y / (float)artImgH);
+            const glm::vec4 pc = camFromDesign * glm::vec4(lx, ly, 0.0f, 1.0f);
+            if (!(pc.z > 1e-4f)) continue;                       // behind or on the camera plane
+            const float u = fpFx * pc.x / pc.z + fpCx;
+            const float v = fpFy * pc.y / pc.z + fpCy;
+            if (!std::isfinite(u) || !std::isfinite(v)) continue;
+            // Predicted OUTSIDE the frame is not visible, and must not count in the denominator —
+            // that is the whole of 5b.1. The radius is allowed as slack on each edge because a
+            // feature predicted just off-frame can still have its true detection just on it.
+            if (u < -radiusPx || v < -radiusPx || u > frameW + radiusPx || v > frameH + radiusPx) continue;
+            ++predicted;
+
+            grid.candidatesWithin(u, v, radiusPx, cand);
+            if (cand.size() < 2) {
+                // Lowe's ratio needs a second-best to divide by. With one candidate there is nothing
+                // to compare against, and accepting it unconditionally would corroborate any
+                // keypoint that happens to land near the prediction regardless of what it looks
+                // like — a confidence signal that measures the wall's texture density instead of its
+                // agreement with the design, feeding PoseFusion's correction strength.
+                //
+                // Skipping instead deflates `matched` without touching `predicted`, so the cost
+                // shows up as lower confidence rather than as a wrong one. If this count is large,
+                // the radius is too tight and rho wants raising; E6 is where that gets decided
+                // rather than guessed, which is why it is logged.
+                if (cand.size() == 1) ++loneCandidateSkips;
+                continue;
+            }
+            float best = FLT_MAX, second = FLT_MAX;
+            int bestQ = -1;
+            for (int q : cand) {
+                const float d = descDistance(q, a);
+                if (d < best) { second = best; best = d; bestQ = q; }
+                else if (d < second) { second = d; }
+            }
+            if (bestQ < 0) continue;
+            if (best < kCorrobLoweRatio * second) {
+                hit[a] = 1;
+                ++matched;
+                validQuery.push_back(bestQ);
+            }
+        }
+        if (loneCandidateSkips > 0) {
+            LOGI("Corroboration (gated): r=%.1fpx predicted=%d matched=%d lone-candidate skips=%d",
+                 radiusPx, predicted, matched, loneCandidateSkips);
+        }
+    } else {
+        // Pre-Phase-4 global search: every frame descriptor against every artwork descriptor, no
+        // prior, tight ratio. Note the direction is the opposite of the gated path's — here each
+        // FRAME keypoint asks which design feature it is, because there is no predicted location to
+        // ask the question the other way round.
+        cv::Ptr<cv::DescriptorMatcher>& matcher = (descs.type() == CV_32F) ? mL2Matcher : mMatcher;
+        std::vector<std::vector<cv::DMatch>> matches;
+        matcher->knnMatch(descs, artDescs, matches, 2);
+        for (auto& m : matches) {
+            if (m.size() < 2) continue;
+            if (m[0].distance < kRelocLoweRatio * m[1].distance) {
+                int a = m[0].trainIdx;
+                if (a >= 0 && a < (int)hit.size() && !hit[a]) { hit[a] = 1; matched++; }
+                validQuery.push_back(m[0].queryIdx);
+            }
         }
     }
-    // The distortion head's coverage is the principled progress signal; only fall back to this
-    // descriptor-corroboration ratio when the head isn't present.
+
+    // IMPLEMENTATION.md 4.6 — publish what the match actually did. Only the gated path writes these:
+    // the global path measures a different quantity (the whole design, framing included) and
+    // reporting its numbers in the same channels would make the two look comparable.
+    if (gated) {
+        mCorrobPredicted.store(predicted, std::memory_order_relaxed);
+        mCorrobMatched.store(matched, std::memory_order_relaxed);
+        mCorrobSearchRadiusPx.store(radiusPx, std::memory_order_relaxed);
+    }
+
+    // Fold this attempt's hits into the running "has the wall ever answered for this feature" set,
+    // under the generation check — the artwork may have been replaced while the match ran.
+    int everCorroborated = -1;
+    {
+        std::lock_guard<std::mutex> lock(mMutex);
+        if (mArtworkGeneration == artGeneration &&
+            mArtworkCorroborated.size() == (size_t)artDescs.rows) {
+            for (int a = 0; a < artDescs.rows; ++a) if (hit[a]) mArtworkCorroborated[(size_t)a] = 1;
+            everCorroborated = (int)std::count(mArtworkCorroborated.begin(),
+                                               mArtworkCorroborated.end(), (uint8_t)1);
+        }
+    }
+
+    // The distortion head's coverage is the principled progress signal; only fall back to these
+    // descriptor-corroboration ratios when the head isn't present.
     //
-    // Both channels are published from this one ratio for now. They are genuinely the same number
-    // on this path today, because the denominator is every descriptor of the design — including the
-    // parts behind the camera. Phase 5b narrows the CONFIDENCE denominator to the features actually
-    // predicted visible, at which point the two diverge and a close-up of one corner stops being
-    // capped by framing rather than by agreement. Progress keeps the whole-design denominator,
-    // which is the correct one for it.
-    if (artDescs.rows > 0 && !mDistortionHead.isLoaded()) {
-        const float ratio = (float)matched / (float)artDescs.rows;
-        mPaintingProgress.store(ratio, std::memory_order_relaxed);
-        mCorroborationConfidence.store(ratio, std::memory_order_relaxed);
+    // The two channels have DIFFERENT denominators now, which is the point of Phase 4/5b.
+    //
+    // PROGRESS is cumulative over the whole design: how much of the artwork the wall has ever
+    // answered for. It has to be cumulative because the gated match only ever looks at the part of
+    // the design in frame, so an instantaneous ratio would measure where the artist is standing. It
+    // is also what getPaintingProgress() already promises — hours, roughly monotonic, never decayed.
+    //
+    // CONFIDENCE is instantaneous over the predicted-visible set: of the design features the current
+    // pose says should be in view, how many does the wall back right now. A close-up of one corner
+    // is no longer capped by framing rather than by agreement (5b.1).
+    if (!mDistortionHead.isLoaded()) {
+        if (everCorroborated >= 0 && artDescs.rows > 0) {
+            mPaintingProgress.store((float)everCorroborated / (float)artDescs.rows,
+                                    std::memory_order_relaxed);
+        }
+        if (gated) {
+            // 4.8: zero predicted-visible is "the artist is not looking at the design", NOT "the
+            // wall does not corroborate it". Publishing 0.0 would be a measurement never taken, and
+            // PoseFusion scales its correction strength by this.
+            mCorroborationConfidence.store(
+                predicted > 0 ? (float)matched / (float)predicted : kCorroborationUnmeasured,
+                std::memory_order_relaxed);
+        } else if (artDescs.rows > 0) {
+            mCorroborationConfidence.store((float)matched / (float)artDescs.rows,
+                                           std::memory_order_relaxed);
+        }
     }
 
     // --- Teleological self-grow (opt-in) ---------------------------------------------------------
@@ -889,7 +1091,9 @@ void MobileGS::tryUpdateFingerprint(const cv::Mat& grayClean,
     // backstop, but it still mutates the authoritative set, so it stays OFF unless explicitly enabled.
     if (!mSelfGrowEnabled.load(std::memory_order_relaxed) || validQuery.empty()) return;
 
-    // pnpMatches, not `matches` — that name is already the knnMatch result vector in this scope.
+    // pnpMatches, not `matches`: that name used to be the knnMatch result vector in this scope, and
+    // although Phase 4 moved it inside the global-fallback branch the reason to keep them apart
+    // stands — one counts descriptor correspondences, the other counts the PnP's.
     cv::Matx33d R; cv::Vec3d t; double fx, fy, cx, cy; int inliers; int pnpMatches; long seq;
     std::vector<cv::Point3f> wall;
     {
@@ -1046,12 +1250,50 @@ void MobileGS::clearWallFingerprint() {
     // this project's features into its map on the strength of a different project's target.
     mArtworkDescriptors.release();
     mArtworkKeypoints3D.clear();
+    mArtworkKeypoints2D.clear();
+    mArtworkCorroborated.clear();
+    ++mArtworkGeneration;
+    mArtworkImageW = 0;
+    mArtworkImageH = 0;
+    // The design's placement belongs to the project that placed it. Left behind, the corroboration
+    // match would predict the next project's design features at the previous design's location on
+    // the wall — a gated search that is confidently, precisely looking in the wrong place, which
+    // reads downstream as "the wall does not corroborate" rather than as a stale-state bug.
+    mHasDesignPlacement = false;
+    mDesignHalfW = 0.0f;
+    mDesignHalfH = 0.0f;
     mWallPatch.release();
     mPaintingProgress.store(0.0f, std::memory_order_relaxed);
     // Back to "never measured", not to zero — the next project has not been looked at yet, and
     // reporting a confident 0 would be a measurement it never made.
     mCorroborationConfidence.store(kCorroborationUnmeasured, std::memory_order_relaxed);
+    mCorrobPredicted.store(-1, std::memory_order_relaxed);
+    mCorrobMatched.store(-1, std::memory_order_relaxed);
+    mCorrobSearchRadiusPx.store(-1.0f, std::memory_order_relaxed);
     mLastGrowSeq = 0;
+}
+
+// IMPLEMENTATION.md 4.5. Takes the composition Kotlin already built for the Phi partition rather
+// than the two factors, deliberately: recomposing it here would be a second derivation of the same
+// quantity in a file that cannot see whether the anchor it was relative to is still the live one.
+void MobileGS::setDesignPlacement(const float* fpFromDesign16, float halfW, float halfH) {
+    std::lock_guard<std::mutex> lock(mMutex);
+    if (!fpFromDesign16 || !(halfW > 0.0f) || !(halfH > 0.0f) ||
+        !std::isfinite(halfW) || !std::isfinite(halfH)) {
+        // A refusal, not a guess. Without a usable placement the corroboration match falls back to
+        // the global search — Phase 4 off, which is a state the code already handles correctly.
+        mHasDesignPlacement = false;
+        mDesignHalfW = 0.0f;
+        mDesignHalfH = 0.0f;
+        return;
+    }
+    for (int i = 0; i < 16; ++i) {
+        if (!std::isfinite(fpFromDesign16[i])) { mHasDesignPlacement = false; return; }
+    }
+    memcpy(mDesignFpFromDesign, fpFromDesign16, 16 * sizeof(float));
+    mDesignHalfW = halfW;
+    mDesignHalfH = halfH;
+    mHasDesignPlacement = true;
 }
 
 void MobileGS::restoreWallFeatureMap(const cv::Mat& d, const std::vector<cv::Point3f>& p,
@@ -1260,6 +1502,13 @@ void MobileGS::setArtworkFingerprint(const cv::Mat& composite, const uint8_t* de
     // bailed on the option-A path, so painting-progress never registered.
     std::vector<cv::Point3f> pts3d;
     cv::Mat keepDescs = descs;
+    // IMPLEMENTATION.md 4.5 — kept in lockstep with keepDescs, INCLUDING through the depth filter
+    // below. The filter rebuilds the descriptor matrix from a subset of rows; a 2D list built before
+    // it and stored afterwards would be indexed by descriptor row and silently return a different
+    // feature's pixel, which projects to a plausible place and corroborates the wrong thing.
+    std::vector<cv::Point2f> keepPts2d;
+    keepPts2d.reserve(kps.size());
+    for (const auto& kp : kps) keepPts2d.push_back(kp.pt);
     if (depthData && depthW > 0 && depthH > 0 && depthStride > 0 && intr) {
         const float fx = intr[0], fy = intr[1], cx = intr[2], cy = intr[3];
         const float scaleX = (float)depthW / (float)composite.cols;
@@ -1278,9 +1527,14 @@ void MobileGS::setArtworkFingerprint(const cv::Mat& composite, const uint8_t* de
         }
         if (!validIdx.empty()) {
             cv::Mat validDescs((int)validIdx.size(), descs.cols, descs.type());
-            for (int k = 0; k < (int)validIdx.size(); ++k)
+            std::vector<cv::Point2f> validPts2d;
+            validPts2d.reserve(validIdx.size());
+            for (int k = 0; k < (int)validIdx.size(); ++k) {
                 descs.row(validIdx[k]).copyTo(validDescs.row(k));
+                validPts2d.push_back(kps[(size_t)validIdx[k]].pt);
+            }
             keepDescs = validDescs;   // keep descriptors aligned 1:1 with pts3d
+            keepPts2d = std::move(validPts2d);
         }
     }
 
@@ -1289,6 +1543,15 @@ void MobileGS::setArtworkFingerprint(const cv::Mat& composite, const uint8_t* de
         std::lock_guard<std::mutex> lock(mMutex);
         mArtworkDescriptors = keepDescs.clone();
         mArtworkKeypoints3D = std::move(pts3d);
+        mArtworkKeypoints2D = std::move(keepPts2d);
+        mArtworkImageW = gray.cols;
+        mArtworkImageH = gray.rows;
+        // A new design means nothing corroborated so far corroborates THIS one.
+        mArtworkCorroborated.assign((size_t)mArtworkDescriptors.rows, 0);
+        ++mArtworkGeneration;
+        mCorrobPredicted.store(-1, std::memory_order_relaxed);
+        mCorrobMatched.store(-1, std::memory_order_relaxed);
+        mCorrobSearchRadiusPx.store(-1.0f, std::memory_order_relaxed);
         mPaintingProgress.store(0.0f, std::memory_order_relaxed);
         // A new design means every prior corroboration reading was against a different target.
         mCorroborationConfidence.store(kCorroborationUnmeasured, std::memory_order_relaxed);

--- a/core/nativebridge/src/main/cpp/MobileGS.cpp
+++ b/core/nativebridge/src/main/cpp/MobileGS.cpp
@@ -260,6 +260,18 @@ void MobileGS::relocThreadFunc() {
         // Leaving a previous lock's value in place would widen or narrow the corroboration search
         // on the strength of a pose that is no longer the one being predicted from.
         mLastRelocReprojPx.store(-1.0f, std::memory_order_relaxed);
+        // ...and the same rule again for the corroboration counters (IMPLEMENTATION.md 4.6). These
+        // are written only on a GATED attempt, so without a reset here one gated attempt's numbers
+        // stayed live across every subsequent tick that fell back to the global search — a red
+        // FEW_INLIERS row on the overlay sitting next to a healthy "Corrob 30/40", and, worse, the
+        // same measurement copied into every eval CSV row until the next gated attempt, which turns
+        // any rate E6 computes from these columns into a count of ticks rather than of attempts.
+        // Reset alongside the backbone trio because they are the same kind of number and the
+        // convention has to be one convention.
+        mCorrobPredicted.store(-1, std::memory_order_relaxed);
+        mCorrobMatched.store(-1, std::memory_order_relaxed);
+        mCorrobLoneSkips.store(-1, std::memory_order_relaxed);
+        mCorrobSearchRadiusPx.store(-1.0f, std::memory_order_relaxed);
 
         if (!mRelocEnabled) {
             mLastRelocReject.store(kRelocDisabled, std::memory_order_relaxed);
@@ -910,6 +922,7 @@ void MobileGS::tryUpdateFingerprint(const cv::Mat& grayClean,
     std::vector<int> validQuery;   // clean keypoints that corroborate the artwork (self-grow candidates)
     int matched = 0;
     int predicted = -1;            // -1 = no gated attempt ran; 0 is a real reading
+    int loneSkips = -1;            // likewise: 0 skips is a measurement, not an absence
     float radiusPx = -1.0f;
 
     if (gated) {
@@ -987,10 +1000,17 @@ void MobileGS::tryUpdateFingerprint(const cv::Mat& grayClean,
                 // like — a confidence signal that measures the wall's texture density instead of its
                 // agreement with the design, feeding PoseFusion's correction strength.
                 //
-                // Skipping instead deflates `matched` without touching `predicted`, so the cost
-                // shows up as lower confidence rather than as a wrong one. If this count is large,
-                // the radius is too tight and rho wants raising; E6 is where that gets decided
-                // rather than guessed, which is why it is logged.
+                // Skipping deflates `matched` without touching `predicted`, so the cost shows up
+                // as lower confidence — but "lower confidence" is not free: it maps through
+                // PoseFusion's alpha to LESS relocalization correction and therefore more
+                // accumulated drift, which is the failure corroboration exists to prevent. So this
+                // is conservative against false snapping and anti-conservative against drift, and
+                // the only thing that tells you which side you are on is the rate.
+                //
+                // Published on its own diagnostic channel rather than logged, because at the MIN_PX
+                // floor a sparse frame can skip most of what it predicted and the symptom — a wall
+                // that has apparently stopped corroborating — looks identical to an unpainted one.
+                // E6 sets rho against this number.
                 if (cand.size() == 1) ++loneCandidateSkips;
                 continue;
             }
@@ -1008,6 +1028,7 @@ void MobileGS::tryUpdateFingerprint(const cv::Mat& grayClean,
                 validQuery.push_back(bestQ);
             }
         }
+        loneSkips = loneCandidateSkips;
         if (loneCandidateSkips > 0) {
             LOGI("Corroboration (gated): r=%.1fpx predicted=%d matched=%d lone-candidate skips=%d",
                  radiusPx, predicted, matched, loneCandidateSkips);
@@ -1036,19 +1057,30 @@ void MobileGS::tryUpdateFingerprint(const cv::Mat& grayClean,
     if (gated) {
         mCorrobPredicted.store(predicted, std::memory_order_relaxed);
         mCorrobMatched.store(matched, std::memory_order_relaxed);
+        mCorrobLoneSkips.store(loneSkips, std::memory_order_relaxed);
         mCorrobSearchRadiusPx.store(radiusPx, std::memory_order_relaxed);
     }
 
-    // Fold this attempt's hits into the running "has the wall ever answered for this feature" set,
-    // under the generation check — the artwork may have been replaced while the match ran.
+    // Fold this attempt's hits into the running corroboration counts, under the generation check —
+    // the artwork may have been replaced while the match ran.
+    //
+    // GATED ATTEMPTS ONLY. The fallback branch above is the pre-Phase-4 global search: an
+    // unconstrained descriptor match with no geometric agreement behind it, and feeding a signal
+    // that never decays from a match that was never localized is how a monotone counter saturates
+    // on noise. A gated hit means the wall shows this design feature within a few pixels of where
+    // the design says it should be AND wins the ratio test among its neighbours; that is a
+    // materially stronger claim, and it is the only one allowed to move progress.
     int everCorroborated = -1;
-    {
+    if (gated) {
         std::lock_guard<std::mutex> lock(mMutex);
         if (mArtworkGeneration == artGeneration &&
             mArtworkCorroborated.size() == (size_t)artDescs.rows) {
-            for (int a = 0; a < artDescs.rows; ++a) if (hit[a]) mArtworkCorroborated[(size_t)a] = 1;
-            everCorroborated = (int)std::count(mArtworkCorroborated.begin(),
-                                               mArtworkCorroborated.end(), (uint8_t)1);
+            everCorroborated = 0;
+            for (int a = 0; a < artDescs.rows; ++a) {
+                uint8_t& c = mArtworkCorroborated[(size_t)a];
+                if (hit[a] && c < kCorrobConfirmations) ++c;
+                if (c >= kCorrobConfirmations) ++everCorroborated;
+            }
         }
     }
 
@@ -1065,21 +1097,46 @@ void MobileGS::tryUpdateFingerprint(const cv::Mat& grayClean,
     // CONFIDENCE is instantaneous over the predicted-visible set: of the design features the current
     // pose says should be in view, how many does the wall back right now. A close-up of one corner
     // is no longer capped by framing rather than by agreement (5b.1).
+    //
+    // Both channels switch definition on `havePlacement`, NOT on `gated`. A design placement is
+    // stable across frames while a lock is not, so keying on the lock would flip progress between
+    // two different measurements every time the artist looked away and back — two definitions
+    // alternating in one readout is worse than either alone.
     if (!mDistortionHead.isLoaded()) {
-        if (everCorroborated >= 0 && artDescs.rows > 0) {
-            mPaintingProgress.store((float)everCorroborated / (float)artDescs.rows,
+        if (havePlacement) {
+            // Phase 4 is active for this project. A tick with no lock publishes nothing and leaves
+            // the last value standing, because the alternative is replacing a cumulative reading
+            // with an instantaneous one from a different denominator.
+            if (everCorroborated >= 0 && artDescs.rows > 0) {
+                mPaintingProgress.store((float)everCorroborated / (float)artDescs.rows,
+                                        std::memory_order_relaxed);
+            }
+        } else if (artDescs.rows > 0) {
+            // No placement ever pushed: Phase 4 is off for this project and this is exactly the
+            // pre-Phase-4 instantaneous whole-design ratio.
+            mPaintingProgress.store((float)matched / (float)artDescs.rows,
                                     std::memory_order_relaxed);
         }
+
         if (gated) {
             // 4.8: zero predicted-visible is "the artist is not looking at the design", NOT "the
-            // wall does not corroborate it". Publishing 0.0 would be a measurement never taken, and
-            // PoseFusion scales its correction strength by this.
+            // wall does not corroborate it". Publishing 0.0 would be a measurement never taken.
+            //
+            // Note what this does and does not buy. PoseFusion cannot tell the two apart —
+            // ArRenderer coerces the negative to 0f and CONF_FLOOR absorbs both, so `effConf` is
+            // byte-identical either way. The value is entirely in the diagnostics and the eval CSV,
+            // which is where E6 has to separate "looking away" from "looked, found nothing".
             mCorroborationConfidence.store(
                 predicted > 0 ? (float)matched / (float)predicted : kCorroborationUnmeasured,
                 std::memory_order_relaxed);
-        } else if (artDescs.rows > 0) {
+        } else if (!havePlacement && artDescs.rows > 0) {
             mCorroborationConfidence.store((float)matched / (float)artDescs.rows,
                                            std::memory_order_relaxed);
+        } else {
+            // Placement exists but this attempt had no pose to predict from. That is an attempt
+            // that ran and produced no usable measurement, which is precisely what the decay is
+            // for — the last reading is getting stale, and saying so beats repeating it.
+            decayCorroboration();
         }
     }
 
@@ -1269,6 +1326,7 @@ void MobileGS::clearWallFingerprint() {
     mCorroborationConfidence.store(kCorroborationUnmeasured, std::memory_order_relaxed);
     mCorrobPredicted.store(-1, std::memory_order_relaxed);
     mCorrobMatched.store(-1, std::memory_order_relaxed);
+    mCorrobLoneSkips.store(-1, std::memory_order_relaxed);
     mCorrobSearchRadiusPx.store(-1.0f, std::memory_order_relaxed);
     mLastGrowSeq = 0;
 }
@@ -1551,6 +1609,7 @@ void MobileGS::setArtworkFingerprint(const cv::Mat& composite, const uint8_t* de
         ++mArtworkGeneration;
         mCorrobPredicted.store(-1, std::memory_order_relaxed);
         mCorrobMatched.store(-1, std::memory_order_relaxed);
+        mCorrobLoneSkips.store(-1, std::memory_order_relaxed);
         mCorrobSearchRadiusPx.store(-1.0f, std::memory_order_relaxed);
         mPaintingProgress.store(0.0f, std::memory_order_relaxed);
         // A new design means every prior corroboration reading was against a different target.

--- a/core/nativebridge/src/main/cpp/MobileGS.cpp
+++ b/core/nativebridge/src/main/cpp/MobileGS.cpp
@@ -207,6 +207,459 @@ void MobileGS::getConfidenceAvgs(float& outVisible, float& outGlobal) const {
 void MobileGS::updatePersistentMesh(const cv::Mat& depth, const cv::Mat& color, const float* viewMat, const float* projMat) {}
 void MobileGS::getPersistentMesh(std::vector<float>& outVertices, std::vector<float>& outWeights) {}
 
+/**
+ * One relocalization attempt over one frame: snapshot the fingerprint, detect, match, solve, publish.
+ *
+ * EVALUATION.md 3.1 — split out of relocThreadFunc so an eval run can call it INLINE instead of
+ * handing the frame to a background worker. Thread interleaving is one of the three named sources of
+ * replay non-determinism: the worker's sleep is `locked ? 200 : 60` ms, so which frames it happens to
+ * receive depends on scheduling, and two replays of the same recording sample the recording
+ * differently. That turns a parameter A/B into a comparison of two different frame subsets, which is
+ * the single most common way a tuning exercise produces confident nonsense.
+ *
+ * The extraction is deliberately mechanical — the body is unchanged except that the three
+ * loop-level `continue`s became `return`s, since each meant "this attempt is over" and never
+ * "skip to the next frame". Any other edit here would have been a relocalizer change smuggled in
+ * behind an eval affordance.
+ *
+ * @param relocView the VIO view matrix snapshotted alongside the frame, for the rectifying warp.
+ */
+void MobileGS::runRelocPass(const cv::Mat& frame, const float* relocView) {
+    cv::Mat wallDescs;
+    std::vector<cv::Point3f> wallKps3d;
+    // Phase 2: parallel to wallKps3d, or empty for a legacy fingerprint (= all backbone).
+    std::vector<uint8_t> wallRegions;
+    cv::Mat wallPatch;
+    float fpIntrinsics[4];
+    bool hasFpView = false;
+    // Phase 2b snapshot: the persistent feature map + the last reloc pose, used (when the flag is on)
+    // as the frustum-gate prior. The map is co-registered to the fingerprint anchor, so its points
+    // share wallKps3d's frame and the prior pose (camera_from_fpWorld) projects them directly.
+    cv::Mat mapDescs;
+    std::vector<cv::Point3f> mapKps3d;
+    float mapPriorPose[16];
+    long mapPriorSeq = 0;
+    {
+        std::lock_guard<std::mutex> lock(mMutex);
+        wallDescs = mWallDescriptors.clone();
+        wallKps3d = mWallKeypoints3D;
+        wallRegions = mWallRegions;
+        wallPatch = mWallPatch.clone();
+        memcpy(fpIntrinsics, mFingerprintIntrinsics, 4 * sizeof(float));
+        hasFpView = mHasFingerprintView;
+        mapDescs = mMapDescriptors.clone();
+        mapKps3d = mMapPoints3D;
+        memcpy(mapPriorPose, mPnpCamFromFpWorld, 16 * sizeof(float));
+        mapPriorSeq = mPnpResultSeq.load(std::memory_order_relaxed);
+    }
+
+    // 2.11: reset the backbone counters BEFORE the early-outs below, so an attempt that never
+    // reaches the fingerprint publishes "not measured" instead of the previous attempt's numbers.
+    mLastRelocBackboneFeatures.store(-1, std::memory_order_relaxed);
+    mLastRelocBackboneMatches.store(-1, std::memory_order_relaxed);
+    mLastRelocBackboneInliers.store(-1, std::memory_order_relaxed);
+    // Same rule for the reprojection residual (IMPLEMENTATION.md 4.3): it is only meaningful
+    // for the attempt that produced it, and the search radius reads it as a drift measurement.
+    // Leaving a previous lock's value in place would widen or narrow the corroboration search
+    // on the strength of a pose that is no longer the one being predicted from.
+    mLastRelocReprojPx.store(-1.0f, std::memory_order_relaxed);
+    // ...and the same rule again for the corroboration counters (IMPLEMENTATION.md 4.6). These
+    // are written only on a GATED attempt, so without a reset here one gated attempt's numbers
+    // stayed live across every subsequent tick that fell back to the global search — a red
+    // FEW_INLIERS row on the overlay sitting next to a healthy "Corrob 30/40", and, worse, the
+    // same measurement copied into every eval CSV row until the next gated attempt, which turns
+    // any rate E6 computes from these columns into a count of ticks rather than of attempts.
+    // Reset alongside the backbone trio because they are the same kind of number and the
+    // convention has to be one convention.
+    mCorrobPredicted.store(-1, std::memory_order_relaxed);
+    mCorrobMatched.store(-1, std::memory_order_relaxed);
+    mCorrobLoneSkips.store(-1, std::memory_order_relaxed);
+    mCorrobSearchRadiusPx.store(-1.0f, std::memory_order_relaxed);
+
+    if (!mRelocEnabled) {
+        mLastRelocReject.store(kRelocDisabled, std::memory_order_relaxed);
+        return;
+    }
+    if (wallDescs.empty() || wallKps3d.empty()) {
+        // No fingerprint, or one carrying descriptors but no 3D points (the depth-path result when
+        // the depth API is off). Either way PnP has nothing to solve against, so the whole thread
+        // idles here — silently, before this reject code existed.
+        mLastRelocReject.store(kRelocNoFingerprint, std::memory_order_relaxed);
+        return;
+    }
+
+    // IMPLEMENTATION.md 2.7 — honour the partition only when it indexes THIS point set. A
+    // regions array of the wrong length is treated as absent (all backbone) rather than
+    // subscripted, so a legacy or mismatched fingerprint relocalizes exactly as on main.
+    // Hoisted out of buildCorr so the filter below and the count published here cannot drift
+    // apart: they must agree about which fingerprint is partitioned or the diagnostics describe
+    // a different point set from the one PnP saw.
+    const bool usePartition = wallRegions.size() == wallKps3d.size();
+    // 2.11: how many stored points PnP is allowed to draw on. An UNPARTITIONED fingerprint is
+    // 2.7's legacy all-backbone case, so it reports its FULL point count — not zero, and not the
+    // -1 sentinel. Zero here is a real measurement meaning F_out is empty (the artwork covers
+    // the whole wall), which is the one state reloc cannot recover from; reporting a legacy
+    // fingerprint as zero would raise that alarm on every project saved before Phase 2.
+    mLastRelocBackboneFeatures.store(
+        usePartition
+            ? (int)std::count(wallRegions.begin(), wallRegions.end(), kRegionOutside)
+            : (int)wallKps3d.size(),
+        std::memory_order_relaxed);
+
+    if (frame.empty()) return;
+
+    // Optionally enhance the RGB frame under low light before grayscale conversion
+    cv::Mat workFrame = frame;
+    if (mEnhancer.isLoaded() && mLightLevel < kLowLightThreshold) {
+        cv::Mat enhanced;
+        if (mEnhancer.enhance(frame, enhanced)) workFrame = enhanced;
+    }
+    cv::Mat gray;
+    cv::cvtColor(workFrame, gray, cv::COLOR_RGB2GRAY);
+    normalizeForFeatures(gray); // illumination-normalize to match the (also-normalized) fingerprint
+
+    // SuperPoint usable when loaded and the wall fingerprint is float-typed (or empty).
+    const bool spOk = mSuperPoint.isLoaded() &&
+        (wallDescs.empty() || wallDescs.type() == CV_32F);
+
+    // Detect + Lowe-ratio match a gray image against the wall fingerprint. When Hback is non-empty
+    // the matched keypoints are mapped through it (rectified frame -> current image) before being
+    // stored, so the returned 2D points are ALWAYS in the current camera image — exactly what the
+    // PnP below expects.
+    // Detect base-frame features ONCE and reuse them: SuperPoint is an ONNX model, so detecting the
+    // same gray twice (plain pass + map matching) would roughly double per-reloc cost. The scaled and
+    // rectified passes run on different images, so buildCorr still detects internally for those.
+    std::vector<cv::KeyPoint> baseKps; cv::Mat baseDescs;
+    {
+        bool sp = spOk;
+        if (sp && !mSuperPoint.detect(gray, baseKps, baseDescs)) sp = false;
+        if (!sp) mFeatureDetector->detectAndCompute(gray, cv::noArray(), baseKps, baseDescs);
+    }
+    mLastRelocDetected.store((int)baseKps.size(), std::memory_order_relaxed);
+
+    auto buildCorr = [&](const cv::Mat& g, const cv::Mat& Hback,
+                         std::vector<cv::Point2f>& outImg, std::vector<cv::Point3f>& outObj,
+                         std::vector<uint8_t>& outFromBackbone,
+                         const std::vector<cv::KeyPoint>* preKps = nullptr, const cv::Mat* preDescs = nullptr) {
+        std::vector<cv::KeyPoint> localKps; cv::Mat localDescs;
+        if (!(preKps && preDescs)) {
+            bool sp = spOk;
+            if (sp && !mSuperPoint.detect(g, localKps, localDescs)) sp = false;
+            if (!sp) mFeatureDetector->detectAndCompute(g, cv::noArray(), localKps, localDescs);
+        }
+        const std::vector<cv::KeyPoint>& kps = (preKps && preDescs) ? *preKps : localKps;
+        const cv::Mat& descs = (preKps && preDescs) ? *preDescs : localDescs;
+        if (descs.empty() || wallDescs.empty()) return;
+        if (descs.type() != wallDescs.type()) return;
+        // trainIdx indexes wallDescs' ROWS but is used to subscript wallKps3d, so the two must be
+        // the same length. Every in-tree producer keeps them aligned; a truncated or hand-edited
+        // .gxr does not, and the result would be an out-of-bounds vector read feeding garbage 3D
+        // points into solvePnPRansac. The map path (below) already guards this; the wall path did
+        // not. Refuse rather than relocalize against nonsense.
+        if (wallKps3d.size() != (size_t)wallDescs.rows) return;
+
+        cv::Ptr<cv::DescriptorMatcher>& matcher = (descs.type() == CV_32F) ? mL2Matcher : mMatcher;
+        std::vector<std::vector<cv::DMatch>> matches;
+        matcher->knnMatch(descs, wallDescs, matches, 2);
+        for (auto& match : matches) {
+            if (match.size() < 2) continue;
+            if (match[0].distance < kRelocLoweRatio * match[1].distance) {
+                // PAPER.md §5: the reloc PnP solves the GLOBAL problem, with no prior, and must
+                // therefore see only the backbone. Points under the artwork (INSIDE) are the
+                // work surface — they decay as it is painted, which is exactly what makes
+                // accuracy degrade with task progress. BAND straddles the edge and is trusted by
+                // neither side. Corroboration against F_in happens later, once a pose exists.
+                if (usePartition && wallRegions[match[0].trainIdx] != kRegionOutside) continue;
+                cv::Point2f p = kps[match[0].queryIdx].pt;
+                if (!Hback.empty()) {
+                    std::vector<cv::Point2f> in{p}, outp;
+                    cv::perspectiveTransform(in, outp, Hback);
+                    p = outp[0];
+                }
+                outImg.push_back(p);
+                outObj.push_back(wallKps3d[match[0].trainIdx]);
+                // Everything that survives the filter above is F_out: under a partition because
+                // non-OUTSIDE rows were skipped, and without one because 2.7's zero-length rule
+                // makes the whole fingerprint backbone. Recorded per correspondence rather than
+                // counted, because the inlier attribution below indexes back through this.
+                outFromBackbone.push_back(1);
+            }
+        }
+    };
+
+    std::vector<cv::Point2f> imgPts;
+    std::vector<cv::Point3f> objPts;
+    // 2.11: parallel to imgPts/objPts — 1 where the correspondence came from a backbone point.
+    std::vector<uint8_t> corrFromBackbone;
+    buildCorr(gray, cv::Mat(), imgPts, objPts, corrFromBackbone, &baseKps, &baseDescs);
+
+    // Multi-scale matching (distance robustness). SuperPoint isn't scale-invariant, and the marks
+    // shrink in the frame from far away and grow up close, so also match the frame DOWN- and
+    // UP-scaled, mapping the matched points back to full-res with a scale homography (Hback). These
+    // passes share the plain pass's camera geometry, so they only add consistent correspondences
+    // across distance; PnP RANSAC discards any that don't fit. Covers both ORB and SuperPoint
+    // fingerprints, beyond ORB's own pyramid range.
+    for (float s : {0.5f, 2.0f}) {
+        cv::Mat scaled;
+        cv::resize(gray, scaled, cv::Size(), s, s, cv::INTER_LINEAR);
+        double hdata[] = {1.0/(double)s, 0.0, 0.0, 0.0, 1.0/(double)s, 0.0, 0.0, 0.0, 1.0};
+        cv::Mat Hback = cv::Mat(3, 3, CV_64F, hdata).clone();
+        buildCorr(scaled, Hback, imgPts, objPts, corrFromBackbone);
+    }
+
+    // Plane-guided rectification (perspective robustness for oblique views). The marks lie on a
+    // known plane and VIO gives a pose, so the oblique-vs-frontal distortion is a homography we can
+    // pre-cancel: warp the live frame into the fingerprint's frontal frame, match, and ADD the
+    // correspondences mapped back to the current image (RANSAC filters any that don't fit).
+    // Published so the diagnostics can show whether this pass is actually running. It was dead in
+    // practice for a long time (nothing set mHasFingerprintView on the live capture path), so
+    // "did rectification fire, and did it help" is worth being able to read off the device rather
+    // than infer. -1 = the pass was not eligible at all this attempt.
+    mLastRelocObliquityDeg.store(-1, std::memory_order_relaxed);
+    mLastRelocRectifiedCorr.store(0, std::memory_order_relaxed);
+    if (hasFpView && mIsArCoreTracking.load(std::memory_order_relaxed) && wallKps3d.size() >= 12) {
+        cv::Mat Hcur_fp, Hfp_cur; double obliqDeg = 0.0;
+        const bool haveH = computeRectifyHomography(relocView, Hcur_fp, Hfp_cur, obliqDeg);
+        if (haveH) mLastRelocObliquityDeg.store((int)(obliqDeg + 0.5), std::memory_order_relaxed);
+        if (haveH && obliqDeg > 25.0) {
+            cv::Mat grayRect;
+            cv::warpPerspective(gray, grayRect, Hfp_cur, gray.size());
+            size_t before = imgPts.size();
+            buildCorr(grayRect, Hcur_fp, imgPts, objPts, corrFromBackbone);
+            mLastRelocRectifiedCorr.store((int)(imgPts.size() - before), std::memory_order_relaxed);
+            if (imgPts.size() > before)
+                LOGI("Reloc: rectified (obliquity %.0f deg) added %zu corr (total %zu)",
+                     obliqDeg, imgPts.size() - before, imgPts.size());
+        }
+    }
+
+    // --- Persistent feature-map matching (Phase 2b; default OFF via mMapRelocEnabled) ---
+    // When the overlay is larger than the marks, the marks leave frame; the map carries features
+    // across the whole wall so reloc still locks. Hard constraint: NEVER brute-force the whole map —
+    // frustum-gate to the subset the last reloc pose says is in view, then match only those and
+    // APPEND the correspondences (same fingerprint frame + intrinsics) so PnP solves over both.
+    // Requires a prior pose (mapPriorSeq>0, i.e. the fingerprint has locked at least once) and a
+    // matching descriptor type. Default-off, so this is inert until device-validated.
+    if (mMapRelocEnabled.load(std::memory_order_relaxed) && !mapDescs.empty() && mapPriorSeq > 0
+            && mapDescs.type() == wallDescs.type() && mapKps3d.size() == (size_t)mapDescs.rows) {
+        glm::mat4 camFromFp = glm::make_mat4(mapPriorPose);
+        double gfx = (fpIntrinsics[0] > 0.f) ? (double)fpIntrinsics[0] : 1000.0;
+        double gfy = (fpIntrinsics[1] > 0.f) ? (double)fpIntrinsics[1] : 1000.0;
+        double gcx = (fpIntrinsics[0] > 0.f) ? (double)fpIntrinsics[2] : gray.cols * 0.5;
+        double gcy = (fpIntrinsics[1] > 0.f) ? (double)fpIntrinsics[3] : gray.rows * 0.5;
+        std::vector<int> visible;
+        visible.reserve(mapKps3d.size());
+        for (int i = 0; i < (int)mapKps3d.size(); ++i) {
+            glm::vec4 pc = camFromFp * glm::vec4(mapKps3d[i].x, mapKps3d[i].y, mapKps3d[i].z, 1.0f);
+            if (pc.z <= 0.05f) continue; // behind / too close to the camera
+            float u = (float)(gfx * pc.x / pc.z + gcx);
+            float v = (float)(gfy * pc.y / pc.z + gcy);
+            if (u >= 0.f && u < gray.cols && v >= 0.f && v < gray.rows) visible.push_back(i);
+        }
+        if (visible.size() >= 8) {
+            // Preallocate the gated descriptor block with the right size+type and copy rows
+            // (cv::Mat has no usable reserve() on an empty/typeless matrix). Reuse the base detection.
+            cv::Mat gatedDescs((int)visible.size(), mapDescs.cols, mapDescs.type());
+            for (size_t i = 0; i < visible.size(); ++i)
+                mapDescs.row(visible[i]).copyTo(gatedDescs.row((int)i));
+            if (!baseDescs.empty() && baseDescs.type() == gatedDescs.type()) {
+                cv::Ptr<cv::DescriptorMatcher>& matcher = (baseDescs.type() == CV_32F) ? mL2Matcher : mMatcher;
+                std::vector<std::vector<cv::DMatch>> matches;
+                matcher->knnMatch(baseDescs, gatedDescs, matches, 2);
+                size_t before = imgPts.size();
+                for (auto& m : matches) {
+                    if (m.size() < 2) continue;
+                    if (m[0].distance < kRelocLoweRatio * m[1].distance) {
+                        imgPts.push_back(baseKps[m[0].queryIdx].pt);
+                        objPts.push_back(mapKps3d[visible[m[0].trainIdx]]);
+                        // NOT backbone: the persistent map is a separate point set that Φ has
+                        // never classified, so counting it in F_out would report a backbone the
+                        // partition never vouched for — and mask an empty F_out on exactly the
+                        // configuration (large overlay, marks off-frame) the map exists for.
+                        corrFromBackbone.push_back(0);
+                    }
+                }
+                if (imgPts.size() > before)
+                    LOGI("Reloc map: gated %zu/%zu pts, added %zu corr (total %zu)",
+                         visible.size(), mapKps3d.size(), imgPts.size() - before, imgPts.size());
+            }
+        }
+    }
+
+    // Distortion head (optional, docs/DISTORTION_HEAD.md): when the model + canonical patch are
+    // present, compare the live view (cropped around the coarse match centroid) against the
+    // fingerprint patch -> matchability (relock confidence) + coverage (= painting-progress). The
+    // corners/H -> IPPE prior is a later increment; here we consume the cheap signals. Inert unless
+    // the distortion_head.onnx asset is bundled. Uses RAW gray (the head's SuperPoint expects it).
+    if (mDistortionHead.isLoaded() && !wallPatch.empty() && !imgPts.empty()) {
+        float cxs = 0, cys = 0;
+        for (const auto& p : imgPts) { cxs += p.x; cys += p.y; }
+        cxs /= (float)imgPts.size(); cys /= (float)imgPts.size();
+        cv::Mat headGray;
+        cv::cvtColor(workFrame, headGray, cv::COLOR_RGB2GRAY);
+        int side = std::min(headGray.cols, headGray.rows);
+        int x0 = std::max(0, std::min((int)cxs - side / 2, headGray.cols - side));
+        int y0 = std::max(0, std::min((int)cys - side / 2, headGray.rows - side));
+        cv::Mat crop = headGray(cv::Rect(x0, y0, side, side)).clone();
+        std::array<float, 13> dist{};
+        if (mDistortionHead.run(crop, wallPatch, dist)) {
+            const float matchability = dist[11], coverage = dist[12];
+            if (matchability > 0.5f) {
+                // A trusted look at the wall: it measures BOTH channels, and they are different
+                // quantities. Coverage says how much of the design is realized (progress);
+                // matchability says how much to trust this frame (confidence).
+                mPaintingProgress.store(coverage, std::memory_order_relaxed);
+                mCorroborationConfidence.store(matchability, std::memory_order_relaxed);
+            } else {
+                // The head looked and did not recognize the wall. That is a statement about THIS
+                // FRAME, not about the mural, so only confidence decays. Decaying progress here
+                // is what made a three-frame glitch read as the mural being un-painted.
+                decayCorroboration();
+            }
+            LOGI("DistortionHead: match %.2f coverage %.2f tilt %.0f log2scale %.2f",
+                 matchability, coverage, dist[8], dist[9]);
+        } else {
+            decayCorroboration();   // head refused to run — no information either way
+        }
+    } else if (mDistortionHead.isLoaded()) {
+        // Head is loaded but there was no patch or no correspondences to centre the crop on, so
+        // no attempt happened at all. Still a confidence statement, never a progress one.
+        decayCorroboration();
+    }
+
+    // Lowered floors so a close-up PARTIAL view (only a corner of the marks visible) can still
+    // localize: PnP needs only a handful of correspondences. The inlier RATIO (published below) is
+    // the quality gate PoseFusion actually trusts, so being permissive here is safe.
+    mLastRelocMatches.store((int)imgPts.size(), std::memory_order_relaxed);
+    mLastRelocInliers.store(0, std::memory_order_relaxed);
+    // corrFromBackbone is parallel to imgPts by construction, and the inlier attribution below
+    // subscripts it with indices into imgPts. A future pass that appends to one and not the
+    // other would make that read out of bounds, so a length disagreement publishes "not
+    // measured" instead of a wrong number.
+    const bool haveBackboneFlags = corrFromBackbone.size() == imgPts.size();
+    // 2.11: counted SEPARATELY from mLastRelocMatches, never in place of it. The same shortfall
+    // means different things — a low total is "the frame is not looking at the registered wall",
+    // a low backbone under a healthy total is "everything it can see is under the artwork" — and
+    // those call for opposite advice (aim differently vs. shrink the design / step back).
+    mLastRelocBackboneMatches.store(
+        haveBackboneFlags
+            ? (int)std::count(corrFromBackbone.begin(), corrFromBackbone.end(), (uint8_t)1)
+            : -1,
+        std::memory_order_relaxed);
+    if (imgPts.size() < 8) {
+        // Distinguish "the detector found nothing / the descriptors don't even compare" from
+        // "features were found but too few agreed with the fingerprint" — they call for opposite
+        // fixes (light/focus/texture vs. aim at the registered area).
+        mLastRelocReject.store(baseDescs.empty() ? kRelocNoFeatures : kRelocFewMatches,
+                               std::memory_order_relaxed);
+    }
+    if (imgPts.size() >= 8) {
+        cv::Mat rvec, tvec;
+        std::vector<int> inliers;
+        // Camera matrix: reuse the intrinsics the fingerprint's 3D points were built with (keeps
+        // the 2D<->3D correspondence consistent) when available, else a coarse default. The old
+        // hardcoded init supplied only 6 of the 9 entries, leaving the bottom row uninitialised.
+        double fx = 1000.0, fy = 1000.0, cx = 960.0, cy = 540.0;
+        if (fpIntrinsics[0] > 0.0f && fpIntrinsics[1] > 0.0f) {
+            fx = fpIntrinsics[0]; fy = fpIntrinsics[1];
+            cx = fpIntrinsics[2]; cy = fpIntrinsics[3];
+        }
+        double idata[] = {fx, 0.0, cx, 0.0, fy, cy, 0.0, 0.0, 1.0};
+        cv::Mat intr = cv::Mat(3, 3, CV_64F, idata).clone();
+        StageTimer _pnpTimer(&mStageAccumMs[4], &mStageSamples[4]);
+        // EVALUATION.md 3.1: solvePnPRansac draws random samples, so two replays of the same
+        // recording can disagree and a parameter A/B reports RANSAC variance as an effect.
+        // Re-seeded immediately before EVERY solve, not once at start-up: the reloc thread is
+        // one of several consumers of the global cv::theRNG(), so a single seeding would drift
+        // as soon as anything else drew from it. Negative = leave it alone, which is the
+        // production default and keeps this inert outside an eval run.
+        const long long evalSeed = mEvalRngSeed.load(std::memory_order_relaxed);
+        if (evalSeed >= 0) cv::theRNG().state = (uint64_t)evalSeed;
+        if (!cv::solvePnPRansac(objPts, imgPts, intr, cv::Mat(), rvec, tvec, false, 100, 8.0, 0.99, inliers)) {
+            mLastRelocReject.store(kRelocPnpFailed, std::memory_order_relaxed);
+        } else {
+            mLastRelocInliers.store((int)inliers.size(), std::memory_order_relaxed);
+            // 2.11: which of those inliers RANSAC drew from F_out. Left at -1 on the PnP-failed
+            // branch above, because no inlier set exists there to attribute — that is "not
+            // measured", not "no backbone agreed".
+            if (haveBackboneFlags) {
+                int backboneInliers = 0;
+                for (int idx : inliers) {
+                    if (idx >= 0 && idx < (int)corrFromBackbone.size() && corrFromBackbone[idx]) ++backboneInliers;
+                }
+                mLastRelocBackboneInliers.store(backboneInliers, std::memory_order_relaxed);
+            }
+            if (inliers.size() < 6) {
+                mLastRelocReject.store(kRelocFewInliers, std::memory_order_relaxed);
+            }
+            if (inliers.size() >= 6) {
+                // Refine on the RANSAC inliers. The marks lie on the wall plane, so resolve the
+                // planar two-fold (flip) ambiguity with IPPE and keep whichever pose reprojects
+                // best — but only adopt it if it strictly beats the RANSAC pose, so a non-coplanar
+                // inlier set can never make relocalization worse.
+                {
+                    std::vector<cv::Point3f> inObj; std::vector<cv::Point2f> inImg;
+                    inObj.reserve(inliers.size()); inImg.reserve(inliers.size());
+                    for (int idx : inliers) { inObj.push_back(objPts[idx]); inImg.push_back(imgPts[idx]); }
+                    auto reproj = [&](const cv::Mat& rv, const cv::Mat& tv) {
+                        std::vector<cv::Point2f> pr;
+                        cv::projectPoints(inObj, rv, tv, intr, cv::Mat(), pr);
+                        double e = 0; for (size_t k = 0; k < pr.size(); ++k) e += cv::norm(pr[k] - inImg[k]);
+                        return e;
+                    };
+                    double bestErr = reproj(rvec, tvec);
+                    try {
+                        std::vector<cv::Mat> rvecs, tvecs;
+                        int n = cv::solvePnPGeneric(inObj, inImg, intr, cv::Mat(), rvecs, tvecs,
+                                                    false, cv::SOLVEPNP_IPPE);
+                        for (int s = 0; s < n; ++s) {
+                            double e = reproj(rvecs[s], tvecs[s]);
+                            if (e < bestErr) { bestErr = e; rvecs[s].copyTo(rvec); tvecs[s].copyTo(tvec); }
+                        }
+                    } catch (const cv::Exception&) { /* keep RANSAC pose */ }
+                    // IMPLEMENTATION.md 4.3 — publish the MEAN, not the sum `reproj` returns.
+                    // The sum grows with the inlier count, so a better lock would report a worse
+                    // error and the corroboration search would tighten exactly when it has the
+                    // most to gain from staying put. Divided by the same set it was summed over.
+                    if (!inObj.empty()) {
+                        mLastRelocReprojPx.store((float)(bestErr / (double)inObj.size()),
+                                                 std::memory_order_relaxed);
+                    }
+                }
+                cv::Mat R;
+                cv:: Rodrigues(rvec, R);
+
+                // PnP gives T_camera_from_fingerprintWorld (a view matrix). DO NOT write it to
+                // mAnchorMatrix (a world-space MODEL matrix) — that caused overlay teleport.
+                // Publish the raw result; Kotlin composes inverse(V_current)*pnp*fpAnchor with the
+                // FRESH view matrix (see PoseFusion).
+                glm::mat4 pnpMat = glm::mat4(1.0f);
+                for(int i=0; i<3; ++i) {
+                    for(int j=0; j<3; ++j) pnpMat[j][i] = (float)R.at<double>(i,j);
+                    pnpMat[3][i] = (float)tvec.at<double>(i);
+                }
+                {
+                    std::lock_guard<std::mutex> lock(mMutex);
+                    memcpy(mPnpCamFromFpWorld, glm::value_ptr(pnpMat), 16 * sizeof(float));
+                }
+                mPnpInlierCount.store((int)inliers.size(), std::memory_order_relaxed);
+                mPnpMatchCount.store((int)imgPts.size(), std::memory_order_relaxed);
+                mPnpResultSeq.fetch_add(1, std::memory_order_relaxed);
+                mLastRelocReject.store(kRelocOk, std::memory_order_relaxed);
+                LOGI("Relocalization: PnP match published (%zu/%zu inliers)", inliers.size(), imgPts.size());
+                // Phase 3 passive build: grow the feature map from this locked frame (default OFF).
+                if (mMapBuildEnabled.load(std::memory_order_relaxed))
+                    growMapFromReloc(pnpMat, baseKps, baseDescs, fx, fy, cx, cy);
+            }
+        }
+    }
+
+    // Teleological gatekeeper: update painting-progress from how much of the artwork base the clean
+    // frame now corroborates. No-op until an artwork is registered; read-only on the reloc set.
+    // Hands over this frame's detection so it isn't recomputed (see tryUpdateFingerprint).
+    tryUpdateFingerprint(gray, &baseKps, &baseDescs);
+}
+
 void MobileGS::relocThreadFunc() {
     setpriority(PRIO_PROCESS, 0, 10); // Standard background priority
     JniThreadAttacher attacher;
@@ -222,439 +675,11 @@ void MobileGS::relocThreadFunc() {
             mRelocRequested = false;
         }
 
-        cv::Mat wallDescs;
-        std::vector<cv::Point3f> wallKps3d;
-        // Phase 2: parallel to wallKps3d, or empty for a legacy fingerprint (= all backbone).
-        std::vector<uint8_t> wallRegions;
-        cv::Mat wallPatch;
-        float fpIntrinsics[4];
-        bool hasFpView = false;
-        // Phase 2b snapshot: the persistent feature map + the last reloc pose, used (when the flag is on)
-        // as the frustum-gate prior. The map is co-registered to the fingerprint anchor, so its points
-        // share wallKps3d's frame and the prior pose (camera_from_fpWorld) projects them directly.
-        cv::Mat mapDescs;
-        std::vector<cv::Point3f> mapKps3d;
-        float mapPriorPose[16];
-        long mapPriorSeq = 0;
-        {
-            std::lock_guard<std::mutex> lock(mMutex);
-            wallDescs = mWallDescriptors.clone();
-            wallKps3d = mWallKeypoints3D;
-            wallRegions = mWallRegions;
-            wallPatch = mWallPatch.clone();
-            memcpy(fpIntrinsics, mFingerprintIntrinsics, 4 * sizeof(float));
-            hasFpView = mHasFingerprintView;
-            mapDescs = mMapDescriptors.clone();
-            mapKps3d = mMapPoints3D;
-            memcpy(mapPriorPose, mPnpCamFromFpWorld, 16 * sizeof(float));
-            mapPriorSeq = mPnpResultSeq.load(std::memory_order_relaxed);
-        }
-
-        // 2.11: reset the backbone counters BEFORE the early-outs below, so an attempt that never
-        // reaches the fingerprint publishes "not measured" instead of the previous attempt's numbers.
-        mLastRelocBackboneFeatures.store(-1, std::memory_order_relaxed);
-        mLastRelocBackboneMatches.store(-1, std::memory_order_relaxed);
-        mLastRelocBackboneInliers.store(-1, std::memory_order_relaxed);
-        // Same rule for the reprojection residual (IMPLEMENTATION.md 4.3): it is only meaningful
-        // for the attempt that produced it, and the search radius reads it as a drift measurement.
-        // Leaving a previous lock's value in place would widen or narrow the corroboration search
-        // on the strength of a pose that is no longer the one being predicted from.
-        mLastRelocReprojPx.store(-1.0f, std::memory_order_relaxed);
-        // ...and the same rule again for the corroboration counters (IMPLEMENTATION.md 4.6). These
-        // are written only on a GATED attempt, so without a reset here one gated attempt's numbers
-        // stayed live across every subsequent tick that fell back to the global search — a red
-        // FEW_INLIERS row on the overlay sitting next to a healthy "Corrob 30/40", and, worse, the
-        // same measurement copied into every eval CSV row until the next gated attempt, which turns
-        // any rate E6 computes from these columns into a count of ticks rather than of attempts.
-        // Reset alongside the backbone trio because they are the same kind of number and the
-        // convention has to be one convention.
-        mCorrobPredicted.store(-1, std::memory_order_relaxed);
-        mCorrobMatched.store(-1, std::memory_order_relaxed);
-        mCorrobLoneSkips.store(-1, std::memory_order_relaxed);
-        mCorrobSearchRadiusPx.store(-1.0f, std::memory_order_relaxed);
-
-        if (!mRelocEnabled) {
-            mLastRelocReject.store(kRelocDisabled, std::memory_order_relaxed);
-            continue;
-        }
-        if (wallDescs.empty() || wallKps3d.empty()) {
-            // No fingerprint, or one carrying descriptors but no 3D points (the depth-path result when
-            // the depth API is off). Either way PnP has nothing to solve against, so the whole thread
-            // idles here — silently, before this reject code existed.
-            mLastRelocReject.store(kRelocNoFingerprint, std::memory_order_relaxed);
-            continue;
-        }
-
-        // IMPLEMENTATION.md 2.7 — honour the partition only when it indexes THIS point set. A
-        // regions array of the wrong length is treated as absent (all backbone) rather than
-        // subscripted, so a legacy or mismatched fingerprint relocalizes exactly as on main.
-        // Hoisted out of buildCorr so the filter below and the count published here cannot drift
-        // apart: they must agree about which fingerprint is partitioned or the diagnostics describe
-        // a different point set from the one PnP saw.
-        const bool usePartition = wallRegions.size() == wallKps3d.size();
-        // 2.11: how many stored points PnP is allowed to draw on. An UNPARTITIONED fingerprint is
-        // 2.7's legacy all-backbone case, so it reports its FULL point count — not zero, and not the
-        // -1 sentinel. Zero here is a real measurement meaning F_out is empty (the artwork covers
-        // the whole wall), which is the one state reloc cannot recover from; reporting a legacy
-        // fingerprint as zero would raise that alarm on every project saved before Phase 2.
-        mLastRelocBackboneFeatures.store(
-            usePartition
-                ? (int)std::count(wallRegions.begin(), wallRegions.end(), kRegionOutside)
-                : (int)wallKps3d.size(),
-            std::memory_order_relaxed);
-
-        if (frame.empty()) continue;
-
-        // Optionally enhance the RGB frame under low light before grayscale conversion
-        cv::Mat workFrame = frame;
-        if (mEnhancer.isLoaded() && mLightLevel < kLowLightThreshold) {
-            cv::Mat enhanced;
-            if (mEnhancer.enhance(frame, enhanced)) workFrame = enhanced;
-        }
-        cv::Mat gray;
-        cv::cvtColor(workFrame, gray, cv::COLOR_RGB2GRAY);
-        normalizeForFeatures(gray); // illumination-normalize to match the (also-normalized) fingerprint
-
-        // SuperPoint usable when loaded and the wall fingerprint is float-typed (or empty).
-        const bool spOk = mSuperPoint.isLoaded() &&
-            (wallDescs.empty() || wallDescs.type() == CV_32F);
-
-        // Detect + Lowe-ratio match a gray image against the wall fingerprint. When Hback is non-empty
-        // the matched keypoints are mapped through it (rectified frame -> current image) before being
-        // stored, so the returned 2D points are ALWAYS in the current camera image — exactly what the
-        // PnP below expects.
-        // Detect base-frame features ONCE and reuse them: SuperPoint is an ONNX model, so detecting the
-        // same gray twice (plain pass + map matching) would roughly double per-reloc cost. The scaled and
-        // rectified passes run on different images, so buildCorr still detects internally for those.
-        std::vector<cv::KeyPoint> baseKps; cv::Mat baseDescs;
-        {
-            bool sp = spOk;
-            if (sp && !mSuperPoint.detect(gray, baseKps, baseDescs)) sp = false;
-            if (!sp) mFeatureDetector->detectAndCompute(gray, cv::noArray(), baseKps, baseDescs);
-        }
-        mLastRelocDetected.store((int)baseKps.size(), std::memory_order_relaxed);
-
-        auto buildCorr = [&](const cv::Mat& g, const cv::Mat& Hback,
-                             std::vector<cv::Point2f>& outImg, std::vector<cv::Point3f>& outObj,
-                             std::vector<uint8_t>& outFromBackbone,
-                             const std::vector<cv::KeyPoint>* preKps = nullptr, const cv::Mat* preDescs = nullptr) {
-            std::vector<cv::KeyPoint> localKps; cv::Mat localDescs;
-            if (!(preKps && preDescs)) {
-                bool sp = spOk;
-                if (sp && !mSuperPoint.detect(g, localKps, localDescs)) sp = false;
-                if (!sp) mFeatureDetector->detectAndCompute(g, cv::noArray(), localKps, localDescs);
-            }
-            const std::vector<cv::KeyPoint>& kps = (preKps && preDescs) ? *preKps : localKps;
-            const cv::Mat& descs = (preKps && preDescs) ? *preDescs : localDescs;
-            if (descs.empty() || wallDescs.empty()) return;
-            if (descs.type() != wallDescs.type()) return;
-            // trainIdx indexes wallDescs' ROWS but is used to subscript wallKps3d, so the two must be
-            // the same length. Every in-tree producer keeps them aligned; a truncated or hand-edited
-            // .gxr does not, and the result would be an out-of-bounds vector read feeding garbage 3D
-            // points into solvePnPRansac. The map path (below) already guards this; the wall path did
-            // not. Refuse rather than relocalize against nonsense.
-            if (wallKps3d.size() != (size_t)wallDescs.rows) return;
-
-            cv::Ptr<cv::DescriptorMatcher>& matcher = (descs.type() == CV_32F) ? mL2Matcher : mMatcher;
-            std::vector<std::vector<cv::DMatch>> matches;
-            matcher->knnMatch(descs, wallDescs, matches, 2);
-            for (auto& match : matches) {
-                if (match.size() < 2) continue;
-                if (match[0].distance < kRelocLoweRatio * match[1].distance) {
-                    // PAPER.md §5: the reloc PnP solves the GLOBAL problem, with no prior, and must
-                    // therefore see only the backbone. Points under the artwork (INSIDE) are the
-                    // work surface — they decay as it is painted, which is exactly what makes
-                    // accuracy degrade with task progress. BAND straddles the edge and is trusted by
-                    // neither side. Corroboration against F_in happens later, once a pose exists.
-                    if (usePartition && wallRegions[match[0].trainIdx] != kRegionOutside) continue;
-                    cv::Point2f p = kps[match[0].queryIdx].pt;
-                    if (!Hback.empty()) {
-                        std::vector<cv::Point2f> in{p}, outp;
-                        cv::perspectiveTransform(in, outp, Hback);
-                        p = outp[0];
-                    }
-                    outImg.push_back(p);
-                    outObj.push_back(wallKps3d[match[0].trainIdx]);
-                    // Everything that survives the filter above is F_out: under a partition because
-                    // non-OUTSIDE rows were skipped, and without one because 2.7's zero-length rule
-                    // makes the whole fingerprint backbone. Recorded per correspondence rather than
-                    // counted, because the inlier attribution below indexes back through this.
-                    outFromBackbone.push_back(1);
-                }
-            }
-        };
-
-        std::vector<cv::Point2f> imgPts;
-        std::vector<cv::Point3f> objPts;
-        // 2.11: parallel to imgPts/objPts — 1 where the correspondence came from a backbone point.
-        std::vector<uint8_t> corrFromBackbone;
-        buildCorr(gray, cv::Mat(), imgPts, objPts, corrFromBackbone, &baseKps, &baseDescs);
-
-        // Multi-scale matching (distance robustness). SuperPoint isn't scale-invariant, and the marks
-        // shrink in the frame from far away and grow up close, so also match the frame DOWN- and
-        // UP-scaled, mapping the matched points back to full-res with a scale homography (Hback). These
-        // passes share the plain pass's camera geometry, so they only add consistent correspondences
-        // across distance; PnP RANSAC discards any that don't fit. Covers both ORB and SuperPoint
-        // fingerprints, beyond ORB's own pyramid range.
-        for (float s : {0.5f, 2.0f}) {
-            cv::Mat scaled;
-            cv::resize(gray, scaled, cv::Size(), s, s, cv::INTER_LINEAR);
-            double hdata[] = {1.0/(double)s, 0.0, 0.0, 0.0, 1.0/(double)s, 0.0, 0.0, 0.0, 1.0};
-            cv::Mat Hback = cv::Mat(3, 3, CV_64F, hdata).clone();
-            buildCorr(scaled, Hback, imgPts, objPts, corrFromBackbone);
-        }
-
-        // Plane-guided rectification (perspective robustness for oblique views). The marks lie on a
-        // known plane and VIO gives a pose, so the oblique-vs-frontal distortion is a homography we can
-        // pre-cancel: warp the live frame into the fingerprint's frontal frame, match, and ADD the
-        // correspondences mapped back to the current image (RANSAC filters any that don't fit).
-        // Published so the diagnostics can show whether this pass is actually running. It was dead in
-        // practice for a long time (nothing set mHasFingerprintView on the live capture path), so
-        // "did rectification fire, and did it help" is worth being able to read off the device rather
-        // than infer. -1 = the pass was not eligible at all this attempt.
-        mLastRelocObliquityDeg.store(-1, std::memory_order_relaxed);
-        mLastRelocRectifiedCorr.store(0, std::memory_order_relaxed);
-        if (hasFpView && mIsArCoreTracking.load(std::memory_order_relaxed) && wallKps3d.size() >= 12) {
-            cv::Mat Hcur_fp, Hfp_cur; double obliqDeg = 0.0;
-            const bool haveH = computeRectifyHomography(relocView, Hcur_fp, Hfp_cur, obliqDeg);
-            if (haveH) mLastRelocObliquityDeg.store((int)(obliqDeg + 0.5), std::memory_order_relaxed);
-            if (haveH && obliqDeg > 25.0) {
-                cv::Mat grayRect;
-                cv::warpPerspective(gray, grayRect, Hfp_cur, gray.size());
-                size_t before = imgPts.size();
-                buildCorr(grayRect, Hcur_fp, imgPts, objPts, corrFromBackbone);
-                mLastRelocRectifiedCorr.store((int)(imgPts.size() - before), std::memory_order_relaxed);
-                if (imgPts.size() > before)
-                    LOGI("Reloc: rectified (obliquity %.0f deg) added %zu corr (total %zu)",
-                         obliqDeg, imgPts.size() - before, imgPts.size());
-            }
-        }
-
-        // --- Persistent feature-map matching (Phase 2b; default OFF via mMapRelocEnabled) ---
-        // When the overlay is larger than the marks, the marks leave frame; the map carries features
-        // across the whole wall so reloc still locks. Hard constraint: NEVER brute-force the whole map —
-        // frustum-gate to the subset the last reloc pose says is in view, then match only those and
-        // APPEND the correspondences (same fingerprint frame + intrinsics) so PnP solves over both.
-        // Requires a prior pose (mapPriorSeq>0, i.e. the fingerprint has locked at least once) and a
-        // matching descriptor type. Default-off, so this is inert until device-validated.
-        if (mMapRelocEnabled.load(std::memory_order_relaxed) && !mapDescs.empty() && mapPriorSeq > 0
-                && mapDescs.type() == wallDescs.type() && mapKps3d.size() == (size_t)mapDescs.rows) {
-            glm::mat4 camFromFp = glm::make_mat4(mapPriorPose);
-            double gfx = (fpIntrinsics[0] > 0.f) ? (double)fpIntrinsics[0] : 1000.0;
-            double gfy = (fpIntrinsics[1] > 0.f) ? (double)fpIntrinsics[1] : 1000.0;
-            double gcx = (fpIntrinsics[0] > 0.f) ? (double)fpIntrinsics[2] : gray.cols * 0.5;
-            double gcy = (fpIntrinsics[1] > 0.f) ? (double)fpIntrinsics[3] : gray.rows * 0.5;
-            std::vector<int> visible;
-            visible.reserve(mapKps3d.size());
-            for (int i = 0; i < (int)mapKps3d.size(); ++i) {
-                glm::vec4 pc = camFromFp * glm::vec4(mapKps3d[i].x, mapKps3d[i].y, mapKps3d[i].z, 1.0f);
-                if (pc.z <= 0.05f) continue; // behind / too close to the camera
-                float u = (float)(gfx * pc.x / pc.z + gcx);
-                float v = (float)(gfy * pc.y / pc.z + gcy);
-                if (u >= 0.f && u < gray.cols && v >= 0.f && v < gray.rows) visible.push_back(i);
-            }
-            if (visible.size() >= 8) {
-                // Preallocate the gated descriptor block with the right size+type and copy rows
-                // (cv::Mat has no usable reserve() on an empty/typeless matrix). Reuse the base detection.
-                cv::Mat gatedDescs((int)visible.size(), mapDescs.cols, mapDescs.type());
-                for (size_t i = 0; i < visible.size(); ++i)
-                    mapDescs.row(visible[i]).copyTo(gatedDescs.row((int)i));
-                if (!baseDescs.empty() && baseDescs.type() == gatedDescs.type()) {
-                    cv::Ptr<cv::DescriptorMatcher>& matcher = (baseDescs.type() == CV_32F) ? mL2Matcher : mMatcher;
-                    std::vector<std::vector<cv::DMatch>> matches;
-                    matcher->knnMatch(baseDescs, gatedDescs, matches, 2);
-                    size_t before = imgPts.size();
-                    for (auto& m : matches) {
-                        if (m.size() < 2) continue;
-                        if (m[0].distance < kRelocLoweRatio * m[1].distance) {
-                            imgPts.push_back(baseKps[m[0].queryIdx].pt);
-                            objPts.push_back(mapKps3d[visible[m[0].trainIdx]]);
-                            // NOT backbone: the persistent map is a separate point set that Φ has
-                            // never classified, so counting it in F_out would report a backbone the
-                            // partition never vouched for — and mask an empty F_out on exactly the
-                            // configuration (large overlay, marks off-frame) the map exists for.
-                            corrFromBackbone.push_back(0);
-                        }
-                    }
-                    if (imgPts.size() > before)
-                        LOGI("Reloc map: gated %zu/%zu pts, added %zu corr (total %zu)",
-                             visible.size(), mapKps3d.size(), imgPts.size() - before, imgPts.size());
-                }
-            }
-        }
-
-        // Distortion head (optional, docs/DISTORTION_HEAD.md): when the model + canonical patch are
-        // present, compare the live view (cropped around the coarse match centroid) against the
-        // fingerprint patch -> matchability (relock confidence) + coverage (= painting-progress). The
-        // corners/H -> IPPE prior is a later increment; here we consume the cheap signals. Inert unless
-        // the distortion_head.onnx asset is bundled. Uses RAW gray (the head's SuperPoint expects it).
-        if (mDistortionHead.isLoaded() && !wallPatch.empty() && !imgPts.empty()) {
-            float cxs = 0, cys = 0;
-            for (const auto& p : imgPts) { cxs += p.x; cys += p.y; }
-            cxs /= (float)imgPts.size(); cys /= (float)imgPts.size();
-            cv::Mat headGray;
-            cv::cvtColor(workFrame, headGray, cv::COLOR_RGB2GRAY);
-            int side = std::min(headGray.cols, headGray.rows);
-            int x0 = std::max(0, std::min((int)cxs - side / 2, headGray.cols - side));
-            int y0 = std::max(0, std::min((int)cys - side / 2, headGray.rows - side));
-            cv::Mat crop = headGray(cv::Rect(x0, y0, side, side)).clone();
-            std::array<float, 13> dist{};
-            if (mDistortionHead.run(crop, wallPatch, dist)) {
-                const float matchability = dist[11], coverage = dist[12];
-                if (matchability > 0.5f) {
-                    // A trusted look at the wall: it measures BOTH channels, and they are different
-                    // quantities. Coverage says how much of the design is realized (progress);
-                    // matchability says how much to trust this frame (confidence).
-                    mPaintingProgress.store(coverage, std::memory_order_relaxed);
-                    mCorroborationConfidence.store(matchability, std::memory_order_relaxed);
-                } else {
-                    // The head looked and did not recognize the wall. That is a statement about THIS
-                    // FRAME, not about the mural, so only confidence decays. Decaying progress here
-                    // is what made a three-frame glitch read as the mural being un-painted.
-                    decayCorroboration();
-                }
-                LOGI("DistortionHead: match %.2f coverage %.2f tilt %.0f log2scale %.2f",
-                     matchability, coverage, dist[8], dist[9]);
-            } else {
-                decayCorroboration();   // head refused to run — no information either way
-            }
-        } else if (mDistortionHead.isLoaded()) {
-            // Head is loaded but there was no patch or no correspondences to centre the crop on, so
-            // no attempt happened at all. Still a confidence statement, never a progress one.
-            decayCorroboration();
-        }
-
-        // Lowered floors so a close-up PARTIAL view (only a corner of the marks visible) can still
-        // localize: PnP needs only a handful of correspondences. The inlier RATIO (published below) is
-        // the quality gate PoseFusion actually trusts, so being permissive here is safe.
-        mLastRelocMatches.store((int)imgPts.size(), std::memory_order_relaxed);
-        mLastRelocInliers.store(0, std::memory_order_relaxed);
-        // corrFromBackbone is parallel to imgPts by construction, and the inlier attribution below
-        // subscripts it with indices into imgPts. A future pass that appends to one and not the
-        // other would make that read out of bounds, so a length disagreement publishes "not
-        // measured" instead of a wrong number.
-        const bool haveBackboneFlags = corrFromBackbone.size() == imgPts.size();
-        // 2.11: counted SEPARATELY from mLastRelocMatches, never in place of it. The same shortfall
-        // means different things — a low total is "the frame is not looking at the registered wall",
-        // a low backbone under a healthy total is "everything it can see is under the artwork" — and
-        // those call for opposite advice (aim differently vs. shrink the design / step back).
-        mLastRelocBackboneMatches.store(
-            haveBackboneFlags
-                ? (int)std::count(corrFromBackbone.begin(), corrFromBackbone.end(), (uint8_t)1)
-                : -1,
-            std::memory_order_relaxed);
-        if (imgPts.size() < 8) {
-            // Distinguish "the detector found nothing / the descriptors don't even compare" from
-            // "features were found but too few agreed with the fingerprint" — they call for opposite
-            // fixes (light/focus/texture vs. aim at the registered area).
-            mLastRelocReject.store(baseDescs.empty() ? kRelocNoFeatures : kRelocFewMatches,
-                                   std::memory_order_relaxed);
-        }
-        if (imgPts.size() >= 8) {
-            cv::Mat rvec, tvec;
-            std::vector<int> inliers;
-            // Camera matrix: reuse the intrinsics the fingerprint's 3D points were built with (keeps
-            // the 2D<->3D correspondence consistent) when available, else a coarse default. The old
-            // hardcoded init supplied only 6 of the 9 entries, leaving the bottom row uninitialised.
-            double fx = 1000.0, fy = 1000.0, cx = 960.0, cy = 540.0;
-            if (fpIntrinsics[0] > 0.0f && fpIntrinsics[1] > 0.0f) {
-                fx = fpIntrinsics[0]; fy = fpIntrinsics[1];
-                cx = fpIntrinsics[2]; cy = fpIntrinsics[3];
-            }
-            double idata[] = {fx, 0.0, cx, 0.0, fy, cy, 0.0, 0.0, 1.0};
-            cv::Mat intr = cv::Mat(3, 3, CV_64F, idata).clone();
-            StageTimer _pnpTimer(&mStageAccumMs[4], &mStageSamples[4]);
-            // EVALUATION.md 3.1: solvePnPRansac draws random samples, so two replays of the same
-            // recording can disagree and a parameter A/B reports RANSAC variance as an effect.
-            // Re-seeded immediately before EVERY solve, not once at start-up: the reloc thread is
-            // one of several consumers of the global cv::theRNG(), so a single seeding would drift
-            // as soon as anything else drew from it. Negative = leave it alone, which is the
-            // production default and keeps this inert outside an eval run.
-            const long long evalSeed = mEvalRngSeed.load(std::memory_order_relaxed);
-            if (evalSeed >= 0) cv::theRNG().state = (uint64_t)evalSeed;
-            if (!cv::solvePnPRansac(objPts, imgPts, intr, cv::Mat(), rvec, tvec, false, 100, 8.0, 0.99, inliers)) {
-                mLastRelocReject.store(kRelocPnpFailed, std::memory_order_relaxed);
-            } else {
-                mLastRelocInliers.store((int)inliers.size(), std::memory_order_relaxed);
-                // 2.11: which of those inliers RANSAC drew from F_out. Left at -1 on the PnP-failed
-                // branch above, because no inlier set exists there to attribute — that is "not
-                // measured", not "no backbone agreed".
-                if (haveBackboneFlags) {
-                    int backboneInliers = 0;
-                    for (int idx : inliers) {
-                        if (idx >= 0 && idx < (int)corrFromBackbone.size() && corrFromBackbone[idx]) ++backboneInliers;
-                    }
-                    mLastRelocBackboneInliers.store(backboneInliers, std::memory_order_relaxed);
-                }
-                if (inliers.size() < 6) {
-                    mLastRelocReject.store(kRelocFewInliers, std::memory_order_relaxed);
-                }
-                if (inliers.size() >= 6) {
-                    // Refine on the RANSAC inliers. The marks lie on the wall plane, so resolve the
-                    // planar two-fold (flip) ambiguity with IPPE and keep whichever pose reprojects
-                    // best — but only adopt it if it strictly beats the RANSAC pose, so a non-coplanar
-                    // inlier set can never make relocalization worse.
-                    {
-                        std::vector<cv::Point3f> inObj; std::vector<cv::Point2f> inImg;
-                        inObj.reserve(inliers.size()); inImg.reserve(inliers.size());
-                        for (int idx : inliers) { inObj.push_back(objPts[idx]); inImg.push_back(imgPts[idx]); }
-                        auto reproj = [&](const cv::Mat& rv, const cv::Mat& tv) {
-                            std::vector<cv::Point2f> pr;
-                            cv::projectPoints(inObj, rv, tv, intr, cv::Mat(), pr);
-                            double e = 0; for (size_t k = 0; k < pr.size(); ++k) e += cv::norm(pr[k] - inImg[k]);
-                            return e;
-                        };
-                        double bestErr = reproj(rvec, tvec);
-                        try {
-                            std::vector<cv::Mat> rvecs, tvecs;
-                            int n = cv::solvePnPGeneric(inObj, inImg, intr, cv::Mat(), rvecs, tvecs,
-                                                        false, cv::SOLVEPNP_IPPE);
-                            for (int s = 0; s < n; ++s) {
-                                double e = reproj(rvecs[s], tvecs[s]);
-                                if (e < bestErr) { bestErr = e; rvecs[s].copyTo(rvec); tvecs[s].copyTo(tvec); }
-                            }
-                        } catch (const cv::Exception&) { /* keep RANSAC pose */ }
-                        // IMPLEMENTATION.md 4.3 — publish the MEAN, not the sum `reproj` returns.
-                        // The sum grows with the inlier count, so a better lock would report a worse
-                        // error and the corroboration search would tighten exactly when it has the
-                        // most to gain from staying put. Divided by the same set it was summed over.
-                        if (!inObj.empty()) {
-                            mLastRelocReprojPx.store((float)(bestErr / (double)inObj.size()),
-                                                     std::memory_order_relaxed);
-                        }
-                    }
-                    cv::Mat R;
-                    cv:: Rodrigues(rvec, R);
-
-                    // PnP gives T_camera_from_fingerprintWorld (a view matrix). DO NOT write it to
-                    // mAnchorMatrix (a world-space MODEL matrix) — that caused overlay teleport.
-                    // Publish the raw result; Kotlin composes inverse(V_current)*pnp*fpAnchor with the
-                    // FRESH view matrix (see PoseFusion).
-                    glm::mat4 pnpMat = glm::mat4(1.0f);
-                    for(int i=0; i<3; ++i) {
-                        for(int j=0; j<3; ++j) pnpMat[j][i] = (float)R.at<double>(i,j);
-                        pnpMat[3][i] = (float)tvec.at<double>(i);
-                    }
-                    {
-                        std::lock_guard<std::mutex> lock(mMutex);
-                        memcpy(mPnpCamFromFpWorld, glm::value_ptr(pnpMat), 16 * sizeof(float));
-                    }
-                    mPnpInlierCount.store((int)inliers.size(), std::memory_order_relaxed);
-                    mPnpMatchCount.store((int)imgPts.size(), std::memory_order_relaxed);
-                    mPnpResultSeq.fetch_add(1, std::memory_order_relaxed);
-                    mLastRelocReject.store(kRelocOk, std::memory_order_relaxed);
-                    LOGI("Relocalization: PnP match published (%zu/%zu inliers)", inliers.size(), imgPts.size());
-                    // Phase 3 passive build: grow the feature map from this locked frame (default OFF).
-                    if (mMapBuildEnabled.load(std::memory_order_relaxed))
-                        growMapFromReloc(pnpMat, baseKps, baseDescs, fx, fy, cx, cy);
-                }
-            }
-        }
-
-        // Teleological gatekeeper: update painting-progress from how much of the artwork base the clean
-        // frame now corroborates. No-op until an artwork is registered; read-only on the reloc set.
-        // Hands over this frame's detection so it isn't recomputed (see tryUpdateFingerprint).
-        tryUpdateFingerprint(gray, &baseKps, &baseDescs);
+        // The whole attempt. In EVAL SYNC MODE this worker never gets here: scheduleRelocCheck runs
+        // the pass on the caller's thread and never sets mRelocRequested, so the wait above simply
+        // parks. (Switching modes mid-run can let one already-queued request through; the flag is an
+        // eval affordance set before a run starts, not a live toggle.)
+        runRelocPass(frame, relocView);
 
         // Back off only once locked. A flat 200 ms capped every state at 5 Hz, including the one that
         // matters most — hunting for the first lock, or re-acquiring after the artist looks away —
@@ -1258,6 +1283,20 @@ void MobileGS::setViewportSize(int w, int h) { mScreenWidth = w; mScreenHeight =
 void MobileGS::setRelocEnabled(bool e) { mRelocEnabled = e; }
 
 void MobileGS::setEvalRngSeed(long long seed) { mEvalRngSeed.store(seed, std::memory_order_relaxed); }
+
+void MobileGS::setEvalSyncReloc(bool enabled, int everyN) {
+    // Floored at 1. Zero would divide by zero in the cadence test; negative would make `n % everyN`
+    // never zero, so the mode would be "on" and silently never relocalize -- which on a replay looks
+    // exactly like relocalization being broken, and would be blamed on whatever parameter the run
+    // was varying.
+    mEvalSyncEveryN.store(std::max(1, everyN), std::memory_order_relaxed);
+    // Reset on the transition, not only on enable: two runs in one process must start their cadence
+    // from the same phase, or "every 5th frame" means a different five frames per run and the
+    // determinism this exists to provide is not there.
+    mEvalSyncFrameCounter.store(0, std::memory_order_relaxed);
+    mEvalSyncReloc.store(enabled, std::memory_order_relaxed);
+    LOGI("Eval sync-reloc %s (every %d frames)", enabled ? "ON" : "off", std::max(1, everyN));
+}
 void MobileGS::restoreWallFingerprint(const cv::Mat& d, const std::vector<cv::Point3f>& p) {
     std::lock_guard<std::mutex> lock(mMutex);
     mWallDescriptors = d.clone();
@@ -1472,6 +1511,22 @@ void MobileGS::alignToFingerprint(const uint8_t* data, size_t size) {
 }
 bool MobileGS::relocWantsFrame() {
     if (!mRelocEnabled) return false;
+    // EVAL SYNC MODE deliberately does NOT filter by cadence here, and the cost of that is real:
+    // mRelocRequested is never set in sync mode, so the throttle below always answers "yes" and the
+    // caller pays a full-frame YUV->RGB conversion plus a rotate for every frame the every-N test is
+    // about to discard.
+    //
+    // The obvious fix -- peek `(counter + 1) % everyN` here -- DEADLOCKS, and the way it does is
+    // worth writing down because it looks correct. The counter advances only inside
+    // scheduleRelocCheck, which the caller invokes only when this returns true. At everyN=5 the peek
+    // sees 1, refuses, the counter never moves, and the peek sees 1 forever: sync mode is "on" and
+    // never relocalizes. Moving the increment here instead would make scheduleRelocCheck's cadence
+    // depend on this function having been called first -- a coupling across two files that the next
+    // call site to appear would break silently.
+    //
+    // So the waste is accepted, and it is bounded: this is an eval affordance whose own comment
+    // already says the inline cadence is not one a real device would choose. Correct cadence beats a
+    // saved conversion on a path that exists to make measurements comparable.
     if (mRelocRequested) return false; // worker still holds the previous frame
     std::lock_guard<std::mutex> lock(mMutex);
     return !mWallDescriptors.empty();
@@ -1489,6 +1544,28 @@ void MobileGS::scheduleRelocCheck(const cv::Mat& f) {
         // never nests with mRelocMutex below.
         std::lock_guard<std::mutex> lock(mMutex);
         if (mWallDescriptors.empty()) return; // nothing to match against yet
+    }
+    // EVALUATION.md 3.1 — inline mode. Run the pass on THIS thread, one frame in N, and never set
+    // mRelocRequested, so the background worker stays parked on its condition variable rather than
+    // racing us for the same frame.
+    //
+    // The frame is NOT copied into mRelocColorFrame here. Copying it would publish it to a worker
+    // that is not going to read it, and the pass takes the frame by reference anyway; the only thing
+    // that shared buffer buys is the hand-off this mode exists to remove.
+    if (mEvalSyncReloc.load(std::memory_order_relaxed)) {
+        const int everyN = std::max(1, mEvalSyncEveryN.load(std::memory_order_relaxed));
+        const long long n = mEvalSyncFrameCounter.fetch_add(1, std::memory_order_relaxed) + 1;
+        if (n % everyN != 0) return;
+        float view[16];
+        {
+            // Same snapshot the async path takes, under the same lock, so the rectifying warp sees
+            // the view that goes with this frame in both modes. Running inline does not make an
+            // unsynchronized read of mViewMatrix safe -- updateCamera is still another thread.
+            std::lock_guard<std::mutex> lock(mMutex);
+            memcpy(view, mViewMatrix, 16 * sizeof(float));
+        }
+        runRelocPass(f, view);
+        return;
     }
     {
         std::lock_guard<std::mutex> lock(mRelocMutex);

--- a/core/nativebridge/src/main/cpp/include/KeypointGrid.h
+++ b/core/nativebridge/src/main/cpp/include/KeypointGrid.h
@@ -114,7 +114,16 @@ private:
      */
     int cellFloor(float v, float minV) const {
         if (!std::isfinite(v)) return v > 0.0f ? INT32_MAX : INT32_MIN;
-        const double idx = std::floor((double)(v - minV) / (double)mCell);
+        // FLOAT division, matching the Kotlin reference's `(v - min) / cellSize` on Float operands.
+        // Promoting to double here computes a more accurate quotient, which sounds like an
+        // improvement and is a divergence: at a boundary where the float quotient rounds up to
+        // exactly an integer and the double quotient does not, the two implementations return
+        // different cells and the out-of-range reject fires on one side and not the other. The
+        // reference is the specification; being more precise than it is still being different from
+        // it. Widened to double only for the floor and the range clamp, where no such disagreement
+        // is possible.
+        const float q = (v - minV) / mCell;
+        const double idx = std::floor((double)q);
         if (idx > (double)INT32_MAX) return INT32_MAX;
         if (idx < (double)INT32_MIN) return INT32_MIN;
         return (int)idx;

--- a/core/nativebridge/src/main/cpp/include/KeypointGrid.h
+++ b/core/nativebridge/src/main/cpp/include/KeypointGrid.h
@@ -1,0 +1,133 @@
+#ifndef GRAFFITIXR_KEYPOINT_GRID_H
+#define GRAFFITIXR_KEYPOINT_GRID_H
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <vector>
+#include <opencv2/core.hpp>
+
+/**
+ * IMPLEMENTATION.md 4.5 — transliteration of
+ * `feature/ar/.../anchor/KeypointGrid.kt`.
+ *
+ * The Kotlin file is the reference and carries the rationale; `KeypointGridTest` holds it to a
+ * brute-force equivalence check across radii both below and above the cell size. This file must
+ * reproduce that behaviour exactly, and the two errors it is most likely to reintroduce are called
+ * out inline below because both produce a plausible, slightly-wrong answer rather than a crash:
+ * fewer corroborated features and nothing else.
+ *
+ * ## The contract
+ *
+ * [candidatesWithin] guarantees only one direction: **every** keypoint within `radius` of the query
+ * is returned. It may return extras — the swept cells cover a rectangle, not a circle — and the
+ * caller applies whatever exact test it needs. The grid exists to make the candidate set small; the
+ * ratio test that follows is what decides matches.
+ */
+class KeypointGrid {
+public:
+    KeypointGrid() = default;
+
+    /**
+     * Bucket the keypoints.
+     *
+     * @param cellSize edge length of a bucket in pixels — pass the search radius. Floored at 1 px so
+     *   a degenerate radius cannot produce an unbounded grid.
+     */
+    void build(const std::vector<cv::KeyPoint>& kps, float cellSize) {
+        mCell = (std::isfinite(cellSize) && cellSize >= 1.0f) ? cellSize : 1.0f;
+        mCols = 0; mRows = 0; mMinX = 0.0f; mMinY = 0.0f;
+        mCells.clear();
+        if (kps.empty()) return;
+
+        float minX = std::numeric_limits<float>::max();
+        float minY = std::numeric_limits<float>::max();
+        float maxX = -std::numeric_limits<float>::max();
+        float maxY = -std::numeric_limits<float>::max();
+        for (const auto& kp : kps) {
+            // A non-finite keypoint would poison the bounds and collapse the whole grid to one cell,
+            // quietly turning the local search back into a global one.
+            if (!std::isfinite(kp.pt.x) || !std::isfinite(kp.pt.y)) continue;
+            if (kp.pt.x < minX) minX = kp.pt.x;
+            if (kp.pt.x > maxX) maxX = kp.pt.x;
+            if (kp.pt.y < minY) minY = kp.pt.y;
+            if (kp.pt.y > maxY) maxY = kp.pt.y;
+        }
+        if (minX > maxX) return;   // every keypoint was non-finite
+
+        mMinX = minX; mMinY = minY;
+        mCols = std::max(1, (int)((maxX - minX) / mCell) + 1);
+        mRows = std::max(1, (int)((maxY - minY) / mCell) + 1);
+        mCells.assign((size_t)mCols * (size_t)mRows, {});
+        for (int i = 0; i < (int)kps.size(); ++i) {
+            const auto& p = kps[(size_t)i].pt;
+            if (!std::isfinite(p.x) || !std::isfinite(p.y)) continue;
+            const int c = clampi((int)((p.x - mMinX) / mCell), 0, mCols - 1);
+            const int r = clampi((int)((p.y - mMinY) / mCell), 0, mRows - 1);
+            mCells[(size_t)r * (size_t)mCols + (size_t)c].push_back(i);
+        }
+    }
+
+    /**
+     * Indices of every keypoint whose cell could hold a point within [radius] of (x, y).
+     *
+     * Sweeps the cell RANGE covering the query's bounding box, not a fixed 3x3. Those coincide only
+     * when cellSize >= radius; the caller may query one grid at several radii (the drift terms move
+     * the radius frame to frame), and a hard-coded 3x3 would then silently miss candidates.
+     */
+    void candidatesWithin(float x, float y, float radius, std::vector<int>& out) const {
+        out.clear();
+        if (mCols == 0 || mRows == 0) return;
+        if (radius < 0.0f || !std::isfinite(radius)) return;
+        if (!std::isfinite(x) || !std::isfinite(y)) return;
+
+        // Computed UNCLAMPED first, so a query whose range lies entirely outside the grid returns
+        // nothing. Clamping straight into [0, count) — the obvious way to write this — silently maps
+        // a distant query onto the edge cells and hands back their contents, which on a grid one
+        // cell wide (few or tightly clustered keypoints) means every keypoint in the frame for a
+        // query nowhere near any of them.
+        const int c0raw = cellFloor(x - radius, mMinX);
+        const int c1raw = cellFloor(x + radius, mMinX);
+        const int r0raw = cellFloor(y - radius, mMinY);
+        const int r1raw = cellFloor(y + radius, mMinY);
+        if (c1raw < 0 || c0raw > mCols - 1 || r1raw < 0 || r0raw > mRows - 1) return;
+
+        const int c0 = clampi(c0raw, 0, mCols - 1);
+        const int c1 = clampi(c1raw, 0, mCols - 1);
+        const int r0 = clampi(r0raw, 0, mRows - 1);
+        const int r1 = clampi(r1raw, 0, mRows - 1);
+        for (int r = r0; r <= r1; ++r) {
+            const size_t base = (size_t)r * (size_t)mCols;
+            for (int c = c0; c <= c1; ++c) {
+                const auto& bucket = mCells[base + (size_t)c];
+                out.insert(out.end(), bucket.begin(), bucket.end());
+            }
+        }
+    }
+
+private:
+    /**
+     * Unclamped cell index, which may be negative or past the last cell. std::floor, NOT a plain
+     * int cast: truncation goes toward zero, so a query half a cell to the LEFT of the origin would
+     * land in cell 0 instead of -1 and the out-of-range test above would never fire on that side.
+     */
+    int cellFloor(float v, float minV) const {
+        if (!std::isfinite(v)) return v > 0.0f ? INT32_MAX : INT32_MIN;
+        const double idx = std::floor((double)(v - minV) / (double)mCell);
+        if (idx > (double)INT32_MAX) return INT32_MAX;
+        if (idx < (double)INT32_MIN) return INT32_MIN;
+        return (int)idx;
+    }
+
+    static int clampi(int v, int lo, int hi) { return v < lo ? lo : (v > hi ? hi : v); }
+
+    float mCell = 1.0f;
+    float mMinX = 0.0f;
+    float mMinY = 0.0f;
+    int mCols = 0;
+    int mRows = 0;
+    std::vector<std::vector<int>> mCells;
+};
+
+#endif  // GRAFFITIXR_KEYPOINT_GRID_H

--- a/core/nativebridge/src/main/cpp/include/MobileGS.h
+++ b/core/nativebridge/src/main/cpp/include/MobileGS.h
@@ -125,6 +125,24 @@ public:
      */
     static constexpr float kCorroborationDecay = 0.9f;
 
+    /**
+     * IMPLEMENTATION.md 4.7 — the two Lowe ratios, named apart so E7 can sweep them independently.
+     *
+     * They were the same literal `0.75f` written at four call sites, which made them look like one
+     * decision. They are not. The reloc match is a GLOBAL search over the backbone with no prior — as
+     * are the two map matches, which is why those keep `kRelocLoweRatio` — where a
+     * loose ratio admits false correspondences that RANSAC then has to reject; the corroboration
+     * match after Phase 4 searches a candidate set roughly 0.2% the size, where the false-positive
+     * population has already collapsed and the same threshold throws away true matches for nothing.
+     * Phase 4's entire justification is that the constraint lets this one be LOOSENED — so it has to
+     * be a separate number, or the effect cannot be measured.
+     *
+     * Both are pre-registered priors (PARAMETERS.md section 5). `kRelocLoweRatio` is the value that
+     * shipped; `kCorrobLoweRatio` is the paper's suggested 0.85, and E7 sets it for real.
+     */
+    static constexpr float kRelocLoweRatio = 0.75f;
+    static constexpr float kCorrobLoweRatio = 0.85f;
+
     /** Last [RelocReject]. */
     int lastRelocReject() const { return mLastRelocReject.load(std::memory_order_relaxed); }
     /** Correspondences built by the last attempt, successful or not. */
@@ -151,6 +169,47 @@ public:
     int lastRelocBackboneMatches() const { return mLastRelocBackboneMatches.load(std::memory_order_relaxed); }
     /** RANSAC inliers that came from F_out points; -1 when PnP never produced an inlier set. */
     int lastRelocBackboneInliers() const { return mLastRelocBackboneInliers.load(std::memory_order_relaxed); }
+
+    /**
+     * IMPLEMENTATION.md 4.6 — the corroboration match's own counts, so the effect Phase 4 claims can
+     * be seen rather than argued about.
+     *
+     * `corrobPredicted` is how many design features the current pose puts inside the frame;
+     * `corrobMatched` is how many of those the wall answered for. Both -1 until a GATED attempt has
+     * run: the global fallback path measures a different thing (every descriptor of the design,
+     * framing included) and reporting its numbers here would make the two look comparable.
+     *
+     * Zero predicted is a real reading — the artist is looking away from the design — and is the
+     * state 4.8 exists to keep distinct from zero matched.
+     */
+    int corrobPredicted() const { return mCorrobPredicted.load(std::memory_order_relaxed); }
+    int corrobMatched() const { return mCorrobMatched.load(std::memory_order_relaxed); }
+    /** Search radius the last gated attempt used, in pixels, or -1 when no gated attempt has run. */
+    float corrobSearchRadiusPx() const { return mCorrobSearchRadiusPx.load(std::memory_order_relaxed); }
+    /**
+     * Mean reprojection error over the last lock's PnP inliers, in pixels, or -1 when not measured.
+     *
+     * Feeds the search radius' drift term (SearchRadius.h) and is a diagnostic in its own right.
+     * Bounded above by the RANSAC inlier threshold by construction, which is why the gain applied to
+     * it is not 1.0 — see `SearchRadius.REPROJ_GAIN`.
+     */
+    float lastRelocReprojPx() const { return mLastRelocReprojPx.load(std::memory_order_relaxed); }
+
+    /**
+     * IMPLEMENTATION.md 4.5 — where the design sits, so the corroboration match can predict where
+     * each of its features should appear.
+     *
+     * @param fpFromDesign16 the design's model matrix expressed in the WALL FINGERPRINT frame,
+     *   column-major. This is exactly `FingerprintPartition.partition`'s `designInPointFrame`
+     *   (`captureAnchorCam * rigidModelAnchorLocal`) — the same composition Phi is classified with,
+     *   deliberately, because a second derivation of the same quantity is a second chance to get the
+     *   frame wrong. RIGID: the overlay's scale is folded into the extents, not this matrix.
+     * @param halfW,halfH the design's effective (scale-included) half-extents in metres.
+     *
+     * Pass a null pointer or a non-positive extent to clear the placement, which returns the
+     * corroboration match to the global search it did before Phase 4.
+     */
+    void setDesignPlacement(const float* fpFromDesign16, float halfW, float halfH);
 
     void scheduleRelocCheck(const cv::Mat& colorFrame);
     /**
@@ -340,6 +399,34 @@ private:
     static constexpr uint8_t kRegionOutside = 2;
     cv::Mat mArtworkDescriptors;
     std::vector<cv::Point3f> mArtworkKeypoints3D;
+    // IMPLEMENTATION.md 4.5 — the artwork features' 2D positions in the composite the descriptors
+    // were detected on, kept 1:1 with mArtworkDescriptors THROUGH the depth-path row filter in
+    // setArtworkFingerprint. mArtworkKeypoints3D is not usable for this: it is empty on the shipping
+    // path (the design composite carries no depth) and, when depth does exist, it is expressed in
+    // the artwork CAPTURE camera's frame, which has no relation to the wall fingerprint frame the
+    // reloc pose is in. Predicting where a design feature should appear goes through the design's
+    // placement instead, which is a frame the app actually knows.
+    std::vector<cv::Point2f> mArtworkKeypoints2D;
+    // Pixel size of that composite; the design-plane mapping is parametric in it, so a design
+    // re-registered at a different resolution stays correct without rescaling the keypoints.
+    int mArtworkImageW = 0;
+    int mArtworkImageH = 0;
+    // One flag per artwork descriptor: has the wall EVER answered for this feature? Painting
+    // progress is the popcount over this, not the current frame's match count.
+    //
+    // Before Phase 4 the instantaneous ratio was already the whole design's, so a frame that saw
+    // everything reported everything. The gated match only ever looks at the part of the design in
+    // view, so the instantaneous ratio would become a statement about where the artist is standing.
+    // Accumulating is also closer to what getPaintingProgress() already promises — "on the timescale
+    // of hours, roughly monotonic. Never decayed." Cleared whenever a new artwork is registered,
+    // because every prior reading was against a different target.
+    std::vector<uint8_t> mArtworkCorroborated;
+    // Bumped whenever the artwork is replaced or cleared. tryUpdateFingerprint snapshots the
+    // descriptors under the lock, spends milliseconds matching outside it, and then merges its
+    // result back in; without this it would merge into whatever artwork is registered by then. The
+    // sizes alone are not enough — a design swapped for one with the same feature count would pass a
+    // length check and corrupt the accumulator with another target's hits.
+    long mArtworkGeneration = 0;
     std::atomic<float> mPaintingProgress{0.0f};
     // -1 = never measured, which is NOT the same as 0.0 = measured and found nothing. Zero is a
     // legitimate reading here, so it cannot double as the "no data yet" sentinel.
@@ -382,6 +469,14 @@ private:
     float mFingerprintAnchorMatrix[16] = {1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1};
     // fx,fy,cx,cy the wall fingerprint's 3D points were built with; {0,..} => unset (use a default).
     float mFingerprintIntrinsics[4] = {0,0,0,0};
+    // IMPLEMENTATION.md 4.5 — the design's rigid pose in the FINGERPRINT frame plus its
+    // scale-included half-extents. Guarded by mMutex like everything else here, and false until
+    // Kotlin has pushed a placement: absent means the corroboration match falls back to the global
+    // search, which is Phase 4 turned off rather than Phase 4 guessing.
+    float mDesignFpFromDesign[16] = {1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1};
+    float mDesignHalfW = 0.0f;
+    float mDesignHalfH = 0.0f;
+    bool mHasDesignPlacement = false;
     // VIO view matrix at fingerprint-capture time + flag; used to rectify oblique live views to the
     // fingerprint's frontal frame before matching (perspective-robust matching). False for fingerprints
     // restored without a capture view (rectification is then skipped — plain matching still runs).
@@ -465,5 +560,14 @@ private:
     std::atomic<int>        mLastRelocBackboneFeatures{-1};
     std::atomic<int>        mLastRelocBackboneMatches{-1};
     std::atomic<int>        mLastRelocBackboneInliers{-1};
+    // IMPLEMENTATION.md 4.6 — the corroboration match's counts and the radius it used. All -1 for
+    // "no gated attempt has run", following the same rule as the trio above: zero predicted is a
+    // real reading (the artist is not looking at the design) and cannot double as the default.
+    std::atomic<int>        mCorrobPredicted{-1};
+    std::atomic<int>        mCorrobMatched{-1};
+    std::atomic<float>      mCorrobSearchRadiusPx{-1.0f};
+    // Mean reprojection error over the last lock's PnP inliers, in pixels. -1 = not measured, and it
+    // stays -1 on every path that does not reach a refined inlier set.
+    std::atomic<float>      mLastRelocReprojPx{-1.0f};
     cv::Mat                 mRelocColorFrame;
 };

--- a/core/nativebridge/src/main/cpp/include/MobileGS.h
+++ b/core/nativebridge/src/main/cpp/include/MobileGS.h
@@ -143,6 +143,26 @@ public:
     static constexpr float kRelocLoweRatio = 0.75f;
     static constexpr float kCorrobLoweRatio = 0.85f;
 
+    /**
+     * How many separate gated attempts must corroborate a design feature before it counts toward
+     * painting progress.
+     *
+     * Progress accumulates and never decays, which is what the channel promises — but a
+     * monotone counter with no false-positive bound saturates on noise given enough ticks. The
+     * reloc loop runs at 5 Hz locked, so even one spurious match per attempt would walk a
+     * 1500-feature design to "100% painted" in minutes on a bare wall.
+     *
+     * Two, not one, and not five. One is the unbounded case. Two costs a genuinely painted feature
+     * nothing — it corroborates on every attempt it is in view for, so it confirms on the next tick
+     * — while removing the entire class of TRANSIENT false positives, which is the class that
+     * ratchets. It does not defend against a persistent false positive: a wall feature that really
+     * does sit near a design feature's prediction and really does win the ratio test will confirm,
+     * and no counter threshold changes that. That is a limit of descriptor corroboration, not of
+     * this constant, and it is why E6 measures progress against ground truth rather than trusting
+     * it.
+     */
+    static constexpr uint8_t kCorrobConfirmations = 2;
+
     /** Last [RelocReject]. */
     int lastRelocReject() const { return mLastRelocReject.load(std::memory_order_relaxed); }
     /** Correspondences built by the last attempt, successful or not. */
@@ -184,6 +204,18 @@ public:
      */
     int corrobPredicted() const { return mCorrobPredicted.load(std::memory_order_relaxed); }
     int corrobMatched() const { return mCorrobMatched.load(std::memory_order_relaxed); }
+    /**
+     * Predicted-visible features the gated match REFUSED to test, because their neighbourhood held
+     * a single candidate and Lowe's ratio has nothing to divide by. -1 when no gated attempt ran.
+     *
+     * Published rather than logged because it is the number that decides whether the phase works.
+     * These skips deflate `corrobMatched` without touching `corrobPredicted`, so a radius that is
+     * too tight does not announce itself as an error — it announces itself as a wall that has
+     * stopped corroborating, which is indistinguishable from an unpainted one. At the `MIN_PX`
+     * floor a sparse frame can skip most of what it predicted; with this on the channel that is a
+     * reading E6 can act on instead of an unknown.
+     */
+    int corrobLoneSkips() const { return mCorrobLoneSkips.load(std::memory_order_relaxed); }
     /** Search radius the last gated attempt used, in pixels, or -1 when no gated attempt has run. */
     float corrobSearchRadiusPx() const { return mCorrobSearchRadiusPx.load(std::memory_order_relaxed); }
     /**
@@ -565,6 +597,7 @@ private:
     // real reading (the artist is not looking at the design) and cannot double as the default.
     std::atomic<int>        mCorrobPredicted{-1};
     std::atomic<int>        mCorrobMatched{-1};
+    std::atomic<int>        mCorrobLoneSkips{-1};
     std::atomic<float>      mCorrobSearchRadiusPx{-1.0f};
     // Mean reprojection error over the last lock's PnP inliers, in pixels. -1 = not measured, and it
     // stays -1 on every path that does not reach a refined inlier set.

--- a/core/nativebridge/src/main/cpp/include/MobileGS.h
+++ b/core/nativebridge/src/main/cpp/include/MobileGS.h
@@ -306,6 +306,25 @@ public:
      * RANSAC draw the identical sample sequence forever.
      */
     void setEvalRngSeed(long long seed);
+    /**
+     * EVALUATION.md 3.1 — enable inline relocalization at one pass per [everyN] frames.
+     *
+     * @param everyN clamped to at least 1. Pass 0 or negative and you would get either a divide by
+     *   zero or a mode that never runs; both are worse than the honest floor, and a silent
+     *   never-runs would look exactly like relocalization being broken.
+     *
+     * Disabling resets the frame counter, so two runs in one process start their cadence from the
+     * same phase rather than wherever the previous run left off — otherwise "every 5th frame" would
+     * mean a different five frames per run, which is the non-determinism this exists to remove.
+     */
+    void setEvalSyncReloc(bool enabled, int everyN);
+    /** True when inline relocalization is active — for the run-identity sidecar's sync/async field. */
+    bool isEvalSyncReloc() const { return mEvalSyncReloc.load(std::memory_order_relaxed); }
+    /** The cadence in force, or 0 when sync mode is off. Reported alongside the flag. */
+    int evalSyncEveryN() const {
+        return mEvalSyncReloc.load(std::memory_order_relaxed)
+            ? mEvalSyncEveryN.load(std::memory_order_relaxed) : 0;
+    }
     void setVoxelSize(float size);
     void setParallaxMinDegrees(float deg);
     void setMappingPaused(bool paused) { mMappingPaused = paused; }
@@ -381,6 +400,11 @@ private:
     std::atomic<bool> mMapRunning{false};
 
     void relocThreadFunc();
+    /**
+     * EVALUATION.md 3.1 — one relocalization attempt over one frame, callable either from the
+     * background worker or inline from the caller in eval sync mode.
+     */
+    void runRelocPass(const cv::Mat& frame, const float* relocView);
     // Teleological self-grow (gatekeeper stage): measure how much of the registered artwork base is now
     // corroborated by real wall content in the clean camera frame -> mPaintingProgress. Read-only on the
     // reloc fingerprint; the promotion step (adding validated new marks) is staged separately.
@@ -523,6 +547,30 @@ private:
     // explicitly enabled"; the initializer said otherwise and the header won, which meant every
     // release build promoted unsupervised with no user-facing switch to stop it.
     std::atomic<bool> mSelfGrowEnabled{false};
+
+    /**
+     * EVALUATION.md 3.1 — run relocalization INLINE on the calling thread, one pass every Nth
+     * frame, instead of handing frames to the background worker.
+     *
+     * The second of the three named sources of replay non-determinism. RANSAC's RNG is seeded
+     * (mEvalRngSeed) and the frame order is fixed by the recording, but the worker's
+     * `locked ? 200 : 60` ms sleep means WHICH frames it receives is a scheduling outcome. Two
+     * replays of one recording therefore sample it differently, and a parameter A/B silently
+     * becomes a comparison of two different frame subsets.
+     *
+     * Off by default and gated at the JNI call site to debuggable builds, because this is an
+     * evaluation affordance and not a behaviour change: run inline and the reloc cost lands on the
+     * caller's thread at a cadence no real device would choose. EVALUATION.md is explicit that both
+     * are reported — the async numbers are what users get, the sync numbers are what is comparable.
+     */
+    std::atomic<bool>     mEvalSyncReloc{false};
+    std::atomic<int>      mEvalSyncEveryN{1};
+    /**
+     * Frames seen since sync mode was enabled, for the every-Nth decision. Not atomic-incremented
+     * for correctness across threads — scheduleRelocCheck is called from the one render thread —
+     * but atomic so enabling the mode from another thread cannot tear it.
+     */
+    std::atomic<long long> mEvalSyncFrameCounter{0};
 
     /** Fixed RANSAC seed for reproducible replay, or <0 for "leave the RNG alone" (default). */
     std::atomic<long long> mEvalRngSeed{-1};

--- a/core/nativebridge/src/main/cpp/include/SearchRadius.h
+++ b/core/nativebridge/src/main/cpp/include/SearchRadius.h
@@ -1,0 +1,82 @@
+#ifndef GRAFFITIXR_SEARCH_RADIUS_H
+#define GRAFFITIXR_SEARCH_RADIUS_H
+
+#include <cmath>
+#include <algorithm>
+
+/**
+ * IMPLEMENTATION.md 4.5 — transliteration of
+ * `feature/ar/.../anchor/SearchRadius.kt`.
+ *
+ * The Kotlin file is the reference and carries the full rationale; `SearchRadiusTest` pins the
+ * scaling relationships this file has to reproduce. Keep the two in step: every constant here is a
+ * pre-registered prior from PARAMETERS.md section 5 that E6/E7/E11 are expected to move, and a value
+ * that moves on one side only is a silent divergence between the tested reference and the code that
+ * actually runs.
+ *
+ * Written as a header rather than inline in MobileGS.cpp so the correspondence is one file to one
+ * file and a reviewer can diff them side by side.
+ */
+namespace searchradius {
+
+/** PARAMETERS.md section 5. Mirrors SearchRadius.RHO / MIN_PX / MAX_PX / ERR_GAIN / REPROJ_GAIN. */
+constexpr float kRho = 0.05f;
+constexpr float kMinPx = 4.0f;
+constexpr float kMaxPx = 120.0f;
+constexpr float kErrGain = 1.0f;
+constexpr float kReprojGain = 2.0f;
+/** Negative, never 0 — zero is a legitimate reading for both drift inputs. */
+constexpr float kNotMeasured = -1.0f;
+
+/**
+ * The single length that stands in for an anisotropic design: geometric mean, not max or min.
+ *
+ * The radius bounds how far a pose prediction can be wrong, and that error is isotropic in the image
+ * whatever the artwork's aspect ratio.
+ */
+inline float designExtentScalar(float halfW, float halfH) {
+    if (halfW <= 0.0f || halfH <= 0.0f) return 0.0f;
+    return std::sqrt(halfW * halfH);
+}
+
+/**
+ * Search radius in pixels for a corroboration match.
+ *
+ * Degenerate geometry yields kMaxPx, NOT kMinPx. A too-wide search costs precision, which the ratio
+ * test still filters; a too-tight one returns no candidates at all and reads downstream as "the wall
+ * does not corroborate the design" — indistinguishable from a genuinely unpainted wall.
+ *
+ * @param poseErrMm  measured pose error in millimetres, negative when not measured.
+ * @param reprojErrPx reloc PnP mean inlier reprojection error in pixels, negative when not measured.
+ *   Added in pixels and deliberately NOT multiplied by pxPerMeter — it is already an image-space
+ *   quantity, and projecting it again would square the perspective. pxPerMeter is in scope right
+ *   beside it, which is exactly why this is spelled out.
+ */
+inline float pixels(float rho, float designHalfWMeters, float designHalfHMeters,
+                    float wallDistanceMeters, float focalLengthPx,
+                    float poseErrMm, float reprojErrPx = kNotMeasured,
+                    float errGain = kErrGain, float reprojGain = kReprojGain,
+                    float minPx = kMinPx, float maxPx = kMaxPx) {
+    const float halfExtent = designExtentScalar(designHalfWMeters, designHalfHMeters);
+    if (halfExtent <= 0.0f || wallDistanceMeters <= 0.0f || focalLengthPx <= 0.0f || rho <= 0.0f) {
+        return maxPx;
+    }
+    if (!std::isfinite(halfExtent) || !std::isfinite(wallDistanceMeters) ||
+        !std::isfinite(focalLengthPx)) {
+        return maxPx;
+    }
+
+    const float pxPerMeter = focalLengthPx / wallDistanceMeters;
+    const float scaleTermPx = rho * halfExtent * pxPerMeter;
+    const float driftTermPx = (poseErrMm >= 0.0f && std::isfinite(poseErrMm))
+        ? errGain * (poseErrMm / 1000.0f) * pxPerMeter : 0.0f;
+    const float reprojTermPx = (reprojErrPx >= 0.0f && std::isfinite(reprojErrPx))
+        ? reprojGain * reprojErrPx : 0.0f;
+
+    const float r = scaleTermPx + driftTermPx + reprojTermPx;
+    return std::min(std::max(r, minPx), maxPx);
+}
+
+}  // namespace searchradius
+
+#endif  // GRAFFITIXR_SEARCH_RADIUS_H

--- a/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
+++ b/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
@@ -4,6 +4,7 @@ package com.hereliesaz.graffitixr.nativebridge
 import android.content.res.AssetManager
 import android.graphics.Bitmap
 import android.util.Log
+import com.hereliesaz.graffitixr.common.model.CorroborationDiagnostics
 import com.hereliesaz.graffitixr.common.model.Fingerprint
 import com.hereliesaz.graffitixr.common.model.RelocDiagnostics
 import com.hereliesaz.graffitixr.common.model.RelocReject
@@ -239,13 +240,18 @@ class SlamManager @Inject constructor(
 
     /**
      * Why the last relocalization attempt did not publish a pose, and how far it got. See
-     * [RelocDiagnostics]; the native side packs NINE values into one int[] so the read is a
-     * consistent snapshot rather than nine racing getters. (Three separate comments used to say
-     * three, four and six; the array was six wide until 2.11 added the three backbone counts.)
+     * [RelocDiagnostics]; the native side packs ELEVEN values into one int[] so the read is a
+     * consistent snapshot rather than eleven racing getters. (Three separate comments used to say
+     * three, four and six; the array was six wide until 2.11 added the three backbone counts, and
+     * nine until 4.6 added the two corroboration counts.)
      *
-     * A short array falls back to the default [RelocDiagnostics] — whose backbone fields are the -1
-     * "not measured" sentinel, not 0 — rather than to a partially-filled one, so an old .so paired
-     * with this build reads as unmeasured instead of as an empty backbone.
+     * A short array falls back to the default [RelocDiagnostics] — whose backbone and corroboration
+     * fields are the -1 "not measured" sentinel, not 0 — rather than to a partially-filled one, so
+     * an old .so paired with this build reads as unmeasured instead of as an empty backbone.
+     *
+     * The width check is `< 9`, not `< 11`, on purpose: everything through index 8 is what a 2.11-era
+     * .so provides, and refusing the whole record because it predates 4.6 would throw away nine good
+     * diagnostics to avoid two missing ones. The two are read only when they are actually there.
      */
     fun getRelocDiagnostics(): RelocDiagnostics {
         val v = nativeGetRelocDiagnostics()
@@ -260,7 +266,40 @@ class SlamManager @Inject constructor(
             backboneFeatures = v[6],
             backboneMatches = v[7],
             backboneInliers = v[8],
+            corrobPredicted = if (v.size > 9) v[9] else -1,
+            corrobMatched = if (v.size > 10) v[10] else -1,
         )
+    }
+
+    /**
+     * IMPLEMENTATION.md 4.6 — the corroboration path's two float readings: the search radius the
+     * last gated attempt used, and the mean reprojection error over the last lock's PnP inliers.
+     * Both in pixels, both `-1f` when not measured.
+     *
+     * A separate call from [getRelocDiagnostics] only because these are floats and that channel is
+     * an `int[]`; rounding a sub-pixel radius to an int to share the array would destroy the reading
+     * at exactly the tight radii the phase is trying to measure.
+     */
+    fun getCorroborationDiagnostics(): CorroborationDiagnostics {
+        val v = nativeGetCorroborationDiagnostics()
+        if (v == null || v.size < 2) return CorroborationDiagnostics()
+        return CorroborationDiagnostics(searchRadiusPx = v[0], relocReprojPx = v[1])
+    }
+
+    /**
+     * IMPLEMENTATION.md 4.5 — tell the engine where the design sits, so the corroboration match can
+     * predict where each design feature should appear instead of searching the whole frame.
+     *
+     * @param fpFromDesign16 the design's model matrix in the WALL FINGERPRINT frame, column-major.
+     *   This is `FingerprintPartition.partition`'s `designInPointFrame`
+     *   (`captureAnchorCam * rigidModelAnchorLocal`) — pass that composition, do not rebuild it. It
+     *   is rigid: the overlay's scale belongs in the extents, not in this matrix.
+     * @param halfW,halfH the design's effective (scale-included) half-extents in metres.
+     *
+     * Pass `null` to clear, which returns corroboration to its pre-Phase-4 global search.
+     */
+    fun setDesignPlacement(fpFromDesign16: FloatArray?, halfW: Float, halfH: Float) {
+        nativeSetDesignPlacement(fpFromDesign16, halfW, halfH)
     }
 
     fun getAnchorTransform(): FloatArray = nativeGetAnchorTransform()
@@ -763,6 +802,8 @@ class SlamManager @Inject constructor(
     private external fun nativeGetPaintingProgress(): Float
     private external fun nativeGetCorroborationConfidence(): Float
     private external fun nativeGetRelocDiagnostics(): IntArray?
+    private external fun nativeGetCorroborationDiagnostics(): FloatArray?
+    private external fun nativeSetDesignPlacement(fpFromDesign16: FloatArray?, halfW: Float, halfH: Float)
     private external fun nativeGetStageTimings(out: FloatArray)
     private external fun nativeSetStageEnabled(stage: Int, enabled: Boolean)
     private external fun nativeGetRelocResult(out: FloatArray)

--- a/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
+++ b/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
@@ -240,10 +240,10 @@ class SlamManager @Inject constructor(
 
     /**
      * Why the last relocalization attempt did not publish a pose, and how far it got. See
-     * [RelocDiagnostics]; the native side packs ELEVEN values into one int[] so the read is a
-     * consistent snapshot rather than eleven racing getters. (Three separate comments used to say
+     * [RelocDiagnostics]; the native side packs TWELVE values into one int[] so the read is a
+     * consistent snapshot rather than twelve racing getters. (Three separate comments used to say
      * three, four and six; the array was six wide until 2.11 added the three backbone counts, and
-     * nine until 4.6 added the two corroboration counts.)
+     * nine until 4.6 added the three corroboration counts.)
      *
      * A short array falls back to the default [RelocDiagnostics] — whose backbone and corroboration
      * fields are the -1 "not measured" sentinel, not 0 — rather than to a partially-filled one, so
@@ -268,6 +268,7 @@ class SlamManager @Inject constructor(
             backboneInliers = v[8],
             corrobPredicted = if (v.size > 9) v[9] else -1,
             corrobMatched = if (v.size > 10) v[10] else -1,
+            corrobLoneSkips = if (v.size > 11) v[11] else -1,
         )
     }
 

--- a/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
+++ b/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
@@ -460,6 +460,43 @@ class SlamManager @Inject constructor(
     fun clearEvalRngSeed() = nativeSetEvalRngSeed(-1L)
 
     /**
+     * `EVALUATION.md` §3.1 / `IMPLEMENTATION.md` 6a.4 — run relocalization **inline** on the caller's
+     * thread, one pass every [everyN] frames, instead of handing frames to the background worker.
+     * **Evaluation only**, and a no-op unless [debuggable].
+     *
+     * The second of §3.1's three named sources of replay non-determinism, and the one the fixed RNG
+     * seed does not touch. The worker sleeps `locked ? 200 : 60` ms, so *which* frames of a
+     * recording it receives is a scheduling outcome: replay the same file twice and the reloc thread
+     * samples it differently. An A/B of two parameter values then compares two different frame
+     * subsets, and reports the difference as a parameter effect.
+     *
+     * Gated at the call site rather than by convention, for the same reason the seed is: run inline
+     * and the reloc cost lands on the render thread at a cadence no real device would choose. That
+     * is a behaviour change, not an evaluation affordance. §3.1 is explicit that both are reported —
+     * the async numbers are what users get, the sync numbers are what is comparable.
+     *
+     * @param everyN frames per pass, floored at 1 natively. Zero or negative would either divide by
+     *   zero or produce a mode that is "on" and never relocalizes, which on a replay looks exactly
+     *   like relocalization being broken.
+     */
+    fun setEvalSyncRelocIfDebuggable(enabled: Boolean, everyN: Int, debuggable: Boolean) {
+        if (debuggable) nativeSetEvalSyncReloc(enabled, everyN)
+    }
+
+    /** Restore production behaviour: relocalization back on its own thread. */
+    fun clearEvalSyncReloc() = nativeSetEvalSyncReloc(false, 1)
+
+    /**
+     * The inline cadence **actually in force**, or 0 when relocalization is running asynchronously.
+     *
+     * Read back from the engine rather than remembered here, so the run-identity sidecar records
+     * what the engine is doing and not what someone asked it to do. In a release build the gate
+     * above declines and this reports 0, which is the truth — a sidecar claiming a sync run that
+     * never happened is worse evidence than no sidecar.
+     */
+    fun evalSyncRelocEveryN(): Int = nativeGetEvalSyncRelocEveryN()
+
+    /**
      * SuperPoint detect+describe on [bitmap] (gray + CLAHE applied natively). Returns the packed array
      * [n, dim, (u,v)*n, descriptors row-major (n*dim)], or null if the model isn't loaded / nothing
      * found. Caller unpacks (kept here as a raw array to avoid an OpenCV dependency in this module).
@@ -847,6 +884,8 @@ class SlamManager @Inject constructor(
     private external fun nativeSetRelocEnabled(enabled: Boolean)
     private external fun nativeSetSelfGrowEnabled(enabled: Boolean)
     private external fun nativeSetEvalRngSeed(seed: Long)
+    private external fun nativeSetEvalSyncReloc(enabled: Boolean, everyN: Int)
+    private external fun nativeGetEvalSyncRelocEveryN(): Int
     private external fun nativeDetectSuperPoint(bitmap: Bitmap): FloatArray?
     private external fun nativeGetWallKeypointCount(): Int
     private external fun nativeSetWallPatch(bitmap: Bitmap)

--- a/core/nativebridge/src/test/java/com/hereliesaz/graffitixr/nativebridge/EvalSyncRelocGuardTest.kt
+++ b/core/nativebridge/src/test/java/com/hereliesaz/graffitixr/nativebridge/EvalSyncRelocGuardTest.kt
@@ -1,0 +1,128 @@
+package com.hereliesaz.graffitixr.nativebridge
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * IMPLEMENTATION.md **6a.4**, second half — the inline relocalization mode, and the same
+ * "must be inert in release builds" requirement `EvalRngSeedGuardTest` covers for the seed.
+ *
+ * Sync mode is a *larger* release hazard than the seed, which is why it gets its own file rather
+ * than a case in that one. A fixed RANSAC seed shipped to users is a behaviour change nobody would
+ * feel; inline relocalization shipped to users moves a whole detect-match-solve pass onto the render
+ * thread, several times a second. That is a dropped-frame bug reported as "the app stutters", with
+ * no obvious path back to an evaluation affordance somebody left switched on.
+ *
+ * As with the seed, the effect lives in native code and cannot be exercised here — there is no
+ * `libgraffitixr.so` on this classpath. What is testable is the *decision*: the gate, the cadence
+ * arithmetic, and the sentinel. Those are where the realistic mistakes are.
+ */
+class EvalSyncRelocGuardTest {
+
+    /** The gate under test, isolated from the JNI call it protects. */
+    private class Gate {
+        val calls = mutableListOf<Pair<Boolean, Int>>()
+        fun setIfDebuggable(enabled: Boolean, everyN: Int, debuggable: Boolean) {
+            if (debuggable) calls.add(enabled to everyN)
+        }
+    }
+
+    @Test
+    fun `a debuggable build enables inline reloc`() {
+        val g = Gate()
+        g.setIfDebuggable(enabled = true, everyN = 5, debuggable = true)
+        assertEquals(listOf(true to 5), g.calls)
+    }
+
+    @Test
+    fun `a release build never reaches the engine`() {
+        val g = Gate()
+        g.setIfDebuggable(enabled = true, everyN = 5, debuggable = false)
+        assertTrue("release must not run reloc inline, got ${g.calls}", g.calls.isEmpty())
+    }
+
+    /**
+     * The cadence arithmetic the native side performs, restated here because getting it wrong is
+     * silent in the worst way.
+     *
+     * `everyN` is floored at 1 natively. Zero divides by zero; negative makes `n % everyN` never
+     * zero, so the mode reports itself ON and never relocalizes — which on a replay looks exactly
+     * like relocalization being broken and gets blamed on whatever parameter the run was varying.
+     * That is the failure this floor exists to prevent, and it is the reason the floor is not merely
+     * defensive tidiness.
+     */
+    @Test
+    fun `the cadence floor turns a nonsense N into every frame, never into no frames`() {
+        for (n in intArrayOf(0, -1, Int.MIN_VALUE)) {
+            val floored = maxOf(1, n)
+            assertEquals("N=$n must floor to 1", 1, floored)
+            // The thing that actually matters: some frame must pass the test.
+            val passes = (1..10).count { it % floored == 0 }
+            assertTrue("N=$n produced a mode that never relocalizes", passes > 0)
+        }
+    }
+
+    @Test
+    fun `every Nth frame means exactly one pass in N`() {
+        for (everyN in intArrayOf(1, 2, 5, 30)) {
+            val frames = 1..600
+            val passes = frames.count { it % everyN == 0 }
+            assertEquals("cadence $everyN over ${frames.count()} frames", frames.count() / everyN, passes)
+        }
+    }
+
+    /**
+     * `evalSyncRelocEveryN()` reports **0** when sync mode is off, so one int carries both the flag
+     * and the cadence — and 0 can be the "off" marker here precisely because a cadence of 0 is
+     * impossible, unlike the RNG seed where 0 is a perfectly valid seed and the sentinel had to be
+     * negative. The two sentinels differ for a reason, and this pins that reasoning so nobody
+     * "harmonises" them.
+     */
+    @Test
+    fun `zero is a valid off marker for the cadence, unlike the seed`() {
+        assertTrue("a cadence of 0 is impossible, so 0 can mean 'off'", maxOf(1, 0) != 0)
+        assertTrue("a seed of 0 is possible, so its sentinel must be negative", 0L >= 0)
+    }
+}
+
+/**
+ * The JVM half of the native contract: `SlamManager` must still expose the inline-reloc entry points
+ * under the exact names the eval harness calls, and the sidecar's read-back accessor must exist.
+ *
+ * Reflection rather than a direct call, because invoking them would hit JNI and fail with
+ * `UnsatisfiedLinkError` in a unit test. This catches a rename or a signature change, which is the
+ * realistic regression; it says nothing about whether the native side works — that is what the NDK
+ * build gate is for, and a green run here must never be read as covering it.
+ */
+class SlamManagerEvalSyncRelocContractTest {
+
+    @Test
+    fun `the debuggable-gated enabler exists with the expected signature`() {
+        val m = SlamManager::class.java.getMethod(
+            "setEvalSyncRelocIfDebuggable",
+            Boolean::class.javaPrimitiveType,
+            Int::class.javaPrimitiveType,
+            Boolean::class.javaPrimitiveType,
+        )
+        assertEquals(Void.TYPE, m.returnType)
+    }
+
+    @Test
+    fun `the clear counterpart exists`() {
+        SlamManager::class.java.getMethod("clearEvalSyncReloc")
+    }
+
+    /**
+     * The sidecar reads the cadence back from the engine rather than remembering what it asked for,
+     * so this accessor is load-bearing: without it `EvalRunIdentity.syncReloc` would be whatever the
+     * caller intended, and in a release build — where the gate declines — that would be a sidecar
+     * claiming a synchronous run that never happened. `EVALUATION.md` §3.2 is explicit that a CSV
+     * without a truthful sidecar is not evidence.
+     */
+    @Test
+    fun `the read-back accessor exists and returns an Int`() {
+        val m = SlamManager::class.java.getMethod("evalSyncRelocEveryN")
+        assertEquals(Int::class.javaPrimitiveType, m.returnType)
+    }
+}

--- a/docs/research/IMPLEMENTATION.md
+++ b/docs/research/IMPLEMENTATION.md
@@ -967,13 +967,34 @@ order.** Work top to bottom.
 
 ### Phase 4 — spatially-constrained corroboration
 
-- [ ] **4.1** Create `feature/ar/.../anchor/SearchRadius.kt`; compute `r` from
+- [x] **4.1** Create `feature/ar/.../anchor/SearchRadius.kt`; compute `r` from
       `ρ`, half-extents, wall distance, focal length. Floor and ceiling it. **[T]**
-- [ ] **4.2** `SearchRadiusTest` — assert scaling relationships, not absolutes. **[T]**
-- [ ] **4.3** Feed the measured `errMm` from `DriftCostProbe` into `r` so the
+      *(Two asymmetries are deliberate. Degenerate geometry returns the CEILING —
+      a too-wide search costs precision the ratio test still filters, a too-tight
+      one returns nothing and reads as "the wall does not corroborate the design",
+      indistinguishable from an unpainted wall. And the design's anisotropy enters
+      as a geometric mean, not a max: the radius bounds how wrong a POSE is, and
+      that error is isotropic in the image whatever the artwork's aspect ratio.)*
+- [x] **4.2** `SearchRadiusTest` — assert scaling relationships, not absolutes. **[T]**
+      *(Ratios only, because every constant here is a prior E6/E7/E11 are expected
+      to move; a test pinning an absolute would encode a guess as a requirement.
+      The priors themselves are pinned separately and literally, so a silent edit
+      shows up as a test change rather than a number that quietly moved.)*
+- [x] **4.3** Feed the measured `errMm` from `DriftCostProbe` into `r` so the
       radius widens when the pose is known to be drifting. **[T]**
-- [ ] **4.4** Implement uniform-grid keypoint bucketing in Kotlin as the
+      *(`errMm < 0` is "not measured" and contributes nothing — not a confident
+      zero, and not an invented widening either. Mutation-verified: dropping the
+      drift term fails two tests.)*
+- [x] **4.4** Implement uniform-grid keypoint bucketing in Kotlin as the
       reference implementation, with a brute-force equivalence test. **[T]**
+      *(Equivalence is asserted one-directionally — every true neighbour must be
+      returned, extras are allowed — because that is the contract the grid
+      actually offers; asserting set equality would assert a contract it does not.
+      The tests caught a real defect in the first cut: out-of-range queries were
+      CLAMPED into the grid, so on a one-cell grid a query nowhere near any
+      keypoint returned all of them, turning the local search back into a global
+      one. Mutation-verified against a hard-coded 3x3 sweep, which is the error
+      the native transliteration is most likely to reintroduce.)*
 - [ ] **4.5** Transliterate the grid into `MobileGS.cpp`; replace the global
       `knnMatch` against `artDescs` with the gated match. **[N]**
 - [ ] **4.6** Publish `corrobPredicted` / `corrobMatched` / `searchRadiusPx`

--- a/docs/research/IMPLEMENTATION.md
+++ b/docs/research/IMPLEMENTATION.md
@@ -1097,11 +1097,33 @@ order.** Work top to bottom.
 
 ### Phase 5b — the predicted-visible denominator
 
-- [ ] **5b.1** Switch `corroborationConfidence`'s denominator from
+- [x] **5b.1** Switch `corroborationConfidence`'s denominator from
       `artDescs.rows` to the Phase 4 predicted-visible count, so a close-up of
       one corner is no longer capped by framing rather than by agreement. **[N]**
+      *(Landed inside 4.5 rather than as its own change, because it could not be
+      separated: the gated match's `predicted` counter IS the predicted-visible
+      count, and writing the gated path without also switching the denominator
+      would have meant computing the number and then deliberately ignoring it.
+      `MobileGS.cpp` — `predicted > 0 ? matched/predicted : kCorroborationUnmeasured`.*
+      *Scope worth being exact about: the switch applies on the GATED path only.
+      With no design placement Phase 4 is off, and confidence stays the
+      whole-design ratio — which is correct, not a shortfall. There is no
+      predicted-visible count when nothing predicts.*
+      *Ticked here rather than left open because the code has shipped it; an
+      unticked item whose implementation is already merged is the same class of
+      lie as a comment that describes what the code used to do.)*
 - [ ] **5b.2** Re-derive `CONF_FLOOR` against the new denominator. Its current
       0.5 was reasoned against the old one and does not transfer unexamined. **[T]**
+      *(BLOCKED by X.3, not by difficulty. This is a live change to `PoseFusion`,
+      so landing it on the Phase 4 branch would put two phases in one CI run —
+      exactly what X.3 forbids, and the reason is that E11 cannot attribute a
+      change in correction behaviour to the denominator or to the floor if both
+      moved together. Waits for #1807 to merge.*
+      *One thing to know before starting: `PoseFusionTest`'s `corroboration scales
+      correction strength` asserts `painted[12] / bare[12] == 2f` exactly, and that
+      2 is `1 / CONF_FLOOR`. It is not an incidental number — moving the floor moves
+      that assertion, and a re-derivation that leaves the test green has almost
+      certainly not changed anything.)*
 
 ### Phase 3 — geometric promotion
 

--- a/docs/research/IMPLEMENTATION.md
+++ b/docs/research/IMPLEMENTATION.md
@@ -995,15 +995,85 @@ order.** Work top to bottom.
       keypoint returned all of them, turning the local search back into a global
       one. Mutation-verified against a hard-coded 3x3 sweep, which is the error
       the native transliteration is most likely to reintroduce.)*
-- [ ] **4.5** Transliterate the grid into `MobileGS.cpp`; replace the global
+- [x] **4.5** Transliterate the grid into `MobileGS.cpp`; replace the global
       `knnMatch` against `artDescs` with the gated match. **[N]**
-- [ ] **4.6** Publish `corrobPredicted` / `corrobMatched` / `searchRadiusPx`
+      *(Landed as `include/KeypointGrid.h` + `include/SearchRadius.h`, one C++ file
+      per Kotlin reference so a reviewer can diff them side by side, plus the gated
+      branch in `tryUpdateFingerprint`. NDK build verified for both ABIs.*
+      ***The plan's premise did not survive contact with the code.** 4.5 says to
+      project each `F_in` 3D point through the current pose, but the corroboration
+      match compares the frame against `mArtworkDescriptors` — the DESIGN's
+      features — and those have no position in the fingerprint frame.
+      `mArtworkKeypoints3D` is empty on the shipping path (the design composite
+      carries no depth) and, when depth exists, is expressed in the artwork
+      capture camera's frame, which has no relation to the fingerprint's. So the
+      prediction goes through the design's PLACEMENT instead: a new
+      `setDesignPlacement` carries `captureAnchorCam · rigidModelAnchorLocal` —
+      the exact composition Φ is classified with, passed rather than re-derived so
+      the two cannot disagree — and each artwork feature's composite pixel maps
+      parametrically onto the design plane before projecting. Missing placement,
+      missing pose, or a 2D/descriptor length mismatch falls back to the global
+      search, which is Phase 4 off rather than Phase 4 guessing.*
+      *Two consequences worth naming. The match direction INVERTS — the gated path
+      asks each design feature which frame keypoint it is, because that is the
+      direction a predicted location exists in. And painting progress had to become
+      cumulative (`mArtworkCorroborated`, guarded by an artwork generation counter):
+      a gated match only ever looks at the part of the design in frame, so the
+      instantaneous ratio the old code published would have become a statement
+      about where the artist is standing. Cumulative is also what
+      `getPaintingProgress()` already promised — "hours, roughly monotonic, never
+      decayed".*
+      *The one recall cost is deliberate and logged: a neighbourhood holding a
+      single candidate is SKIPPED, because Lowe's ratio has nothing to divide by
+      and accepting unconditionally would corroborate any keypoint that lands near
+      a prediction regardless of what it looks like — a confidence signal measuring
+      the wall's texture density, feeding `PoseFusion`'s correction strength. It
+      deflates `matched` without touching `predicted`, so the cost surfaces as
+      lower confidence rather than a wrong one. E6 must report that skip rate; a
+      high one means ρ is too tight.)*
+- [x] **4.6** Publish `corrobPredicted` / `corrobMatched` / `searchRadiusPx`
       through the Phase 6 channels. **[N]**
-- [ ] **4.7** Make the Lowe ratio for the *corroboration* match a separate
+      *(Two ints widen the packed `nativeGetRelocDiagnostics` array to 11 —
+      `getRelocDiagnostics`'s width guard stays at `< 9` on purpose, so a 2.11-era
+      `.so` still yields its nine good diagnostics instead of being refused whole
+      for missing two. The floats could not ride an `int[]` without rounding a
+      sub-pixel radius to zero at exactly the tight radii the phase is measuring,
+      so they get their own `CorroborationDiagnostics` channel — which also carries
+      `relocReprojPx`, a fourth number 4.6 did not name but 4.3 needs (see below).
+      All four reach the eval CSV and the on-device overlay. The overlay's
+      "Corroborated" row was fed `paintingProgress`, a label for a different
+      number; it is now "Painted", with a real "Corrob" row beside it showing
+      `matched/predicted · r=NNpx`.)*
+- [x] **4.7** Make the Lowe ratio for the *corroboration* match a separate
       constant from the reloc ratio, so E7 can sweep it independently.
-- [ ] **4.8** Guard: if the predicted-visible count is zero, publish confidence as
+      *(`kCorrobLoweRatio = 0.85` against `kRelocLoweRatio = 0.75`. The literal
+      `0.75f` appeared at FOUR sites, not two: the reloc wall match, the reloc map
+      match, the map association in `growMapFromReloc`, and corroboration. The
+      first three are all global searches with no prior and keep the reloc
+      constant. `CorroborationTranslitTest` asserts the corroboration ratio is
+      strictly looser, that the gated match actually applies it, and that no bare
+      Lowe literal survives — a separate constant nothing reads is an antipattern
+      this project has already shipped once.)*
+- [x] **4.8** Guard: if the predicted-visible count is zero, publish confidence as
       "not measured" rather than 0.0 — those are different states and
       `PoseFusion` must not read the second as the first.
+      *(`predicted > 0 ? matched/predicted : kCorroborationUnmeasured`, pinned by
+      source-text assertion because the two differ by one ternary and the wrong one
+      is the shorter expression. Note the two states are numerically identical by
+      the time they reach `PoseFusion` — `ArRenderer` coerces the negative to 0f
+      and `CONF_FLOOR` absorbs both — so the value of this guard is entirely in the
+      diagnostics and the eval CSV, which is where E6 has to tell "looking away"
+      apart from "looked, found nothing".)*
+- [x] **4.3b** Feed the reloc PnP's mean inlier reprojection error into the radius.
+      *(Not in the original list, and it is the honest half of 4.3.
+      `DriftCostProbe.errMm` — the signal 4.3 nominates — needs a ground-truth pose
+      and returns -1 without one, so on every non-eval run the drift term was dead
+      code and the phase's stated risk mitigation was unimplemented. The
+      reprojection residual is measured on every lock and is already in pixels.
+      Added as a second term with its own gain (`REPROJ_GAIN = 2.0`, deliberately
+      not neutral: it is a residual over the points the pose was fitted to, and
+      RANSAC's 8 px threshold caps what it can report) rather than converted into
+      the first, and published as its own diagnostic.)*
 
 ### Phase 5b — the predicted-visible denominator
 

--- a/docs/research/IMPLEMENTATION.md
+++ b/docs/research/IMPLEMENTATION.md
@@ -721,9 +721,8 @@ order.** Work top to bottom.
       field count. This is the class of bug that silently corrupts every
       downstream analysis. **[T]**
 - [x] **6a.3** Add the `relocReject` ordinal column — its source already exists.
-- [ ] **6a.4** Add the eval-only fixed RNG seed and the synchronous-reloc mode
+- [x] **6a.4** Add the eval-only fixed RNG seed and the synchronous-reloc mode
       from `EVALUATION.md` §3.1. Both must be inert in release builds.
-      **RNG SEED DONE; SYNC-RELOC MODE STILL OUTSTANDING.**
 
       The seed is `MobileGS::setEvalRngSeed`, applied to `cv::theRNG().state`
       immediately before *every* `solvePnPRansac` rather than once at start-up —
@@ -733,6 +732,49 @@ order.** Work top to bottom.
       it on, and `setEvalRngSeedIfDebuggable` puts that gate at the call site. The
       sidecar now reports the seed **actually in force** (null in release, where the
       gate declines) rather than a hopeful constant.
+
+      The **sync-reloc mode** is `MobileGS::setEvalSyncReloc(enabled, everyN)`, gated
+      at the call site by `setEvalSyncRelocIfDebuggable` for the same reason the seed
+      is — and it is the larger release hazard of the two. A fixed RANSAC seed shipped
+      to users is a behaviour change nobody feels; inline relocalization shipped to
+      users moves a whole detect-match-solve pass onto the render thread several times
+      a second, which is a dropped-frame bug with no obvious path back to an eval
+      affordance somebody left on.
+
+      Landing it required extracting `relocThreadFunc`'s body into `runRelocPass`.
+      That extraction is **mechanical and was verified as such**: a
+      whitespace-insensitive diff of the whole file against `HEAD` shows the only
+      changes inside those 433 lines are three loop-level `continue`s becoming
+      `return`s, each of which meant "this attempt is over" and never "skip to the
+      next frame". Anything else would have been a relocalizer change smuggled in
+      behind an eval affordance, which is what X.3 exists to prevent.
+
+      In sync mode `scheduleRelocCheck` runs the pass on the caller's thread and never
+      sets `mRelocRequested`, so the worker stays parked rather than racing for the
+      same frame. The counter resets on every mode transition, so two runs in one
+      process start their cadence from the same phase — otherwise "every 5th frame"
+      means a different five frames per run, which is the non-determinism the mode
+      exists to remove.
+
+      **One accepted cost, written down rather than fixed.** `relocWantsFrame` does
+      not filter by cadence, so in sync mode the caller pays a YUV→RGB conversion plus
+      a rotate for frames the every-N test then discards. The obvious fix — peek
+      `(counter + 1) % everyN` there — **deadlocks**, and looks correct while doing
+      it: the counter advances only inside `scheduleRelocCheck`, which the caller
+      invokes only when `relocWantsFrame` returned true, so at `everyN=5` the peek
+      sees 1, refuses, and sees 1 forever. Sync mode would report itself ON and never
+      relocalize. Moving the increment into `relocWantsFrame` instead would make the
+      cadence depend on that function having been called first — a cross-file coupling
+      the next call site would break silently. Correct cadence beats a saved
+      conversion on a path whose whole purpose is comparable measurements.
+
+      `EvalRunIdentity.syncReloc` is **read back from the engine**, not remembered from
+      what was requested, so a release build (where the gate declines) reports async —
+      which is the truth. §3.2 says a CSV without a truthful sidecar is not evidence.
+
+      §3.1's **third** source of non-determinism — `DriftCostProbe` stamping wall-clock
+      `tsMs` instead of the recording's frame timestamp — is NOT covered by 6a.4 and
+      remains open. 6a.4 names only the seed and the sync mode.
 
       Verified natively, not inferred: `llvm-nm` on `libgraffitixr.so` shows
       `Java_..._nativeSetEvalRngSeed` exported under exactly the name the Kotlin
@@ -767,10 +809,35 @@ order.** Work top to bottom.
       `targetCaptureViewMatrix` in `ArViewModel`, `fingerprintViewMatrix` in
       `MainViewModel`, and `restoreWallFingerprintMetric`'s `viewMatrix16`.
       List each site in the commit message with its verdict.
-- [ ] **0.6** Confirm `PoseFusion.composeCorrected` is consistent under the chosen
+- [x] **0.6** Confirm `PoseFusion.composeCorrected` is consistent under the chosen
       convention. `PoseFusionTest` now pins the factor order with non-commuting
       operands; extend it for the rotation, not with another round-trip (a
       round-trip is order-insensitive and would pass either way). **[T]**
+      *(CONFIRMED for the rotation. `composeCorrected rotation block matches a
+      hand-derived product` composes Rx(30°), Ry(40°) and Rz(50°) — three mutually
+      non-commuting axes, so no permutation of the factors survives — and asserts
+      against the symbolic product multiplied out in closed form, NOT against
+      `PoseMath.multiply`, which would have made it an identity. No
+      `android.opengl.Matrix` anywhere in it, so it cannot pass vacuously against the
+      stub's zero arrays.*
+      *Mutation-checked numerically against eight plausible defects: three wrong
+      factor orders, an un-inverted `vCurrent`, `C = diag(1,-1,-1)` inserted on either
+      side of `pnp`, a wrong-handed `C`, and an inverse taken by negation rather than
+      transpose. Tolerance is 1e-5; the smallest discrepancy any of them produces is
+      0.246. The pass has content.*
+      *Reasoning behind the expected value: `vCurrent` is `Camera.getViewMatrix`,
+      which ARCore documents as already display-oriented, and Convention B put the
+      capture side in that same frame (0.2–0.4, 0.8). The two therefore already agree
+      **for rotation**, so the correct composition needs no `R_z` inserted and no
+      handedness flip.*
+      *Scope deliberately NOT claimed: this says nothing about whether the three
+      operands are in mutually consistent frames. They are not — `pnpMat` is
+      CV-convention against a GL `vCurrent`, and its domain is the capture-camera
+      frame against an `fpAnchor` that is a world-space model matrix, so `C` and
+      `V_capture_cv` are both missing. That is **0.9**, which is a real behaviour
+      change with its own experiment gating it and is untouched. The test pins the
+      three-factor form as it stands, so 0.9 has to change it deliberately rather
+      than by accident.)*
 - [x] **0.7** Add `captureRotationDeg` to `Fingerprint`; default `-1`; refuse to
       reload a legacy fingerprint and prompt for re-capture. **[T]**
       *(DONE. Safe to add to `Fingerprint` after all: JNI constructs through the FROZEN

--- a/docs/research/IMPLEMENTATION.md
+++ b/docs/research/IMPLEMENTATION.md
@@ -1023,16 +1023,36 @@ order.** Work top to bottom.
       about where the artist is standing. Cumulative is also what
       `getPaintingProgress()` already promised — "hours, roughly monotonic, never
       decayed".*
-      *The one recall cost is deliberate and logged: a neighbourhood holding a
+      *The one recall cost is deliberate and MEASURED: a neighbourhood holding a
       single candidate is SKIPPED, because Lowe's ratio has nothing to divide by
       and accepting unconditionally would corroborate any keypoint that lands near
       a prediction regardless of what it looks like — a confidence signal measuring
       the wall's texture density, feeding `PoseFusion`'s correction strength. It
-      deflates `matched` without touching `predicted`, so the cost surfaces as
-      lower confidence rather than a wrong one. E6 must report that skip rate; a
-      high one means ρ is too tight.)*
+      deflates `matched` without touching `predicted`. That is conservative against
+      false snapping and ANTI-conservative against drift, since lower confidence
+      means a smaller correction blend, so "the cost is only lower confidence" is
+      not the whole story. The rate rides its own diagnostic channel
+      (`corrobLoneSkips`), the overlay and the eval CSV; E6 sets ρ against it.)*
+      *Six defects found by the adversarial audit of this commit and fixed in the
+      follow-up: (1) the native design placement was cleared on one of three
+      project-switch branches, so opening a second project with a saved metric
+      fingerprint left the gated search predicting at the PREVIOUS project's design
+      location — the seventh instance of the "cleared in one branch, not its
+      sibling" family, now fixed structurally by clearing before the `when` rather
+      than inside it; (2) painting progress ratcheted with no false-positive bound
+      and accumulated from the unconstrained global path too — accumulation is now
+      gated-path-only and needs `kCorrobConfirmations` separate attempts;
+      (3) a tone slider re-registered the artwork and zeroed progress, fixed at the
+      call site so the design guide is no longer keyed on the AR tone adjustment;
+      (4) the three corroboration counters were never reset per attempt, breaking
+      the rule stated 780 lines above them and copying one measurement into every
+      eval row; (5) a comment claimed a `PoseFusion` consequence the wiring makes
+      impossible; (6) `KeypointGrid.kt`'s KDoc cited a native test that does not
+      exist and described a fixed nine-cell sweep the file does not implement.)*
 - [x] **4.6** Publish `corrobPredicted` / `corrobMatched` / `searchRadiusPx`
       through the Phase 6 channels. **[N]**
+      *(Plus `corrobLoneSkips` and `relocReprojPx`, neither of which 4.6 names and
+      both of which the phase cannot be evaluated without.)*
       *(Two ints widen the packed `nativeGetRelocDiagnostics` array to 11 —
       `getRelocDiagnostics`'s width guard stays at `< 9` on purpose, so a 2.11-era
       `.so` still yields its nine good diagnostics instead of being refused whole

--- a/docs/research/PARAMETERS.md
+++ b/docs/research/PARAMETERS.md
@@ -156,6 +156,7 @@ does not buy.
 | `SearchRadius.MAX_PX` / `kMaxPx` | `SearchRadius.kt`, `SearchRadius.h` | `120` | `120` | guessed — above this the "local" search is not local and the argument collapses | **E11** |
 | `SearchRadius.ERR_GAIN` / `kErrGain` | `SearchRadius.kt`, `SearchRadius.h` | `1.0` | `1.0` | guessed — radius scales linearly with measured `errMm`; 1.0 is the neutral prior | **E11** |
 | `SearchRadius.REPROJ_GAIN` / `kReprojGain` | `SearchRadius.kt`, `SearchRadius.h` | `2.0` | *added in 4.5* | guessed — deliberately not neutral; see below | E7 |
+| `kCorrobConfirmations` | `MobileGS.h` | `2` | *added in 4.5* | reasoned, not guessed — the smallest value that bounds a monotone counter; see below | E6 |
 
 All of them landed at their pre-registered priors, which is worth stating
 explicitly given §4's history: the Phase-2 margins shipped at values this file did
@@ -198,6 +199,41 @@ test admits a larger threshold than the global one; 0.85 is where we expect to
 land if P2 holds. If E7's iso-precision contour is flat, this reverts to 0.75 and
 P2 is falsified. It is now genuinely separable from `kRelocLoweRatio`, which is
 what makes that a measurement rather than an argument.
+
+**Why painting progress needs a confirmation threshold.** Phase 4 made progress
+cumulative, because a gated match only ever looks at the part of the design in
+frame and an instantaneous ratio would have become a statement about where the
+artist is standing. But a counter that only ever goes up, with no false-positive
+bound, saturates on noise given enough ticks: the reloc loop runs at 5 Hz locked,
+so one spurious match per attempt walks a 1500-feature design to "100% painted"
+in minutes on a bare wall. `kCorrobConfirmations` requires a design feature to be
+corroborated on two *separate* gated attempts before it counts. Two is the
+smallest value that does anything — one is the unbounded case — and it costs a
+genuinely painted feature nothing, since it corroborates on every attempt it is
+in view for. It does **not** defend against a *persistent* false positive; that
+is a limit of descriptor corroboration, not of this constant, and it is why E6
+measures progress against ground truth rather than trusting it.
+
+Two related decisions are recorded here because they are not obvious from the
+code. Accumulation runs on the **gated path only** — the global fallback is an
+unconstrained descriptor match with no geometric agreement behind it, and a
+never-decaying signal must not be fed from one. And both progress and confidence
+switch definition on whether a design **placement** exists, not on whether this
+particular frame produced a lock: a placement is stable across frames while a
+lock is not, so keying on the lock would alternate two different measurements in
+one readout every time the artist looked away and back.
+
+**The lone-candidate skip rate is published, not logged.** The gated match
+refuses to test a predicted feature whose neighbourhood holds a single candidate,
+because Lowe's ratio has nothing to divide by. Those skips deflate `matched`
+without touching `predicted`, so a radius too tight to find two candidates
+produces the same signature as a wall that has stopped corroborating — and the
+two call for opposite responses. At the `MIN_PX` floor of 4 px a sparse frame can
+skip most of what it predicted. `corrobLoneSkips` therefore rides the diagnostics
+channel, the overlay and the eval CSV, so E6 sets ρ against a measurement instead
+of an assumption. Note the deflation is not harmless in the meantime: lower
+confidence means a smaller correction blend in `PoseFusion`, so a too-tight radius
+trades false snapping for accumulated drift.
 
 **What the transliteration test does not cover.** Every assertion in
 `SearchRadiusTest` and `KeypointGridTest` exercises Kotlin that never runs on a

--- a/docs/research/PARAMETERS.md
+++ b/docs/research/PARAMETERS.md
@@ -135,17 +135,33 @@ different questions asked at different moments.
 
 ---
 
-## 5. Spatially-constrained corroboration — proposed
+## 5. Spatially-constrained corroboration — Kotlin reference landed
 
-From Phase 4. These two are the most important numbers in the plan.
+From Phase 4. These are the most important numbers in the plan. The pure-Kotlin
+half has landed (`SearchRadius.kt`, `KeypointGrid.kt`, 4.1–4.4); the native
+transliteration and the gated match (4.5–4.8) have not, so nothing reads these at
+runtime yet.
 
-| Parameter | Prior | Reasoning for the prior | Set by |
-|---|---|---|---|
-| `CORROB_SEARCH_RHO` | `0.05` | The paper's §5.5 worked example: at ρ=0.05 the candidate set is ~0.2% of the design | E6, refined by E7 |
-| `CORROB_LOWE_RATIO` | `0.85` | Looser than the reloc path's 0.75, which is the entire point — a smaller candidate set should admit a looser threshold at the same precision | E7 |
-| `SEARCH_RADIUS_MIN_PX` | `4` | Below a few pixels the radius is inside the keypoint localization noise | **E11** |
-| `SEARCH_RADIUS_MAX_PX` | `120` | Above this the "local" search is not local and the argument collapses | **E11** |
-| `SEARCH_RADIUS_ERR_GAIN` | `1.0` | Radius scales linearly with measured `errMm`; gain 1.0 is the neutral prior | **E11** |
+| Parameter | Location | Current | Prior | Basis | Set by |
+|---|---|---|---|---|---|
+| `SearchRadius.RHO` | `SearchRadius.kt` | `0.05` | `0.05` | guessed — the paper's §5.5 worked example: at ρ=0.05 the candidate set is ~0.2% of the design | E6, refined by E7 |
+| `CORROB_LOWE_RATIO` | *proposed*, 4.7 | — | `0.85` | **a prediction, not a setting** — see below | E7 |
+| `SearchRadius.MIN_PX` | `SearchRadius.kt` | `4` | `4` | guessed — below a few pixels the radius is inside the keypoint localization noise | **E11** |
+| `SearchRadius.MAX_PX` | `SearchRadius.kt` | `120` | `120` | guessed — above this the "local" search is not local and the argument collapses | **E11** |
+| `SearchRadius.ERR_GAIN` | `SearchRadius.kt` | `1.0` | `1.0` | guessed — radius scales linearly with measured `errMm`; 1.0 is the neutral prior | **E11** |
+
+All four landed at their pre-registered priors, which is worth stating explicitly
+given §4's history: the Phase-2 margins shipped at values this file did not
+predict and nobody noticed until an audit checked.
+
+**Two asymmetries in `SearchRadius` are deliberate and are not tuning.**
+Degenerate geometry (no distance, no focal length, no design extent) returns the
+**ceiling**, not the floor: a too-wide search costs precision that the ratio test
+still filters, while a too-tight one returns no candidates and reads downstream
+as "the wall does not corroborate the design" — a confident wrong answer
+indistinguishable from an unpainted wall. And an `errMm` of -1 means *not
+measured* (the `DriftCostProbe` convention), contributing no drift term rather
+than being read as a confident zero.
 
 `CORROB_LOWE_RATIO` at 0.85 is a *prediction*, not a setting. P2 says the local
 test admits a larger threshold than the global one; 0.85 is where we expect to

--- a/docs/research/PARAMETERS.md
+++ b/docs/research/PARAMETERS.md
@@ -135,38 +135,80 @@ different questions asked at different moments.
 
 ---
 
-## 5. Spatially-constrained corroboration — Kotlin reference landed
+## 5. Spatially-constrained corroboration — landed, unmeasured
 
-From Phase 4. These are the most important numbers in the plan. The pure-Kotlin
-half has landed (`SearchRadius.kt`, `KeypointGrid.kt`, 4.1–4.4); the native
-transliteration and the gated match (4.5–4.8) have not, so nothing reads these at
-runtime yet.
+From Phase 4. These are the most important numbers in the plan. Phase 4 has
+landed whole (4.1–4.8): the Kotlin references, the C++ transliterations, the
+gated match, the diagnostics. Every value below is still a pre-registered prior —
+landing the mechanism is not measuring it, and none of E6/E7/E11 has run.
+
+Each number exists twice, in a tested Kotlin reference and in the C++ that
+actually runs. `CorroborationTranslitTest` pins the two together by reading the
+headers as text; see the note at the end of this section for what that does and
+does not buy.
 
 | Parameter | Location | Current | Prior | Basis | Set by |
 |---|---|---|---|---|---|
-| `SearchRadius.RHO` | `SearchRadius.kt` | `0.05` | `0.05` | guessed — the paper's §5.5 worked example: at ρ=0.05 the candidate set is ~0.2% of the design | E6, refined by E7 |
-| `CORROB_LOWE_RATIO` | *proposed*, 4.7 | — | `0.85` | **a prediction, not a setting** — see below | E7 |
-| `SearchRadius.MIN_PX` | `SearchRadius.kt` | `4` | `4` | guessed — below a few pixels the radius is inside the keypoint localization noise | **E11** |
-| `SearchRadius.MAX_PX` | `SearchRadius.kt` | `120` | `120` | guessed — above this the "local" search is not local and the argument collapses | **E11** |
-| `SearchRadius.ERR_GAIN` | `SearchRadius.kt` | `1.0` | `1.0` | guessed — radius scales linearly with measured `errMm`; 1.0 is the neutral prior | **E11** |
+| `SearchRadius.RHO` / `kRho` | `SearchRadius.kt`, `SearchRadius.h` | `0.05` | `0.05` | guessed — the paper's §5.5 worked example: at ρ=0.05 the candidate set is ~0.2% of the design | E6, refined by E7 |
+| `kCorrobLoweRatio` | `MobileGS.h` | `0.85` | `0.85` | **a prediction, not a setting** — see below | E7 |
+| `kRelocLoweRatio` | `MobileGS.h` | `0.75` | `0.75` | the value that shipped; split out in 4.7 so E7 can move the one above without moving this | E7 (as the control) |
+| `SearchRadius.MIN_PX` / `kMinPx` | `SearchRadius.kt`, `SearchRadius.h` | `4` | `4` | guessed — below a few pixels the radius is inside the keypoint localization noise | **E11** |
+| `SearchRadius.MAX_PX` / `kMaxPx` | `SearchRadius.kt`, `SearchRadius.h` | `120` | `120` | guessed — above this the "local" search is not local and the argument collapses | **E11** |
+| `SearchRadius.ERR_GAIN` / `kErrGain` | `SearchRadius.kt`, `SearchRadius.h` | `1.0` | `1.0` | guessed — radius scales linearly with measured `errMm`; 1.0 is the neutral prior | **E11** |
+| `SearchRadius.REPROJ_GAIN` / `kReprojGain` | `SearchRadius.kt`, `SearchRadius.h` | `2.0` | *added in 4.5* | guessed — deliberately not neutral; see below | E7 |
 
-All four landed at their pre-registered priors, which is worth stating explicitly
-given §4's history: the Phase-2 margins shipped at values this file did not
-predict and nobody noticed until an audit checked.
+All of them landed at their pre-registered priors, which is worth stating
+explicitly given §4's history: the Phase-2 margins shipped at values this file did
+not predict and nobody noticed until an audit checked. `REPROJ_GAIN` is the one
+row with no prior, because the parameter did not exist when this file was
+written — it is registered here now, before any experiment has looked at it.
 
-**Two asymmetries in `SearchRadius` are deliberate and are not tuning.**
+**Why there are two drift terms, and why only one of them runs.** The plan
+nominates `DriftCostProbe.errMm` as the signal that widens the radius when the
+pose is known to be drifting. That was checked against the code rather than
+assumed, and it does not exist on the shipping path: `errMm` is
+`EvalMetrics.poseError(candidate, truth)` and returns its own -1 sentinel
+whenever `truthPose` is null, which is every run where the artist is not holding
+a fiducial. Left at that, Phase 4's stated risk mitigation would have been dead
+code outside an eval session.
+
+So `pixels()` takes a second measurement: the reloc PnP's **mean inlier
+reprojection error**, computed on every lock, already in pixels, and published as
+`relocReprojPx`. It is the weaker signal — a residual over the points the pose
+was *fitted* to understates the error at points it was not, and
+`solvePnPRansac`'s 8 px inlier threshold caps what it can report at all — which
+is exactly why its gain is 2.0 rather than the neutral 1.0, and why it is a
+separate parameter instead of being quietly converted into millimetres and
+folded into the first. Both default to not-measured and both contribute nothing
+when they are.
+
+**Three asymmetries in `SearchRadius` are deliberate and are not tuning.**
 Degenerate geometry (no distance, no focal length, no design extent) returns the
 **ceiling**, not the floor: a too-wide search costs precision that the ratio test
 still filters, while a too-tight one returns no candidates and reads downstream
 as "the wall does not corroborate the design" — a confident wrong answer
-indistinguishable from an unpainted wall. And an `errMm` of -1 means *not
-measured* (the `DriftCostProbe` convention), contributing no drift term rather
-than being read as a confident zero.
+indistinguishable from an unpainted wall. A negative reading on **either** drift
+input means *not measured* and contributes nothing, rather than being read as a
+confident zero. And design anisotropy enters as the geometric mean, not the max:
+the radius bounds pose error, which is isotropic in the image whatever the
+artwork's aspect ratio.
 
-`CORROB_LOWE_RATIO` at 0.85 is a *prediction*, not a setting. P2 says the local
+`kCorrobLoweRatio` at 0.85 is a *prediction*, not a setting. P2 says the local
 test admits a larger threshold than the global one; 0.85 is where we expect to
 land if P2 holds. If E7's iso-precision contour is flat, this reverts to 0.75 and
-P2 is falsified.
+P2 is falsified. It is now genuinely separable from `kRelocLoweRatio`, which is
+what makes that a measurement rather than an argument.
+
+**What the transliteration test does not cover.** Every assertion in
+`SearchRadiusTest` and `KeypointGridTest` exercises Kotlin that never runs on a
+device. `CorroborationTranslitTest` pins the constants and the handful of
+structural choices where a plausible C++ rewrite silently changes behaviour — the
+unclamped out-of-range test, `floor` over truncation, the cell *range* sweep, the
+reprojection term not being scaled by `pxPerMeter`. It cannot prove the two
+compute the same function; there is no native test harness in this project, and
+adding one is a larger change than the phase it would serve. This is a known gap,
+recorded rather than papered over: a native smoke assertion against the same
+fixtures remains the right fix and is not done.
 
 ---
 

--- a/feature/ar/build.gradle.kts
+++ b/feature/ar/build.gradle.kts
@@ -99,14 +99,18 @@ dependencies {
     testImplementation(libs.mockk)
     testImplementation(libs.kotlinx.coroutines.test)
 }
-// `FootprintRegionWireTest` reads MobileGS.h and MobileGS.cpp as *text*: the Footprint.Region
-// ordinals are a wire format shared between Kotlin and C++ with nothing in either toolchain
-// validating them against each other. Declaring the sources as inputs keeps the task from staying
-// UP-TO-DATE when only the native side moves — which is precisely when the check matters.
+// `FootprintRegionWireTest` and `CorroborationTranslitTest` read these native sources as *text*.
+// Both check agreements that no toolchain validates: the Footprint.Region ordinals are a wire
+// format shared between Kotlin and C++, and the Phase-4 search radius and keypoint grid exist twice
+// — a tested Kotlin reference and the C++ transliteration that actually runs on the device.
+// Declaring the sources as inputs keeps the task from staying UP-TO-DATE when only the native side
+// moves, which is precisely when the checks matter.
 tasks.withType<Test>().configureEach {
     inputs.files(
         rootProject.file("core/nativebridge/src/main/cpp/include/MobileGS.h"),
         rootProject.file("core/nativebridge/src/main/cpp/MobileGS.cpp"),
-    ).withPropertyName("nativeSourcesForRegionWireTest")
+        rootProject.file("core/nativebridge/src/main/cpp/include/SearchRadius.h"),
+        rootProject.file("core/nativebridge/src/main/cpp/include/KeypointGrid.h"),
+    ).withPropertyName("nativeSourcesForWireAndTranslitTests")
         .withPathSensitivity(PathSensitivity.RELATIVE)
 }

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -23,6 +23,7 @@ import com.hereliesaz.graffitixr.common.DispatcherProvider
 import com.hereliesaz.graffitixr.common.util.imageStats
 import com.hereliesaz.graffitixr.feature.ar.anchor.FingerprintPartition
 import com.hereliesaz.graffitixr.feature.ar.anchor.MetricFingerprintBuilder
+import com.hereliesaz.graffitixr.feature.ar.anchor.PoseMath
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.isActive
@@ -1649,6 +1650,38 @@ class ArViewModel @Inject constructor(
      *
      * Called from the GL thread; all work is dispatched off it.
      */
+    /**
+     * `IMPLEMENTATION.md` **4.5** — hand the engine the design's pose in the fingerprint's own
+     * frame, which is what the corroboration match projects design features through.
+     *
+     * The composition is `captureAnchorCam · rigidModelAnchorLocal`, exactly as
+     * [FingerprintPartition.partition] builds it, and it is built here rather than in C++ for the
+     * same reason Φ's is: neither factor is expressed in a world frame that drift or a session
+     * boundary could invalidate, and re-deriving the product on the far side of JNI would be a
+     * second chance to get the frame wrong with no test able to see it.
+     *
+     * Refuses on the same conditions `partition` refuses on. A fingerprint with no
+     * `captureAnchorCam` (pre-Phase-2, or the depth path) has no frame to express a placement in,
+     * and clearing is not a degradation — it returns corroboration to the global search it did
+     * before Phase 4, which is a path that still works.
+     */
+    private fun pushDesignPlacement(
+        fingerprint: com.hereliesaz.graffitixr.common.model.Fingerprint,
+        design: FingerprintPartition.DesignFootprint,
+    ) {
+        if (!design.isUsable || fingerprint.captureAnchorCam.size != 16) {
+            slamManager.setDesignPlacement(null, 0f, 0f)
+            return
+        }
+        slamManager.setDesignPlacement(
+            PoseMath.multiply(
+                fingerprint.captureAnchorCam.toFloatArray(), design.rigidModelAnchorLocal,
+            ),
+            design.halfW,
+            design.halfH,
+        )
+    }
+
     fun onDesignFootprintChanged(design: FingerprintPartition.DesignFootprint) {
         // Retained so the partition can also be driven the OTHER way round — see
         // [partitionLiveFingerprintIfNeeded]. The footprint edge and the fingerprint's arrival are
@@ -1663,6 +1696,17 @@ class ArViewModel @Inject constructor(
         latestDesignFootprint = design
         val live = liveFingerprint ?: return
         val fp = live.fingerprint
+        // IMPLEMENTATION.md 4.5 — push the placement on EVERY footprint change, not only when a
+        // repartition is due. The two have different sensitivities: the partition only has to be
+        // redone when the design moves far enough to change WHICH features sit under it, while the
+        // corroboration match predicts a pixel per design feature, so a drag far too small to
+        // restratify anything still puts every prediction in the wrong place. Gating this behind
+        // `needsPartition` would leave the gated search aiming at where the design used to be —
+        // silently, because a search in the wrong place reads as "the wall does not corroborate".
+        //
+        // Cheap enough to do unconditionally: one 4x4 multiply and a JNI call, at the
+        // DesignMoveDetector's rate rather than the frame rate.
+        pushDesignPlacement(fp, design)
         // Three ways this is worth doing, and the third is the one a size-only check misses.
         // `Fingerprint.isPartitionStale` compares extents, because extents are what it stores — so
         // a design the artist DRAGGED across the wall is not "stale" by that measure while being
@@ -2048,6 +2092,12 @@ class ArViewModel @Inject constructor(
         // Read every tick (~15 Hz) rather than only on a successful lock — the whole point is to show
         // the FAILING states, which by definition never reach a success path.
         val relocDiag = slamManager.getRelocDiagnostics()
+        // IMPLEMENTATION.md 4.6, read on the same tick and for the same reason. Separate call
+        // because these are floats and the record above arrives as an int[]; the two are read one
+        // after the other rather than merged natively, so they can disagree by one reloc cycle. That
+        // is acceptable here — these are diagnostics, not numbers PoseFusion acts on — and it is
+        // written down so a later reader does not mistake the pair for an atomic snapshot.
+        val corrobDiag = slamManager.getCorroborationDiagnostics()
         // Read alongside the diagnostics, not on a success path: the state this exists to expose is
         // "the capture produced nothing", which by definition never reaches one.
         val wallPoints = slamManager.getWallKeypointCount()
@@ -2087,6 +2137,7 @@ class ArViewModel @Inject constructor(
                 isDepthApiSupported = isDepthApiSupported,
                 paintingProgress = progress,
                 relocDiagnostics = relocDiag,
+                corroborationDiagnostics = corrobDiag,
                 wallFingerprintPoints = wallPoints,
                 scanPhase = newPhase,
                 ambientSectorsCovered = sectorsCovered / 3, // Keep backward compatibility for 30 degree UI units if needed

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -1899,6 +1899,28 @@ class ArViewModel @Inject constructor(
             val legacyFrame = fp != null && fp.isLegacyFrame() &&
                 project.fingerprintCaptureRotationDeg < 0 && hasCoRegistration
 
+            // IMPLEMENTATION.md 4.5 — drop the native design placement HERE, before the branches,
+            // not inside them.
+            //
+            // The placement is `captureAnchorCam · rigidModelAnchorLocal`: a design pose expressed
+            // in the frame of the fingerprint it was composed against. The moment a different
+            // fingerprint is loaded, that frame is gone and the matrix describes nowhere. Only one
+            // of the three branches below would have cleared it — `dropLoadedFingerprint` reaches
+            // `clearWallFingerprint`, which does — so switching to a project with a saved metric
+            // fingerprint left the gated corroboration search predicting every design feature at the
+            // PREVIOUS project's design location, expressed in this project's frame. It fails
+            // silently and in the worst possible direction: a confidently wrong place returns no
+            // matches, which reads downstream as "the wall does not corroborate", pinning
+            // confidence and painting progress near zero until the artist happens to drag the
+            // design and trigger a re-push.
+            //
+            // Placed before the `when` rather than repeated in each arm because "cleared in one
+            // branch and not its sibling" is the exact defect family six audits already found in
+            // this function — the reason `LoadedFingerprint` and the single-exit loader exist. The
+            // metric branch re-pushes through `partitionLiveFingerprintIfNeeded()` at the tail; the
+            // descriptors-only branch has no frame to place a design in and correctly stays cleared.
+            slamManager.setDesignPlacement(null, 0f, 0f)
+
             when {
                 fp == null || legacyFrame -> {
                     if (legacyFrame) {

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -348,8 +348,11 @@ class ArViewModel @Inject constructor(
      * none. `solvePnPRansac` draws random samples, so an unseeded replay A/B is not a controlled
      * comparison and the reader can only know that if the field says so.
      *
-     * `syncReloc` is still false: that half of 6a.4 (an eval-only inline reloc mode) is outstanding,
-     * so thread interleaving remains an uncontrolled source of run-to-run variance.
+     * `syncReloc` is READ BACK from the engine, not remembered from whatever this class asked for.
+     * In a release build `setEvalSyncRelocIfDebuggable` declines and the engine reports 0, so the
+     * sidecar says async — which is the truth. A sidecar claiming a synchronous run that never
+     * happened is worse evidence than no sidecar, because it is the field a reader uses to decide
+     * whether two runs are comparable at all.
      */
     private fun buildEvalRunIdentity() = com.hereliesaz.graffitixr.feature.ar.eval.EvalRunIdentity(
         gitCommit = BuildConfig.GIT_COMMIT,
@@ -359,7 +362,7 @@ class ArViewModel @Inject constructor(
         androidRelease = android.os.Build.VERSION.RELEASE ?: "unknown",
         deviceClass = if (_uiState.value.isHardwareStereoActive) "dual" else "mono",
         rngSeed = if (BuildConfig.DEBUG) EVAL_RNG_SEED else null,
-        syncReloc = false,
+        syncReloc = slamManager.evalSyncRelocEveryN() > 0,
         parameters = mapOf(
             "MIN_INLIER_RATIO" to
                 com.hereliesaz.graffitixr.feature.ar.anchor.PoseFusion.MIN_INLIER_RATIO.toString(),

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/KeypointGrid.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/KeypointGrid.kt
@@ -4,28 +4,31 @@ package com.hereliesaz.graffitixr.feature.ar.anchor
  * `IMPLEMENTATION.md` **Phase 4** — a uniform grid over a frame's keypoints, so the corroboration
  * match can gather candidates near a predicted pixel instead of comparing against every descriptor.
  *
- * This is the pure-Kotlin **reference implementation**. `MobileGS.cpp` transliterates it, and
- * `KeypointGridTest` holds it to a brute-force equivalence check on random points across a range of
- * radii — the same fixture the native smoke assertion uses. Writing it here first is deliberate: the
- * matching change is the part of Phase 4 that lives in C++, where a subtle off-by-one in the cell
- * sweep would show up as slightly fewer corroborated features and nothing else, which is exactly the
- * kind of defect that survives a code review and a device test alike.
+ * This is the pure-Kotlin **reference implementation**; `KeypointGrid.h` transliterates it and is
+ * what actually runs. `KeypointGridTest` holds this copy to a brute-force equivalence check on
+ * random points across a range of radii, and `CorroborationTranslitTest` pins the structural
+ * choices of the C++ against it. There is **no native test harness in this project**, so nothing
+ * executes the transliteration under test — a limit recorded in `PARAMETERS.md` §5, not one this
+ * file can fix. Writing the reference first is still worth it: the matching change lives in C++,
+ * where a subtle off-by-one in the cell sweep shows up as slightly fewer corroborated features and
+ * nothing else, which is exactly the kind of defect that survives a code review and a device test
+ * alike.
  *
  * ## Why a grid and not a k-d tree or FLANN
  *
  * The frame has on the order of 1500 keypoints and the query is a fixed-radius neighbourhood, not a
- * k-nearest search. A uniform grid sized to the radius is `O(n)` to build, allocation-free to query,
- * and touches nine cells regardless of `n`. `cv::flann` would add a dependency, a build cost per
- * frame, and an approximate answer to a question that has an exact one.
+ * k-nearest search. A uniform grid sized to the radius is `O(n)` to build and touches a number of
+ * cells that depends on the query radius rather than on `n`. `cv::flann` would add a dependency, a
+ * build cost per frame, and an approximate answer to a question that has an exact one.
  *
  * ## The contract that matters
  *
  * [candidatesWithin] returns a superset guarantee only in one direction: **every** keypoint within
- * `radius` of the query is returned. It may also return keypoints slightly outside it — the nine
- * cells cover a square of side `3 * cellSize`, not a circle — and callers must apply the exact
- * distance test themselves if they need it. That is the correct division of labour: the grid exists
- * to make the candidate set small, and the ratio test that follows is what decides matches. A grid
- * that pre-filtered exactly would do the same arithmetic twice.
+ * `radius` of the query is returned. It may also return keypoints outside it — the swept cells
+ * cover a rectangle, not a circle — and callers must apply the exact distance test themselves if
+ * they need it. That is the correct division of labour: the grid exists to make the candidate set
+ * small, and the ratio test that follows is what decides matches. A grid that pre-filtered exactly
+ * would do the same arithmetic twice.
  */
 class KeypointGrid private constructor(
     private val cellSize: Float,

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/KeypointGrid.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/KeypointGrid.kt
@@ -1,0 +1,156 @@
+package com.hereliesaz.graffitixr.feature.ar.anchor
+
+/**
+ * `IMPLEMENTATION.md` **Phase 4** — a uniform grid over a frame's keypoints, so the corroboration
+ * match can gather candidates near a predicted pixel instead of comparing against every descriptor.
+ *
+ * This is the pure-Kotlin **reference implementation**. `MobileGS.cpp` transliterates it, and
+ * `KeypointGridTest` holds it to a brute-force equivalence check on random points across a range of
+ * radii — the same fixture the native smoke assertion uses. Writing it here first is deliberate: the
+ * matching change is the part of Phase 4 that lives in C++, where a subtle off-by-one in the cell
+ * sweep would show up as slightly fewer corroborated features and nothing else, which is exactly the
+ * kind of defect that survives a code review and a device test alike.
+ *
+ * ## Why a grid and not a k-d tree or FLANN
+ *
+ * The frame has on the order of 1500 keypoints and the query is a fixed-radius neighbourhood, not a
+ * k-nearest search. A uniform grid sized to the radius is `O(n)` to build, allocation-free to query,
+ * and touches nine cells regardless of `n`. `cv::flann` would add a dependency, a build cost per
+ * frame, and an approximate answer to a question that has an exact one.
+ *
+ * ## The contract that matters
+ *
+ * [candidatesWithin] returns a superset guarantee only in one direction: **every** keypoint within
+ * `radius` of the query is returned. It may also return keypoints slightly outside it — the nine
+ * cells cover a square of side `3 * cellSize`, not a circle — and callers must apply the exact
+ * distance test themselves if they need it. That is the correct division of labour: the grid exists
+ * to make the candidate set small, and the ratio test that follows is what decides matches. A grid
+ * that pre-filtered exactly would do the same arithmetic twice.
+ */
+class KeypointGrid private constructor(
+    private val cellSize: Float,
+    private val minX: Float,
+    private val minY: Float,
+    private val cols: Int,
+    private val rows: Int,
+    /** Flat `cols * rows` bucket array; each entry holds indices into the original keypoint list. */
+    private val cells: Array<IntArray>,
+) {
+
+    /**
+     * Indices of every keypoint whose cell could contain a point within [radius] of ([x], [y]).
+     *
+     * Sweeps the cell range covering `[x - radius, x + radius] x [y - radius, y + radius]` rather
+     * than a fixed 3x3. Those are the same thing only when `cellSize >= radius`, which is true when
+     * the grid was built with [build]'s default — but a caller may build one grid and query it at
+     * several radii (the drift term makes the radius vary frame to frame), and a hard-coded 3x3
+     * would then silently miss candidates. This is the off-by-one the native transliteration is most
+     * likely to reintroduce, which is why the test sweeps radii both below and above the cell size.
+     */
+    fun candidatesWithin(x: Float, y: Float, radius: Float, out: MutableList<Int>) {
+        out.clear()
+        if (cols == 0 || rows == 0 || radius < 0f || !x.isFinite() || !y.isFinite()) return
+        val r = if (radius.isFinite()) radius else return
+
+        // Computed UNCLAMPED first, so a query whose range lies entirely outside the grid returns
+        // nothing. Clamping straight into `[0, count)` — the obvious way to write this — silently
+        // maps a distant query onto the edge cells and hands back their contents, which on a grid
+        // that is one cell wide (few or tightly clustered keypoints) means every keypoint in the
+        // frame for a query nowhere near any of them. Caught by the single-keypoint and coincident
+        // fixtures in KeypointGridTest, which is why they are there.
+        val c0raw = cellFloor(x - r, minX)
+        val c1raw = cellFloor(x + r, minX)
+        val r0raw = cellFloor(y - r, minY)
+        val r1raw = cellFloor(y + r, minY)
+        if (c1raw < 0 || c0raw > cols - 1 || r1raw < 0 || r0raw > rows - 1) return
+
+        val c0 = c0raw.coerceIn(0, cols - 1)
+        val c1 = c1raw.coerceIn(0, cols - 1)
+        val r0 = r0raw.coerceIn(0, rows - 1)
+        val r1 = r1raw.coerceIn(0, rows - 1)
+        for (row in r0..r1) {
+            val base = row * cols
+            for (col in c0..c1) {
+                val bucket = cells[base + col]
+                for (i in bucket) out.add(i)
+            }
+        }
+    }
+
+    /** Convenience overload; allocates. Use the [out] form in a per-feature loop. */
+    fun candidatesWithin(x: Float, y: Float, radius: Float): List<Int> =
+        ArrayList<Int>().also { candidatesWithin(x, y, radius, it) }
+
+    /**
+     * Unclamped cell index, which may be negative or past the last cell. `floor`, not `toInt`:
+     * `toInt` truncates toward zero, so a query 0.5 cells to the LEFT of the origin lands in cell 0
+     * instead of -1 and the out-of-range test above would never fire on that side.
+     */
+    private fun cellFloor(v: Float, min: Float): Int {
+        if (!v.isFinite()) return if (v > 0f) Int.MAX_VALUE else Int.MIN_VALUE
+        return kotlin.math.floor((v - min) / cellSize).toInt()
+    }
+
+    companion object {
+        /**
+         * Bucket `n` keypoints given as a flat `[x0, y0, x1, y1, ...]` array.
+         *
+         * @param cellSize edge length of a bucket in pixels. Pass the search radius: cells much
+         *   smaller than the radius mean sweeping many of them, and cells much larger mean each one
+         *   holds candidates that are nowhere near. Floored at 1 px so a degenerate radius cannot
+         *   produce an unbounded grid.
+         */
+        fun build(pointsXY: FloatArray, cellSize: Float): KeypointGrid {
+            val n = pointsXY.size / 2
+            val cell = if (cellSize.isFinite() && cellSize >= 1f) cellSize else 1f
+            if (n == 0) return KeypointGrid(cell, 0f, 0f, 0, 0, emptyArray())
+
+            var minX = Float.MAX_VALUE
+            var minY = Float.MAX_VALUE
+            var maxX = -Float.MAX_VALUE
+            var maxY = -Float.MAX_VALUE
+            for (i in 0 until n) {
+                val x = pointsXY[i * 2]
+                val y = pointsXY[i * 2 + 1]
+                // A non-finite keypoint would poison the bounds and collapse the whole grid to one
+                // cell, quietly turning the local search back into a global one.
+                if (!x.isFinite() || !y.isFinite()) continue
+                if (x < minX) minX = x
+                if (x > maxX) maxX = x
+                if (y < minY) minY = y
+                if (y > maxY) maxY = y
+            }
+            if (minX > maxX) return KeypointGrid(cell, 0f, 0f, 0, 0, emptyArray())
+
+            val cols = (((maxX - minX) / cell).toInt() + 1).coerceAtLeast(1)
+            val rows = (((maxY - minY) / cell).toInt() + 1).coerceAtLeast(1)
+
+            // Two passes: count, then fill. One pass into growable lists would allocate an
+            // ArrayList per cell for a grid that is mostly empty at 1500 points.
+            val counts = IntArray(cols * rows)
+            for (i in 0 until n) {
+                val b = bucketOf(pointsXY, i, minX, minY, cell, cols, rows) ?: continue
+                counts[b]++
+            }
+            val cells = Array(cols * rows) { IntArray(counts[it]) }
+            val fill = IntArray(cols * rows)
+            for (i in 0 until n) {
+                val b = bucketOf(pointsXY, i, minX, minY, cell, cols, rows) ?: continue
+                cells[b][fill[b]++] = i
+            }
+            return KeypointGrid(cell, minX, minY, cols, rows, cells)
+        }
+
+        private fun bucketOf(
+            pointsXY: FloatArray, i: Int,
+            minX: Float, minY: Float, cell: Float, cols: Int, rows: Int,
+        ): Int? {
+            val x = pointsXY[i * 2]
+            val y = pointsXY[i * 2 + 1]
+            if (!x.isFinite() || !y.isFinite()) return null
+            val c = (((x - minX) / cell).toInt()).coerceIn(0, cols - 1)
+            val r = (((y - minY) / cell).toInt()).coerceIn(0, rows - 1)
+            return r * cols + c
+        }
+    }
+}

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/SearchRadius.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/SearchRadius.kt
@@ -1,0 +1,111 @@
+package com.hereliesaz.graffitixr.feature.ar.anchor
+
+import kotlin.math.sqrt
+
+/**
+ * `IMPLEMENTATION.md` **Phase 4** — how far from a predicted pixel the corroboration match is
+ * allowed to look.
+ *
+ * Once `F_out` has produced a pose, every `F_in` point has a *predicted* image location, so matching
+ * stops being a global search and becomes a local one. `PAPER.md` §5.5's worked example puts the
+ * candidate set at roughly 0.2% of the design's features at `ρ = 0.05` — and that collapse in
+ * false positives is what lets the Lowe ratio be *loosened* (`CORROB_LOWE_RATIO`, 0.85 against the
+ * reloc path's 0.75) instead of tightened. A constraint buying back recall is the phase's entire
+ * justification, which is why E6/E7 measure both sides of it.
+ *
+ * This is the pure-Kotlin reference. `MobileGS.cpp` transliterates it, and
+ * `SearchRadiusTest` pins the scaling relationships the transliteration has to preserve.
+ *
+ * ## Why the radius is not a constant
+ *
+ * The stated risk for this phase is a radius that is too tight *after the pose has drifted* —
+ * starving corroboration exactly when it is most needed, and doing it silently. So `r` has two
+ * terms:
+ *
+ *  - a **scale** term, `ρ` × the design's on-screen size, which keeps the search scale-free: the
+ *    same fraction of the artwork whether the artist is a metre away or five;
+ *  - a **drift** term, the measured recent pose error projected into pixels, which widens the search
+ *    precisely when the prediction is known to be unreliable.
+ *
+ * The drift term reads `errMm` from `DriftCostProbe` rather than a fixed allowance, because a fixed
+ * allowance is either too tight when drifting or too loose when not, and there is no value that is
+ * both.
+ */
+object SearchRadius {
+
+    /**
+     * Search radius in pixels for a corroboration match.
+     *
+     * @param rho normalized search radius, as a fraction of the design's half-extent.
+     * @param designHalfWMeters the design's **effective** (scale-included) half-width in metres.
+     * @param designHalfHMeters likewise the half-height.
+     * @param wallDistanceMeters camera-to-wall distance along the view axis.
+     * @param focalLengthPx the intrinsics' focal length, in pixels, for the frame being matched.
+     * @param poseErrMm the measured recent pose error in millimetres, or **negative when not
+     *   measured** — the `DriftCostProbe` convention. Not-measured contributes no drift term, which
+     *   is the honest reading: an unmeasured error is not a zero error, but it is also not a licence
+     *   to widen the search by an invented amount.
+     *
+     * Returns a value clamped to `[MIN_PX, MAX_PX]`. Degenerate geometry — a non-positive distance
+     * or focal length, or a design with no extent — yields [MAX_PX] rather than [MIN_PX]: when the
+     * estimate cannot be computed, the failure that matters is the tight one. A too-wide search
+     * costs precision, which the ratio test still filters; a too-tight search silently returns no
+     * candidates at all and reads downstream as "the wall does not corroborate the design".
+     */
+    fun pixels(
+        rho: Float,
+        designHalfWMeters: Float,
+        designHalfHMeters: Float,
+        wallDistanceMeters: Float,
+        focalLengthPx: Float,
+        poseErrMm: Float,
+        errGain: Float = ERR_GAIN,
+        minPx: Float = MIN_PX,
+        maxPx: Float = MAX_PX,
+    ): Float {
+        val halfExtent = designExtentScalar(designHalfWMeters, designHalfHMeters)
+        if (halfExtent <= 0f || wallDistanceMeters <= 0f || focalLengthPx <= 0f || rho <= 0f) {
+            return maxPx
+        }
+        if (!halfExtent.isFinite() || !wallDistanceMeters.isFinite() || !focalLengthPx.isFinite()) {
+            return maxPx
+        }
+
+        // Metres-to-pixels at the wall: a length L metres at distance d subtends L * f / d pixels.
+        val pxPerMeter = focalLengthPx / wallDistanceMeters
+
+        val scaleTermPx = rho * halfExtent * pxPerMeter
+        // Negative errMm is "not measured" (DriftCostProbe's sentinel), not zero error.
+        val driftTermPx =
+            if (poseErrMm >= 0f && poseErrMm.isFinite()) errGain * (poseErrMm / 1000f) * pxPerMeter
+            else 0f
+
+        return (scaleTermPx + driftTermPx).coerceIn(minPx, maxPx)
+    }
+
+    /**
+     * The single length that stands in for an anisotropic design.
+     *
+     * Geometric mean, not max or min. The radius is a **search bound**, not a metric: it says how
+     * far a prediction might be wrong, and that error is isotropic in the image regardless of the
+     * artwork's aspect ratio. Taking the max would widen the search on a long thin design for no
+     * reason connected to the pose; taking the min would tighten it, which is the failure mode this
+     * phase's risk section names. The geometric mean is the scale-free middle, and it degrades to
+     * the side length on a square design.
+     */
+    fun designExtentScalar(halfW: Float, halfH: Float): Float =
+        if (halfW <= 0f || halfH <= 0f) 0f else sqrt(halfW * halfH)
+
+    /**
+     * Pre-registered priors from `PARAMETERS.md` §5. None is measured; E6/E7/E11 set them.
+     *
+     * `RHO` is the paper's worked example. `MIN_PX` is where a radius disappears into keypoint
+     * localization noise; `MAX_PX` is where "local" stops meaning anything and the argument for
+     * loosening the ratio collapses with it. `ERR_GAIN` at 1.0 is the neutral prior — the drift term
+     * contributes exactly the measured error, neither damped nor amplified.
+     */
+    const val RHO = 0.05f
+    const val MIN_PX = 4f
+    const val MAX_PX = 120f
+    const val ERR_GAIN = 1.0f
+}

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/SearchRadius.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/SearchRadius.kt
@@ -24,12 +24,30 @@ import kotlin.math.sqrt
  *
  *  - a **scale** term, `ρ` × the design's on-screen size, which keeps the search scale-free: the
  *    same fraction of the artwork whether the artist is a metre away or five;
- *  - a **drift** term, the measured recent pose error projected into pixels, which widens the search
- *    precisely when the prediction is known to be unreliable.
+ *  - a **drift** term, the measured recent pose error, which widens the search precisely when the
+ *    prediction is known to be unreliable.
  *
- * The drift term reads `errMm` from `DriftCostProbe` rather than a fixed allowance, because a fixed
- * allowance is either too tight when drifting or too loose when not, and there is no value that is
- * both.
+ * The drift term reads a *measurement* rather than a fixed allowance, because a fixed allowance is
+ * either too tight when drifting or too loose when not, and there is no value that is both.
+ *
+ * ## Two drift measurements, because only one of them exists in production
+ *
+ * `DriftCostProbe.errMm` is the phase's nominated signal, and it is the better one — a real
+ * translation error against a ground-truth pose. But it is computed as
+ * `EvalMetrics.poseError(candidate, truth)` and returns the `-1f` sentinel whenever `truthPose` is
+ * null, which on the shipping path it always is: truth comes from a fiducial the artist is not
+ * holding. Feeding only that term would mean the drift term is dead code outside an eval run, and
+ * the phase's stated risk — a radius too tight *after* the pose has drifted — would go unmitigated
+ * on the one path that matters.
+ *
+ * So there is a second term fed by the reloc PnP's **mean inlier reprojection error**, which is
+ * measured on every lock, is already in pixels (no projection, no invented conversion), and is
+ * bounded by the RANSAC inlier threshold by construction. It is a weaker signal — a residual on
+ * the points the pose was *fitted* to understates the error at points it was not — which is what
+ * [REPROJ_GAIN] is for, and why the two terms are separate parameters with separate gains instead
+ * of one being quietly converted into the other.
+ *
+ * Both default to "not measured" and both contribute nothing when they are.
  */
 object SearchRadius {
 
@@ -44,7 +62,11 @@ object SearchRadius {
      * @param poseErrMm the measured recent pose error in millimetres, or **negative when not
      *   measured** — the `DriftCostProbe` convention. Not-measured contributes no drift term, which
      *   is the honest reading: an unmeasured error is not a zero error, but it is also not a licence
-     *   to widen the search by an invented amount.
+     *   to widen the search by an invented amount. Negative on every non-eval run; see the class
+     *   note.
+     * @param reprojErrPx the reloc PnP's mean inlier reprojection error in pixels, or negative when
+     *   not measured. Already in the output's units, so it is added directly — the one drift signal
+     *   available on the shipping path.
      *
      * Returns a value clamped to `[MIN_PX, MAX_PX]`. Degenerate geometry — a non-positive distance
      * or focal length, or a design with no extent — yields [MAX_PX] rather than [MIN_PX]: when the
@@ -59,7 +81,9 @@ object SearchRadius {
         wallDistanceMeters: Float,
         focalLengthPx: Float,
         poseErrMm: Float,
+        reprojErrPx: Float = NOT_MEASURED,
         errGain: Float = ERR_GAIN,
+        reprojGain: Float = REPROJ_GAIN,
         minPx: Float = MIN_PX,
         maxPx: Float = MAX_PX,
     ): Float {
@@ -79,8 +103,12 @@ object SearchRadius {
         val driftTermPx =
             if (poseErrMm >= 0f && poseErrMm.isFinite()) errGain * (poseErrMm / 1000f) * pxPerMeter
             else 0f
+        // Already pixels. Not divided by anything and not scaled by pxPerMeter — a reprojection
+        // residual is measured in the image, so projecting it again would square the perspective.
+        val reprojTermPx =
+            if (reprojErrPx >= 0f && reprojErrPx.isFinite()) reprojGain * reprojErrPx else 0f
 
-        return (scaleTermPx + driftTermPx).coerceIn(minPx, maxPx)
+        return (scaleTermPx + driftTermPx + reprojTermPx).coerceIn(minPx, maxPx)
     }
 
     /**
@@ -103,9 +131,23 @@ object SearchRadius {
      * localization noise; `MAX_PX` is where "local" stops meaning anything and the argument for
      * loosening the ratio collapses with it. `ERR_GAIN` at 1.0 is the neutral prior — the drift term
      * contributes exactly the measured error, neither damped nor amplified.
+     *
+     * `REPROJ_GAIN` is deliberately **not** neutral. Its input is a residual over the inliers the
+     * pose was fitted to, so it is a lower bound on the error at points the fit never saw; and
+     * `solvePnPRansac` is called with an 8 px inlier threshold, which caps the mean it can report
+     * however bad the pose actually is. 2.0 is the smallest gain that keeps the term meaningful
+     * against both, and it is a prior, not a measurement — E7 sets it.
      */
     const val RHO = 0.05f
     const val MIN_PX = 4f
     const val MAX_PX = 120f
     const val ERR_GAIN = 1.0f
+    const val REPROJ_GAIN = 2.0f
+
+    /**
+     * The "no reading" value for both drift inputs. Negative, never 0 — zero is a legitimate
+     * measurement here (a perfectly-tracking pose really does have no error) and cannot double as
+     * the default.
+     */
+    const val NOT_MEASURED = -1f
 }

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/DriftCostProbe.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/DriftCostProbe.kt
@@ -136,6 +136,7 @@ class DriftCostProbe(
             // so writing 0 for absent data would file the best rows and the empty rows together.
             corrobPredicted = reloc?.corrobPredicted ?: EvalSampleLog.NOT_SAMPLED,
             corrobMatched = reloc?.corrobMatched ?: EvalSampleLog.NOT_SAMPLED,
+            corrobLoneSkips = reloc?.corrobLoneSkips ?: EvalSampleLog.NOT_SAMPLED,
             searchRadiusPx = corrob?.searchRadiusPx ?: EvalSampleLog.NOT_SAMPLED_PX,
             relocReprojPx = corrob?.relocReprojPx ?: EvalSampleLog.NOT_SAMPLED_PX,
             captureRotationNeededDeg = captureRotationNeededDeg,

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/DriftCostProbe.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/DriftCostProbe.kt
@@ -64,6 +64,10 @@ class DriftCostProbe(
      * @param reloc          last relocalization diagnostics, or null when not sampled. Logged so a
      *   null relocalization becomes a diagnosis rather than an absence: NO_FEATURES and FEW_INLIERS
      *   call for opposite fixes and the aggregate error number cannot tell them apart.
+     * @param corrob        last corroboration diagnostics, or null when not sampled. Read from
+     *   `SlamManager.getCorroborationDiagnostics()`, which is a separate call from the reloc
+     *   diagnostics only because these two readings are floats; pass it alongside [reloc] so both
+     *   describe the same tick rather than two samples taken at different times.
      * @param captureRotationNeededDeg `rotationNeeded` at the moment the ACTIVE TARGET was
      *   captured, or -1 if unknown. **E0b's independent variable** — the frame mismatch is baked
      *   into the fingerprint at capture, so this and not [liveRotationNeededDeg] is what results
@@ -78,6 +82,7 @@ class DriftCostProbe(
         stageMs: FloatArray,
         cpuPct: Float,
         reloc: com.hereliesaz.graffitixr.common.model.RelocDiagnostics? = null,
+        corrob: com.hereliesaz.graffitixr.common.model.CorroborationDiagnostics? = null,
         captureRotationNeededDeg: Int = EvalSampleLog.NOT_SAMPLED,
         liveRotationNeededDeg: Int = EvalSampleLog.NOT_SAMPLED,
     ) {
@@ -123,6 +128,16 @@ class DriftCostProbe(
             relocBackboneFeatures = reloc?.backboneFeatures ?: EvalSampleLog.NOT_SAMPLED,
             relocBackboneMatches = reloc?.backboneMatches ?: EvalSampleLog.NOT_SAMPLED,
             relocBackboneInliers = reloc?.backboneInliers ?: EvalSampleLog.NOT_SAMPLED,
+            // Same two routes as the backbone counts, and the same rule: native already reports -1
+            // for a quantity it has not measured, so the elvis only covers "no diagnostics were
+            // read this tick at all". Neither route may land on 0. A zero predicted count is the
+            // artist looking away from the design — a real state 4.8 has to keep separate from a
+            // gate that never fired — and a zero reprojection error is what a perfect lock reports,
+            // so writing 0 for absent data would file the best rows and the empty rows together.
+            corrobPredicted = reloc?.corrobPredicted ?: EvalSampleLog.NOT_SAMPLED,
+            corrobMatched = reloc?.corrobMatched ?: EvalSampleLog.NOT_SAMPLED,
+            searchRadiusPx = corrob?.searchRadiusPx ?: EvalSampleLog.NOT_SAMPLED_PX,
+            relocReprojPx = corrob?.relocReprojPx ?: EvalSampleLog.NOT_SAMPLED_PX,
             captureRotationNeededDeg = captureRotationNeededDeg,
             liveRotationNeededDeg = liveRotationNeededDeg,
         )

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/EvalSampleLog.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/EvalSampleLog.kt
@@ -37,6 +37,43 @@ data class EvalSample(
     val relocBackboneMatches: Int = -1,
     val relocBackboneInliers: Int = -1,
     /**
+     * `IMPLEMENTATION.md` **4.6** — design features the pose predicts should be visible in this
+     * frame, and how many of them the wall answered for. -1 = no gated corroboration attempt was
+     * measured this tick.
+     *
+     * These are logged beside the reloc counts rather than folded into them because Phase 4 changed
+     * what a corroboration number means: the pre-Phase-4 global fallback matched the whole design,
+     * including the half behind the camera, so its count and a spatially-gated count are different
+     * quantities and must not share a column.
+     *
+     * **-1, never 0.** Zero predicted-visible is a real reading — the artist has turned away from
+     * the design, so there is nothing to corroborate against and a low ratio means nothing. That is
+     * a different row from one where the corroboration path never ran, and collapsing the two would
+     * put the "looking away" rows into the same bucket as the "gate never fired" rows, which is the
+     * exact confusion 4.8 has to be able to resolve. The pairing matters too: zero predicted with
+     * zero matched is benign, whereas a healthy predicted with zero matched is the wall failing to
+     * corroborate, and only distinct columns can tell those apart.
+     */
+    val corrobPredicted: Int = -1,
+    val corrobMatched: Int = -1,
+    /**
+     * The radius the last gated corroboration search used, and the mean reprojection error over the
+     * last lock's PnP inliers, both in pixels. -1f = not measured.
+     *
+     * Floats, and carried on their own channel out of native for that reason: rounding these to
+     * integers to share the int[] would flatten every sub-pixel reading to 0 or 1 at precisely the
+     * tight radii Phase 4 exists to measure, so the column would be widest-open exactly where it
+     * needs to be sharpest.
+     *
+     * **-1f, never 0f.** A near-zero reprojection error is what a perfect lock actually reports —
+     * it is the *best* outcome this column can carry, not the absence of one — so zero cannot double
+     * as the not-measured marker without making every ideal row indistinguishable from a row where
+     * nothing was measured, and turning the healthiest evidence Phase 4 can produce into missing
+     * data. A zero radius is likewise a real (degenerate) reading, not an absence.
+     */
+    val searchRadiusPx: Float = -1f,
+    val relocReprojPx: Float = -1f,
+    /**
      * `rotationNeeded` **at the moment the active target was captured** — 0, 90, 180 or 270, or -1
      * when no target has been captured this session (a project restored from disk reads -1; see
      * below).
@@ -95,10 +132,19 @@ object EvalSampleLog {
         "relocReject", "relocMatches", "relocInliers", "relocDetected",
         "relocObliquityDeg", "relocRectifiedCorr",
         "relocBackboneFeatures", "relocBackboneMatches", "relocBackboneInliers",
+        "corrobPredicted", "corrobMatched", "searchRadiusPx", "relocReprojPx",
         "captureRotationNeededDeg", "liveRotationNeededDeg",
     )
 
     const val NOT_SAMPLED = -1
+
+    /**
+     * The same sentinel for the pixel-valued columns. Spelled as its own constant rather than a bare
+     * `-1f` at each use site so a reader can see that [searchRadiusPx][EvalSample.searchRadiusPx]
+     * and [relocReprojPx][EvalSample.relocReprojPx] are absent for the same reason as every Int
+     * column beside them, and so a later change to the convention has one place to change.
+     */
+    const val NOT_SAMPLED_PX = -1f
 
     val CSV_HEADER: String = COLUMNS.joinToString(",")
 
@@ -115,6 +161,8 @@ object EvalSampleLog {
             s.relocObliquityDeg.toString(), s.relocRectifiedCorr.toString(),
             s.relocBackboneFeatures.toString(), s.relocBackboneMatches.toString(),
             s.relocBackboneInliers.toString(),
+            s.corrobPredicted.toString(), s.corrobMatched.toString(),
+            s.searchRadiusPx.toString(), s.relocReprojPx.toString(),
             s.captureRotationNeededDeg.toString(), s.liveRotationNeededDeg.toString(),
         )
     }

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/EvalSampleLog.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/EvalSampleLog.kt
@@ -69,10 +69,28 @@ data class EvalSample(
      * it is the *best* outcome this column can carry, not the absence of one — so zero cannot double
      * as the not-measured marker without making every ideal row indistinguishable from a row where
      * nothing was measured, and turning the healthiest evidence Phase 4 can produce into missing
-     * data. A zero radius is likewise a real (degenerate) reading, not an absence.
+     * data.
+     *
+     * The radius is a different case and an earlier version of this note got it wrong: it can
+     * **never** be 0. `SearchRadius.pixels` clamps every path into `[MIN_PX, MAX_PX]` = `[4, 120]`,
+     * and its degenerate branch returns the ceiling. So a `0` in this column is not a degenerate
+     * reading to interpret — it is corrupt data, and should be treated as one.
      */
     val searchRadiusPx: Float = -1f,
     val relocReprojPx: Float = -1f,
+    /**
+     * Predicted-visible features the gated match **refused to test**, because their neighbourhood
+     * held a single candidate and Lowe's ratio needs two. -1 = not sampled; 0 is a real reading and
+     * the one that says the radius is comfortable.
+     *
+     * This column is why the phase is falsifiable. Skips deflate [corrobMatched] without touching
+     * [corrobPredicted], so a radius too tight to find two candidates produces the same CSV
+     * signature as a wall that has stopped corroborating — and the two call for opposite responses
+     * (raise ρ vs. investigate the paint). At the `MIN_PX` floor a sparse frame can skip most of
+     * what it predicted, so without this column E6 could report a confidence collapse and attribute
+     * it to the wrong cause with no way to tell.
+     */
+    val corrobLoneSkips: Int = -1,
     /**
      * `rotationNeeded` **at the moment the active target was captured** — 0, 90, 180 or 270, or -1
      * when no target has been captured this session (a project restored from disk reads -1; see
@@ -132,7 +150,7 @@ object EvalSampleLog {
         "relocReject", "relocMatches", "relocInliers", "relocDetected",
         "relocObliquityDeg", "relocRectifiedCorr",
         "relocBackboneFeatures", "relocBackboneMatches", "relocBackboneInliers",
-        "corrobPredicted", "corrobMatched", "searchRadiusPx", "relocReprojPx",
+        "corrobPredicted", "corrobMatched", "corrobLoneSkips", "searchRadiusPx", "relocReprojPx",
         "captureRotationNeededDeg", "liveRotationNeededDeg",
     )
 
@@ -162,6 +180,7 @@ object EvalSampleLog {
             s.relocBackboneFeatures.toString(), s.relocBackboneMatches.toString(),
             s.relocBackboneInliers.toString(),
             s.corrobPredicted.toString(), s.corrobMatched.toString(),
+            s.corrobLoneSkips.toString(),
             s.searchRadiusPx.toString(), s.relocReprojPx.toString(),
             s.captureRotationNeededDeg.toString(), s.liveRotationNeededDeg.toString(),
         )

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -1302,6 +1302,12 @@ class ArRenderer(
                     // here and reused for the reloc columns below, so the row's truth flag and its
                     // diagnostics describe the same relocalization rather than two samples.
                     val relocDiag = slamManager.getRelocDiagnostics()
+                    // The corroboration path's two pixel-valued readings. A second call rather than
+                    // two more slots in the reloc int[] because a radius rounded to an integer is
+                    // destroyed at exactly the tight radii Phase 4 is trying to measure. Read here,
+                    // next to relocDiag, so a row's corroboration numbers describe the same tick as
+                    // its reject code instead of straddling two attempts.
+                    val corrobDiag = slamManager.getCorroborationDiagnostics()
                     val marksVisible = relocDiag.reject == com.hereliesaz.graffitixr.common.model
                         .RelocReject.OK && relocDiag.inliers >= MIN_TRUTH_INLIERS
                     val truth = if (marksVisible) {
@@ -1324,6 +1330,7 @@ class ArRenderer(
                         // FloatArrays per tick. (An earlier comment here said "four atomics", which
                         // was neither the count nor the mechanism.)
                         reloc = relocDiag,
+                        corrob = corrobDiag,
                         // E0b's independent variable is the rotation that was in force AT CAPTURE,
                         // because that is the one baked into the fingerprint's 3D points. Sampling
                         // the live rotation here instead — which an earlier version of this call

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/CorroborationTranslitTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/CorroborationTranslitTest.kt
@@ -1,0 +1,184 @@
+package com.hereliesaz.graffitixr.feature.ar.anchor
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * `IMPLEMENTATION.md` **4.5** — [SearchRadius] and [KeypointGrid] are Kotlin *references* that
+ * `SearchRadius.h` and `KeypointGrid.h` transliterate, and the running code is the C++ one.
+ *
+ * That is an uncomfortable arrangement: every test in `SearchRadiusTest` and `KeypointGridTest`
+ * exercises a copy of the algorithm that never executes on a device. There is no native test
+ * harness in this project, and adding one — a second toolchain, a gtest dependency, a CI target —
+ * is a larger change than the phase it would be serving.
+ *
+ * So this file pins what *can* be pinned from Kotlin: that the two sides agree on the numbers and
+ * on the handful of structural choices where a plausible rewrite silently changes behaviour. It
+ * cannot prove the C++ computes the same function. It can prove nobody edited one side's constant
+ * and left the other, which is the divergence with the highest probability and the lowest
+ * visibility — a radius quietly twice as wide produces no error, no crash and no wrong pixel, just
+ * a corroboration rate that drifts away from the one the experiments were designed against.
+ *
+ * The reads are source-text reads, like `FootprintRegionWireTest`'s, and for the same stated reason:
+ * the alternative is a comment asking for the two to be kept in sync.
+ */
+class CorroborationTranslitTest {
+
+    @Test
+    fun `the native search-radius constants are the Kotlin ones`() {
+        val native = constants(source("core/nativebridge/src/main/cpp/include/SearchRadius.h"))
+        assertEquals(
+            "SearchRadius.h declares an unexpected set of constants; found $native",
+            setOf("kRho", "kMinPx", "kMaxPx", "kErrGain", "kReprojGain", "kNotMeasured"),
+            native.keys,
+        )
+        assertEquals("rho", SearchRadius.RHO, native.getValue("kRho"), 0f)
+        assertEquals("min", SearchRadius.MIN_PX, native.getValue("kMinPx"), 0f)
+        assertEquals("max", SearchRadius.MAX_PX, native.getValue("kMaxPx"), 0f)
+        assertEquals("err gain", SearchRadius.ERR_GAIN, native.getValue("kErrGain"), 0f)
+        assertEquals("reproj gain", SearchRadius.REPROJ_GAIN, native.getValue("kReprojGain"), 0f)
+        assertEquals("sentinel", SearchRadius.NOT_MEASURED, native.getValue("kNotMeasured"), 0f)
+    }
+
+    /**
+     * The three asymmetries the Kotlin tests exist to protect, each phrased as the C++ expression
+     * that carries it. A transliteration that reversed any of them would still compile, still run,
+     * and still produce a number in the right range.
+     */
+    @Test
+    fun `the native search radius keeps the deliberate asymmetries`() {
+        val src = source("core/nativebridge/src/main/cpp/include/SearchRadius.h").readText()
+        // Degenerate geometry must fail WIDE. A too-tight search returns nothing and reads
+        // downstream as "the wall does not corroborate", which is a confident wrong answer.
+        assertTrue(
+            "degenerate geometry must return maxPx, not minPx",
+            Regex("""rho\s*<=\s*0\.0f\)\s*\{\s*\n\s*return maxPx;""").containsMatchIn(src),
+        )
+        // A negative reading is "not measured" and contributes nothing — for BOTH drift inputs.
+        assertTrue(
+            "poseErrMm must be gated on >= 0",
+            src.contains("(poseErrMm >= 0.0f && std::isfinite(poseErrMm))"),
+        )
+        assertTrue(
+            "reprojErrPx must be gated on >= 0",
+            src.contains("(reprojErrPx >= 0.0f && std::isfinite(reprojErrPx))"),
+        )
+        // The reprojection residual is already pixels. Multiplying it by pxPerMeter is the error the
+        // Kotlin test `the reprojection term is pixels and is not reprojected again` guards against,
+        // and pxPerMeter is in scope one line above it in the C++.
+        assertTrue(
+            "the reprojection term must not be scaled by pxPerMeter",
+            src.contains("reprojGain * reprojErrPx"),
+        )
+        // Anisotropy averages, and the geometric mean is what makes rho scale-free.
+        assertTrue(
+            "the design extent must be the geometric mean",
+            src.contains("std::sqrt(halfW * halfH)"),
+        )
+    }
+
+    /**
+     * The grid's two structural traps, both of which the Kotlin tests caught during development and
+     * neither of which produces anything but "slightly fewer corroborated features" when wrong.
+     */
+    @Test
+    fun `the native grid sweeps a cell range and rejects out-of-range queries unclamped`() {
+        val src = source("core/nativebridge/src/main/cpp/include/KeypointGrid.h").readText()
+        // The out-of-range test must run on the UNCLAMPED indices. Clamping first maps a distant
+        // query onto the edge cells and returns their contents — on a one-cell grid, every keypoint
+        // in the frame for a query nowhere near any of them.
+        assertTrue(
+            "the raw cell indices must be tested before they are clamped",
+            src.contains("if (c1raw < 0 || c0raw > mCols - 1 || r1raw < 0 || r0raw > mRows - 1) return;"),
+        )
+        val clampAt = src.indexOf("const int c0 = clampi(c0raw")
+        val rejectAt = src.indexOf("if (c1raw < 0 ||")
+        assertTrue("the reject must come before the clamp", rejectAt in 0 until clampAt)
+        // floor, not truncation. A query half a cell left of the origin truncates to 0 instead of
+        // -1, and the reject above would never fire on that side.
+        assertTrue(
+            "cellFloor must use std::floor, not an int cast",
+            src.contains("std::floor((double)(v - minV) / (double)mCell)"),
+        )
+        // A cell RANGE, not a fixed 3x3 — the caller queries one grid at several radii.
+        assertTrue(
+            "the sweep must be over the computed range",
+            src.contains("for (int r = r0; r <= r1; ++r)") && src.contains("for (int c = c0; c <= c1; ++c)"),
+        )
+        // A non-finite keypoint must not poison the bounds and collapse the grid to one cell,
+        // which would turn the local search silently back into a global one.
+        assertTrue(
+            "build must skip non-finite keypoints when computing bounds",
+            src.contains("if (!std::isfinite(kp.pt.x) || !std::isfinite(kp.pt.y)) continue;"),
+        )
+    }
+
+    /**
+     * `IMPLEMENTATION.md` **4.7** — the corroboration ratio must be its own constant, and it must be
+     * looser than the reloc one. Looser is the whole claim of the phase: the spatial constraint
+     * collapses the false-positive population, and that is what buys back the recall a global
+     * search had to throw away. If the two were ever equal the constraint would be pure cost.
+     */
+    @Test
+    fun `the corroboration Lowe ratio is separate from the reloc one and looser`() {
+        val native = constants(source("core/nativebridge/src/main/cpp/include/MobileGS.h"))
+        val reloc = native["kRelocLoweRatio"]
+        val corrob = native["kCorrobLoweRatio"]
+        assertTrue("MobileGS.h must declare kRelocLoweRatio; found ${native.keys}", reloc != null)
+        assertTrue("MobileGS.h must declare kCorrobLoweRatio; found ${native.keys}", corrob != null)
+        assertTrue(
+            "the corroboration ratio ($corrob) must be looser than the reloc ratio ($reloc)",
+            corrob!! > reloc!!,
+        )
+        // Literal, so a silent edit to a value E7 is waiting on shows up as a test change.
+        assertEquals(0.75f, reloc, 0f)
+        assertEquals(0.85f, corrob, 0f)
+
+        // And the gated match must actually use it. A separate constant nothing reads is the
+        // antipattern this project has shipped before.
+        val cpp = source("core/nativebridge/src/main/cpp/MobileGS.cpp").readText()
+        assertTrue(
+            "the gated corroboration match must apply kCorrobLoweRatio",
+            cpp.contains("best < kCorrobLoweRatio * second"),
+        )
+        assertTrue(
+            "no bare 0.75f Lowe literal may survive in MobileGS.cpp",
+            !Regex("""distance\s*<\s*0\.75f""").containsMatchIn(cpp) &&
+                !Regex("""<\s*0\.75f\s*\*\s*\w+\[1\]""").containsMatchIn(cpp),
+        )
+    }
+
+    /**
+     * `IMPLEMENTATION.md` **4.8** — zero predicted-visible is "the artist is looking away", not
+     * "the wall does not corroborate". Pinned against the source because the two differ by one
+     * ternary and the wrong one is the shorter, more obvious expression.
+     */
+    @Test
+    fun `zero predicted-visible publishes the unmeasured sentinel, not zero`() {
+        val cpp = source("core/nativebridge/src/main/cpp/MobileGS.cpp").readText()
+        assertTrue(
+            "confidence must fall back to kCorroborationUnmeasured when nothing is predicted visible",
+            cpp.contains("predicted > 0 ? (float)matched / (float)predicted : kCorroborationUnmeasured"),
+        )
+    }
+
+    /** `NAME = <number>f` pairs from a C++ header, floats only. */
+    private fun constants(file: File): Map<String, Float> =
+        Regex("""constexpr float (\w+)\s*=\s*(-?[\d.]+)f""")
+            .findAll(file.readText())
+            .associate { it.groupValues[1] to it.groupValues[2].toFloat() }
+
+    private fun source(relative: String): File {
+        // Test working directories differ between Gradle and IDE runs, so walk up rather than
+        // assuming one. Failing loudly here beats a silently-skipped assertion.
+        var dir: File? = File("").absoluteFile
+        while (dir != null) {
+            val f = File(dir, relative)
+            if (f.isFile) return f
+            dir = dir.parentFile
+        }
+        throw AssertionError("could not find $relative from ${File("").absolutePath}")
+    }
+}

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/CorroborationTranslitTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/CorroborationTranslitTest.kt
@@ -100,7 +100,17 @@ class CorroborationTranslitTest {
         // -1, and the reject above would never fire on that side.
         assertTrue(
             "cellFloor must use std::floor, not an int cast",
-            src.contains("std::floor((double)(v - minV) / (double)mCell)"),
+            src.contains("std::floor((double)q)"),
+        )
+        // ...and the DIVISION must stay in float, matching the Kotlin reference's Float operands.
+        // Computing the quotient in double is more accurate and therefore different: at a boundary
+        // where the float quotient rounds up to an exact integer and the double one does not, the
+        // two implementations disagree about the cell and the out-of-range reject fires on one side
+        // only. This assertion previously pinned the double form, i.e. the test whose job is proving
+        // the two agree was pinning the one expression where they could not.
+        assertTrue(
+            "the cell quotient must be computed in float, as the Kotlin reference does",
+            src.contains("const float q = (v - minV) / mCell;"),
         )
         // A cell RANGE, not a fixed 3x3 — the caller queries one grid at several radii.
         assertTrue(

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/KeypointGridTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/KeypointGridTest.kt
@@ -1,0 +1,164 @@
+package com.hereliesaz.graffitixr.feature.ar.anchor
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.random.Random
+
+/**
+ * `IMPLEMENTATION.md` **4.4** — the grid against a brute-force reference, on random points across a
+ * range of radii.
+ *
+ * The property under test is one-directional and that is the whole design: the grid must return
+ * **every** keypoint within the radius, and is allowed to return extras. So the assertion is
+ * `bruteForce ⊆ grid`, not set equality — asserting equality would be asserting a contract the
+ * implementation deliberately does not offer, and would fail on points that are inside the swept
+ * cells but outside the circle.
+ *
+ * The seed is fixed. A randomized test that cannot be re-run identically reports a failure nobody
+ * can reproduce, which in a geometry routine is barely better than no test.
+ *
+ * These fixtures are also what the native transliteration has to reproduce, so a radius that works
+ * here is a claim about `MobileGS.cpp` too.
+ */
+class KeypointGridTest {
+
+    private fun bruteForce(pts: FloatArray, x: Float, y: Float, r: Float): Set<Int> {
+        val out = HashSet<Int>()
+        val r2 = r * r
+        for (i in 0 until pts.size / 2) {
+            val dx = pts[i * 2] - x
+            val dy = pts[i * 2 + 1] - y
+            if (dx * dx + dy * dy <= r2) out.add(i)
+        }
+        return out
+    }
+
+    private fun randomPoints(n: Int, seed: Int, w: Float = 1920f, h: Float = 1080f): FloatArray {
+        val rnd = Random(seed)
+        return FloatArray(n * 2) { if (it % 2 == 0) rnd.nextFloat() * w else rnd.nextFloat() * h }
+    }
+
+    /**
+     * The headline equivalence. Radii deliberately span **below and above** the cell size: the grid
+     * sweeps a cell range rather than a fixed 3x3 precisely so a query wider than the cell still
+     * works, and a hard-coded 3x3 — the likeliest transliteration error — passes at `radius <=
+     * cellSize` and fails here.
+     */
+    @Test
+    fun `the grid returns every point a brute-force search finds`() {
+        val pts = randomPoints(1500, seed = 20260801)
+        val cellSize = 16f
+        val grid = KeypointGrid.build(pts, cellSize)
+        val rnd = Random(7)
+        val scratch = ArrayList<Int>()
+
+        for (radius in floatArrayOf(1f, 4f, 15f, 16f, 17f, 40f, 120f, 400f)) {
+            repeat(40) {
+                val qx = rnd.nextFloat() * 1920f
+                val qy = rnd.nextFloat() * 1080f
+                grid.candidatesWithin(qx, qy, radius, scratch)
+                val got = scratch.toSet()
+                val expected = bruteForce(pts, qx, qy, radius)
+                assertTrue(
+                    "radius=$radius query=($qx,$qy) missed ${(expected - got).size} of " +
+                        "${expected.size} true neighbours",
+                    got.containsAll(expected),
+                )
+            }
+        }
+    }
+
+    /**
+     * The grid has to be *worth* having. If it returned nearly everything it would be correct and
+     * useless — and the phase's entire argument is that the candidate set collapses, which is what
+     * lets the Lowe ratio be loosened afterwards.
+     */
+    @Test
+    fun `the candidate set is a small fraction of the frame`() {
+        val n = 1500
+        val pts = randomPoints(n, seed = 4242)
+        val grid = KeypointGrid.build(pts, cellSize = 16f)
+        val rnd = Random(99)
+        var total = 0
+        val scratch = ArrayList<Int>()
+        repeat(200) {
+            grid.candidatesWithin(rnd.nextFloat() * 1920f, rnd.nextFloat() * 1080f, 16f, scratch)
+            total += scratch.size
+        }
+        val meanFraction = total / 200.0 / n
+        assertTrue(
+            "a 16 px search over a 1920x1080 frame returned $meanFraction of all keypoints on " +
+                "average; the local search is not local",
+            meanFraction < 0.02,
+        )
+    }
+
+    @Test
+    fun `an empty keypoint set yields no candidates`() {
+        val grid = KeypointGrid.build(FloatArray(0), 16f)
+        assertEquals(0, grid.candidatesWithin(100f, 100f, 50f).size)
+    }
+
+    @Test
+    fun `a single keypoint is found from inside its radius and missed from outside`() {
+        val grid = KeypointGrid.build(floatArrayOf(100f, 100f), 16f)
+        assertTrue(grid.candidatesWithin(100f, 100f, 1f).contains(0))
+        assertTrue(grid.candidatesWithin(110f, 100f, 20f).contains(0))
+        // Far enough that no swept cell can reach it.
+        assertTrue(grid.candidatesWithin(1000f, 1000f, 10f).isEmpty())
+    }
+
+    /**
+     * All points on one spot is the degenerate clustering case — every keypoint in one bucket. It
+     * must still answer correctly rather than divide by a zero extent.
+     */
+    @Test
+    fun `coincident keypoints do not collapse the grid`() {
+        val pts = FloatArray(200) { if (it % 2 == 0) 500f else 500f }
+        val grid = KeypointGrid.build(pts, 16f)
+        assertEquals(100, grid.candidatesWithin(500f, 500f, 1f).size)
+        assertTrue(grid.candidatesWithin(900f, 900f, 10f).isEmpty())
+    }
+
+    /**
+     * A non-finite keypoint must not poison the bounds. If it did, `minX`/`maxX` would go infinite,
+     * the grid would collapse to a single cell, and every query would return every point — the local
+     * search silently becoming a global one, which is a performance and precision regression that no
+     * assertion elsewhere would catch.
+     */
+    @Test
+    fun `a NaN keypoint does not collapse the grid to one cell`() {
+        val pts = floatArrayOf(
+            10f, 10f,
+            Float.NaN, 50f,
+            1000f, 800f,
+            20f, 20f,
+        )
+        val grid = KeypointGrid.build(pts, 16f)
+        val near = grid.candidatesWithin(15f, 15f, 20f)
+        assertTrue("the two nearby points must be found", near.containsAll(listOf(0, 3)))
+        assertTrue("the far point must not be", !near.contains(2))
+    }
+
+    @Test
+    fun `a degenerate cell size does not produce an unbounded grid`() {
+        val pts = randomPoints(100, seed = 5)
+        for (cell in floatArrayOf(0f, -1f, Float.NaN, Float.POSITIVE_INFINITY)) {
+            val grid = KeypointGrid.build(pts, cell)
+            val got = grid.candidatesWithin(960f, 540f, 50f)
+            assertTrue("cellSize=$cell produced $got", got.containsAll(bruteForce(pts, 960f, 540f, 50f)))
+        }
+    }
+
+    /** The `out` overload must clear, or a per-feature loop accumulates every previous query. */
+    @Test
+    fun `the reusable buffer is cleared on each query`() {
+        val grid = KeypointGrid.build(randomPoints(300, seed = 11), 16f)
+        val scratch = ArrayList<Int>()
+        grid.candidatesWithin(500f, 500f, 100f, scratch)
+        val first = scratch.size
+        grid.candidatesWithin(500f, 500f, 100f, scratch)
+        assertEquals("a repeated query must not double the buffer", first, scratch.size)
+    }
+}

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/PoseFusionTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/PoseFusionTest.kt
@@ -1,5 +1,7 @@
 package com.hereliesaz.graffitixr.feature.ar.anchor
 
+import kotlin.math.cos
+import kotlin.math.sin
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -87,6 +89,77 @@ class PoseFusionTest {
         val move = trans(3f, -2f, 7f)
         val bothMoved = PoseFusion.composeCorrected(move, move, fpAnchor)
         for (i in 0 until 16) assertEquals("trans element $i", neitherRotated[i], bothMoved[i], 1e-4f)
+    }
+
+    /**
+     * `IMPLEMENTATION.md` **0.6**, rotation half.
+     *
+     * The order test above pins the factors with ONE rotation and a translation, which fixes where
+     * the anchor lands but says almost nothing about the 3×3 block — a rotation composed on the
+     * wrong side, or through a wrong-handed frame conversion, can still put the origin in the right
+     * place. This asserts the whole rotation block against a matrix derived by hand.
+     *
+     * What 0.6 settled (`PAPER.md` §8.3): `vCurrent` is `Camera.getViewMatrix`, which ARCore
+     * documents as already display-oriented, and convention B puts the capture side in the same
+     * display frame. So the two sides agree *for rotation* and the composition needs **no** `R_z`
+     * inserted and **no** handedness flip between `inverse(vCurrent)` and `pnpMat`. The expected
+     * rotation is therefore exactly `Rx(−30) · Ry(40) · Rz(50)` and nothing else — which is a claim
+     * with content, because every one of the plausible defects lands somewhere else:
+     *
+     *  - factors reordered → the three axes do not commute, so any permutation moves the block;
+     *  - `vCurrent` not inverted → `sin(30)` changes sign in rows 1 and 2;
+     *  - a `C = diag(1,−1,−1)` inserted between the first two factors → `C·Ry(b)·C = Ry(−b)`, so
+     *    `sin(40)` flips wherever it appears;
+     *  - an inverse taken by negating rather than transposing → mirrored, not rotated.
+     *
+     * The expected entries below are written out from the symbolic product of the three axis
+     * rotations, NOT by calling [PoseMath.multiply] — deriving them the way the code derives them
+     * would make this an identity rather than a check. Nothing here touches `android.opengl.Matrix`,
+     * which is a return-default stub in this source set and would make any assertion built on it
+     * pass against an array of zeros.
+     *
+     * Deliberately NOT in scope: whether the three operands are in mutually consistent frames. They
+     * are not — see the test above and 0.9. This pins the three-factor form as it stands, so 0.9's
+     * two extra factors have to change it on purpose rather than by accident.
+     */
+    @Test fun `composeCorrected rotation block matches a hand-derived product`() {
+        val a = Math.toRadians(30.0).toFloat(); val ca = cos(a); val sa = sin(a)
+        val b = Math.toRadians(40.0).toFloat(); val cb = cos(b); val sb = sin(b)
+        val g = Math.toRadians(50.0).toFloat(); val cg = cos(g); val sg = sin(g)
+        val tx = 1f; val ty = 2f; val tz = 3f
+
+        // Column-major (element [col*4+row]), same layout PoseMath and ARCore use. Right-handed,
+        // matching the existing rotZ fixture above: column 0 of Rz(90) is (0,1,0), i.e. +X → +Y.
+        val vCurrent = floatArrayOf(1f,0f,0f,0f, 0f,ca,sa,0f, 0f,-sa,ca,0f, 0f,0f,0f,1f)   // Rx(30)
+        val pnpMat = floatArrayOf(cb,0f,-sb,0f, 0f,1f,0f,0f, sb,0f,cb,0f, 0f,0f,0f,1f)     // Ry(40)
+        val fpAnchor = floatArrayOf(cg,sg,0f,0f, -sg,cg,0f,0f, 0f,0f,1f,0f, tx,ty,tz,1f)   // Rz(50), t
+
+        // E = Rx(-a)·Ry(b)·Rz(g), multiplied out by hand.
+        //   Rx(-a)·Ry(b) = [ cb      0    sb   ]
+        //                  [-sa·sb   ca   sa·cb]
+        //                  [-ca·sb  -sa   ca·cb]
+        // then right-multiplied by Rz(g), whose third column is (0,0,1) — which is why column 2 of E
+        // is just column 2 of that intermediate.
+        val e = arrayOf(
+            floatArrayOf(cb * cg,                    -cb * sg,                   sb),
+            floatArrayOf(ca * sg - sa * sb * cg,     ca * cg + sa * sb * sg,     sa * cb),
+            floatArrayOf(-ca * sb * cg - sa * sg,    ca * sb * sg - sa * cg,     ca * cb),
+        )
+        // The first two factors carry no translation, so the composed translation is the same
+        // intermediate applied to fpAnchor's t.
+        val et = floatArrayOf(
+            cb * tx + sb * tz,
+            -sa * sb * tx + ca * ty + sa * cb * tz,
+            -ca * sb * tx - sa * ty + ca * cb * tz,
+        )
+
+        val r = PoseFusion.composeCorrected(vCurrent, pnpMat, fpAnchor)
+        for (row in 0 until 3) for (col in 0 until 3) {
+            assertEquals("rotation [$row][$col]", e[row][col], r[col * 4 + row], 1e-5f)
+        }
+        for (i in 0 until 3) assertEquals("translation [$i]", et[i], r[12 + i], 1e-5f)
+        assertEquals(0f, r[3], 1e-6f); assertEquals(0f, r[7], 1e-6f)
+        assertEquals(0f, r[11], 1e-6f); assertEquals(1f, r[15], 1e-6f)
     }
 
     @Test fun `blend alpha 0 returns current, alpha 1 returns target`() {

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/SearchRadiusTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/SearchRadiusTest.kt
@@ -36,11 +36,14 @@ class SearchRadiusTest {
         dist: Float = DIST_M,
         focal: Float = FOCAL_PX,
         errMm: Float = NO_ERR,
+        reprojPx: Float = NO_ERR,
         // Wide bounds so the clamp does not silently absorb the relationship under test. The clamp
         // has its own tests below.
         minPx: Float = 0f,
         maxPx: Float = 1e6f,
-    ) = SearchRadius.pixels(rho, halfW, halfH, dist, focal, errMm, minPx = minPx, maxPx = maxPx)
+    ) = SearchRadius.pixels(
+        rho, halfW, halfH, dist, focal, errMm, reprojPx, minPx = minPx, maxPx = maxPx,
+    )
 
     @Test
     fun `radius scales inversely with distance to the wall`() {
@@ -124,6 +127,47 @@ class SearchRadiusTest {
         assertEquals("any negative sentinel behaves the same", r(errMm = 0f), r(errMm = -999f), 1e-4f)
     }
 
+    /**
+     * The reprojection residual is measured **in the image**, so it is added in pixels and must not
+     * be scaled by the metres-to-pixels factor. Projecting an already-projected quantity would
+     * square the perspective: the term would grow as the artist steps closer, on a signal whose
+     * whole point is that it is already expressed in the output's units.
+     *
+     * This is the transliteration error most likely to appear in `MobileGS.cpp`, where `pxPerMeter`
+     * is sitting right there in scope next to the other drift term.
+     */
+    @Test
+    fun `the reprojection term is pixels and is not reprojected again`() {
+        val expected = SearchRadius.REPROJ_GAIN * 3f
+        assertEquals(expected, r(reprojPx = 3f) - r(reprojPx = 0f), expected * 1e-3f)
+        // The same reading at half the distance must add the same number of pixels. If the term
+        // were multiplied by pxPerMeter this delta would double.
+        val nearDelta = r(dist = 1f, reprojPx = 3f) - r(dist = 1f, reprojPx = 0f)
+        assertEquals("the pixel term must not depend on wall distance", expected, nearDelta, expected * 1e-3f)
+    }
+
+    @Test
+    fun `an unmeasured reprojection error contributes nothing`() {
+        assertEquals(r(reprojPx = 0f), r(reprojPx = -1f), 1e-4f)
+        assertEquals(r(reprojPx = 0f), r(reprojPx = Float.NaN), 1e-4f)
+    }
+
+    /**
+     * The two drift signals are independent measurements of the same failure, not alternatives, so
+     * a run that has both must widen by both. Asserted because the tempting implementation — an
+     * `if/else` picking whichever is measured — reads as reasonable and silently discards the
+     * ground-truth term on exactly the eval runs that exist to measure it.
+     */
+    @Test
+    fun `both drift signals contribute when both are measured`() {
+        val neither = r(errMm = NO_ERR, reprojPx = NO_ERR)
+        val mmOnly = r(errMm = 20f, reprojPx = NO_ERR)
+        val pxOnly = r(errMm = NO_ERR, reprojPx = 3f)
+        val both = r(errMm = 20f, reprojPx = 3f)
+        assertEquals("the terms must add", (mmOnly - neither) + (pxOnly - neither), both - neither,
+            (both - neither) * 1e-3f)
+    }
+
     // -------------------------------------------------------------------------------------
     // Clamping and degenerate inputs
     // -------------------------------------------------------------------------------------
@@ -177,5 +221,7 @@ class SearchRadiusTest {
         assertEquals(4f, SearchRadius.MIN_PX, 0f)
         assertEquals(120f, SearchRadius.MAX_PX, 0f)
         assertEquals(1.0f, SearchRadius.ERR_GAIN, 0f)
+        assertEquals(2.0f, SearchRadius.REPROJ_GAIN, 0f)
+        assertEquals(-1f, SearchRadius.NOT_MEASURED, 0f)
     }
 }

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/SearchRadiusTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/SearchRadiusTest.kt
@@ -1,0 +1,181 @@
+package com.hereliesaz.graffitixr.feature.ar.anchor
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * `IMPLEMENTATION.md` **4.2** — the search radius, asserted on **scaling relationships, not
+ * absolutes**.
+ *
+ * That instruction is the point of the file. Every constant here is a pre-registered prior that E6,
+ * E7 and E11 are expected to move, so a test pinning `r == 37.2f` would encode a guess as a
+ * requirement and would have to be rewritten the moment the experiment it is waiting for reports.
+ * What must not change under any sweep is the *shape*: twice the distance halves the radius, twice
+ * the focal length doubles it, ρ enters linearly. Those are geometry, not tuning.
+ *
+ * The values are also what `MobileGS.cpp`'s transliteration has to reproduce, so a ratio that holds
+ * here is a claim about both implementations.
+ */
+class SearchRadiusTest {
+
+    private companion object {
+        const val RHO = SearchRadius.RHO
+        const val HALF_W = 0.8f
+        const val HALF_H = 0.5f
+        const val DIST_M = 2.0f
+        const val FOCAL_PX = 1400f
+        /** Not measured — DriftCostProbe's sentinel, so the drift term is out of the way. */
+        const val NO_ERR = -1f
+    }
+
+    private fun r(
+        rho: Float = RHO,
+        halfW: Float = HALF_W,
+        halfH: Float = HALF_H,
+        dist: Float = DIST_M,
+        focal: Float = FOCAL_PX,
+        errMm: Float = NO_ERR,
+        // Wide bounds so the clamp does not silently absorb the relationship under test. The clamp
+        // has its own tests below.
+        minPx: Float = 0f,
+        maxPx: Float = 1e6f,
+    ) = SearchRadius.pixels(rho, halfW, halfH, dist, focal, errMm, minPx = minPx, maxPx = maxPx)
+
+    @Test
+    fun `radius scales inversely with distance to the wall`() {
+        val near = r(dist = 1.0f)
+        val far = r(dist = 2.0f)
+        assertEquals("doubling the distance must halve the radius", near / 2f, far, near * 1e-4f)
+        assertTrue(far < near)
+    }
+
+    @Test
+    fun `radius scales linearly with focal length`() {
+        val short = r(focal = 700f)
+        val long = r(focal = 1400f)
+        assertEquals("doubling the focal length must double the radius", short * 2f, long, long * 1e-4f)
+    }
+
+    @Test
+    fun `radius scales linearly with rho`() {
+        val tight = r(rho = 0.05f)
+        val loose = r(rho = 0.10f)
+        assertEquals("doubling rho must double the radius", tight * 2f, loose, loose * 1e-4f)
+    }
+
+    /**
+     * The design's size enters through the geometric mean, so a design scaled up by `k` on both axes
+     * scales the radius by `k` — the property that makes ρ scale-free. A max- or min-based scalar
+     * would also pass this; the anisotropy test below is what separates them.
+     */
+    @Test
+    fun `radius scales linearly with a uniformly larger design`() {
+        val small = r(halfW = 0.8f, halfH = 0.5f)
+        val big = r(halfW = 1.6f, halfH = 1.0f)
+        assertEquals(small * 2f, big, big * 1e-4f)
+    }
+
+    /**
+     * Anisotropy is deliberately averaged, not maximised. The radius bounds how wrong a *pose*
+     * prediction can be, and that error is isotropic in the image whatever the artwork's aspect
+     * ratio — so a long thin design must not get a wider search than a square one of the same area.
+     */
+    @Test
+    fun `a long thin design gets the same radius as a square one of equal area`() {
+        val square = r(halfW = 1.0f, halfH = 1.0f)
+        val thin = r(halfW = 4.0f, halfH = 0.25f)
+        assertEquals("equal area must give equal radius", square, thin, square * 1e-4f)
+        assertTrue("...and it must not be the max half-extent", thin < r(halfW = 4.0f, halfH = 4.0f))
+    }
+
+    // -------------------------------------------------------------------------------------
+    // The drift term — 4.3
+    // -------------------------------------------------------------------------------------
+
+    /**
+     * The phase's stated risk is a radius too tight after the pose has drifted, starving
+     * corroboration exactly when it is needed. A measured error must therefore *widen* the search.
+     */
+    @Test
+    fun `a measured pose error widens the radius`() {
+        val steady = r(errMm = 0f)
+        val drifting = r(errMm = 20f)
+        assertTrue("20 mm of measured error must widen the search", drifting > steady)
+    }
+
+    /** With gain 1.0 the drift term is exactly the measured error in pixels, added on. */
+    @Test
+    fun `the drift term is the measured error projected into pixels`() {
+        val pxPerMeter = FOCAL_PX / DIST_M
+        val expectedDelta = 0.020f * pxPerMeter // 20 mm at gain 1.0
+        assertEquals(expectedDelta, r(errMm = 20f) - r(errMm = 0f), expectedDelta * 1e-3f)
+    }
+
+    /**
+     * `-1` is `DriftCostProbe`'s "not measured", and it is not zero. It must contribute **nothing**
+     * rather than being read as a confident zero error — but it also must not invent a widening, so
+     * unmeasured and zero happen to produce the same radius here. The distinction is asserted
+     * against a *negative* value being treated as a magnitude, which would narrow or widen wrongly.
+     */
+    @Test
+    fun `an unmeasured pose error contributes no drift term`() {
+        assertEquals(r(errMm = 0f), r(errMm = -1f), 1e-4f)
+        assertEquals("any negative sentinel behaves the same", r(errMm = 0f), r(errMm = -999f), 1e-4f)
+    }
+
+    // -------------------------------------------------------------------------------------
+    // Clamping and degenerate inputs
+    // -------------------------------------------------------------------------------------
+
+    @Test
+    fun `the radius is floored and ceiled`() {
+        // Very far away and a tiny design: the scale term collapses toward zero.
+        assertEquals(SearchRadius.MIN_PX, SearchRadius.pixels(RHO, 0.01f, 0.01f, 50f, 100f, NO_ERR), 0f)
+        // Very close to a large design: the scale term explodes.
+        assertEquals(SearchRadius.MAX_PX, SearchRadius.pixels(RHO, 5f, 5f, 0.2f, 3000f, NO_ERR), 0f)
+    }
+
+    /**
+     * Unusable geometry yields the CEILING, not the floor, and the asymmetry is deliberate.
+     *
+     * A too-wide search costs precision, which the ratio test still filters. A too-tight one returns
+     * no candidates at all and reads downstream as "the wall does not corroborate the design" — a
+     * confident wrong answer rather than a degraded one, and indistinguishable from a genuinely
+     * unpainted wall.
+     */
+    @Test
+    fun `degenerate geometry fails wide, not narrow`() {
+        val cases = mapOf(
+            "zero distance" to SearchRadius.pixels(RHO, HALF_W, HALF_H, 0f, FOCAL_PX, NO_ERR),
+            "negative distance" to SearchRadius.pixels(RHO, HALF_W, HALF_H, -1f, FOCAL_PX, NO_ERR),
+            "zero focal length" to SearchRadius.pixels(RHO, HALF_W, HALF_H, DIST_M, 0f, NO_ERR),
+            "no design extent" to SearchRadius.pixels(RHO, 0f, HALF_H, DIST_M, FOCAL_PX, NO_ERR),
+            "zero rho" to SearchRadius.pixels(0f, HALF_W, HALF_H, DIST_M, FOCAL_PX, NO_ERR),
+            "NaN distance" to SearchRadius.pixels(RHO, HALF_W, HALF_H, Float.NaN, FOCAL_PX, NO_ERR),
+            "infinite focal" to
+                SearchRadius.pixels(RHO, HALF_W, HALF_H, DIST_M, Float.POSITIVE_INFINITY, NO_ERR),
+        )
+        for ((name, value) in cases) {
+            assertEquals("$name must fail wide", SearchRadius.MAX_PX, value, 0f)
+        }
+    }
+
+    /** A NaN error must not poison the result into NaN — the clamp cannot rescue that. */
+    @Test
+    fun `a NaN pose error is ignored rather than propagated`() {
+        val value = r(errMm = Float.NaN)
+        assertTrue("got $value", value.isFinite())
+        assertEquals(r(errMm = -1f), value, 1e-4f)
+    }
+
+    @Test
+    fun `the pre-registered priors are the ones PARAMETERS documents`() {
+        // Literal, so a silent edit to a value E6/E7/E11 are waiting on shows up as a test change
+        // rather than as a number that quietly moved.
+        assertEquals(0.05f, SearchRadius.RHO, 0f)
+        assertEquals(4f, SearchRadius.MIN_PX, 0f)
+        assertEquals(120f, SearchRadius.MAX_PX, 0f)
+        assertEquals(1.0f, SearchRadius.ERR_GAIN, 0f)
+    }
+}

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/eval/EvalSampleLogTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/eval/EvalSampleLogTest.kt
@@ -45,6 +45,7 @@ class EvalSampleLogTest {
                 "nativeHeapKb,relocReject,relocMatches,relocInliers,relocDetected," +
                 "relocObliquityDeg,relocRectifiedCorr," +
                 "relocBackboneFeatures,relocBackboneMatches,relocBackboneInliers," +
+                "corrobPredicted,corrobMatched,searchRadiusPx,relocReprojPx," +
                 "captureRotationNeededDeg,liveRotationNeededDeg",
             EvalSampleLog.CSV_HEADER,
         )
@@ -59,8 +60,12 @@ class EvalSampleLogTest {
             nativeHeapKb = 20480L,
         )
         assertEquals(
+            // Six reloc, three backbone and two corroboration Int columns default to -1; the two
+            // pixel columns are Floats, so their -1f sentinel prints as -1.0; then the two rotation
+            // columns. The float spelling is part of the contract a consumer parses, not an
+            // incidental formatting detail, so it is written out here literally.
             "12,dual,true,1.5,0.25,3.0,1.0,2.0,0.0,4.0,1.0,8.0,30.0,-450.0,31.0,20480," +
-                "-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1",
+                "-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1.0,-1.0,-1,-1",
             EvalSampleLog.toCsvRow(row),
         )
     }
@@ -337,5 +342,43 @@ class EvalSampleLogTest {
         val fields = EvalSampleLog.fields(sample(reloc = d))
         assertEquals("0", fields[EvalSampleLog.COLUMNS.indexOf("relocDetected")])
         assertEquals("0", fields[EvalSampleLog.COLUMNS.indexOf("relocMatches")])
+    }
+
+    /**
+     * The Phase 4 twin of the backbone trap, for all four corroboration columns at once.
+     *
+     * Every one of these quantities has a *legitimate* zero, and for the two float columns the zero
+     * is the good news rather than the bad. A zero `corrobPredicted` means the artist has turned
+     * away from the design — real, expected, and the state `IMPLEMENTATION.md` 4.8 has to keep
+     * separate from "the gated corroboration attempt never ran at all", because a low confidence
+     * ratio means nothing in the first case and something in the second. A near-zero
+     * `relocReprojPx` is what a *perfect* lock reports: had 0 doubled as the not-measured marker,
+     * the best rows Phase 4 can produce would have been filed as missing data, and the pixel columns
+     * would have been blindest exactly where the result is strongest.
+     *
+     * Asserted against literal strings, including the `.0` the Float columns print, because those
+     * spellings are what a downstream consumer parses.
+     */
+    @Test
+    fun `a measured corroboration zero is distinct from not sampled`() {
+        val lookingAway = sample().copy(
+            corrobPredicted = 0, corrobMatched = 0,
+            searchRadiusPx = 0f, relocReprojPx = 0f,
+        )
+        val measured = EvalSampleLog.fields(lookingAway)
+        val unsampled = EvalSampleLog.fields(sample())
+        val cases = listOf(
+            Triple("corrobPredicted", "0", "-1"),
+            Triple("corrobMatched", "0", "-1"),
+            Triple("searchRadiusPx", "0.0", "-1.0"),
+            Triple("relocReprojPx", "0.0", "-1.0"),
+        )
+        for ((col, zero, sentinel) in cases) {
+            val i = EvalSampleLog.COLUMNS.indexOf(col)
+            assertTrue("$col is not a column", i >= 0)
+            assertEquals("$col: a measured zero must log as zero", zero, measured[i])
+            assertEquals("$col: an unmeasured tick must log the sentinel", sentinel, unsampled[i])
+            assertTrue("$col: a measured zero must not read as absent", measured[i] != unsampled[i])
+        }
     }
 }

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/eval/EvalSampleLogTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/eval/EvalSampleLogTest.kt
@@ -1,6 +1,7 @@
 package com.hereliesaz.graffitixr.feature.ar.eval
 
 import com.hereliesaz.graffitixr.common.model.RelocDiagnostics
+import com.hereliesaz.graffitixr.feature.ar.anchor.SearchRadius
 import com.hereliesaz.graffitixr.common.model.RelocReject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -45,7 +46,7 @@ class EvalSampleLogTest {
                 "nativeHeapKb,relocReject,relocMatches,relocInliers,relocDetected," +
                 "relocObliquityDeg,relocRectifiedCorr," +
                 "relocBackboneFeatures,relocBackboneMatches,relocBackboneInliers," +
-                "corrobPredicted,corrobMatched,searchRadiusPx,relocReprojPx," +
+                "corrobPredicted,corrobMatched,corrobLoneSkips,searchRadiusPx,relocReprojPx," +
                 "captureRotationNeededDeg,liveRotationNeededDeg",
             EvalSampleLog.CSV_HEADER,
         )
@@ -60,12 +61,12 @@ class EvalSampleLogTest {
             nativeHeapKb = 20480L,
         )
         assertEquals(
-            // Six reloc, three backbone and two corroboration Int columns default to -1; the two
+            // Six reloc, three backbone and three corroboration Int columns default to -1; the two
             // pixel columns are Floats, so their -1f sentinel prints as -1.0; then the two rotation
             // columns. The float spelling is part of the contract a consumer parses, not an
             // incidental formatting detail, so it is written out here literally.
             "12,dual,true,1.5,0.25,3.0,1.0,2.0,0.0,4.0,1.0,8.0,30.0,-450.0,31.0,20480," +
-                "-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1.0,-1.0,-1,-1",
+                "-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1.0,-1.0,-1,-1",
             EvalSampleLog.toCsvRow(row),
         )
     }
@@ -345,16 +346,22 @@ class EvalSampleLogTest {
     }
 
     /**
-     * The Phase 4 twin of the backbone trap, for all four corroboration columns at once.
+     * The Phase 4 twin of the backbone trap, across the corroboration columns.
      *
-     * Every one of these quantities has a *legitimate* zero, and for the two float columns the zero
-     * is the good news rather than the bad. A zero `corrobPredicted` means the artist has turned
-     * away from the design — real, expected, and the state `IMPLEMENTATION.md` 4.8 has to keep
-     * separate from "the gated corroboration attempt never ran at all", because a low confidence
-     * ratio means nothing in the first case and something in the second. A near-zero
+     * Every one of these quantities has a *legitimate* zero, and for `relocReprojPx` the zero is
+     * the good news rather than the bad. A zero `corrobPredicted` means the artist has turned away
+     * from the design — real, expected, and the state `IMPLEMENTATION.md` 4.8 has to keep separate
+     * from "the gated corroboration attempt never ran at all", because a low confidence ratio means
+     * nothing in the first case and something in the second. A zero `corrobLoneSkips` is the
+     * healthy reading: every predicted feature had enough neighbours to test. And a near-zero
      * `relocReprojPx` is what a *perfect* lock reports: had 0 doubled as the not-measured marker,
      * the best rows Phase 4 can produce would have been filed as missing data, and the pixel columns
      * would have been blindest exactly where the result is strongest.
+     *
+     * `searchRadiusPx` is the one column with **no** legitimate zero — `SearchRadius.pixels` clamps
+     * every path into `[MIN_PX, MAX_PX]` — so it is exercised at its floor instead. A 0 in that
+     * column means corrupt data, and a test asserting a "measured zero" for it would have been
+     * pinning a state the code cannot produce.
      *
      * Asserted against literal strings, including the `.0` the Float columns print, because those
      * spellings are what a downstream consumer parses.
@@ -362,15 +369,16 @@ class EvalSampleLogTest {
     @Test
     fun `a measured corroboration zero is distinct from not sampled`() {
         val lookingAway = sample().copy(
-            corrobPredicted = 0, corrobMatched = 0,
-            searchRadiusPx = 0f, relocReprojPx = 0f,
+            corrobPredicted = 0, corrobMatched = 0, corrobLoneSkips = 0,
+            searchRadiusPx = SearchRadius.MIN_PX, relocReprojPx = 0f,
         )
         val measured = EvalSampleLog.fields(lookingAway)
         val unsampled = EvalSampleLog.fields(sample())
         val cases = listOf(
             Triple("corrobPredicted", "0", "-1"),
             Triple("corrobMatched", "0", "-1"),
-            Triple("searchRadiusPx", "0.0", "-1.0"),
+            Triple("corrobLoneSkips", "0", "-1"),
+            Triple("searchRadiusPx", "4.0", "-1.0"),
             Triple("relocReprojPx", "0.0", "-1.0"),
         )
         for ((col, zero, sentinel) in cases) {

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Sat Aug 01 22:24:41 UTC 2026
-versionBuild=14481
+#Sat Aug 01 22:46:47 UTC 2026
+versionBuild=14486
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=347
+versionPatch=352

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Sat Aug 01 20:17:57 UTC 2026
-versionBuild=14476
+#Sat Aug 01 20:32:46 UTC 2026
+versionBuild=14479
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=342
+versionPatch=345

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Sat Aug 01 19:48:50 UTC 2026
-versionBuild=14466
+#Sat Aug 01 20:17:57 UTC 2026
+versionBuild=14476
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=332
+versionPatch=342

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Sat Aug 01 20:32:46 UTC 2026
-versionBuild=14479
+#Sat Aug 01 22:24:41 UTC 2026
+versionBuild=14481
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=345
+versionPatch=347

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Sat Aug 01 19:20:44 UTC 2026
-versionBuild=14459
+#Sat Aug 01 19:48:50 UTC 2026
+versionBuild=14466
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=325
+versionPatch=332


### PR DESCRIPTION
`IMPLEMENTATION.md` Phase 4, whole (4.1–4.8), plus one item the plan was missing — then a round of adversarial audit that found six defects in it.

Once `F_out` has produced a pose, every design feature has a predicted pixel. The corroboration match stops comparing every frame descriptor against every design descriptor and compares each design feature against the handful of keypoints near where it should be. That collapse in false positives is what lets the Lowe ratio be *loosened* — the one place in the system where a constraint buys back recall instead of costing it, and the phase's entire justification.

## The plan's premise did not survive contact with the code

4.5 says to project each `F_in` 3D point through the current pose. But the corroboration match is against `mArtworkDescriptors` — the **design's** features — and those have no position in the fingerprint frame. `mArtworkKeypoints3D` is empty on the shipping path (the design composite carries no depth) and, where depth exists, is expressed in the artwork capture camera's frame, which has no relation to the fingerprint's.

So the prediction goes through the design's **placement** instead. `setDesignPlacement` carries `captureAnchorCam · rigidModelAnchorLocal` — the exact composition Φ is classified with, passed across JNI rather than re-derived, so the two cannot disagree about where the design is — and each artwork feature's composite pixel maps parametrically onto the design plane before projecting. A missing placement, a missing pose, or a 2D/descriptor length mismatch falls back to the global search: Phase 4 off, not Phase 4 guessing.

## What changed as a consequence

- **The match direction inverts.** The gated path asks each design feature which frame keypoint it is, because that is the direction a predicted location exists in.
- **Painting progress became cumulative.** A gated match only ever looks at the part of the design in frame, so the instantaneous ratio would have become a statement about where the artist is standing. Cumulative is also what `getPaintingProgress()` already promised — hours, roughly monotonic, never decayed. See the audit section for what that first attempt got wrong.

## 4.3's drift signal was dead code on the shipping path

`DriftCostProbe.errMm` is `EvalMetrics.poseError(candidate, truth)` and returns its own `-1` whenever `truthPose` is null — every run where the artist is not holding a fiducial. So the term meant to widen the search when the pose has drifted never fired outside an eval session, and the phase's stated risk mitigation was unimplemented.

Added the reloc PnP's **mean inlier reprojection error** as a second term: measured on every lock, already in pixels, published as `relocReprojPx`. Its gain is `2.0` and deliberately not neutral — it is a residual over the points the pose was *fitted* to, and RANSAC's 8 px inlier threshold caps what it can report — which is why it is a separate parameter rather than quietly converted into millimetres and folded into the first.

## One recall cost, deliberate and measured

A neighbourhood holding a single candidate is **skipped**. Lowe's ratio has nothing to divide by, and accepting unconditionally would corroborate any keypoint that lands near a prediction regardless of what it looks like — a confidence signal measuring the wall's texture density, feeding `PoseFusion`'s correction strength.

Skipping deflates `matched` without touching `predicted`. That is conservative against false snapping and **anti-conservative against drift** — lower confidence means a smaller correction blend — so "the cost is only lower confidence" is not the whole story. And a radius too tight to find two candidates produces the same signature as a wall that has stopped corroborating, which calls for the opposite response. At the `MIN_PX` floor of 4 px a sparse frame can skip most of what it predicted, so the rate rides its own diagnostic channel (`corrobLoneSkips`), the overlay, and the eval CSV. E6 sets ρ against a measurement rather than an assumption.

## 4.7 found four sites, not two

The literal `0.75f` appeared at the reloc wall match, the reloc map match, the map association in `growMapFromReloc`, and corroboration. The three global searches keep `kRelocLoweRatio`; only corroboration gets `kCorrobLoweRatio = 0.85`.

## Diagnostics (4.6)

Three ints widen the packed `nativeGetRelocDiagnostics` array to 12 — the Kotlin width guard stays at `< 9` on purpose, so a 2.11-era `.so` still yields its nine good diagnostics instead of being refused whole for missing three. The floats could not ride an `int[]` without rounding a sub-pixel radius to zero at exactly the tight radii the phase is measuring, so they get their own channel. All of them reach the eval CSV and the on-device overlay.

The overlay's `Corroborated` row was fed `paintingProgress` — a label for a different number. It is now `Painted`, with a real `Corrob` row beside it showing `matched/predicted · r=NNpx`, and the skip count when it is non-zero.

## The audit round: six defects

An adversarial audit of the first commit confirmed the geometry and the transliteration, and found six things wrong with everything around them. All are fixed in `c8e0406`.

1. **The design placement was cleared on one of three project-switch branches.** Only the `fp == null || legacyFrame` arm reaches `clearWallFingerprint`; opening a second project with a saved metric fingerprint left native holding project A's design pose expressed in project B's frame. Every prediction then lands somewhere confidently wrong, returns nothing, and reads downstream as "the wall does not corroborate" — pinning confidence and progress near zero until the artist happened to drag the design. This is the **seventh** instance of the "cleared in one branch, not its sibling" family in that one function, so the fix is structural: clear before the `when`, not inside it.

2. **Painting progress ratcheted with no false-positive bound**, and accumulated from the unconstrained global path as well. One spurious match per attempt at 5 Hz walks a 1500-feature design to "100% painted" in minutes on a bare wall. Accumulation is now gated-path-only, and a feature must be corroborated on `kCorrobConfirmations` = 2 separate attempts. That bounds *transient* false positives; it does not bound persistent ones, which is a limit of descriptor corroboration and is why E6 measures progress against ground truth. Both channels now switch definition on whether a **placement** exists rather than on whether this frame produced a lock — a placement is stable across frames and a lock is not.

3. **Nudging the opacity slider reset painting progress to 0%.** `arToneKey` drove `updatePaintingGuide`, which re-registers the artwork. Cheap before Phase 4; expensive after, when progress has to climb back one confirmed feature at a time. Fixed at the call site — tone is how the overlay should *look*, not what the artwork *is*.

4. **The corroboration counters were never reset per attempt**, breaking a rule stated 780 lines above them and applied there to the backbone trio. One gated attempt's numbers stayed live across every non-gated tick, copying a single measurement into every eval row.

5. A comment asserted a `PoseFusion` consequence the wiring makes impossible — `ArRenderer` coerces the negative sentinel to `0f` and `CONF_FLOOR` absorbs both.

6. `KeypointGrid.kt`'s KDoc cited a native smoke assertion that does not exist and described a fixed nine-cell sweep, contradicted twenty lines later by the same file.

Also: `cellFloor` computed its quotient in `double` where the Kotlin reference uses `float`. More accurate and therefore *different* — and `CorroborationTranslitTest` had pinned the `double` form, so the test whose job is proving the two agree was pinning the one expression where they could not.

## Known gap, recorded rather than papered over

Every assertion in `SearchRadiusTest` and `KeypointGridTest` exercises Kotlin that never runs on a device. `CorroborationTranslitTest` pins the constants and the structural choices a plausible C++ rewrite would silently change — the unclamped out-of-range test, `floor` over truncation, the cell *range* sweep, the reprojection term not being scaled by `pxPerMeter`, the float quotient. It cannot prove the two compute the same function. There is no native test harness in this project, and adding one is a larger change than the phase it would serve. Stated in `PARAMETERS.md` §5.

`KeypointGrid`'s own test caught a real defect before it shipped: cell indices were clamped into range *before* the out-of-range check, so on a one-cell grid a query nowhere near any keypoint returned all of them — the local search quietly becoming a global one.

## Verification

- NDK build clean for `arm64-v8a` and `armeabi-v7a`; `nativeSetDesignPlacement` present in both `.so`s.
- `:core:common`, `:core:nativebridge`, `:feature:ar`, `:feature:editor` unit tests green; `:app` compiles.
- `SearchRadius` mutation-verified three ways (hard-coded 3×3 sweep, dropped drift term, degenerate-fails-narrow) — all caught.
- **Not device-tested.** Nothing here has been run against a real wall, and none of E6/E7/E11 has run. Every parameter is still a pre-registered prior. `kCorrobConfirmations` is reasoned rather than measured; the lone-candidate skip rate is now observable but has never been observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Q5WXFiVLeN4sXa9bPCSDA