### PR TITLE
6a.5: stamp eval samples with the recording's clock, not the wall clock

### DIFF
--- a/docs/research/IMPLEMENTATION.md
+++ b/docs/research/IMPLEMENTATION.md
@@ -773,8 +773,43 @@ order.** Work top to bottom.
       which is the truth. §3.2 says a CSV without a truthful sidecar is not evidence.
 
       §3.1's **third** source of non-determinism — `DriftCostProbe` stamping wall-clock
-      `tsMs` instead of the recording's frame timestamp — is NOT covered by 6a.4 and
-      remains open. 6a.4 names only the seed and the sync mode.
+      `tsMs` instead of the recording's frame timestamp — is NOT named by 6a.4, which
+      covers only the seed and the sync mode. It is nevertheless **now closed**; see
+      6a.5 below, added because a gap found while closing an item should not become
+      invisible for want of a number.
+
+- [x] **6a.5** Stamp eval samples with the recording's frame timestamp, not the wall
+      clock — `EVALUATION.md` §3.1's third and last source of replay
+      non-determinism. **[T]**
+      *(Not in the original checklist. §3.1 names three sources and 6a.4 named two, so
+      this one had no number; it is given one here rather than left as a sentence in
+      another item's annotation.*
+      *`ArRenderer` passes ARCore's `Frame.getTimestamp()` into `probe.onTick`. During
+      `startPlayback` ARCore replays the RECORDED value, so two replays of one file
+      produce rows that align frame-for-frame — which is what a parameter A/B needs
+      before it can subtract one run from another. With the seed and the sync mode
+      already landed, this was the last thing keeping two replays of one recording
+      from being comparable row by row.*
+      *The decision — which clock, and what to do without a frame stamp — lives in
+      `EvalClock` rather than inside the probe, because `DriftCostProbe` needs a
+      `Context` and writes files, so nothing in it is reachable from a JVM test. The
+      headline test asserts the PROPERTY (two replays with disagreeing wall clocks
+      produce identical stamps) rather than restating the division.*
+      *Zero takes the wall-clock fallback, not the frame path. ARCore's timestamps are
+      monotonic nanoseconds so 0 is not a reading — but a caller not yet wired up
+      passes Long's default of 0, and treating that as a frame stamp would file every
+      row of a live session at the epoch: internally consistent, entirely wrong,
+      invisible until someone correlated the CSV with something else.
+      Mutation-verified — relaxing the guard to `>= 0` fails that test.*
+      ***Two deliberate scope decisions, stated rather than slipped in.*** *(1) The CSV
+      FILENAME keeps the wall clock: it is `eval_${deviceClass}_${nowMs()}.csv`, and
+      frame time would make two replays of one recording collide on one filename —
+      destroying the second run's data to gain determinism in a field nothing aligns
+      on. (2) `markTrackingLoss` and the relock stamp ALSO move to the frame clock,
+      which §3.1 item 3 does not ask for. `recoveryMs` is `relock - loss`; leaving both
+      ends on the wall clock would leave a number `EVALUATION.md` reports per mechanism
+      measuring scheduling — the same defect the item describes, one field over. A
+      recovery with one end on each clock is not a duration.)*
 
       Verified natively, not inferred: `llvm-nm` on `libgraffitixr.so` shows
       `Java_..._nativeSetEvalRngSeed` exported under exactly the name the Kotlin

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/DriftCostProbe.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/DriftCostProbe.kt
@@ -23,6 +23,17 @@ class DriftCostProbe(
     private var relockMs: Long? = null
     private var logFile: File? = null
 
+    /**
+     * `EVALUATION.md` §3.1 — the most recent frame timestamp in milliseconds, or -1 before the first
+     * tick. Held so the two stamps taken OUTSIDE [onTick] can also read the frame clock.
+     *
+     * `markTrackingLoss` is called from an overlay button, between ticks; there is no frame in its
+     * hand. Using the last one the probe saw is the right reading, because what §3.1 is buying is
+     * that two replays of one recording produce the same numbers — and the last frame before a
+     * button press is the same frame in both replays, whereas the wall clock is not the same time.
+     */
+    @Volatile private var lastFrameMs: Long = -1L
+
     @Volatile var lastMetrics = EvalLiveMetrics()
 
     private val batteryManager by lazy {
@@ -46,14 +57,34 @@ class DriftCostProbe(
         }
         logFile = f
         usableFrames = 0; totalFrames = 0; lossMs = null; relockMs = null
+        // Reset with the rest of the run state, or the first tick of run two would be stamped with
+        // the last frame of run one.
+        lastFrameMs = -1L
         recentTranslations.clear()
         return f
     }
 
     fun stop() { logFile = null }
 
-    /** Marks an induced tracking loss (overlay button) so the next re-lock yields recovery time. */
-    fun markTrackingLoss() { lossMs = nowMs(); relockMs = null }
+    /**
+     * Marks an induced tracking loss (overlay button) so the next re-lock yields recovery time.
+     *
+     * Stamped on the FRAME clock, not the wall clock. §3.1 item 3 names only `tsMs`, and this is a
+     * deliberate widening rather than an oversight: `recoveryMs` is `relock - loss`, so leaving both
+     * ends on the wall clock would leave recovery time measuring scheduling — the same defect the
+     * item describes, one field over, in a number `EVALUATION.md` reports per mechanism.
+     */
+    fun markTrackingLoss() { lossMs = evalClockMs(); relockMs = null }
+
+    /**
+     * The frame clock when one has been seen, the wall clock otherwise. See [EvalClock.stampMs] for
+     * why the fallback exists rather than a refusal.
+     */
+    private fun evalClockMs(): Long =
+        EvalClock.stampMs(
+            if (lastFrameMs >= 0L) lastFrameMs * 1_000_000L else EvalClock.NOT_SAMPLED_NS,
+            nowMs,
+        )
 
     /**
      * @param candidatePose 4x4 column-major pose of the mechanism under test (or the active fused pose)
@@ -74,6 +105,9 @@ class DriftCostProbe(
      *   must be grouped by. See [EvalSample.captureRotationNeededDeg].
      * @param liveRotationNeededDeg `rotationNeeded` for this tick — how the device is held right
      *   now. Secondary; see [EvalSample.liveRotationNeededDeg].
+     * @param frameTimestampNs ARCore's `Frame.getTimestamp()` for this frame, or
+     *   [EvalClock.NOT_SAMPLED_NS]. During playback ARCore replays the RECORDED value, which is what
+     *   makes two replays of one file align row-for-row — see [EvalClock].
      */
     fun onTick(
         candidatePose: FloatArray,
@@ -85,13 +119,20 @@ class DriftCostProbe(
         corrob: com.hereliesaz.graffitixr.common.model.CorroborationDiagnostics? = null,
         captureRotationNeededDeg: Int = EvalSampleLog.NOT_SAMPLED,
         liveRotationNeededDeg: Int = EvalSampleLog.NOT_SAMPLED,
+        frameTimestampNs: Long = EvalClock.NOT_SAMPLED_NS,
     ) {
         val file = logFile ?: return
+        // Recorded BEFORE the early return below would have mattered and before anything reads the
+        // clock, so every stamp in this tick — the row, and a relock detected inside it — comes from
+        // the same frame rather than from this frame and the previous one.
+        val stampMs = EvalClock.stampMs(frameTimestampNs, nowMs)
+        if (frameTimestampNs > 0L) lastFrameMs = stampMs
         totalFrames++
         if (isTracking) usableFrames++
 
-        // Recovery: first re-lock after an induced loss.
-        if (lossMs != null && relockMs == null && isTracking) relockMs = nowMs()
+        // Recovery: first re-lock after an induced loss. On the frame clock, matching
+        // markTrackingLoss — a recovery measured with one end on each clock is not a duration.
+        if (lossMs != null && relockMs == null && isTracking) relockMs = stampMs
 
         // Jitter window (translation column of the candidate pose).
         val t = floatArrayOf(candidatePose[12], candidatePose[13], candidatePose[14])
@@ -102,7 +143,11 @@ class DriftCostProbe(
         val err = if (truthPose != null) EvalMetrics.poseError(candidatePose, truthPose) else null
 
         val sample = EvalSample(
-            tsMs = nowMs(),
+            // EVALUATION.md 3.1 item 3: the RECORDING's frame timestamp, so two replays of one file
+            // produce rows that align frame-for-frame and can be subtracted. Falls back to the wall
+            // clock only when there is no frame stamp — a live session, which is not being aligned
+            // against anything.
+            tsMs = stampMs,
             deviceClass = deviceClass,
             marksVisible = marksVisible,
             errMm = err?.translationMm ?: -1f,

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/EvalClock.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/EvalClock.kt
@@ -1,0 +1,49 @@
+package com.hereliesaz.graffitixr.feature.ar.eval
+
+/**
+ * `EVALUATION.md` §3.1, the **third** source of replay non-determinism — the one the fixed RNG seed
+ * and the synchronous-reloc mode do not touch.
+ *
+ * §3.1 names three, and 6a.4 only closed two. The seed makes RANSAC draw the same samples; sync mode
+ * makes the reloc thread see the same frames. Neither changes the fact that `DriftCostProbe` stamped
+ * every row with `System.currentTimeMillis()`. Replay a recording twice and the two CSVs describe
+ * the same frames at different times, so they cannot be aligned row-for-row — which is what a
+ * parameter A/B needs before it can subtract one from the other. §3.1's wording is exact: *"Use the
+ * frame timestamp from the recording, not the system clock, so runs align frame-for-frame."*
+ *
+ * ARCore's `Frame.getTimestamp()` is that timestamp. During `Session.startPlayback` it replays the
+ * **recorded** values rather than the live clock, so two replays of one file produce identical
+ * stamps — which is the whole property being bought.
+ *
+ * ## Why this is a separate object rather than three lines inside the probe
+ *
+ * `DriftCostProbe` needs a `Context` and writes files, so nothing in it is reachable from a JVM unit
+ * test. The clock *decision* — which source to use, and what to do when the frame stamp is absent —
+ * is the part that can be got wrong, so it lives here where a test can reach it.
+ */
+object EvalClock {
+
+    /**
+     * "No frame timestamp for this tick." Negative, not 0, and not for the usual reason: ARCore's
+     * timestamps are monotonic-clock nanoseconds, so 0 is not a plausible reading — but a *default*
+     * of 0 would silently stamp every row of a live (non-replay) session at the epoch, and the CSV
+     * would look internally consistent while being wrong. A negative sentinel cannot be mistaken for
+     * a reading by anything downstream.
+     */
+    const val NOT_SAMPLED_NS = -1L
+
+    /**
+     * The timestamp to write into a sample row.
+     *
+     * Prefers the frame clock; falls back to the wall clock when there is no frame stamp — a live
+     * session that is not replaying anything, or a caller that has not been wired to pass one.
+     * Falling back rather than refusing is deliberate: an ad-hoc debugging run with wall-clock rows
+     * is still useful, whereas a probe that declined to log would be strictly worse than the
+     * behaviour this replaces. Determinism is what §3.1 wants *for replays*, and a replay always has
+     * a frame stamp.
+     *
+     * @param frameTimestampNs ARCore's `Frame.getTimestamp()`, or [NOT_SAMPLED_NS].
+     */
+    fun stampMs(frameTimestampNs: Long, wallClockMs: () -> Long): Long =
+        if (frameTimestampNs > 0L) frameTimestampNs / 1_000_000L else wallClockMs()
+}

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -1342,6 +1342,13 @@ class ArRenderer(
                         // ones worth a second look.
                         liveRotationNeededDeg =
                             (sensorOrientation - displayRotationHelper.getRotation() * 90 + 360) % 360,
+                        // EVALUATION.md 3.1 item 3 — the RECORDING's clock, not the wall clock.
+                        // ARCore replays the recorded value during startPlayback, so two replays of
+                        // one file produce rows that align frame-for-frame; wall-clock rows describe
+                        // the same frames at different times and cannot be subtracted. This is the
+                        // third of 3.1's three non-determinism sources; the RNG seed and the
+                        // sync-reloc mode closed the other two.
+                        frameTimestampNs = frame.timestamp,
                     )
                 }
 

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/eval/EvalClockTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/eval/EvalClockTest.kt
@@ -1,0 +1,84 @@
+package com.hereliesaz.graffitixr.feature.ar.eval
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * `EVALUATION.md` §3.1 item 3 — the clock a sample row is stamped with.
+ *
+ * The property that matters is not "the arithmetic is right"; it is that **two replays of one
+ * recording produce identical stamps**. That is the whole reason the item exists: §3.1's other two
+ * fixes make RANSAC and the reloc thread deterministic, and rows that still carry wall-clock times
+ * cannot be aligned between runs, so a parameter A/B has nothing to subtract.
+ *
+ * So the headline test replays the same frame stamps through two "runs" whose wall clocks disagree
+ * and asserts the outputs match — which is the claim, stated as a test, rather than a restatement of
+ * the division.
+ */
+class EvalClockTest {
+
+    /**
+     * The property, directly. Two runs, identical recorded frame stamps, wall clocks an hour apart
+     * and ticking at different rates. If the stamps did not come from the frames, these diverge on
+     * the first row.
+     */
+    @Test
+    fun `two replays of one recording produce identical stamps`() {
+        val recordedFrames = longArrayOf(
+            1_000_000_000L, 1_033_366_667L, 1_066_733_334L, 1_100_100_001L, 5_400_000_000L,
+        )
+        var wallA = 1_700_000_000_000L
+        var wallB = 1_700_003_600_000L   // an hour later
+        val runA = recordedFrames.map { EvalClock.stampMs(it) { wallA += 17; wallA } }
+        val runB = recordedFrames.map { EvalClock.stampMs(it) { wallB += 31; wallB } }
+
+        assertEquals("the same recording must stamp the same in both runs", runA, runB)
+        // ...and the run really did have differing wall clocks, or the test proves nothing.
+        assertNotEquals(wallA, wallB)
+    }
+
+    /**
+     * Nanoseconds to milliseconds, truncating. Asserted against hand-computed values rather than by
+     * dividing again, which would be the code restating itself.
+     */
+    @Test
+    fun `a frame stamp is nanoseconds converted to milliseconds`() {
+        assertEquals(1_000L, EvalClock.stampMs(1_000_000_000L) { fail() })
+        assertEquals(1_033L, EvalClock.stampMs(1_033_366_667L) { fail() })
+        // Truncation, not rounding: 1.9995 ms is 1, and that is fine — the stamp only has to be a
+        // consistent function of the frame, not a rounded one.
+        assertEquals(1L, EvalClock.stampMs(1_999_500L) { fail() })
+    }
+
+    /**
+     * The fallback. A live session has no recorded frame to align against, so wall-clock rows are
+     * the honest answer there — and refusing to log would be strictly worse than the behaviour this
+     * replaces.
+     */
+    @Test
+    fun `no frame stamp falls back to the wall clock`() {
+        assertEquals(42L, EvalClock.stampMs(EvalClock.NOT_SAMPLED_NS) { 42L })
+        assertEquals(42L, EvalClock.stampMs(-999L) { 42L })
+    }
+
+    /**
+     * Zero must take the fallback, and this is the case a plainer `>= 0` test would get wrong.
+     *
+     * ARCore's timestamps are monotonic-clock nanoseconds, so 0 is not a reading. But a caller that
+     * has not been wired up yet passes the Long default of 0, and treating that as a frame stamp
+     * would silently file every row of a live session at the epoch — internally consistent, entirely
+     * wrong, and invisible until someone tried to correlate the CSV with anything else.
+     */
+    @Test
+    fun `a zero frame stamp is not a reading`() {
+        assertEquals(7L, EvalClock.stampMs(0L) { 7L })
+        assertTrue("the sentinel must be negative, so 0 cannot be mistaken for it",
+            EvalClock.NOT_SAMPLED_NS < 0L)
+    }
+
+    /** Fails the test if the wall clock is consulted when it should not be. */
+    private fun fail(): Long =
+        throw AssertionError("the wall clock must not be read when a frame stamp is present")
+}

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Sat Aug 01 23:27:17 UTC 2026
-versionBuild=14497
+#Sun Aug 02 04:59:12 UTC 2026
+versionBuild=14500
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=363
+versionPatch=366


### PR DESCRIPTION
`EVALUATION.md` §3.1 names **three** sources of replay non-determinism. The RNG seed closed the first, the synchronous-reloc mode the second. This is the third — and it had no todo number, because 6a.4 named only the other two. I found it while closing 6a.4 and recorded it then; it gets a number here rather than staying a sentence inside another item's annotation.

## The defect

`DriftCostProbe` stamped every row with `System.currentTimeMillis()`. Replay a recording twice and the two CSVs describe **the same frames at different times**, so they cannot be aligned row-for-row — which is exactly what a parameter A/B needs before it can subtract one run from the other.

§3.1's wording is exact: *"Use the frame timestamp from the recording, not the system clock, so runs align frame-for-frame."*

With the seed and the sync mode already landed, this was the last thing standing between two replays of one recording and a comparable pair.

## The fix

`ArRenderer` passes ARCore's `Frame.getTimestamp()` into `probe.onTick`. During `startPlayback` ARCore replays the **recorded** value rather than the live clock, which is the property being bought.

The clock *decision* — which source to use, and what to do when there is no frame stamp — lives in a new `EvalClock` rather than inside the probe. `DriftCostProbe` needs a `Context` and writes files, so nothing in it is reachable from a JVM unit test, and the decision is the part that can be got wrong.

The headline test asserts the **property**: two replays of one recorded frame sequence, with wall clocks an hour apart ticking at different rates, produce identical stamps. That is the claim stated as a test, rather than a restatement of the division.

## Zero is not a reading

`stampMs` takes the fallback at `0`, not the frame path, and this is the case a plainer `>= 0` guard gets wrong. ARCore's timestamps are monotonic-clock nanoseconds, so 0 is not a plausible reading — but a caller not yet wired up passes `Long`'s default of `0`, and treating that as a frame stamp would file every row of a live session at the epoch. Internally consistent, entirely wrong, and invisible until someone tried to correlate the CSV with anything else.

**Mutation-verified:** relaxing the guard from `> 0` to `>= 0` fails that test.

## Two scope decisions, stated rather than slipped in

**1. The CSV filename keeps the wall clock.** It is `eval_${deviceClass}_${nowMs()}.csv`. Frame time would make two replays of one recording collide on a single filename — destroying the second run's data to gain determinism in a field nothing aligns on.

**2. `markTrackingLoss` and the relock stamp also move to the frame clock**, which §3.1 item 3 does *not* ask for. `recoveryMs` is `relock - loss`; leaving both ends on the wall clock would leave a number `EVALUATION.md` reports per mechanism measuring scheduling — the same defect the item describes, one field over. A recovery with one end on each clock is not a duration.

Because `markTrackingLoss` is called from an overlay button, between ticks, the probe holds the last frame stamp it saw. That is the right reading: the last frame before a button press is the *same frame* in both replays, whereas the wall clock is not the same time.

## Verification

- `:core:common`, `:core:nativebridge`, `:feature:ar`, `:feature:editor` unit tests green; `:app` compiles.
- No native change; the NDK is untouched.
- **Not device-tested**, and no eval run has been performed — this makes replays *comparable*, it does not measure anything.

## Where this leaves the plan

Every numbered phase in `IMPLEMENTATION.md` is now complete (0, 1, 2, 3, 4, 5a, 5b, 6a), and all three of §3.1's determinism sources are closed. What remains is not phase work:

- **2.10 and X.2** need a replayed recording this environment cannot produce. Genuinely blocked.
- **0.9** (`composeCorrected`'s GL/CV and capture-view factors) is held for the user's decision. 0.6 confirmed the rotation composition and explicitly did *not* claim the three operands are in mutually consistent frames — they are not.
- **X.1 and X.3** are standing practices, not tasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Q5WXFiVLeN4sXa9bPCSDA

---
_Generated by [Claude Code](https://claude.ai/code/session_011Q5WXFiVLeN4sXa9bPCSDA)_

## Summary by Sourcery

Stamp AR evaluation samples and tracking recovery metrics with ARCore frame timestamps via a new EvalClock helper, so replayed recordings produce deterministic, comparable CSV logs.

Enhancements:
- Introduce EvalClock utility to centralize frame-vs-wall clock selection for eval timestamps.
- Update DriftCostProbe and ArRenderer to use frame-based timestamps while preserving wall-clock-based CSV filenames.
- Document completion of determinism item 6a.5 in IMPLEMENTATION.md and bump project version metadata.

Tests:
- Add EvalClock unit tests to verify deterministic stamping, unit conversion, and fallback behavior when frame timestamps are missing or zero.