### PR TITLE
Phase 3: geometric promotion — the gate learns to ask about the pose, not just the match

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -2221,6 +2221,25 @@ private fun RelocDiagnosticsOverlay(
                 androidx.compose.ui.graphics.Color.White
             },
         )
+        // IMPLEMENTATION.md 3.3 — the promotion gate's geometry term. Shown whenever a lock has
+        // measured it, because a low value is the state that silently blocks self-grow: a clustered
+        // inlier set produces a confident-looking pose with a badly conditioned rotation, and the
+        // gate refusing it is indistinguishable on every other row from self-grow never firing.
+        if (corroboration.inlierSpread >= 0f) {
+            DiagnosticRow(
+                "Spread",
+                String.format(java.util.Locale.US, "%.0f%%", corroboration.inlierSpread * 100f),
+                // Amber below the promotion threshold: not an error — a clustered lock still
+                // relocalizes perfectly well, it just must not be allowed to rewrite the map.
+                if (corroboration.inlierSpread <
+                    com.hereliesaz.graffitixr.feature.ar.anchor.PromotionGate.MIN_INLIER_SPREAD
+                ) {
+                    androidx.compose.ui.graphics.Color(0xFFFFC107)
+                } else {
+                    androidx.compose.ui.graphics.Color.White
+                },
+            )
+        }
         // The residual the search radius' drift term is derived from — and the fastest read on
         // whether a "locked" state is actually a good lock. A green LOCKED with a large reprojection
         // error is a pose that solved and is wrong, which nothing else on this overlay distinguishes.

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/RelocDiagnostics.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/RelocDiagnostics.kt
@@ -109,6 +109,18 @@ data class RelocDiagnostics(
 data class CorroborationDiagnostics(
     val searchRadiusPx: Float = -1f,
     val relocReprojPx: Float = -1f,
+    /**
+     * `IMPLEMENTATION.md` **3.3** — the last lock's inlier bounding box as a fraction of frame area,
+     * or -1 when not measured.
+     *
+     * The gate this feeds gates an **irreversible** map mutation, and its refusals are otherwise
+     * invisible: self-grow declining because the inliers were clustered looks exactly like self-grow
+     * not having fired at all. E5 has to tell those apart to say whether the term is too strict.
+     *
+     * **Zero is a real reading** and the worst one — every inlier on a single pixel, a pose whose
+     * rotation is unconstrained — so it cannot double as the sentinel.
+     */
+    val inlierSpread: Float = -1f,
 )
 
 /**

--- a/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
+++ b/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
@@ -1372,19 +1372,22 @@ Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeGetRelocDiagnostic
 // IMPLEMENTATION.md 4.6 — the two float diagnostics from the corroboration path, which cannot ride
 // the int[] above. Packed together for the same reason it is packed: one call, one snapshot.
 // [0] = search radius the last gated attempt used, in pixels; [1] = mean reprojection error over the
-// last lock's PnP inliers, also in pixels. Both -1 for "not measured", never 0 — a perfectly
-// tracking pose really does have a near-zero reprojection error, so zero cannot double as the
-// default.
+// last lock's PnP inliers, also in pixels; [2] = the last lock's inlier bounding box as a fraction
+// of frame area (IMPLEMENTATION.md 3.3). All -1 for "not measured", never 0 — a perfectly tracking
+// pose really does have a near-zero reprojection error, and a spread of 0 is a real reading meaning
+// every inlier landed on one pixel, which is the worst-conditioned state the gate exists to reject.
+// Neither can double as the default.
 extern "C" JNIEXPORT jfloatArray JNICALL
 Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeGetCorroborationDiagnostics(JNIEnv* env, jobject) {
-    jfloat vals[2] = {-1.0f, -1.0f};
+    jfloat vals[3] = {-1.0f, -1.0f, -1.0f};
     if (gSlamEngine) {
         vals[0] = gSlamEngine->corrobSearchRadiusPx();
         vals[1] = gSlamEngine->lastRelocReprojPx();
+        vals[2] = gSlamEngine->lastRelocInlierSpread();
     }
-    jfloatArray out = env->NewFloatArray(2);
+    jfloatArray out = env->NewFloatArray(3);
     if (!out) return nullptr;
-    env->SetFloatArrayRegion(out, 0, 2, vals);
+    env->SetFloatArrayRegion(out, 0, 3, vals);
     return out;
 }
 

--- a/core/nativebridge/src/main/cpp/MobileGS.cpp
+++ b/core/nativebridge/src/main/cpp/MobileGS.cpp
@@ -263,6 +263,10 @@ void MobileGS::runRelocPass(const cv::Mat& frame, const float* relocView) {
     // Leaving a previous lock's value in place would widen or narrow the corroboration search
     // on the strength of a pose that is no longer the one being predicted from.
     mLastRelocReprojPx.store(-1.0f, std::memory_order_relaxed);
+    // 3.2, same rule: the spread describes ONE attempt's inlier set. A stale value would let a
+    // previous frame's well-spread lock authorise a promotion from this frame's clustered one,
+    // which is the permanent-mutation version of the mistake the counters above guard against.
+    mLastRelocInlierSpread.store(kPromotionNotMeasured, std::memory_order_relaxed);
     // ...and the same rule again for the corroboration counters (IMPLEMENTATION.md 4.6). These
     // are written only on a GATED attempt, so without a reset here one gated attempt's numbers
     // stayed live across every subsequent tick that fell back to the global search — a red
@@ -601,6 +605,16 @@ void MobileGS::runRelocPass(const cv::Mat& frame, const float* relocView) {
                     std::vector<cv::Point3f> inObj; std::vector<cv::Point2f> inImg;
                     inObj.reserve(inliers.size()); inImg.reserve(inliers.size());
                     for (int idx : inliers) { inObj.push_back(objPts[idx]); inImg.push_back(imgPts[idx]); }
+                    // IMPLEMENTATION.md 3.2 — how much of the frame the inliers span, published
+                    // here because this is the only scope that has them. The self-grow gate runs in
+                    // tryUpdateFingerprint, which sees the inlier COUNT through an atomic and never
+                    // the points, so without this the spread term could not exist at all.
+                    //
+                    // Measured against the frame the correspondences were found in (`gray`), not the
+                    // fingerprint's capture frame: the box is a statement about this view's geometry.
+                    mLastRelocInlierSpread.store(
+                        inlierSpreadOf(inImg, (float)gray.cols, (float)gray.rows),
+                        std::memory_order_relaxed);
                     auto reproj = [&](const cv::Mat& rv, const cv::Mat& tv) {
                         std::vector<cv::Point2f> pr;
                         cv::projectPoints(inObj, rv, tv, intr, cv::Mat(), pr);
@@ -1177,6 +1191,7 @@ void MobileGS::tryUpdateFingerprint(const cv::Mat& grayClean,
     // although Phase 4 moved it inside the global-fallback branch the reason to keep them apart
     // stands — one counts descriptor correspondences, the other counts the PnP's.
     cv::Matx33d R; cv::Vec3d t; double fx, fy, cx, cy; int inliers; int pnpMatches; long seq;
+    float spread = kPromotionNotMeasured; bool trusted = false;
     std::vector<cv::Point3f> wall;
     {
         std::lock_guard<std::mutex> lock(mMutex);
@@ -1190,9 +1205,15 @@ void MobileGS::tryUpdateFingerprint(const cv::Mat& grayClean,
         fx = mFingerprintIntrinsics[0]; fy = mFingerprintIntrinsics[1];
         cx = mFingerprintIntrinsics[2]; cy = mFingerprintIntrinsics[3];
         wall = mWallKeypoints3D;
-        if (growTrusted(inliers, pnpMatches)) mLastGrowSeq = seq; // claim it (yield or not)
+        // 3.2 — read ONCE and reuse, rather than evaluating the same predicate on both sides of the
+        // lock as this did before. With a third input that moves per attempt, the reloc thread can
+        // rewrite it between the two calls, which opens a window where the seq is claimed and the
+        // promotion then refused — or, worse, the reverse.
+        spread = mLastRelocInlierSpread.load(std::memory_order_relaxed);
+        trusted = growTrusted(inliers, pnpMatches, spread);
+        if (trusted) mLastGrowSeq = seq;          // claim it (yield or not)
     }
-    if (!growTrusted(inliers, pnpMatches) || fx <= 0 || fy <= 0 ||
+    if (!trusted || fx <= 0 || fy <= 0 ||
         wall.size() < 12 || wall.size() >= kMaxWallMarks) return;
 
     // Wall plane (n·X = pdist, pdist>0) in the fingerprint frame, fit to the existing marks.
@@ -1233,6 +1254,7 @@ void MobileGS::tryUpdateFingerprint(const cv::Mat& grayClean,
     if (newPts.empty()) return;
 
     size_t promoted = 0, wallNow = 0;
+    int outsideN = 0, insideN = 0, bandN = 0;
     {
         std::lock_guard<std::mutex> lock(mMutex);
         if (mWallDescriptors.type() != newDescs.type() || mWallDescriptors.cols != newDescs.cols ||
@@ -1242,24 +1264,49 @@ void MobileGS::tryUpdateFingerprint(const cv::Mat& grayClean,
         // ceiling + batch.
         const size_t room = kMaxWallMarks - mWallKeypoints3D.size();
         const size_t take = std::min(room, newPts.size());
+        // IMPLEMENTATION.md 3.4 — classify each promotion candidate with Φ, HERE, at promotion time.
+        //
+        // Until this landed every promoted mark was tagged BAND: correct as a refusal (an
+        // unclassified feature must never join the backbone) but it meant self-grow could not
+        // enlarge F_out at all, which is most of what self-grow is for. The placement Phase 4
+        // pushed for the corroboration search is the same matrix Φ needs, so the classification is
+        // now available at exactly the moment a point is being written into the authoritative map.
+        //
+        // No placement means no answer, and no answer still means BAND. That is not a fallback to
+        // the old behaviour by accident — it is the same refusal, for the same reason.
+        const bool canClassify = mHasDesignPlacement && mDesignHalfW > 0.0f && mDesignHalfH > 0.0f;
+        int promotedOutside = 0, promotedInside = 0, promotedBand = 0;
         for (size_t i = 0; i < take; ++i) {
             mWallKeypoints3D.push_back(newPts[i]);
             mWallDescriptors.push_back(newDescs.row((int)i));
             // Keep the partition 1:1 with the points it indexes, or the reloc filter silently
             // switches itself off (its length check fails) and the whole map goes back to being
-            // undifferentiated. Promoted marks are tagged BAND — trusted by NEITHER set — because
-            // nothing here has run Φ on them: admitting an unclassified feature to the backbone is
-            // precisely the corruption the band exists to prevent. IMPLEMENTATION.md 3.4 is the item
-            // that classifies promotion candidates properly; until then self-grow (default OFF)
-            // cannot enlarge F_out.
-            if (!mWallRegions.empty()) mWallRegions.push_back(kRegionBand);
+            // undifferentiated.
+            if (!mWallRegions.empty()) {
+                const uint8_t region = canClassify
+                    ? classifyInFingerprintFrame(mDesignFpFromDesign, mDesignHalfW, mDesignHalfH,
+                                                 newPts[i])
+                    : kRegionBand;
+                // 3.5 — an INSIDE promotion is wet paint: it sits under the artwork and is going to
+                // change again as the artist works over it. Tagged INSIDE, which puts it in F_in,
+                // where the reloc filter already refuses to see it and corroboration can. Whether
+                // those should additionally EXPIRE is 3.5's open half, and IMPLEMENTATION.md is
+                // explicit that it be decided from E5's result rather than in advance — so nothing
+                // here invents a lifetime.
+                if (region == kRegionOutside) ++promotedOutside;
+                else if (region == kRegionInside) ++promotedInside;
+                else ++promotedBand;
+                mWallRegions.push_back(region);
+            }
         }
         // Snapshot inside the lock: these feed a log line below, and reading the containers after
         // the guard released races a concurrent restoreWallFingerprintMetric on the JNI thread.
         promoted = take;
         wallNow = mWallKeypoints3D.size();
+        outsideN = promotedOutside; insideN = promotedInside; bandN = promotedBand;
     }
-    LOGI("Teleological self-grow: promoted %zu marks (wall now %zu)", promoted, wallNow);
+    LOGI("Teleological self-grow: promoted %zu marks (wall now %zu; F_out +%d, F_in +%d, band +%d)",
+         promoted, wallNow, outsideN, insideN, bandN);
 }
 void MobileGS::setArCoreTrackingState(bool t) { mIsArCoreTracking.store(t, std::memory_order_relaxed); }
 

--- a/core/nativebridge/src/main/cpp/include/MobileGS.h
+++ b/core/nativebridge/src/main/cpp/include/MobileGS.h
@@ -5,6 +5,8 @@
 #include "SuperPointDetector.h"
 #include "DistortionHead.h"
 #include "LowLightEnhancer.h"
+#include <cmath>
+#include <limits>
 #include <mutex>
 #include <vector>
 #include <unordered_map>
@@ -105,10 +107,113 @@ public:
      * at a lower absolute count, while a weak ratio still cannot qualify at any count. RANSAC in the
      * reloc PnP remains the geometric backstop for anything this lets through.
      */
-    static bool growTrusted(int inliers, int matches) {
-        if (inliers >= 20) return true;                  // unchanged: a big lock always qualifies
-        if (inliers < 10 || matches <= 0) return false;  // absolute floor — PnP noise below this
-        return (float)inliers / (float)matches >= 0.6f;  // above PoseFusion's 0.5 trust bar
+    static bool growTrusted(int inliers, int matches, float inlierSpread = kPromotionNotMeasured) {
+        // IMPLEMENTATION.md 3.2 — the SPREAD gate, and it comes first because it is the one that
+        // catches the state the match test actively endorses. Twenty inliers clustered in one
+        // textured corner produce a confident-looking pose whose rotation is barely constrained: the
+        // correspondences pin the camera along the viewing ray but let the wall rotate about the
+        // cluster at almost no reprojection cost. Everything in a cluster agrees with everything
+        // else, so the inlier RATIO is high in exactly that state.
+        //
+        // Not-measured FAILS here, which is the opposite of SearchRadius's convention, and the
+        // asymmetry is deliberate: there a missing reading must not narrow a search; here a missing
+        // reading must not authorise a permanent map mutation. Both fail toward the recoverable
+        // outcome, which happens to lie in opposite directions.
+        if (!(inlierSpread >= 0.0f) || !std::isfinite(inlierSpread)) return false;
+        if (inlierSpread < kMinInlierSpread) return false;
+        if (inliers >= kBigLockInliers) return true;     // unchanged: a big lock always qualifies
+        if (inliers < kMinInliers || matches <= 0) return false;  // floor — PnP noise below this
+        return (float)inliers / (float)matches >= kMinInlierRatio;  // above PoseFusion's 0.5 bar
+    }
+
+    /**
+     * IMPLEMENTATION.md 3.2 — the inliers' bounding box as a fraction of frame area.
+     *
+     * Bounding box, not convex hull or covariance: the failure being caught is "all the inliers are
+     * in one corner", and a box catches that at a fraction of the cost. It over-reports for two
+     * distant clusters — which is correct rather than a false pass, since two clusters DO condition
+     * the rotation well. The case it must not miss is the single compact cluster, and a box cannot.
+     *
+     * Returns kPromotionNotMeasured, NOT 0, when it cannot compute an answer. Zero is a real reading
+     * meaning every inlier landed on one pixel — the worst-conditioned state this exists to reject —
+     * so absence and worst-case must not share a value.
+     */
+    static float inlierSpreadOf(const std::vector<cv::Point2f>& pts, float frameW, float frameH) {
+        if (pts.empty() || !(frameW > 0.0f) || !(frameH > 0.0f) ||
+            !std::isfinite(frameW) || !std::isfinite(frameH)) {
+            return kPromotionNotMeasured;
+        }
+        float minX = std::numeric_limits<float>::max(), minY = std::numeric_limits<float>::max();
+        float maxX = -std::numeric_limits<float>::max(), maxY = -std::numeric_limits<float>::max();
+        int seen = 0;
+        for (const auto& p : pts) {
+            // A non-finite point would blow the box out to the whole frame and turn the gate into a
+            // rubber stamp on exactly the degenerate input it exists to catch.
+            if (!std::isfinite(p.x) || !std::isfinite(p.y)) continue;
+            if (p.x < minX) minX = p.x;
+            if (p.x > maxX) maxX = p.x;
+            if (p.y < minY) minY = p.y;
+            if (p.y > maxY) maxY = p.y;
+            ++seen;
+        }
+        if (seen == 0) return kPromotionNotMeasured;
+        // Clamped: an inlier can sit fractionally outside the frame after undistortion, and a box
+        // larger than the frame would report a spread above 1, which the threshold's units exclude.
+        const float w = std::min(1.0f, std::max(0.0f, (maxX - minX) / frameW));
+        const float h = std::min(1.0f, std::max(0.0f, (maxY - minY) / frameH));
+        return w * h;
+    }
+
+    /**
+     * PARAMETERS.md section 7. Mirrors `PromotionGate`'s constants; `CorroborationTranslitTest` pins
+     * the two sides together, because a value edited here and not there is a silent divergence
+     * between the tested reference and the code that actually mutates the map.
+     */
+    static constexpr int   kBigLockInliers = 20;
+    static constexpr int   kMinInliers = 10;
+    static constexpr float kMinInlierRatio = 0.6f;
+    static constexpr float kMinInlierSpread = 0.04f;
+    /** Negative, never 0 — a spread of 0 is a real and maximally bad reading. */
+    static constexpr float kPromotionNotMeasured = -1.0f;
+
+    /**
+     * IMPLEMENTATION.md 3.4 — Φ, transliterated from `Footprint.of` + `Footprint.classify`.
+     *
+     * Classifies a point already expressed in the FINGERPRINT frame against the design's placement.
+     * Returns kRegionOutside / kRegionBand / kRegionInside, matching the wire ordinals exactly.
+     *
+     * @param fpFromDesign the design's RIGID model matrix in the fingerprint frame, column-major —
+     *   `mDesignFpFromDesign`. Rigid, so the inverse is a transpose plus a rotated translation; the
+     *   overlay's scale lives in the half-extents instead, which is `Footprint`'s "scale trap" and
+     *   the reason there is no similarity-inverse branch here.
+     *
+     * Margins default to `FingerprintPartition.DEFAULT_INNER_MARGIN` / `DEFAULT_OUTER_MARGIN`. Note
+     * those are the values that SHIPPED, which are not the ones PARAMETERS.md pre-registered (0.05 /
+     * 0.15) — the discrepancy is recorded in §4 there, and copying the shipped values here keeps
+     * promotion classifying against the same footprint the capture partition used. Two Φs that
+     * disagree about the edge would be worse than either margin being wrong.
+     */
+    static uint8_t classifyInFingerprintFrame(const float* fpFromDesign, float halfW, float halfH,
+                                              const cv::Point3f& p,
+                                              float innerMargin = 0.04f,
+                                              float outerMargin = 0.10f) {
+        if (!(halfW > 1e-6f) || !(halfH > 1e-6f)) return kRegionBand;  // degenerate: trust neither set
+        // Rigid inverse: R^T, then -R^T t. Written out rather than built as a matrix because only
+        // the X and Y rows are needed — Z is the plane normal and Φ discards it by construction.
+        const float* m = fpFromDesign;
+        const float tx = m[12], ty = m[13], tz = m[14];
+        // Row 0 of R^T is column 0 of R = (m[0], m[1], m[2]); likewise row 1.
+        const float ix = -(m[0] * tx + m[1] * ty + m[2] * tz);
+        const float iy = -(m[4] * tx + m[5] * ty + m[6] * tz);
+        const float lx = m[0] * p.x + m[1] * p.y + m[2] * p.z + ix;
+        const float ly = m[4] * p.x + m[5] * p.y + m[6] * p.z + iy;
+        const float u = lx / halfW;
+        const float v = ly / halfH;
+        if (!std::isfinite(u) || !std::isfinite(v)) return kRegionBand;
+        const float d = std::max(std::fabs(u), std::fabs(v));
+        if (d <= 1.0f - innerMargin) return kRegionInside;
+        if (d >= 1.0f + outerMargin) return kRegionOutside;
+        return kRegionBand;
     }
 
     /** Hard ceiling on stored wall marks — a memory guard on the self-grow append. */
@@ -216,6 +321,16 @@ public:
      * reading E6 can act on instead of an unknown.
      */
     int corrobLoneSkips() const { return mCorrobLoneSkips.load(std::memory_order_relaxed); }
+    /**
+     * IMPLEMENTATION.md 3.3 — how much of the frame the last lock's inliers spanned, as a fraction
+     * of frame area, or -1 when not measured.
+     *
+     * Published because the promotion it gates is irreversible and otherwise invisible: a refusal
+     * here looks identical to self-grow simply not having fired, and E5 has to tell those apart to
+     * say whether the term is too strict.
+     */
+    float lastRelocInlierSpread() const { return mLastRelocInlierSpread.load(std::memory_order_relaxed); }
+
     /** Search radius the last gated attempt used, in pixels, or -1 when no gated attempt has run. */
     float corrobSearchRadiusPx() const { return mCorrobSearchRadiusPx.load(std::memory_order_relaxed); }
     /**
@@ -650,5 +765,10 @@ private:
     // Mean reprojection error over the last lock's PnP inliers, in pixels. -1 = not measured, and it
     // stays -1 on every path that does not reach a refined inlier set.
     std::atomic<float>      mLastRelocReprojPx{-1.0f};
+    // IMPLEMENTATION.md 3.2 — the last attempt's inlier bounding box as a fraction of frame area,
+    // or -1 for "not measured". Published from runRelocPass, which is the only scope holding the
+    // inlier POINTS; the self-grow gate sees counts through atomics and would otherwise be blind to
+    // the geometry that actually conditions the pose.
+    std::atomic<float>      mLastRelocInlierSpread{kPromotionNotMeasured};
     cv::Mat                 mRelocColorFrame;
 };

--- a/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
+++ b/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
@@ -284,7 +284,14 @@ class SlamManager @Inject constructor(
     fun getCorroborationDiagnostics(): CorroborationDiagnostics {
         val v = nativeGetCorroborationDiagnostics()
         if (v == null || v.size < 2) return CorroborationDiagnostics()
-        return CorroborationDiagnostics(searchRadiusPx = v[0], relocReprojPx = v[1])
+        return CorroborationDiagnostics(
+            searchRadiusPx = v[0],
+            relocReprojPx = v[1],
+            // Width guard stays at `< 2`, not `< 3`: a Phase-4-era .so provides the first two, and
+            // refusing the record whole for missing the third would discard two good diagnostics to
+            // avoid one absent one. Same reasoning as getRelocDiagnostics'.
+            inlierSpread = if (v.size > 2) v[2] else -1f,
+        )
     }
 
     /**

--- a/docs/research/IMPLEMENTATION.md
+++ b/docs/research/IMPLEMENTATION.md
@@ -1223,20 +1223,79 @@ order.** Work top to bottom.
 
 ### Phase 3 — geometric promotion
 
-- [ ] **3.1** Port `growTrusted` into Kotlin as `PromotionGate.kt` with tests;
+- [x] **3.1** Port `growTrusted` into Kotlin as `PromotionGate.kt` with tests;
       keep the C++ a literal transliteration. **[T]**
-- [ ] **3.2** Add the inlier-spread term (bounding box of inlier image points over
+      *(The match half is behaviour-preserving — same three branches, same values,
+      now named constants. Split into `matchTrusted` and `spreadOk` so 3.2's term
+      could be added without touching it, and so a test can show the two gates are
+      independent rather than asserting it.)*
+- [x] **3.2** Add the inlier-spread term (bounding box of inlier image points over
       frame area) to `PromotionGate` and its transliteration. **[T][N]**
-- [ ] **3.3** Publish `inlierSpread` through the Phase 6 channels. **[N]**
-- [ ] **3.4** Classify each promotion candidate via Φ at promotion time; only
+      *(The failure it catches is one the match test ENDORSES, which is why the
+      spread gate runs FIRST and why that ordering is pinned by source-text
+      assertion: everything inside a cluster agrees with everything else, so a
+      20-inlier corner cluster has a ratio of 1.0 and would return true from the
+      big-lock branch before ever reaching the geometry.*
+      *`inlierSpreadOf` is published from `runRelocPass`, which is the only scope
+      holding the inlier POINTS — the self-grow gate sees counts through atomics and
+      would otherwise be structurally blind to the geometry that conditions the pose.
+      Reset per attempt with the other diagnostics, because a stale value would let a
+      previous frame's well-spread lock authorise a promotion from this frame's
+      clustered one, which is the permanent-mutation version of the staleness bug
+      4.6 already had to fix.*
+      *`growTrusted` was being called TWICE against the same atomics, on both sides
+      of the lock. With a third input that moves per attempt that becomes a window
+      where the seq is claimed and the promotion then refused, or the reverse; it now
+      evaluates once and reuses the result.*
+      *Not-measured FAILS, the opposite of `SearchRadius`'s convention. Both are
+      "fail toward the recoverable outcome" — there a missing reading must not narrow
+      a search, here it must not authorise a permanent mutation. Mutation-verified
+      both ways: harmonising the sentinel fails 1 test, moving the spread gate after
+      the big-lock override fails another.*
+      *The bounding box over-reports for two distant clusters. Accepted, not fixed:
+      two clusters genuinely do condition the rotation well. The case it must never
+      miss is the single compact cluster, and a box cannot.)*
+- [x] **3.3** Publish `inlierSpread` through the Phase 6 channels. **[N]**
+      *(Rides the float channel beside `searchRadiusPx` and `relocReprojPx`, widening
+      it to 3; the Kotlin width guard stays at `< 2` so a Phase-4-era `.so` keeps its
+      two good readings rather than being refused whole. Reaches the eval CSV and the
+      overlay, which shows it amber below the promotion threshold — not an error, a
+      clustered lock still relocalizes fine, it just must not rewrite the map.*
+      *Published because the gate's refusals are otherwise INVISIBLE: self-grow
+      declining because the inliers were clustered looks exactly like self-grow never
+      firing, and E5 has to separate those to say whether the term is too strict.)*
+- [x] **3.4** Classify each promotion candidate via Φ at promotion time; only
       `OUTSIDE` enters the reloc set. **[N]**
-- [ ] **3.5** Route `INSIDE` promotions into `F_in` with a bounded lifetime, or
+      *(Φ transliterated as `classifyInFingerprintFrame`, using the design placement
+      Phase 4 already pushes for the corroboration search — the same matrix, so the
+      two cannot disagree about where the design is. Written out as two dot products
+      rather than a matrix inverse because only the X and Y rows are needed; Z is the
+      plane normal and Φ discards it by construction.*
+      *Before this, every promoted mark was tagged BAND. That was a correct refusal
+      but meant self-grow could never enlarge `F_out` — most of what self-grow is
+      for. **No placement still means BAND**, and that is the same refusal rather
+      than an accidental fallback: "we could not ask" is not evidence of "outside".*
+      *Margins copied from `FingerprintPartition`'s shipped 0.04/0.10, NOT the
+      pre-registered 0.05/0.15 — §4 of PARAMETERS records that discrepancy. Two Φs
+      disagreeing about the edge would be worse than either margin being wrong.)*
+- [x] **3.5** Route `INSIDE` promotions into `F_in` with a bounded lifetime, or
       drop them — decide from E5's result, not in advance.
-- [ ] **3.6** Keep `setSelfGrowEnabled` defaulted **off**. Flip only after E5
+      *(Routed, NOT expired. An INSIDE promotion is tagged INSIDE, which puts it in
+      `F_in` where the reloc filter already refuses to see it and corroboration can.
+      The bounded-lifetime half is deliberately NOT implemented: the item says decide
+      it from E5's result rather than in advance, and inventing a lifetime here would
+      be exactly the pre-judgement it warns against. Ticked because the routing is
+      the part that had to land for 3.4 to mean anything; the open half is named
+      here rather than hidden behind a tick.)*
+- [x] **3.6** Keep `setSelfGrowEnabled` defaulted **off**. Flip only after E5
       shows a positive replayed-dataset effect. (The native default and the eval
       overlay's toggle both said ON until this was corrected — re-check both
       `MobileGS.h`'s initializer and `MainActivity`'s `selfGrowOn` if you touch
       either, because the comment and the initializer disagreed for months.)
+      *(Verified both: `mSelfGrowEnabled{false}` and `mutableStateOf(false)`. Now
+      pinned by a test rather than by re-checking, which is what the parenthetical
+      was asking for — a comment saying "re-check this" is the artefact of a defect
+      that has no test.)*
 
 ### Cross-cutting
 

--- a/docs/research/PARAMETERS.md
+++ b/docs/research/PARAMETERS.md
@@ -272,6 +272,54 @@ fixtures remains the right fix and is not done.
 
 ---
 
+## 7. Geometric promotion — landed, gated off
+
+From Phase 3. These govern the only mechanism in the engine that **permanently
+mutates** the reloc fingerprint, so a wrong value here is not a transient error —
+it is written into the map and compounds. The whole phase ships behind
+`setSelfGrowEnabled`, default **off**, until E5 shows a positive effect on a
+replayed dataset.
+
+Each number exists twice, in `PromotionGate.kt` and in `MobileGS::growTrusted`;
+`CorroborationTranslitTest` pins the two together by reading the header as text.
+
+| Parameter | Location | Current | Prior | Basis | Set by |
+|---|---|---|---|---|---|
+| `BIG_LOCK_INLIERS` / `kBigLockInliers` | `PromotionGate.kt`, `MobileGS.h` | `20` | `20` | the value that shipped — an absolute count that overrides the ratio | E5 |
+| `MIN_INLIERS` / `kMinInliers` | same | `10` | `10` | the value that shipped — below this the ratio is PnP noise | E5 |
+| `MIN_INLIER_RATIO` / `kMinInlierRatio` | same | `0.6` | `0.6` | the value that shipped — above `PoseFusion`'s 0.5 trust bar | E5 |
+| `MIN_INLIER_SPREAD` / `kMinInlierSpread` | same | `0.04` | *added in 3.2* | guessed — a 20% × 20% box; see below | **E5** |
+
+**Why a spread term exists at all.** `growTrusted` measured the *match* — how many
+correspondences survived RANSAC and what fraction they were — and a pose is fitted
+to the *geometry* of its inliers, not their count. Twenty inliers clustered in one
+textured corner produce a confident-looking pose with a badly conditioned
+rotation: the correspondences pin the camera along the viewing ray but let the
+wall rotate about the cluster at almost no reprojection cost. Everything in a
+cluster agrees with everything else, so the inlier **ratio is high** in exactly
+that state — the match test does not merely miss it, it endorses it.
+
+`MIN_INLIER_SPREAD` at 0.04 is the smallest span that cannot be a single textured
+object — a poster, a window frame, a patch of graffiti — at typical painting
+distance, while still admitting the legitimate close-up where the artist is
+working on one part of a large design. It is a guess, and the number matters less
+than the term existing: without it that failure is invisible to every other gate.
+
+**Not-measured FAILS here**, which is the opposite of §5's convention for
+`SearchRadius`. The asymmetry is deliberate and both sides are "fail toward the
+recoverable outcome": there a missing drift reading must not *narrow* a search,
+because a too-tight search reads as "the wall does not corroborate" and looks
+unrecoverable; here a missing spread must not *authorise* a permanent map
+mutation. Recoverable simply lies in opposite directions.
+
+**The bounding box over-reports for two distant clusters**, scoring a full frame
+for two tight groups at opposite corners. That is accepted rather than fixed: two
+clusters genuinely *do* condition the rotation well, which is what the term is
+asking about. The case it must never miss is the single compact cluster, and a box
+cannot miss that.
+
+---
+
 ## 6. Rendering and interaction — set, not swept
 
 Three of these gate the Phase-2 repartition, which costs a classify pass, a

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/PromotionGate.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/PromotionGate.kt
@@ -1,0 +1,149 @@
+package com.hereliesaz.graffitixr.feature.ar.anchor
+
+/**
+ * `IMPLEMENTATION.md` **Phase 3** — whether a relock is trusted enough to promote new marks into the
+ * authoritative reloc fingerprint.
+ *
+ * This is the pure-Kotlin **reference**. `MobileGS::growTrusted` transliterates it, and
+ * `PromotionGateTest` pins the decisions the transliteration has to reproduce. The arrangement
+ * exists because this predicate guards the one mechanism in the engine that **permanently mutates**
+ * the map: a bad promotion is not a transient error, it is written into the fingerprint and
+ * compounds. Phase 3's risk section calls it the only phase that can make the system worse forever
+ * rather than for a frame, which is why the predicate is tested somewhere it can actually be tested
+ * and the C++ is held to it by source-text assertion.
+ *
+ * ## Two questions, not one
+ *
+ * `growTrusted` as it shipped asks only about the **match**: how many correspondences survived
+ * RANSAC, and what fraction of the total they were. That is necessary and it is not sufficient,
+ * because a pose is fitted to the *geometry* of its inliers, not their count.
+ *
+ * Twenty inliers clustered in one textured corner of the frame produce a confident-looking pose with
+ * a badly conditioned rotation: the correspondences pin the camera's position along the viewing ray
+ * but barely constrain its orientation, so the solve is free to rotate the wall about that cluster
+ * at almost no reprojection cost. The inlier ratio is *high* in that state — everything in the
+ * cluster agrees — so the match test not only fails to catch it, it actively endorses it.
+ *
+ * So [trusted] asks a second question: do the inliers **span** the frame. Cheap — a bounding box
+ * over the inlier image points, as a fraction of frame area — and it kills exactly the failure the
+ * first test cannot see.
+ */
+object PromotionGate {
+
+    /**
+     * @param inliers RANSAC inliers from the reloc PnP.
+     * @param matches correspondences the solve was given.
+     * @param inlierSpread the inliers' bounding box as a fraction of frame area, in `[0, 1]`, or
+     *   **negative when not measured** — the project-wide sentinel. Not-measured is treated as
+     *   *failing* the spread test, which is the opposite of how `SearchRadius` treats an unmeasured
+     *   drift reading, and the asymmetry is deliberate: there a missing measurement must not narrow
+     *   a search, here a missing measurement must not authorise a permanent map mutation. Both
+     *   choices are "fail toward the recoverable outcome"; the recoverable outcome is just in the
+     *   opposite direction.
+     */
+    fun trusted(
+        inliers: Int,
+        matches: Int,
+        inlierSpread: Float = NOT_MEASURED,
+        minSpread: Float = MIN_INLIER_SPREAD,
+    ): Boolean {
+        if (!spreadOk(inlierSpread, minSpread)) return false
+        return matchTrusted(inliers, matches)
+    }
+
+    /**
+     * The match half, unchanged from what shipped — deliberately kept as its own function so the
+     * spread term can be added without altering it, and so a test can show the two are independent.
+     *
+     * The bootstrap reasoning behind the ratio branch is worth keeping visible: this used to be a
+     * flat `inliers >= 20`, which could not bootstrap. Self-grow is the mechanism that keeps
+     * relocalization alive as the original marks get painted over, so a wall whose marks are already
+     * half-covered — precisely when growth is needed — rarely reaches 20 raw inliers. The fingerprint
+     * could only grow when it was already strong.
+     */
+    fun matchTrusted(inliers: Int, matches: Int): Boolean {
+        if (inliers >= BIG_LOCK_INLIERS) return true          // a big lock always qualifies
+        if (inliers < MIN_INLIERS || matches <= 0) return false  // absolute floor — PnP noise below
+        return inliers.toFloat() / matches.toFloat() >= MIN_INLIER_RATIO
+    }
+
+    /**
+     * The spread half. Split out so `MIN_INLIER_SPREAD` can be swept against a fixed match rule.
+     *
+     * A **non-finite** reading fails, and so does a negative one. NaN is what an area computation
+     * over degenerate or absent points produces, and `NaN >= minSpread` is false in Kotlin anyway —
+     * but relying on that would leave the behaviour to a comparison rule rather than to a decision,
+     * and the C++ transliteration has no such guarantee to lean on.
+     */
+    fun spreadOk(inlierSpread: Float, minSpread: Float = MIN_INLIER_SPREAD): Boolean {
+        if (!inlierSpread.isFinite() || inlierSpread < 0f) return false
+        return inlierSpread >= minSpread
+    }
+
+    /**
+     * Inliers' bounding box as a fraction of frame area.
+     *
+     * Bounding box, not convex hull or covariance: the failure being caught is "all the inliers are
+     * in one corner", and a box catches that at a fraction of the cost. It over-reports for an
+     * L-shaped or diagonal distribution — two tight clusters at opposite corners score a full frame —
+     * which is a real limitation and the honest one to accept, because both of those *are* well
+     * conditioned for rotation. The case it must not miss is the compact cluster, and a box cannot
+     * miss that.
+     *
+     * Returns [NOT_MEASURED] rather than 0 when it cannot compute an answer — no points, a degenerate
+     * frame — because 0 is a real reading meaning "every inlier landed on one pixel", which is the
+     * single worst-conditioned state this exists to reject. If absence read as 0 the two would be
+     * indistinguishable, and the one case where the gate must refuse would look identical to the case
+     * where nobody asked.
+     *
+     * @param pointsXY flat `[x0, y0, x1, y1, ...]` inlier image points, in pixels.
+     */
+    fun spreadOf(pointsXY: FloatArray, frameW: Float, frameH: Float): Float {
+        val n = pointsXY.size / 2
+        if (n == 0 || frameW <= 0f || frameH <= 0f || !frameW.isFinite() || !frameH.isFinite()) {
+            return NOT_MEASURED
+        }
+        var minX = Float.MAX_VALUE
+        var minY = Float.MAX_VALUE
+        var maxX = -Float.MAX_VALUE
+        var maxY = -Float.MAX_VALUE
+        var seen = 0
+        for (i in 0 until n) {
+            val x = pointsXY[i * 2]
+            val y = pointsXY[i * 2 + 1]
+            // A non-finite point would blow the box out to the whole frame and turn the gate into a
+            // rubber stamp — the precise inversion of what it is for.
+            if (!x.isFinite() || !y.isFinite()) continue
+            if (x < minX) minX = x
+            if (x > maxX) maxX = x
+            if (y < minY) minY = y
+            if (y > maxY) maxY = y
+            seen++
+        }
+        if (seen == 0) return NOT_MEASURED
+        // Clamped because an inlier can sit fractionally outside the frame after undistortion, and a
+        // box larger than the frame would report a spread above 1 — a number the threshold's units
+        // do not admit.
+        val w = ((maxX - minX) / frameW).coerceIn(0f, 1f)
+        val h = ((maxY - minY) / frameH).coerceIn(0f, 1f)
+        return w * h
+    }
+
+    /**
+     * Pre-registered priors — `PARAMETERS.md` §7. The three match constants are the values that
+     * shipped in `growTrusted`; `MIN_INLIER_SPREAD` is new and is a guess.
+     *
+     * `MIN_INLIER_SPREAD` at 0.04 is a 20% × 20% box. Chosen as the smallest span that cannot be one
+     * textured object — a poster, a window frame, a patch of graffiti — at typical painting distance,
+     * while still admitting the legitimate close-up where the artist is working on one part of a
+     * large design. It is a prior and E5 sets it; the number matters less than the fact that the
+     * term exists, since without it the spread failure is invisible to every other gate.
+     */
+    const val BIG_LOCK_INLIERS = 20
+    const val MIN_INLIERS = 10
+    const val MIN_INLIER_RATIO = 0.6f
+    const val MIN_INLIER_SPREAD = 0.04f
+
+    /** Negative, never 0 — a spread of 0 is a real and maximally bad reading. */
+    const val NOT_MEASURED = -1f
+}

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/DriftCostProbe.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/DriftCostProbe.kt
@@ -139,6 +139,7 @@ class DriftCostProbe(
             corrobLoneSkips = reloc?.corrobLoneSkips ?: EvalSampleLog.NOT_SAMPLED,
             searchRadiusPx = corrob?.searchRadiusPx ?: EvalSampleLog.NOT_SAMPLED_PX,
             relocReprojPx = corrob?.relocReprojPx ?: EvalSampleLog.NOT_SAMPLED_PX,
+            inlierSpread = corrob?.inlierSpread ?: EvalSampleLog.NOT_SAMPLED_PX,
             captureRotationNeededDeg = captureRotationNeededDeg,
             liveRotationNeededDeg = liveRotationNeededDeg,
         )

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/EvalSampleLog.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/EvalSampleLog.kt
@@ -92,6 +92,19 @@ data class EvalSample(
      */
     val corrobLoneSkips: Int = -1,
     /**
+     * `IMPLEMENTATION.md` **3.3** — the last lock's inlier bounding box as a fraction of frame area.
+     * -1f = not sampled.
+     *
+     * E5's column. Self-grow permanently mutates the map, so its gate has to be strict — and a
+     * strict gate that is too strict is indistinguishable from one that never fired, because both
+     * produce the same absence of promotions. This is the only signal that separates them.
+     *
+     * **-1f, never 0f.** A spread of 0 is a real reading: every inlier on one pixel, the
+     * worst-conditioned pose the gate exists to reject. It is the row that matters most, and it must
+     * not be filed as missing data.
+     */
+    val inlierSpread: Float = -1f,
+    /**
      * `rotationNeeded` **at the moment the active target was captured** — 0, 90, 180 or 270, or -1
      * when no target has been captured this session (a project restored from disk reads -1; see
      * below).
@@ -151,6 +164,7 @@ object EvalSampleLog {
         "relocObliquityDeg", "relocRectifiedCorr",
         "relocBackboneFeatures", "relocBackboneMatches", "relocBackboneInliers",
         "corrobPredicted", "corrobMatched", "corrobLoneSkips", "searchRadiusPx", "relocReprojPx",
+        "inlierSpread",
         "captureRotationNeededDeg", "liveRotationNeededDeg",
     )
 
@@ -182,6 +196,7 @@ object EvalSampleLog {
             s.corrobPredicted.toString(), s.corrobMatched.toString(),
             s.corrobLoneSkips.toString(),
             s.searchRadiusPx.toString(), s.relocReprojPx.toString(),
+            s.inlierSpread.toString(),
             s.captureRotationNeededDeg.toString(), s.liveRotationNeededDeg.toString(),
         )
     }

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/CorroborationTranslitTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/CorroborationTranslitTest.kt
@@ -174,6 +174,88 @@ class CorroborationTranslitTest {
         )
     }
 
+    /**
+     * `IMPLEMENTATION.md` **3.1 / 3.2** — the promotion gate exists twice too, and its stakes are
+     * higher than the search radius': it guards the only mechanism that permanently mutates the
+     * reloc fingerprint. A constant edited on one side and not the other silently changes what gets
+     * written into the map forever.
+     */
+    @Test
+    fun `the native promotion gate constants are the Kotlin ones`() {
+        val header = source("core/nativebridge/src/main/cpp/include/MobileGS.h")
+        val native = constants(header)
+        assertEquals("ratio", PromotionGate.MIN_INLIER_RATIO, native.getValue("kMinInlierRatio"), 0f)
+        assertEquals("spread", PromotionGate.MIN_INLIER_SPREAD, native.getValue("kMinInlierSpread"), 0f)
+        assertEquals("sentinel", PromotionGate.NOT_MEASURED, native.getValue("kPromotionNotMeasured"), 0f)
+
+        val ints = Regex("constexpr int\\s+(\\w+)\\s*=\\s*(-?\\d+)").findAll(header.readText())
+            .associate { it.groupValues[1] to it.groupValues[2].toInt() }
+        assertEquals("big lock", PromotionGate.BIG_LOCK_INLIERS, ints["kBigLockInliers"])
+        assertEquals("min inliers", PromotionGate.MIN_INLIERS, ints["kMinInliers"])
+    }
+
+    /**
+     * The two structural choices in the gate that a plausible rewrite would invert, both silently.
+     */
+    @Test
+    fun `the native gate refuses an unmeasured spread and keeps the two halves ordered`() {
+        val src = source("core/nativebridge/src/main/cpp/include/MobileGS.h").readText()
+        // Not-measured must FAIL, which is the opposite of SearchRadius's convention. A
+        // transliteration that "harmonised" the two would authorise permanent map mutations on every
+        // frame where the spread happened not to be computed.
+        assertTrue(
+            "an unmeasured or non-finite spread must refuse",
+            src.contains("if (!(inlierSpread >= 0.0f) || !std::isfinite(inlierSpread)) return false;"),
+        )
+        // The spread test must come BEFORE the big-lock override, or a 20-inlier cluster — the exact
+        // case 3.2 exists for — returns true from the count branch and never reaches the geometry.
+        val spreadAt = src.indexOf("if (inlierSpread < kMinInlierSpread) return false;")
+        val bigLockAt = src.indexOf("if (inliers >= kBigLockInliers) return true;")
+        assertTrue("the spread gate must precede the big-lock override", spreadAt in 0 until bigLockAt)
+    }
+
+    /**
+     * `IMPLEMENTATION.md` **3.4** — Φ at promotion time, and the refusal when it cannot run.
+     *
+     * Without the classification every promoted mark was tagged BAND: a correct refusal, but it
+     * meant self-grow could never enlarge `F_out`, which is most of what self-grow is for. With it,
+     * the fallback when no design placement exists must STILL be BAND — admitting an unclassified
+     * feature to the backbone is the corruption the band exists to prevent, and "we could not ask"
+     * is not evidence of "outside".
+     */
+    @Test
+    fun `promotions are classified at promotion time and refuse to guess without a placement`() {
+        val src = source("core/nativebridge/src/main/cpp/MobileGS.cpp").readText()
+        assertTrue(
+            "the promotion append must run the footprint operator on each candidate",
+            src.contains("classifyInFingerprintFrame(mDesignFpFromDesign, mDesignHalfW, mDesignHalfH,"),
+        )
+        assertTrue(
+            "no placement must fall back to BAND, never to OUTSIDE",
+            src.contains(": kRegionBand;"),
+        )
+    }
+
+    /**
+     * `IMPLEMENTATION.md` **3.6** — self-grow stays OFF, in the native initializer AND in the eval
+     * overlay's toggle. Pinned because these disagreed with the header's own comment for months: the
+     * comment said "stays OFF unless explicitly enabled" while the initializer shipped ON, so every
+     * release build promoted unsupervised with no user-facing switch to stop it.
+     */
+    @Test
+    fun `self-grow is defaulted off on both sides`() {
+        assertTrue(
+            "the native initializer must be false",
+            source("core/nativebridge/src/main/cpp/include/MobileGS.h").readText()
+                .contains("mSelfGrowEnabled{false}"),
+        )
+        assertTrue(
+            "the overlay toggle must start false",
+            source("app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt").readText()
+                .contains("mutableStateOf(false) }"),
+        )
+    }
+
     /** `NAME = <number>f` pairs from a C++ header, floats only. */
     private fun constants(file: File): Map<String, Float> =
         Regex("""constexpr float (\w+)\s*=\s*(-?[\d.]+)f""")

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/PromotionGateTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/PromotionGateTest.kt
@@ -1,0 +1,188 @@
+package com.hereliesaz.graffitixr.feature.ar.anchor
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * `IMPLEMENTATION.md` **3.1 / 3.2** — the promotion gate, tested where it can be tested.
+ *
+ * This predicate guards the only mechanism in the engine that permanently mutates the reloc
+ * fingerprint. A bad promotion is not a dropped frame; it is written into the map and compounds. So
+ * the tests here are not about coverage — they are the reason the predicate was moved to Kotlin at
+ * all, and `CorroborationTranslitTest`'s sibling assertions hold the C++ to the same decisions.
+ */
+class PromotionGateTest {
+
+    private companion object {
+        /** Comfortably above MIN_INLIER_SPREAD, so the match half is what a case is testing. */
+        const val WIDE = 0.5f
+    }
+
+    // -------------------------------------------------------------------------------------
+    // The match half — 3.1, behaviour-preserving port
+    // -------------------------------------------------------------------------------------
+
+    /**
+     * The bootstrap case, and the reason the flat `inliers >= 20` was replaced. A wall whose marks
+     * are half painted over is exactly when self-grow is needed and exactly when 20 raw inliers is
+     * out of reach; a strong ratio has to qualify at a lower count or the fingerprint can only grow
+     * when it least needs to.
+     */
+    @Test
+    fun `a strong ratio qualifies below the big-lock count`() {
+        assertTrue(PromotionGate.trusted(inliers = 12, matches = 15, inlierSpread = WIDE))
+        assertEquals("12/15 = 0.8, above the ratio bar", 0.8f, 12f / 15f, 1e-6f)
+    }
+
+    @Test
+    fun `a big lock qualifies regardless of ratio`() {
+        // 20/100 is a terrible ratio; the absolute count is the override, as it shipped.
+        assertTrue(PromotionGate.trusted(inliers = 20, matches = 100, inlierSpread = WIDE))
+    }
+
+    @Test
+    fun `below the absolute inlier floor nothing qualifies`() {
+        // 9/9 is a perfect ratio and must still be refused: at that count the ratio is PnP noise.
+        assertTrue("the ratio really is perfect", 9f / 9f >= PromotionGate.MIN_INLIER_RATIO)
+        assertFalse(PromotionGate.trusted(inliers = 9, matches = 9, inlierSpread = WIDE))
+    }
+
+    @Test
+    fun `a weak ratio is refused at any count below the big lock`() {
+        assertFalse(PromotionGate.trusted(inliers = 19, matches = 40, inlierSpread = WIDE))
+        assertTrue("...but the same ratio passes once the count reaches the override",
+            PromotionGate.trusted(inliers = 20, matches = 40, inlierSpread = WIDE))
+    }
+
+    @Test
+    fun `zero or negative matches cannot divide`() {
+        assertFalse(PromotionGate.trusted(inliers = 15, matches = 0, inlierSpread = WIDE))
+        assertFalse(PromotionGate.trusted(inliers = 15, matches = -1, inlierSpread = WIDE))
+    }
+
+    // -------------------------------------------------------------------------------------
+    // The spread half — 3.2
+    // -------------------------------------------------------------------------------------
+
+    /**
+     * The failure 3.2 exists for, stated as a test: a tight cluster with a *perfect* inlier ratio.
+     *
+     * This is the case the match half cannot see — everything in the cluster agrees with everything
+     * else, so the ratio is 1.0 and reads as maximum confidence, while the pose's rotation is barely
+     * constrained. If this test ever passes, the spread term has stopped doing its only job.
+     */
+    @Test
+    fun `a perfect ratio in one corner is refused`() {
+        val corner = FloatArray(60) { i -> if (i % 2 == 0) 40f + (i % 7) else 30f + (i % 5) }
+        val spread = PromotionGate.spreadOf(corner, frameW = 1920f, frameH = 1080f)
+        assertTrue("the fixture must actually be clustered, got $spread",
+            spread < PromotionGate.MIN_INLIER_SPREAD)
+        assertTrue("the match half alone would have said yes",
+            PromotionGate.matchTrusted(inliers = 30, matches = 30))
+        assertFalse(
+            "a clustered inlier set must not authorise a permanent map mutation",
+            PromotionGate.trusted(inliers = 30, matches = 30, inlierSpread = spread),
+        )
+    }
+
+    @Test
+    fun `the same lock spread across the frame is accepted`() {
+        val spanning = floatArrayOf(
+            100f, 100f, 1800f, 120f, 150f, 950f, 1750f, 980f, 900f, 500f,
+        )
+        val spread = PromotionGate.spreadOf(spanning, frameW = 1920f, frameH = 1080f)
+        assertTrue("the fixture must actually span, got $spread", spread > 0.5f)
+        assertTrue(PromotionGate.trusted(inliers = 30, matches = 30, inlierSpread = spread))
+    }
+
+    /**
+     * Not-measured must **fail** here, which is the opposite of `SearchRadius`'s convention, and the
+     * asymmetry is the point. There an unmeasured drift reading must not narrow a search, because a
+     * too-tight search reads as "the wall does not corroborate" and is unrecoverable-looking. Here an
+     * unmeasured spread must not authorise a permanent mutation. Both are "fail toward the
+     * recoverable outcome"; recoverable happens to lie in opposite directions.
+     */
+    @Test
+    fun `an unmeasured spread refuses, unlike an unmeasured drift reading`() {
+        assertFalse(PromotionGate.trusted(inliers = 30, matches = 30,
+            inlierSpread = PromotionGate.NOT_MEASURED))
+        assertFalse(PromotionGate.trusted(inliers = 30, matches = 30, inlierSpread = Float.NaN))
+        // ...and the sentinel is negative for the usual reason: 0 is a real, and maximally bad, value.
+        assertEquals(-1f, PromotionGate.NOT_MEASURED, 0f)
+        assertFalse("every inlier on one pixel is the worst case, not the absent case",
+            PromotionGate.spreadOk(0f))
+    }
+
+    /** The two halves must be independent, or a sweep of one silently moves the other. */
+    @Test
+    fun `spread and match are independent gates`() {
+        // Good spread, bad match.
+        assertFalse(PromotionGate.trusted(inliers = 5, matches = 5, inlierSpread = WIDE))
+        // Good match, bad spread.
+        assertFalse(PromotionGate.trusted(inliers = 30, matches = 30, inlierSpread = 0.001f))
+        // Both good.
+        assertTrue(PromotionGate.trusted(inliers = 30, matches = 30, inlierSpread = WIDE))
+    }
+
+    // -------------------------------------------------------------------------------------
+    // spreadOf
+    // -------------------------------------------------------------------------------------
+
+    @Test
+    fun `spread is the bounding box as a fraction of frame area`() {
+        // A box spanning exactly half the width and half the height is a quarter of the area.
+        val pts = floatArrayOf(0f, 0f, 960f, 540f)
+        assertEquals(0.25f, PromotionGate.spreadOf(pts, 1920f, 1080f), 1e-5f)
+    }
+
+    /**
+     * Two tight clusters at opposite corners score a full frame. That is a real over-report and it is
+     * accepted rather than fixed: both clusters together *do* condition the rotation well, which is
+     * what the term is actually asking about. The case that must never be missed is the single
+     * compact cluster, and a bounding box cannot miss that.
+     */
+    @Test
+    fun `two distant clusters score high, which is correct rather than a false pass`() {
+        val pts = floatArrayOf(10f, 10f, 12f, 14f, 1900f, 1060f, 1898f, 1058f)
+        assertTrue(PromotionGate.spreadOf(pts, 1920f, 1080f) > 0.9f)
+    }
+
+    @Test
+    fun `no points and a degenerate frame report not-measured, not zero`() {
+        assertEquals(-1f, PromotionGate.spreadOf(FloatArray(0), 1920f, 1080f), 0f)
+        assertEquals(-1f, PromotionGate.spreadOf(floatArrayOf(1f, 1f), 0f, 1080f), 0f)
+        assertEquals(-1f, PromotionGate.spreadOf(floatArrayOf(1f, 1f), 1920f, Float.NaN), 0f)
+    }
+
+    /**
+     * A single NaN point must not blow the box out to the whole frame. That would turn the gate into
+     * a rubber stamp on exactly the degenerate input it exists to catch — the precise inversion of
+     * its purpose, and silent.
+     */
+    @Test
+    fun `a non-finite point does not inflate the box`() {
+        val pts = floatArrayOf(100f, 100f, Float.NaN, 50f, 140f, 130f)
+        val spread = PromotionGate.spreadOf(pts, 1920f, 1080f)
+        assertTrue("got $spread", spread.isFinite() && spread < 0.01f)
+        // All points non-finite is absence, not a zero-area box.
+        assertEquals(-1f,
+            PromotionGate.spreadOf(floatArrayOf(Float.NaN, Float.NaN), 1920f, 1080f), 0f)
+    }
+
+    @Test
+    fun `spread is clamped so an out-of-frame inlier cannot exceed one`() {
+        val pts = floatArrayOf(-500f, -500f, 3000f, 2000f)
+        assertEquals(1f, PromotionGate.spreadOf(pts, 1920f, 1080f), 1e-6f)
+    }
+
+    @Test
+    fun `the pre-registered priors are the ones PARAMETERS documents`() {
+        // Literal, so a silent edit to a value E5 is waiting on shows up as a test change.
+        assertEquals(20, PromotionGate.BIG_LOCK_INLIERS)
+        assertEquals(10, PromotionGate.MIN_INLIERS)
+        assertEquals(0.6f, PromotionGate.MIN_INLIER_RATIO, 0f)
+        assertEquals(0.04f, PromotionGate.MIN_INLIER_SPREAD, 0f)
+    }
+}

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/eval/EvalSampleLogTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/eval/EvalSampleLogTest.kt
@@ -47,6 +47,7 @@ class EvalSampleLogTest {
                 "relocObliquityDeg,relocRectifiedCorr," +
                 "relocBackboneFeatures,relocBackboneMatches,relocBackboneInliers," +
                 "corrobPredicted,corrobMatched,corrobLoneSkips,searchRadiusPx,relocReprojPx," +
+                "inlierSpread," +
                 "captureRotationNeededDeg,liveRotationNeededDeg",
             EvalSampleLog.CSV_HEADER,
         )
@@ -66,7 +67,7 @@ class EvalSampleLogTest {
             // columns. The float spelling is part of the contract a consumer parses, not an
             // incidental formatting detail, so it is written out here literally.
             "12,dual,true,1.5,0.25,3.0,1.0,2.0,0.0,4.0,1.0,8.0,30.0,-450.0,31.0,20480," +
-                "-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1.0,-1.0,-1,-1",
+                "-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1.0,-1.0,-1.0,-1,-1",
             EvalSampleLog.toCsvRow(row),
         )
     }

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Sat Aug 01 22:59:13 UTC 2026
-versionBuild=14490
+#Sat Aug 01 23:20:47 UTC 2026
+versionBuild=14496
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=356
+versionPatch=362

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Sat Aug 01 23:20:47 UTC 2026
-versionBuild=14496
+#Sat Aug 01 23:27:17 UTC 2026
+versionBuild=14497
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=362
+versionPatch=363


### PR DESCRIPTION
`IMPLEMENTATION.md` **Phase 3** (3.1–3.6), the last phase in the plan.

This guards the only mechanism in the engine that **permanently mutates** the reloc fingerprint. A bad promotion is not a dropped frame — it is written into the map and compounds. The whole phase ships behind `setSelfGrowEnabled`, default **off**, until E5 shows a positive effect on a replayed dataset.

## The failure the old gate endorsed

`growTrusted` asked only about the **match**: how many correspondences survived RANSAC, and what fraction they were. A pose is fitted to the *geometry* of its inliers, not their count.

Twenty inliers clustered in one textured corner produce a confident-looking pose with a badly conditioned rotation — the correspondences pin the camera along the viewing ray but let the wall rotate about the cluster at almost no reprojection cost. **Everything inside a cluster agrees with everything else, so the inlier ratio is 1.0 in exactly that state.** The match test doesn't merely miss this; it endorses it.

That is why the spread gate runs **first**, and why the ordering is pinned by assertion: placed after the big-lock override, a 20-inlier cluster returns `true` from the count branch and never reaches the geometry.

## Where the spread comes from

`inlierSpreadOf` is published from `runRelocPass`, the only scope holding the inlier *points* — the self-grow gate sees counts through atomics and would otherwise be structurally blind to the geometry that conditions the pose. Reset per attempt with the other diagnostics: a stale value would let a previous frame's well-spread lock authorise a promotion from *this* frame's clustered one, the permanent-mutation version of the staleness bug 4.6 already had to fix.

**Also fixed while here:** `growTrusted` was called **twice** against the same atomics, on both sides of the lock. Harmless with two stable inputs; with a third that moves per attempt it is a window where the seq is claimed and the promotion then refused — or the reverse.

## Not-measured fails here, and that is deliberate

The opposite of `SearchRadius`'s convention. Both are "fail toward the recoverable outcome" — there a missing drift reading must not *narrow* a search, because a too-tight search reads as "the wall does not corroborate" and looks unrecoverable; here a missing spread must not *authorise* a permanent map mutation. Recoverable simply lies in opposite directions.

## Φ at promotion time (3.4)

Classification uses the design placement Phase 4 already pushes for the corroboration search — the same matrix, so the two cannot disagree about where the design is. Written as two dot products rather than a matrix inverse, because only the X and Y rows are needed; Z is the plane normal and Φ discards it by construction.

Before this, **every** promoted mark was tagged `BAND`. A correct refusal, but it meant self-grow could never enlarge `F_out` — most of what self-grow is for. **No placement still means `BAND`**, and that is the same refusal rather than an accidental fallback: "we could not ask" is not evidence of "outside".

Margins copied from `FingerprintPartition`'s **shipped** 0.04/0.10, not the pre-registered 0.05/0.15 — §4 of `PARAMETERS.md` records that discrepancy. Two Φs disagreeing about the edge would be worse than either margin being wrong.

## What 3.5 deliberately does not do

`INSIDE` promotions are **routed** into `F_in` — where the reloc filter already refuses to see them and corroboration can — but **not expired**. The item says decide the lifetime from E5's result rather than in advance, and inventing one here would be exactly the pre-judgement it warns against. The open half is named in the checklist rather than hidden behind the tick.

## Diagnostics (3.3)

`inlierSpread` rides the float channel beside `searchRadiusPx` and `relocReprojPx`, widening it to 3; the Kotlin width guard stays at `< 2` so a Phase-4-era `.so` keeps its two good readings rather than being refused whole. It reaches the eval CSV and the overlay, shown amber below the promotion threshold — not an error, since a clustered lock still relocalizes fine, it just must not rewrite the map.

Published because the gate's refusals are otherwise **invisible**: self-grow declining because the inliers were clustered looks exactly like self-grow never firing, and E5 has to separate those to say whether the term is too strict.

## 3.6

Verified on both sides (`mSelfGrowEnabled{false}`, `mutableStateOf(false)`) and now **pinned by a test** instead of by the checklist asking a future reader to re-check. A comment saying "re-check this" is the artefact of a defect with no test.

## Verification

- NDK build clean for `arm64-v8a` and `armeabi-v7a`.
- `:core:common`, `:core:nativebridge`, `:feature:ar`, `:feature:editor` unit tests green; `:app` compiles.
- **Mutation-verified**: harmonising the not-measured sentinel with `SearchRadius`'s fails a test; moving the spread gate after the big-lock override fails another.
- The bounding box **over-reports** for two distant clusters, scoring a full frame. Accepted rather than fixed — two clusters genuinely do condition the rotation well. The case it must never miss is the single compact cluster, and a box cannot.
- **Not device-tested.** `MIN_INLIER_SPREAD = 0.04` is a guess and E5 sets it. Self-grow remains default-off, so nothing in this PR changes shipped behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Q5WXFiVLeN4sXa9bPCSDA

---
_Generated by [Claude Code](https://claude.ai/code/session_011Q5WXFiVLeN4sXa9bPCSDA)_

## Summary by Sourcery

Introduce a geometry-aware promotion gate for reloc fingerprint updates, add diagnostics and visualisation for inlier spread, and ensure self-grow remains gated off by default while keeping Kotlin and native implementations in sync.

New Features:
- Add PromotionGate Kotlin reference implementation with ratio and inlier-spread based promotion logic and tests.
- Add inlier spread computation and publication from native reloc pipeline through JNI, models, logging, and UI overlay.

Bug Fixes:
- Prevent stale or unmeasured inlier spread values from authorising promotions and fix double evaluation of the promotion gate.
- Ensure promoted marks are region-classified at promotion time and route INSIDE promotions into the appropriate fingerprint partition while preserving BAND as the safe fallback.
- Align self-grow default state to remain off in both native and UI layers, preventing unintended unsupervised promotions.

Enhancements:
- Add geometric classification helper in native code to keep promotion region tagging consistent with capture-time footprint partitioning.
- Tighten coupling between Kotlin and native promotion parameters via tests that read C++ headers to detect divergence.

Tests:
- Add comprehensive unit tests for the PromotionGate behaviour and new transliteration invariants, including ordering and sentinel handling.
- Extend eval logging tests to cover the new inlier spread column and default values.