### PR TITLE
0.9: composeCorrected was in mixed frames — plus diagnostics for what did NOT happen

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -1110,6 +1110,7 @@ class MainActivity : ComponentActivity() {
                                 RelocDiagnosticsOverlay(
                                     diagnostics = arUiState.relocDiagnostics,
                                     corroboration = arUiState.corroborationDiagnostics,
+                                    fusion = arUiState.fusionDiagnostics,
                                     fingerprintPoints = arUiState.evalLiveMetrics.wallCount,
                                     paintingProgress = arUiState.paintingProgress,
                                 )
@@ -2118,6 +2119,7 @@ private const val FEW_FEATURES_IN_FRAME = 100
 private fun RelocDiagnosticsOverlay(
     diagnostics: RelocDiagnostics,
     corroboration: com.hereliesaz.graffitixr.common.model.CorroborationDiagnostics,
+    fusion: com.hereliesaz.graffitixr.common.model.FusionDiagnostics,
     fingerprintPoints: Int,
     paintingProgress: Float,
 ) {
@@ -2192,6 +2194,74 @@ private fun RelocDiagnosticsOverlay(
             },
         )
         DiagnosticRow("FP pts", fingerprintPoints.toString(), androidx.compose.ui.graphics.Color.Cyan)
+
+        // Pose fusion: what is actually happening to the overlay, and when nothing is, WHY.
+        //
+        // Every row above reports a measurement. This one reports a decision, and it is the row to
+        // read first when the complaint is "the overlay drifts" — because six quite different causes
+        // produce that same symptom and nothing else on this overlay separates them. A healthy Reloc
+        // row above a DISABLED or NO CAPTURE POSE here means the relocalizer is working perfectly and
+        // its results are being discarded.
+        val fusionState = fusion.state
+        DiagnosticRow(
+            "Fusion",
+            when (fusionState) {
+                com.hereliesaz.graffitixr.common.model.FusionState.NOT_SAMPLED -> "—"
+                com.hereliesaz.graffitixr.common.model.FusionState.DISABLED -> "OFF"
+                com.hereliesaz.graffitixr.common.model.FusionState.NO_ANCHOR -> "no anchor"
+                // Spelled out rather than abbreviated: this one sends the artist to "re-create the
+                // target", which no other state does, and it is the newest and least familiar.
+                com.hereliesaz.graffitixr.common.model.FusionState.NO_CAPTURE_POSE ->
+                    "OLD TARGET — re-create it"
+                com.hereliesaz.graffitixr.common.model.FusionState.WAITING_FOR_LOCK -> "waiting for lock"
+                com.hereliesaz.graffitixr.common.model.FusionState.COLD_SNAP -> "snapped"
+                com.hereliesaz.graffitixr.common.model.FusionState.BLENDING ->
+                    "blending a=" + String.format(java.util.Locale.US, "%.2f", fusion.lastAlpha)
+                com.hereliesaz.graffitixr.common.model.FusionState.HOLDING -> "holding"
+            },
+            when (fusionState) {
+                // Red for the two that mean corrections are being computed and thrown away, or
+                // cannot be computed at all. Amber for the transient waits. White for working.
+                com.hereliesaz.graffitixr.common.model.FusionState.NO_CAPTURE_POSE,
+                com.hereliesaz.graffitixr.common.model.FusionState.DISABLED ->
+                    androidx.compose.ui.graphics.Color.Red
+                com.hereliesaz.graffitixr.common.model.FusionState.NO_ANCHOR,
+                com.hereliesaz.graffitixr.common.model.FusionState.WAITING_FOR_LOCK ->
+                    androidx.compose.ui.graphics.Color(0xFFFFC107)
+                else -> androidx.compose.ui.graphics.Color.White
+            },
+        )
+        // How far the standing correction is pulling the overlay. A few mm is the system working; a
+        // few hundred is either a real relock after real drift or a composition error like the one
+        // 0.9 fixed — and the two are told apart by whether it STAYS large.
+        if (fusion.correctionMm >= 0f) {
+            DiagnosticRow(
+                "Correction",
+                String.format(java.util.Locale.US, "%.0f mm · %.1f°", fusion.correctionMm, fusion.correctionDeg),
+                if (fusion.correctionMm > 500f) {
+                    androidx.compose.ui.graphics.Color(0xFFFFC107)
+                } else {
+                    androidx.compose.ui.graphics.Color.White
+                },
+            )
+        }
+        // Accepted vs rejected relocks. Rejected ones reached fusion and were refused HERE by
+        // MIN_INLIER_RATIO — a different fault from a relocalizer that never locks, and one the
+        // Reloc row above cannot show because from its side those attempts succeeded.
+        if (fusion.snapsAccepted >= 0) {
+            DiagnosticRow(
+                "Snaps",
+                "${fusion.snapsAccepted} ok · ${fusion.snapsRejected} refused" +
+                    if (fusion.lastInlierRatio >= 0f) {
+                        String.format(java.util.Locale.US, " · last %.2f", fusion.lastInlierRatio)
+                    } else "",
+                if (fusion.snapsAccepted == 0 && fusion.snapsRejected > 0) {
+                    androidx.compose.ui.graphics.Color.Red
+                } else {
+                    androidx.compose.ui.graphics.Color.White
+                },
+            )
+        }
         // IMPLEMENTATION.md 4.6 — the corroboration match's own numbers, which are NOT the row
         // below. "Corrob" is instantaneous: of the design features this pose says are in view, how
         // many the wall backs right now, and the radius the gated search used to decide. "Painted"
@@ -2305,6 +2375,32 @@ private fun EvalOverlay(
         }
     }
 }
+
+/**
+ * The `Corrob` row's value when no gated attempt has run: WHY, rather than a dash.
+ *
+ * Four preconditions can fail and until now all four rendered identically. They call for entirely
+ * different responses, which is the whole reason this is a string and not a bare "—".
+ */
+private fun corrobGateReason(gate: com.hereliesaz.graffitixr.common.model.CorrobGate): String =
+    when (gate) {
+        com.hereliesaz.graffitixr.common.model.CorrobGate.NO_ARTWORK -> "no design registered"
+        com.hereliesaz.graffitixr.common.model.CorrobGate.NO_PLACEMENT -> "design not placed"
+        com.hereliesaz.graffitixr.common.model.CorrobGate.NO_POSE -> "no lock this frame"
+        com.hereliesaz.graffitixr.common.model.CorrobGate.BAD_2D -> "BUG: 2D/desc mismatch"
+        com.hereliesaz.graffitixr.common.model.CorrobGate.NO_INTRINSICS -> "no intrinsics"
+        com.hereliesaz.graffitixr.common.model.CorrobGate.NOT_RUN -> "—"
+        com.hereliesaz.graffitixr.common.model.CorrobGate.GATED -> "—"
+        com.hereliesaz.graffitixr.common.model.CorrobGate.UNKNOWN -> "unknown code"
+    }
+
+/**
+ * Appended to a populated `Corrob` row only when the gate says something the counts do not — i.e.
+ * the numbers came from the GLOBAL fallback rather than the gated match. That is a different
+ * measurement with a different denominator and must not be read as a Phase-4 reading.
+ */
+private fun corrobGateSuffix(gate: com.hereliesaz.graffitixr.common.model.CorrobGate): String =
+    if (gate == com.hereliesaz.graffitixr.common.model.CorrobGate.GATED) "" else " (ungated)"
 
 @Composable
 private fun DiagnosticRow(label: String, value: String, color: Color) {

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/FusionDiagnostics.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/FusionDiagnostics.kt
@@ -1,0 +1,95 @@
+package com.hereliesaz.graffitixr.common.model
+
+/**
+ * What pose fusion is actually doing right now, and — more usefully — what it is **not** doing and
+ * why.
+ *
+ * Every other diagnostic in this project reports a measurement. This one reports a *decision*,
+ * because the failures that have cost the most time here were never wrong numbers: they were stages
+ * that silently did not run. Phase 2's partition was inert on every first capture for weeks. The
+ * self-grow flag shipped ON while its own comment said OFF. `0.9` added a null check that turns
+ * fusion off entirely for a pre-Phase-2 fingerprint — correct, and completely invisible from the
+ * outside, which is exactly the class of thing this exists to end.
+ *
+ * The artist-visible symptom for most of [FusionState] is identical: the overlay sits on the ARCore
+ * backbone and drifts. This says which of six quite different causes produced it.
+ */
+data class FusionDiagnostics(
+    val state: FusionState = FusionState.NOT_SAMPLED,
+    /**
+     * Blend rate the last accepted relock used, or -1 when the last event was not a blend.
+     *
+     * `BASE_ALPHA · inlierRatio · effConf`. Near zero means corrections are being accepted and then
+     * almost entirely ignored — which looks like drift, not like a rejection, and is the reading
+     * that separates "not relocalizing" from "relocalizing and barely acting on it".
+     */
+    val lastAlpha: Float = -1f,
+    /** Inlier ratio of the last relocalization the fusion saw, or -1 when none has arrived. */
+    val lastInlierRatio: Float = -1f,
+    /**
+     * How far the standing correction currently displaces the overlay, in millimetres, or -1 when
+     * there is no correction.
+     *
+     * The single most diagnostic number here. A correction of a few millimetres is the system
+     * working. One of several hundred is either a genuine relock after real drift or a composition
+     * error of the kind `0.9` fixed — and the two are told apart by whether it *stays* large.
+     */
+    val correctionMm: Float = -1f,
+    /** Rotation magnitude of the standing correction in degrees, or -1 when there is none. */
+    val correctionDeg: Float = -1f,
+    /** Relocalizations accepted since the session started. 0 with a healthy reloc row is the alarm. */
+    val snapsAccepted: Int = -1,
+    /**
+     * Relocalizations REJECTED for a low inlier ratio since the session started.
+     *
+     * Counted separately from the reloc diagnostics' own rejects because these got all the way to
+     * fusion and were thrown away *here*, by `MIN_INLIER_RATIO`. A high count beside a healthy
+     * `Reloc` row means the relocalizer is working and fusion does not trust it, which is a
+     * different fix from either half failing alone.
+     */
+    val snapsRejected: Int = -1,
+)
+
+/**
+ * Why the overlay is or is not being corrected. Ordered roughly by how early the gate sits, so a
+ * later value means fusion got further.
+ */
+enum class FusionState {
+    /** No tick has reported yet. Distinct from every real state below. */
+    NOT_SAMPLED,
+
+    /** The fusion flag is off — the eval harness A/B, or a deliberate disable. */
+    DISABLED,
+
+    /** No anchor established yet: nothing to correct. The scanning state, and not a fault. */
+    NO_ANCHOR,
+
+    /**
+     * `IMPLEMENTATION.md` **0.9** — the fingerprint carries no `captureAnchorCam`, so the correction
+     * cannot be composed at all and fusion is skipped.
+     *
+     * This is a **pre-Phase-2 project**, and it is the state most likely to be mistaken for a bug:
+     * everything else looks healthy, relocalization may even be locking, and the overlay still
+     * drifts. The fix is to re-create the target. Correcting anyway would mean composing a
+     * CV-convention PnP result against a world-frame anchor, which `PAPER.md` §8.3 says is worse
+     * than not correcting.
+     */
+    NO_CAPTURE_POSE,
+
+    /** Fusion is live but no relocalization has ever been accepted; drawing the raw backbone. */
+    WAITING_FOR_LOCK,
+
+    /** The last accepted relock was a hard snap: first lock, or one that diverged past the cold thresholds. */
+    COLD_SNAP,
+
+    /** The last accepted relock was eased in at [FusionDiagnostics.lastAlpha]. */
+    BLENDING,
+
+    /**
+     * A correction is standing and being re-applied, but no new relocalization arrived this tick.
+     *
+     * The healthy steady state between locks — and also what a *stale* correction looks like, which
+     * is why [FusionDiagnostics.snapsAccepted] and the reloc row have to be read beside it.
+     */
+    HOLDING,
+}

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/RelocDiagnostics.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/RelocDiagnostics.kt
@@ -88,9 +88,79 @@ data class RelocDiagnostics(
      * accumulated drift, which is the thing corroboration exists to prevent.
      */
     val corrobLoneSkips: Int = -1,
+    /**
+     * `IMPLEMENTATION.md` **4.5** — why the spatially-constrained corroboration match did or did not
+     * run. See [CorrobGate].
+     *
+     * Every failing precondition produces the same observable otherwise: the three counts above read
+     * -1 and the overlay shows a dash. They call for completely different responses — place the
+     * design, aim at the registered wall, re-create the target, file a bug — so collapsing them into
+     * one absence throws away the only information that distinguishes them.
+     */
+    val corrobGate: CorrobGate = CorrobGate.NOT_RUN,
+    /**
+     * `IMPLEMENTATION.md` **Phase 3** — what self-grow did, or which gate declined. See [GrowOutcome].
+     *
+     * Phase 3 is otherwise invisible: self-grow is default-off, hard-gated, and every one of its
+     * refusals is silent by construction, so "the map is not growing" has eight causes that look
+     * identical — one of which is simply the switch being off, as intended.
+     */
+    val growOutcome: GrowOutcome = GrowOutcome.NOT_RUN,
 ) {
     /** Inlier ratio of the last attempt, or 0 when it produced no correspondences. */
     val inlierRatio: Float get() = if (matches > 0) inliers.toFloat() / matches else 0f
+}
+
+/**
+ * Mirrors `MobileGS::CorrobGate`, ordinal for ordinal — the native side reports an int.
+ *
+ * Like `RelocReject`, this is a **wire format** with no compiler checking either side, so the order
+ * is load-bearing. `UNKNOWN` absorbs any value a newer `.so` reports that this build does not know,
+ * rather than throwing or silently reading as the first entry.
+ */
+enum class CorrobGate {
+    /** Ran the gated match. */
+    GATED,
+    /** No design registered — the artwork guide has never been pushed for this project. */
+    NO_ARTWORK,
+    /** No design placement: Phase 4 is inactive here, and the match fell back to a global search. */
+    NO_PLACEMENT,
+    /** Relocalization did not lock this frame, so there is no pose to predict from. */
+    NO_POSE,
+    /** The artwork's 2D positions do not index its descriptors 1:1 — a bug, not a state. */
+    BAD_2D,
+    /** The fingerprint carries no intrinsics to project through. */
+    NO_INTRINSICS,
+    /** No corroboration attempt reached the decision at all. */
+    NOT_RUN,
+    /** A code this build does not know — a newer native library. */
+    UNKNOWN,
+}
+
+/**
+ * Mirrors `MobileGS::GrowOutcome`, ordinal for ordinal. Same wire-format caveat as [CorrobGate].
+ */
+enum class GrowOutcome {
+    /** The promotion block was not reached this attempt. */
+    NOT_RUN,
+    /** Self-grow is switched off. **The default**, and not a fault — Phase 3 ships gated. */
+    DISABLED,
+    /** Nothing in the frame corroborated the design, so there was nothing to promote. */
+    NO_CANDIDATES,
+    /** No fresh relock since the last promotion; the pose would be stale. */
+    STALE_SEQ,
+    /** The promotion gate refused — inlier spread or match quality. Tuning, and E5 sets it. */
+    UNTRUSTED,
+    /** Intrinsics, wall size or the plane fit are degenerate. */
+    NO_GEOMETRY,
+    /** Every candidate back-projected behind the camera or deduplicated against an existing mark. */
+    NO_NEW_POINTS,
+    /** The wall is at its hard ceiling. Not a fault. */
+    AT_CAP,
+    /** Marks were written into the map. */
+    PROMOTED,
+    /** A code this build does not know — a newer native library. */
+    UNKNOWN,
 }
 
 /**

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/UiState.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/UiState.kt
@@ -259,6 +259,14 @@ data class ArUiState(
      */
     val corroborationDiagnostics: CorroborationDiagnostics = CorroborationDiagnostics(),
     /**
+     * What pose fusion decided this frame — and, when it did not run, why.
+     *
+     * The other diagnostics report measurements; this reports a decision. Six quite different causes
+     * produce the same artist-visible symptom (the overlay sits on the backbone and drifts), and
+     * until this existed nothing on screen distinguished them. See [FusionDiagnostics].
+     */
+    val fusionDiagnostics: FusionDiagnostics = FusionDiagnostics(),
+    /**
      * How many 3D points the live wall fingerprint holds — 0 when there is none.
      *
      * The direct answer to "did the target actually get built", read straight from the engine

--- a/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
+++ b/core/nativebridge/src/main/cpp/GraffitiJNI.cpp
@@ -1338,7 +1338,10 @@ Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeGetCorroborationCo
 // answered for, [11] = how many predicted features the gated match refused to test because their
 // neighbourhood held a single candidate (IMPLEMENTATION.md 4.6; all three -1 until a GATED
 // corroboration attempt has run, and 0 for [9] is a real reading meaning the artist is not looking
-// at the design).
+// at the design), [12] = CorrobGate ordinal (why the gated match did or did not run),
+// [13] = GrowOutcome ordinal (what self-grow did, or which gate declined). The last two are
+// REASONS rather than counts: every one of their values produces the same -1s above, and the
+// responses they call for are completely different.
 extern "C" JNIEXPORT jintArray JNICALL
 Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeGetRelocDiagnostics(JNIEnv* env, jobject) {
     // NOT {0, ...}: zero is kRelocOk, so a no-engine fallback of 0 reports a SUCCESSFUL LOCK with
@@ -1348,7 +1351,9 @@ Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeGetRelocDiagnostic
     // the Kotlin-only code that absorbs anything the native side cannot account for; the counts are
     // -1 (not sampled) rather than 0, because zero matches is a real measurement.
     static constexpr jint kRelocUnknownOrdinal = 7;
-    jint vals[12] = {kRelocUnknownOrdinal, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1};
+    // [12] and [13] default to the "not run" ordinals (kCorrobNotRun = 6, kGrowNotRun = 0) rather
+    // than -1: they are enums, and with no engine nothing ran, which is exactly what those say.
+    jint vals[14] = {kRelocUnknownOrdinal, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 6, 0};
     if (gSlamEngine) {
         vals[0] = gSlamEngine->lastRelocReject();
         vals[1] = gSlamEngine->lastRelocMatches();
@@ -1362,10 +1367,12 @@ Java_com_hereliesaz_graffitixr_nativebridge_SlamManager_nativeGetRelocDiagnostic
         vals[9] = gSlamEngine->corrobPredicted();
         vals[10] = gSlamEngine->corrobMatched();
         vals[11] = gSlamEngine->corrobLoneSkips();
+        vals[12] = gSlamEngine->corrobGateReason();
+        vals[13] = gSlamEngine->growOutcome();
     }
-    jintArray out = env->NewIntArray(12);
+    jintArray out = env->NewIntArray(14);
     if (!out) return nullptr;
-    env->SetIntArrayRegion(out, 0, 12, vals);
+    env->SetIntArrayRegion(out, 0, 14, vals);
     return out;
 }
 

--- a/core/nativebridge/src/main/cpp/MobileGS.cpp
+++ b/core/nativebridge/src/main/cpp/MobileGS.cpp
@@ -892,6 +892,10 @@ void MobileGS::growMapFromReloc(const glm::mat4& camFromFp, const std::vector<cv
 void MobileGS::tryUpdateFingerprint(const cv::Mat& grayClean,
                                     const std::vector<cv::KeyPoint>* preKps,
                                     const cv::Mat* preDescs) {
+    // Every early return below leaves a reason behind. "Not run" is the default and is distinct
+    // from every real outcome, so a channel reading kCorrobNotRun means the attempt never reached
+    // the decision — not that the decision was negative.
+    mCorrobGate.store(kCorrobNotRun, std::memory_order_relaxed);
     cv::Mat artDescs;
     std::vector<cv::Point2f> artPts2d;
     int artImgW = 0, artImgH = 0;
@@ -903,7 +907,11 @@ void MobileGS::tryUpdateFingerprint(const cv::Mat& grayClean,
     float fpFx = 0.0f, fpFy = 0.0f, fpCx = 0.0f, fpCy = 0.0f;
     {
         std::lock_guard<std::mutex> lock(mMutex);
-        if (mArtworkDescriptors.empty()) return;
+        if (mArtworkDescriptors.empty()) {
+            // No design registered at all — updatePaintingGuide has never fired for this project.
+            mCorrobGate.store(kCorrobNoArtwork, std::memory_order_relaxed);
+            return;
+        }
         artDescs = mArtworkDescriptors;
         artPts2d = mArtworkKeypoints2D;
         artImgW = mArtworkImageW;
@@ -951,11 +959,18 @@ void MobileGS::tryUpdateFingerprint(const cv::Mat& grayClean,
     //
     // When any of them is missing this falls back to the global knnMatch below, which is exactly
     // pre-Phase-4 behaviour.
-    const bool gated =
-        havePlacement &&
-        mLastRelocReject.load(std::memory_order_relaxed) == kRelocOk &&
-        (int)artPts2d.size() == artDescs.rows &&
-        artImgW > 0 && artImgH > 0 && fpFx > 0.0f && fpFy > 0.0f;
+    // Decomposed rather than written as one boolean, so the channel can say WHICH precondition
+    // failed. All four produce an identical observable otherwise — the counters read -1 and the
+    // overlay shows a dash — and they call for entirely different responses: "place the design",
+    // "aim at the registered wall", "re-create the target", "this is a bug".
+    const int gateReason =
+        !havePlacement ? kCorrobNoPlacement
+        : (mLastRelocReject.load(std::memory_order_relaxed) != kRelocOk) ? kCorrobNoPose
+        : ((int)artPts2d.size() != artDescs.rows || artImgW <= 0 || artImgH <= 0) ? kCorrobBad2d
+        : (!(fpFx > 0.0f) || !(fpFy > 0.0f)) ? kCorrobNoIntrinsics
+        : kCorrobGated;
+    mCorrobGate.store(gateReason, std::memory_order_relaxed);
+    const bool gated = gateReason == kCorrobGated;
 
     std::vector<char> hit(artDescs.rows, 0);
     std::vector<int> validQuery;   // clean keypoints that corroborate the artwork (self-grow candidates)
@@ -1185,7 +1200,14 @@ void MobileGS::tryUpdateFingerprint(const cv::Mat& grayClean,
     // feature is placed on the wall plane via the current relocalized pose. Guarded hard (fresh +
     // confident relock, gatekeeper-validated, capped, deduped) and RANSAC in the reloc PnP is the
     // backstop, but it still mutates the authoritative set, so it stays OFF unless explicitly enabled.
-    if (!mSelfGrowEnabled.load(std::memory_order_relaxed) || validQuery.empty()) return;
+    if (!mSelfGrowEnabled.load(std::memory_order_relaxed)) {
+        mGrowOutcome.store(kGrowDisabled, std::memory_order_relaxed);
+        return;
+    }
+    if (validQuery.empty()) {
+        mGrowOutcome.store(kGrowNoCandidates, std::memory_order_relaxed);
+        return;
+    }
 
     // pnpMatches, not `matches`: that name used to be the knnMatch result vector in this scope, and
     // although Phase 4 moved it inside the global-fallback branch the reason to keep them apart
@@ -1196,7 +1218,10 @@ void MobileGS::tryUpdateFingerprint(const cv::Mat& grayClean,
     {
         std::lock_guard<std::mutex> lock(mMutex);
         seq = mPnpResultSeq.load(std::memory_order_relaxed);
-        if (seq == mLastGrowSeq) return;          // no fresh relock this tick — pose would be stale
+        if (seq == mLastGrowSeq) {                // no fresh relock this tick — pose would be stale
+            mGrowOutcome.store(kGrowStaleSeq, std::memory_order_relaxed);
+            return;
+        }
         inliers = mPnpInlierCount.load(std::memory_order_relaxed);
         pnpMatches = mPnpMatchCount.load(std::memory_order_relaxed);
         const float* M = mPnpCamFromFpWorld;      // camera_from_fpWorld, column-major (OpenCV frame)
@@ -1214,7 +1239,15 @@ void MobileGS::tryUpdateFingerprint(const cv::Mat& grayClean,
         if (trusted) mLastGrowSeq = seq;          // claim it (yield or not)
     }
     if (!trusted || fx <= 0 || fy <= 0 ||
-        wall.size() < 12 || wall.size() >= kMaxWallMarks) return;
+        wall.size() < 12 || wall.size() >= kMaxWallMarks) {
+        // Split so "the gate refused this pose" is distinguishable from "there is nothing to grow
+        // onto" and from "the map is full". The first is tuning (E5 sets MIN_INLIER_SPREAD), the
+        // second is a capture problem, the third is a hard ceiling and not a fault at all.
+        mGrowOutcome.store(
+            wall.size() >= kMaxWallMarks ? kGrowAtCap : (!trusted ? kGrowUntrusted : kGrowNoGeometry),
+            std::memory_order_relaxed);
+        return;
+    }
 
     // Wall plane (n·X = pdist, pdist>0) in the fingerprint frame, fit to the existing marks.
     cv::Mat data((int)wall.size(), 3, CV_32F);
@@ -1224,8 +1257,13 @@ void MobileGS::tryUpdateFingerprint(const cv::Mat& grayClean,
     cv::PCA pca(data, cv::Mat(), cv::PCA::DATA_AS_ROW);
     cv::Vec3d n(pca.eigenvectors.at<float>(2,0), pca.eigenvectors.at<float>(2,1), pca.eigenvectors.at<float>(2,2));
     cv::Vec3d cen(pca.mean.at<float>(0,0), pca.mean.at<float>(0,1), pca.mean.at<float>(0,2));
-    double nn = cv::norm(n); if (nn < 1e-6) return; n /= nn;
-    double pdist = n.dot(cen); if (pdist < 0) { n = -n; pdist = -pdist; } if (pdist < 1e-3) return;
+    // A degenerate plane fit is the same class of refusal as degenerate intrinsics: there is
+    // nothing to project promotions onto.
+    double nn = cv::norm(n);
+    if (nn < 1e-6) { mGrowOutcome.store(kGrowNoGeometry, std::memory_order_relaxed); return; }
+    n /= nn;
+    double pdist = n.dot(cen); if (pdist < 0) { n = -n; pdist = -pdist; }
+    if (pdist < 1e-3) { mGrowOutcome.store(kGrowNoGeometry, std::memory_order_relaxed); return; }
 
     // fp_from_cam = [R^T | -R^T t]: camera centre and per-pixel ray in the fingerprint frame.
     cv::Matx33d Rt = R.t();
@@ -1251,14 +1289,24 @@ void MobileGS::tryUpdateFingerprint(const cv::Mat& grayClean,
         newDescs.push_back(descs.row(q));
         if (newPts.size() >= 30) break;           // cap per relock
     }
-    if (newPts.empty()) return;
+    if (newPts.empty()) {
+        // Candidates existed and every one of them was dropped: back-projected behind the camera,
+        // or deduplicated against a mark already stored.
+        mGrowOutcome.store(kGrowNoNewPoints, std::memory_order_relaxed);
+        return;
+    }
 
     size_t promoted = 0, wallNow = 0;
     int outsideN = 0, insideN = 0, bandN = 0;
     {
         std::lock_guard<std::mutex> lock(mMutex);
         if (mWallDescriptors.type() != newDescs.type() || mWallDescriptors.cols != newDescs.cols ||
-            mWallKeypoints3D.size() >= kMaxWallMarks) return;
+            mWallKeypoints3D.size() >= kMaxWallMarks) {
+            mGrowOutcome.store(
+                mWallKeypoints3D.size() >= kMaxWallMarks ? kGrowAtCap : kGrowNoGeometry,
+                std::memory_order_relaxed);
+            return;
+        }
         // Fill to the cap exactly. Testing the size only BEFORE the loop let a wall sitting at
         // kMaxWallMarks-1 grow by the full per-relock batch, so the documented ceiling was really
         // ceiling + batch.
@@ -1305,6 +1353,7 @@ void MobileGS::tryUpdateFingerprint(const cv::Mat& grayClean,
         wallNow = mWallKeypoints3D.size();
         outsideN = promotedOutside; insideN = promotedInside; bandN = promotedBand;
     }
+    mGrowOutcome.store(kGrowPromoted, std::memory_order_relaxed);
     LOGI("Teleological self-grow: promoted %zu marks (wall now %zu; F_out +%d, F_in +%d, band +%d)",
          promoted, wallNow, outsideN, insideN, bandN);
 }

--- a/core/nativebridge/src/main/cpp/include/MobileGS.h
+++ b/core/nativebridge/src/main/cpp/include/MobileGS.h
@@ -219,6 +219,48 @@ public:
     /** Hard ceiling on stored wall marks — a memory guard on the self-grow append. */
     static constexpr size_t kMaxWallMarks = 5000;
 
+    /**
+     * Why the SPATIALLY-CONSTRAINED corroboration match did or did not run this attempt.
+     *
+     * The gated path has four preconditions and, until this existed, failing any of them produced
+     * exactly the same observable: the corroboration counters read "-1" and the overlay showed a
+     * dash. "Phase 4 is off for this project" and "Phase 4 is on but this frame had no pose" are
+     * completely different situations with completely different fixes.
+     */
+    enum CorrobGate {
+        kCorrobGated = 0,          //!< ran the gated match
+        kCorrobNoArtwork = 1,      //!< no design registered (updatePaintingGuide never fired)
+        kCorrobNoPlacement = 2,    //!< no design placement pushed — Phase 4 inactive for this project
+        kCorrobNoPose = 3,         //!< relocalization did not lock this frame
+        kCorrobBad2d = 4,          //!< artwork 2D positions do not index the descriptors 1:1
+        kCorrobNoIntrinsics = 5,   //!< the fingerprint carries no intrinsics to project through
+        kCorrobNotRun = 6,         //!< no corroboration attempt reached the decision at all
+    };
+
+    /**
+     * What the self-grow promotion did, or the reason it declined.
+     *
+     * Phase 3 is entirely invisible without this. Self-grow is default-OFF, hard-gated, and its
+     * refusals are silent by construction — so "the map is not growing" has eight causes that look
+     * identical from outside, one of which is simply the switch.
+     */
+    enum GrowOutcome {
+        kGrowNotRun = 0,           //!< the promotion block was not reached this attempt
+        kGrowDisabled = 1,         //!< setSelfGrowEnabled(false) — the default, not a fault
+        kGrowNoCandidates = 2,     //!< nothing in the frame corroborated the design
+        kGrowStaleSeq = 3,         //!< no fresh relock since the last promotion; pose would be stale
+        kGrowUntrusted = 4,        //!< the promotion gate refused — inlier spread or match quality
+        kGrowNoGeometry = 5,       //!< intrinsics, wall size or plane fit degenerate
+        kGrowNoNewPoints = 6,      //!< every candidate back-projected behind the camera or deduped
+        kGrowAtCap = 7,            //!< the wall is at kMaxWallMarks
+        kGrowPromoted = 8,         //!< marks were written into the map
+    };
+
+    /** Last [CorrobGate]; see the enum for why this is worth a channel of its own. */
+    int corrobGateReason() const { return mCorrobGate.load(std::memory_order_relaxed); }
+    /** Last [GrowOutcome]. */
+    int growOutcome() const { return mGrowOutcome.load(std::memory_order_relaxed); }
+
     /** Sentinel for "no corroboration attempt has produced a measurement yet". */
     static constexpr float kCorroborationUnmeasured = -1.0f;
 
@@ -770,5 +812,9 @@ private:
     // inlier POINTS; the self-grow gate sees counts through atomics and would otherwise be blind to
     // the geometry that actually conditions the pose.
     std::atomic<float>      mLastRelocInlierSpread{kPromotionNotMeasured};
+    // Why each stage did or did not run. Both default to "not run", which is distinct from every
+    // real outcome — the same rule the -1 counters follow, in enum form.
+    std::atomic<int>        mCorrobGate{kCorrobNotRun};
+    std::atomic<int>        mGrowOutcome{kGrowNotRun};
     cv::Mat                 mRelocColorFrame;
 };

--- a/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
+++ b/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
@@ -211,6 +211,23 @@ class SlamManager @Inject constructor(
      */
     @Volatile var overlayMarkCenterLocal: FloatArray? = null
 
+    /**
+     * `IMPLEMENTATION.md` **0.9** — `Fingerprint.captureAnchorCam`, the anchor's pose in the CAPTURE
+     * camera's CV frame (`V_cv(capture) · anchorModel`), or null when the live fingerprint has none.
+     *
+     * Carried here for the same reason [overlayMarkCenterLocal] is: the renderer needs it every
+     * frame and does not hold the `Fingerprint`. It is the third factor of
+     * `PoseFusion.composeCorrected`, and it replaced a world-frame anchor that put the composition
+     * in the wrong frame entirely.
+     *
+     * **Null means do not correct.** A pre-Phase-2 fingerprint has no `captureAnchorCam`, and there
+     * is no way to compose the correction without it — the world-frame anchor that used to be passed
+     * is precisely the defect. Skipping the correction leaves relocalization off for such a project
+     * rather than pulling the overlay toward a pose computed in mixed frames, which is the failure
+     * `PAPER.md` §8.3 says is worse than not correcting at all.
+     */
+    @Volatile var captureAnchorCam: FloatArray? = null
+
     fun updateDeviceMotion(angularVel: FloatArray, linearVel: FloatArray) {
         nativeUpdateDeviceMotion(angularVel, linearVel)
     }

--- a/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
+++ b/core/nativebridge/src/main/java/com/hereliesaz/graffitixr/nativebridge/SlamManager.kt
@@ -4,7 +4,9 @@ package com.hereliesaz.graffitixr.nativebridge
 import android.content.res.AssetManager
 import android.graphics.Bitmap
 import android.util.Log
+import com.hereliesaz.graffitixr.common.model.CorrobGate
 import com.hereliesaz.graffitixr.common.model.CorroborationDiagnostics
+import com.hereliesaz.graffitixr.common.model.GrowOutcome
 import com.hereliesaz.graffitixr.common.model.Fingerprint
 import com.hereliesaz.graffitixr.common.model.RelocDiagnostics
 import com.hereliesaz.graffitixr.common.model.RelocReject
@@ -286,6 +288,15 @@ class SlamManager @Inject constructor(
             corrobPredicted = if (v.size > 9) v[9] else -1,
             corrobMatched = if (v.size > 10) v[10] else -1,
             corrobLoneSkips = if (v.size > 11) v[11] else -1,
+            // Enums, so an unknown ordinal from a newer .so absorbs into UNKNOWN rather than
+            // reading as whichever entry happens to be first. Absent (older .so) is NOT_RUN, which
+            // is truthful: that library does not run these stages in a way it can report.
+            corrobGate = if (v.size > 12) {
+                CorrobGate.entries.getOrElse(v[12]) { CorrobGate.UNKNOWN }
+            } else CorrobGate.NOT_RUN,
+            growOutcome = if (v.size > 13) {
+                GrowOutcome.entries.getOrElse(v[13]) { GrowOutcome.UNKNOWN }
+            } else GrowOutcome.NOT_RUN,
         )
     }
 

--- a/docs/research/IMPLEMENTATION.md
+++ b/docs/research/IMPLEMENTATION.md
@@ -921,10 +921,40 @@ order.** Work top to bottom.
       This is **pre-existing**, not introduced by Phase 0, and it is not a rotation
       problem — which is why looking only for rotation missed it.
 
-- [ ] **0.9** Fix `composeCorrected`'s GL/CV and capture-view factors (see 0.6). Needs
+- [x] **0.9** Fix `composeCorrected`'s GL/CV and capture-view factors (see 0.6). Needs
       its own experiment: it changes where the overlay lands, and §8.3's warning about
       getting every sign right applies with full force. Do not fold it into a
       rotation commit. **[T]**
+      *(DONE, and landed alone as the item asks. "Needs its own experiment" turned out
+      not to mean "needs a device": there is an invariant that settles it offline.*
+      ***The invariant.** `currentAnchor` computes `newD = corrected · inverse(backbone)`,
+      so if ARCore has not drifted since capture, `backbone` is already right and
+      `corrected` must come back equal to it — the correction must be the identity. Any
+      residual IS the composition error. Against the shipped form the residual was
+      **2.92**: not a rounding artefact, a wholly different pose.*
+      ***Why it is not circular.** The one belief-carrying input is what `solvePnP`
+      returns under zero drift, and that is built from the repo's OWN shipped bridge —
+      `MetricMarks.glViewToCv`, and `MetricFingerprintBuilder`'s
+      `captureAnchorCam = cvView · anchorModel`. The fingerprint frame IS the
+      display-oriented CV capture camera by construction, in code whose fingerprints
+      demonstrably relocalize. Limit, stated: this validates `composeCorrected` against
+      the fingerprint builder and cannot catch an error the two share.*
+      ***The fix.** `corrected = inv(vCurrent) · [D · pnpMat] · captureAnchorCam`.
+      `captureAnchorCam` is a quantity Phase 2 already builds, persists and partitions
+      with, so no new geometry was needed — only a factor the project already had and
+      one existing converter. Residual 4.8e-7.*
+      ***I got it wrong first, and the invariant caught it.** `pnpMat` is a transform,
+      so converting it between conventions is normally the conjugation `D · m · D`. That
+      is wrong here because `captureAnchorCam` carries its own `D`; the trailing factor
+      applies it twice and lands **4.29** from the anchor — worse than the 2.92 defect it
+      was meant to fix. §8.3's warning arriving in person. Both mistakes are pinned.*
+      ***Behaviour change worth knowing:** a pre-Phase-2 fingerprint has no
+      `captureAnchorCam`, and fusion is now SKIPPED for it rather than fed a world-frame
+      anchor. Refusing to correct leaves the overlay on the drifting backbone; correcting
+      in mixed frames pulls it somewhere confidently wrong, and §8.3 says the second is
+      worse.*
+      *Still not device-verified — the invariant proves internal consistency, not that
+      the overlay lands on the wall. That remains E-series work.)*
 - [x] **0.10** `MetricFingerprintBuilder.ingestSingle` stores display-frame
       `res.pointsCam` alongside the **un-rotated** `glView` in the same
       `restoreWallFingerprintMetric` call. Native pairs them in

--- a/docs/research/IMPLEMENTATION.md
+++ b/docs/research/IMPLEMENTATION.md
@@ -1362,6 +1362,56 @@ order.** Work top to bottom.
       was asking for — a comment saying "re-check this" is the artefact of a defect
       that has no test.)*
 
+### Diagnostics — reporting what did NOT happen
+
+- [x] **D.1** Report pose fusion's DECISION, not just its output: `FusionDiagnostics`
+      / `FusionState`, surfaced on the overlay and in the eval CSV.
+      *(Every other diagnostic in this project reports a measurement. The failures
+      that have cost the most time were never wrong numbers — they were stages that
+      silently did not run. Phase 2's partition was inert on every first capture for
+      weeks; self-grow shipped ON while its own comment said OFF; and **0.9 added a
+      null check that turns fusion off entirely for a pre-Phase-2 fingerprint**,
+      which is correct and was completely invisible from outside.*
+      *Six states produce the identical artist-visible symptom — the overlay sits on
+      the backbone and drifts. `DISABLED`, `NO_ANCHOR`, `NO_CAPTURE_POSE`,
+      `WAITING_FOR_LOCK`, `COLD_SNAP`, `BLENDING`, `HOLDING`. The three that mean
+      fusion never ran are reported by `ArRenderer`, because `PoseFusion` is not
+      called in those cases and cannot know.*
+      *Also published: the standing correction's magnitude in mm and degrees — a few
+      mm is the system working, a few hundred is either a real relock or a
+      composition error like 0.9's, told apart by whether it STAYS large — plus
+      accepted-vs-refused snap counts. A refused relock reached fusion and was
+      thrown away by `MIN_INLIER_RATIO`; from the reloc channel's side that attempt
+      SUCCEEDED, so nothing else in the system records it.*
+      *Mutation-verified: counting a refusal as an acceptance fails the test.)*
+- [x] **D.2** Report WHY the gated corroboration match did not run — `CorrobGate`. **[N]**
+      *(Four preconditions, one observable. "No design registered", "design not
+      placed", "no lock this frame" and "2D/descriptor mismatch" all produced the
+      same three `-1`s and the same dash on the overlay, and they call for entirely
+      different responses — one of them is a bug and the others are not. The boolean
+      was decomposed into a reason rather than left as an `&&` chain.*
+      *A populated `Corrob` row now also carries `(ungated)` when the numbers came
+      from the global fallback, because that is a different measurement with a
+      different denominator and must not be read as a Phase-4 reading.)*
+- [x] **D.3** Report what self-grow did or which gate declined — `GrowOutcome`. **[N]**
+      *(Phase 3 was otherwise entirely invisible: default-off, hard-gated, and every
+      refusal silent by construction, so "the map is not growing" had eight causes
+      that looked identical — one being the switch, as intended. `DISABLED`,
+      `NO_CANDIDATES`, `STALE_SEQ`, `UNTRUSTED`, `NO_GEOMETRY`, `NO_NEW_POINTS`,
+      `AT_CAP`, `PROMOTED`. `UNTRUSTED` is the one that means tuning — E5 sets
+      `MIN_INLIER_SPREAD` — and it was previously indistinguishable from the switch
+      being off.)*
+- [x] **D.4** Carry all three through to the eval CSV as ordinals. **[T]**
+      *(Reasons, not measurements, and the eval needs them for the reason the overlay
+      does: a run where corroboration never gated is not a bad result, it is a VOID
+      one, and without these columns it is indistinguishable from a run where the
+      wall genuinely failed to corroborate. Aggregating the two is how a null result
+      gets manufactured.*
+      *The int channel widened 12 → 14 and the two new slots default to their
+      enums' "not run" ordinals rather than -1, because with no engine nothing ran —
+      which is precisely what those values say. Unknown ordinals from a newer `.so`
+      absorb into `UNKNOWN` rather than reading as whichever entry is first.)*
+
 ### Cross-cutting
 
 - [ ] **X.1** Add `docs/research/PARAMETERS.md` entries for every new constant as

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -2132,6 +2132,11 @@ class ArViewModel @Inject constructor(
         // is acceptable here — these are diagnostics, not numbers PoseFusion acts on — and it is
         // written down so a later reader does not mistake the pair for an atomic snapshot.
         val corrobDiag = slamManager.getCorroborationDiagnostics()
+        // Read from the renderer rather than the engine: fusion is a Kotlin-side decision, and the
+        // states that matter most (disabled, no anchor, no capture pose) are ones where PoseFusion
+        // is never invoked and so has nothing to report.
+        val fusionDiag = renderer?.fusionDiagnostics()
+            ?: com.hereliesaz.graffitixr.common.model.FusionDiagnostics()
         // Read alongside the diagnostics, not on a success path: the state this exists to expose is
         // "the capture produced nothing", which by definition never reaches one.
         val wallPoints = slamManager.getWallKeypointCount()
@@ -2172,6 +2177,7 @@ class ArViewModel @Inject constructor(
                 paintingProgress = progress,
                 relocDiagnostics = relocDiag,
                 corroborationDiagnostics = corrobDiag,
+                fusionDiagnostics = fusionDiag,
                 wallFingerprintPoints = wallPoints,
                 scanPhase = newPhase,
                 ambientSectorsCovered = sectorsCovered / 3, // Keep backward compatibility for 30 degree UI units if needed

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -965,6 +965,8 @@ class ArViewModel @Inject constructor(
         // Drop the marks-centering override so a later AR re-entry (or a different project) doesn't
         // center the overlay on a stale target's marks before a new one is built/restored.
         slamManager.overlayMarkCenterLocal = null
+        // 0.9 — same lifetime: without it PoseFusion cannot compose a correction at all.
+        slamManager.captureAnchorCam = null
         // Same argument, for the anchor. The ARCore session and its anchors do not survive this, so
         // "an anchor has been established" must not either — otherwise the next capture's
         // `awaitAnchorTransform` returns immediately with the previous session's pose, which is the
@@ -1827,6 +1829,8 @@ class ArViewModel @Inject constructor(
     private fun dropLoadedFingerprint() {
         slamManager.clearWallFingerprint()
         slamManager.overlayMarkCenterLocal = null
+        // 0.9 — same lifetime: without it PoseFusion cannot compose a correction at all.
+        slamManager.captureAnchorCam = null
         dropPartitionState()
     }
 
@@ -2000,6 +2004,11 @@ class ArViewModel @Inject constructor(
                 // marks after reload, even though the builder doesn't run on a restored fingerprint.
                 slamManager.overlayMarkCenterLocal =
                     if (fp.markCenterLocal.size >= 3) fp.markCenterLocal.toFloatArray() else null
+                // IMPLEMENTATION.md 0.9 — the third factor of PoseFusion.composeCorrected. A
+                // pre-Phase-2 fingerprint has none, and null there means "do not correct" rather
+                // than "correct with the world anchor", which is the frame defect 0.9 fixed.
+                slamManager.captureAnchorCam =
+                    if (fp.captureAnchorCam.size == 16) fp.captureAnchorCam.toFloatArray() else null
             }
 
             loadedFingerprint = incoming
@@ -2734,6 +2743,8 @@ class ArViewModel @Inject constructor(
         if (active) {
             doodleFingerprintBuilt = false
             slamManager.overlayMarkCenterLocal = null
+        // 0.9 — same lifetime: without it PoseFusion cannot compose a correction at all.
+        slamManager.captureAnchorCam = null
             doodleCaptureJob = viewModelScope.launch {
                 // Two budgets, because they bound different failures:
                 //

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/MetricFingerprintBuilder.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/MetricFingerprintBuilder.kt
@@ -259,6 +259,9 @@ object MetricFingerprintBuilder {
         // Center the AR overlay on the marks (their centroid), not the screen-center anchor.
         val markCenterLocal = marksCentroidLocal(res.pointsCam, cvView, anchorModel)
         slam.overlayMarkCenterLocal = markCenterLocal
+        // IMPLEMENTATION.md 0.9 — published at capture as well as on reload, or the session that
+        // CREATED the target would relocalize without a correction until the project was reopened.
+        slam.captureAnchorCam = anchorCam.copyOf()
 
         val keptDesc = Mat(res.count, descAll.cols(), descAll.type())
         val keypoints = ArrayList<KeyPoint>(res.count)

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/PoseFusion.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/PoseFusion.kt
@@ -90,8 +90,47 @@ class PoseFusion {
         private fun identity() = floatArrayOf(1f,0f,0f,0f, 0f,1f,0f,0f, 0f,0f,1f,0f, 0f,0f,0f,1f)
 
         /** Corrected anchor model matrix in the CURRENT world frame. All inputs rigid. */
-        fun composeCorrected(vCurrent: FloatArray, pnpMat: FloatArray, fpAnchor: FloatArray): FloatArray =
-            PoseMath.multiply(PoseMath.multiply(PoseMath.rigidInverse(vCurrent), pnpMat), fpAnchor)
+        /**
+         * `IMPLEMENTATION.md` **0.9** — the relocalized anchor pose in the live world frame.
+         *
+         * ```
+         * corrected = inv(vCurrent) · [D · pnpMat] · captureAnchorCam
+         * ```
+         *
+         * Two things were wrong with the form this replaces, `inv(vCurrent) · pnpMat · fpAnchor`:
+         *
+         *  - `pnpMat` comes out of `solvePnP` in the **CV** convention (+Y down, +Z forward) and was
+         *    being chained straight onto a **GL** view inverse, so Y and Z were flipped;
+         *  - its domain is the **fingerprint** frame — the display-oriented CV camera at capture —
+         *    while `fpAnchor` was a world-space model matrix, so the capture view was missing
+         *    entirely.
+         *
+         * [captureAnchorCam] repairs the second and half of the first at once. It is
+         * `V_cv(capture) · anchorModel`, which Phase 2 already builds, persists on the
+         * `Fingerprint`, and partitions the footprint with — so this needs no new geometry, only a
+         * quantity the project already computes for another reason.
+         *
+         * **`D` goes on ONE side, not both.** Converting a *transform* between conventions is
+         * normally the conjugation `D · m · D`, and that is what I wrote first. It is wrong here
+         * because `captureAnchorCam` carries its own `D` (it is a CV view times a model matrix), so
+         * the trailing factor applies it twice — landing 4.29 from the anchor where the original
+         * defect was 2.92, i.e. *worse than doing nothing*. `PAPER.md` §8.3's warning about getting
+         * every sign right is not rhetorical; `ComposeCorrectedFrameTest` pins both mistakes.
+         *
+         * Verified by a zero-drift invariant rather than by inspection: with no drift the correction
+         * must be the identity, so this must return `anchorModel` unchanged. It does, to 4.8e-7.
+         *
+         * @param captureAnchorCam `Fingerprint.captureAnchorCam` — NOT the live anchor pose and NOT
+         *   `getFingerprintAnchor()`. Passing a world-frame anchor here is the defect being fixed.
+         */
+        fun composeCorrected(
+            vCurrent: FloatArray,
+            pnpMat: FloatArray,
+            captureAnchorCam: FloatArray,
+        ): FloatArray = PoseMath.multiply(
+            PoseMath.rigidInverse(vCurrent),
+            PoseMath.multiply(MetricMarks.glViewToCv(pnpMat), captureAnchorCam),
+        )
 
         /** Smoothed interpolation between two rigid poses (translation lerp + quaternion nlerp). */
         fun blend(current: FloatArray, target: FloatArray, alpha: Float): FloatArray {
@@ -116,7 +155,10 @@ class PoseFusion {
      * @param backbone ARCore-consensus model matrix (world frame), the smooth per-frame source
      * @param vCurrent current ARCore view matrix (fresh, GL thread)
      * @param reloc    FloatArray(19): [0..15]=pnpMat, [16]=inlierCount, [17]=matchCount, [18]=seq
-     * @param fpAnchor fingerprint-frame anchor model matrix
+     * @param captureAnchorCam `Fingerprint.captureAnchorCam` — the anchor's pose in the CAPTURE
+     *   camera's CV frame, `V_cv(capture) · anchorModel`. Renamed from `fpAnchor` as part of 0.9:
+     *   the old name and the old value were both a world-frame model matrix, which is the frame
+     *   error that item fixes. See [composeCorrected].
      * @param confGlobal teleological corroboration in [0,1] — the fraction of the registered artwork's
      *        features the real wall currently answers for (MobileGS painting progress). Raises smooth
      *        correction strength from [CONF_FLOOR] at 0% painted to full at 100%, which is the
@@ -127,7 +169,7 @@ class PoseFusion {
         backbone: FloatArray,
         vCurrent: FloatArray,
         reloc: FloatArray,
-        fpAnchor: FloatArray,
+        captureAnchorCam: FloatArray,
         confGlobal: Float,
     ): FloatArray {
         val seq = reloc[18]
@@ -137,7 +179,7 @@ class PoseFusion {
         val isNew = seq > 0f && seq != lastSeq
 
         if (isNew && inlierRatio >= MIN_INLIER_RATIO) {
-            val corrected = composeCorrected(vCurrent, reloc.copyOf(16), fpAnchor)
+            val corrected = composeCorrected(vCurrent, reloc.copyOf(16), captureAnchorCam)
             // World-frame drift correction such that D ∘ backbone == corrected at snap time.
             val newD = PoseMath.multiply(corrected, PoseMath.rigidInverse(backbone))
 

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/PoseFusion.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/PoseFusion.kt
@@ -1,5 +1,8 @@
 package com.hereliesaz.graffitixr.feature.ar.anchor
 
+import com.hereliesaz.graffitixr.common.model.FusionDiagnostics
+import com.hereliesaz.graffitixr.common.model.FusionState
+
 /**
  * Fuses the ARCore-consensus backbone with mark-PnP relocalization into a single rendered anchor
  * model matrix (ARCore world frame).
@@ -178,6 +181,12 @@ class PoseFusion {
         val inlierRatio = if (matchCount > 0f) inliers / matchCount else 0f
         val isNew = seq > 0f && seq != lastSeq
 
+        // Recorded even when the relock is refused below. A relocalization that reached fusion and
+        // was thrown away by MIN_INLIER_RATIO is a different fault from one that never arrived, and
+        // the two look identical from every other channel — the overlay drifts either way.
+        if (isNew) lastInlierRatio = inlierRatio
+        if (isNew && inlierRatio < MIN_INLIER_RATIO) snapsRejected++
+
         if (isNew && inlierRatio >= MIN_INLIER_RATIO) {
             val corrected = composeCorrected(vCurrent, reloc.copyOf(16), captureAnchorCam)
             // World-frame drift correction such that D ∘ backbone == corrected at snap time.
@@ -192,15 +201,71 @@ class PoseFusion {
 
             correction = if (cold && highConf) {
                 coldStart = false
+                lastState = FusionState.COLD_SNAP
+                lastAlpha = -1f          // a snap has no blend rate; -1 says so rather than 1.0
                 newD // instant relock
             } else {
                 val effConf = (CONF_FLOOR + (1f - CONF_FLOOR) * confGlobal.coerceIn(0f, 1f))
                 val alpha = (BASE_ALPHA * inlierRatio * effConf).coerceIn(0f, 1f)
+                lastState = FusionState.BLENDING
+                lastAlpha = alpha
                 blend(correction ?: identity(), newD, alpha)
             }
+            snapsAccepted++
+        } else if (correction != null) {
+            // A correction stands but nothing new arrived. The healthy steady state — and also what
+            // a stale correction looks like, which is why snapsAccepted is published beside it.
+            lastState = FusionState.HOLDING
         }
         lastSeq = seq
         // fused = D ∘ backbone, re-applied every frame (identity drift until the first trusted snap).
         return PoseMath.multiply(correction ?: identity(), backbone)
+    }
+
+    private var lastState = FusionState.WAITING_FOR_LOCK
+    private var lastAlpha = -1f
+    private var lastInlierRatio = -1f
+    private var snapsAccepted = 0
+    private var snapsRejected = 0
+
+    /**
+     * A snapshot of the last decision, for the diagnostic overlay and the eval CSV.
+     *
+     * The magnitudes are computed here rather than stored, because the correction is a matrix and
+     * "how far is it pulling the overlay" is the question a reader actually has. Millimetres and
+     * degrees, both -1 when no correction stands.
+     *
+     * Note this reports what fusion did when it RAN. The states that mean it did not run at all —
+     * disabled, no anchor, no capture pose — are the caller's to report, because only the caller
+     * knows them; see `ArRenderer`.
+     */
+    fun diagnostics(): FusionDiagnostics {
+        val d = correction
+        val mm: Float
+        val deg: Float
+        if (d == null) {
+            mm = -1f; deg = -1f
+        } else {
+            val t = PoseMath.translationOf(d)
+            mm = kotlin.math.sqrt(t[0] * t[0] + t[1] * t[1] + t[2] * t[2]) * 1000f
+            val q = PoseMath.matrixToQuaternion(d)
+            // |w| because q and -q are the same rotation; without it a correction just past 180 deg
+            // would report as a tiny one.
+            val w = kotlin.math.abs(q[3]).coerceIn(0f, 1f)
+            deg = Math.toDegrees(2.0 * kotlin.math.acos(w.toDouble())).toFloat()
+        }
+        return FusionDiagnostics(
+            state = if (d == null && lastState == FusionState.WAITING_FOR_LOCK) {
+                FusionState.WAITING_FOR_LOCK
+            } else {
+                lastState
+            },
+            lastAlpha = lastAlpha,
+            lastInlierRatio = lastInlierRatio,
+            correctionMm = mm,
+            correctionDeg = deg,
+            snapsAccepted = snapsAccepted,
+            snapsRejected = snapsRejected,
+        )
     }
 }

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/DriftCostProbe.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/DriftCostProbe.kt
@@ -117,6 +117,7 @@ class DriftCostProbe(
         cpuPct: Float,
         reloc: com.hereliesaz.graffitixr.common.model.RelocDiagnostics? = null,
         corrob: com.hereliesaz.graffitixr.common.model.CorroborationDiagnostics? = null,
+        fusion: com.hereliesaz.graffitixr.common.model.FusionDiagnostics? = null,
         captureRotationNeededDeg: Int = EvalSampleLog.NOT_SAMPLED,
         liveRotationNeededDeg: Int = EvalSampleLog.NOT_SAMPLED,
         frameTimestampNs: Long = EvalClock.NOT_SAMPLED_NS,
@@ -185,6 +186,13 @@ class DriftCostProbe(
             searchRadiusPx = corrob?.searchRadiusPx ?: EvalSampleLog.NOT_SAMPLED_PX,
             relocReprojPx = corrob?.relocReprojPx ?: EvalSampleLog.NOT_SAMPLED_PX,
             inlierSpread = corrob?.inlierSpread ?: EvalSampleLog.NOT_SAMPLED_PX,
+            // Ordinals, so the CSV stays numeric and a consumer maps them back through the enums.
+            // -1 only for "no diagnostics this tick" — the enums have their own NOT_RUN entries,
+            // which mean something different and must survive the round trip.
+            corrobGate = reloc?.corrobGate?.ordinal ?: EvalSampleLog.NOT_SAMPLED,
+            growOutcome = reloc?.growOutcome?.ordinal ?: EvalSampleLog.NOT_SAMPLED,
+            fusionState = fusion?.state?.ordinal ?: EvalSampleLog.NOT_SAMPLED,
+            fusionCorrectionMm = fusion?.correctionMm ?: EvalSampleLog.NOT_SAMPLED_PX,
             captureRotationNeededDeg = captureRotationNeededDeg,
             liveRotationNeededDeg = liveRotationNeededDeg,
         )

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/EvalSampleLog.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/EvalSampleLog.kt
@@ -105,6 +105,26 @@ data class EvalSample(
      */
     val inlierSpread: Float = -1f,
     /**
+     * Ordinals of the two REASON channels: why the gated corroboration match did or did not run, and
+     * what self-grow did. `CorrobGate` / `GrowOutcome`, -1 when not sampled.
+     *
+     * Reasons rather than measurements, and the eval needs them for the same purpose the overlay
+     * does: a run where corroboration never gated is not a bad result, it is a **void** one, and
+     * without these columns it is indistinguishable from a run where the wall genuinely failed to
+     * corroborate. Aggregating the two together is how a null result gets manufactured.
+     */
+    val corrobGate: Int = -1,
+    val growOutcome: Int = -1,
+    /**
+     * `FusionState` ordinal — what pose fusion did, or why it did not run — and the standing
+     * correction's magnitude in millimetres. -1 when not sampled.
+     *
+     * The correction magnitude is the number to plot against `errMm`: a run where fusion never
+     * corrected and a run where it corrected wrongly both show drift, and only this separates them.
+     */
+    val fusionState: Int = -1,
+    val fusionCorrectionMm: Float = -1f,
+    /**
      * `rotationNeeded` **at the moment the active target was captured** — 0, 90, 180 or 270, or -1
      * when no target has been captured this session (a project restored from disk reads -1; see
      * below).
@@ -164,7 +184,7 @@ object EvalSampleLog {
         "relocObliquityDeg", "relocRectifiedCorr",
         "relocBackboneFeatures", "relocBackboneMatches", "relocBackboneInliers",
         "corrobPredicted", "corrobMatched", "corrobLoneSkips", "searchRadiusPx", "relocReprojPx",
-        "inlierSpread",
+        "inlierSpread", "corrobGate", "growOutcome", "fusionState", "fusionCorrectionMm",
         "captureRotationNeededDeg", "liveRotationNeededDeg",
     )
 
@@ -197,6 +217,8 @@ object EvalSampleLog {
             s.corrobLoneSkips.toString(),
             s.searchRadiusPx.toString(), s.relocReprojPx.toString(),
             s.inlierSpread.toString(),
+            s.corrobGate.toString(), s.growOutcome.toString(),
+            s.fusionState.toString(), s.fusionCorrectionMm.toString(),
             s.captureRotationNeededDeg.toString(), s.liveRotationNeededDeg.toString(),
         )
     }

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -229,6 +229,28 @@ class ArRenderer(
     @Volatile var driftCostProbe: com.hereliesaz.graffitixr.feature.ar.eval.DriftCostProbe? = null
 
     /**
+     * Why pose fusion was skipped this frame, or null when it ran.
+     *
+     * Written on the GL thread and read by the diagnostics tick on another, hence @Volatile. Held as
+     * a nullable rather than folded into `PoseFusion.diagnostics()` because these are precisely the
+     * cases where `PoseFusion` is not called at all and therefore cannot know.
+     */
+    @Volatile var fusionSkipReason: com.hereliesaz.graffitixr.common.model.FusionState? = null
+
+    /**
+     * The last fusion decision, for the overlay and the eval CSV. Combines [fusionSkipReason] — the
+     * states only the renderer can see — with `PoseFusion`'s own record of what it did when it ran.
+     */
+    fun fusionDiagnostics(): com.hereliesaz.graffitixr.common.model.FusionDiagnostics {
+        val skip = fusionSkipReason
+        return if (skip != null) {
+            com.hereliesaz.graffitixr.common.model.FusionDiagnostics(state = skip)
+        } else {
+            poseFusion.diagnostics()
+        }
+    }
+
+    /**
      * Latest physical device attitude, or null when unavailable. Supplied by the ViewModel, which
      * owns the sensor lifecycle — the renderer only reads it, and only at capture.
      */
@@ -1241,6 +1263,19 @@ class ArRenderer(
             // which drifts; correcting in the wrong frame pulls it somewhere confidently wrong, and
             // PAPER.md §8.3 is explicit that the second is worse.
             val captureAnchorCam = slamManager.captureAnchorCam
+            // The three reasons fusion can be skipped are known HERE and nowhere else — PoseFusion
+            // is never called, so it cannot report them. Without this the overlay simply drifts and
+            // every other row on the overlay looks healthy, which is the failure mode this whole
+            // record exists to end. NO_CAPTURE_POSE in particular was introduced by 0.9 and is the
+            // one most likely to be mistaken for a bug: a pre-Phase-2 project relocalizes fine and
+            // is never corrected.
+            fusionSkipReason = when {
+                !fusionEnabled -> com.hereliesaz.graffitixr.common.model.FusionState.DISABLED
+                !anchorEstablished -> com.hereliesaz.graffitixr.common.model.FusionState.NO_ANCHOR
+                captureAnchorCam == null ->
+                    com.hereliesaz.graffitixr.common.model.FusionState.NO_CAPTURE_POSE
+                else -> null
+            }
             val anchorMatrix: FloatArray = if (fusionEnabled && anchorEstablished && captureAnchorCam != null) {
                 poseFusion.currentAnchor(
                     backbone = backbone,
@@ -1341,6 +1376,10 @@ class ArRenderer(
                         // was neither the count nor the mechanism.)
                         reloc = relocDiag,
                         corrob = corrobDiag,
+                        // What fusion actually did with the relock — including "nothing, and here is
+                        // why". A run that drifts because fusion was skipped and one that drifts
+                        // because it corrected wrongly are indistinguishable without this.
+                        fusion = fusionDiagnostics(),
                         // E0b's independent variable is the rotation that was in force AT CAPTURE,
                         // because that is the one baked into the fingerprint's 3D points. Sampling
                         // the live rotation here instead — which an earlier version of this call

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -1231,12 +1231,22 @@ class ArRenderer(
             }
             // Fuse in the corrected mark-PnP snap (smoothed) when anchored; the flag lets the eval
             // harness A/B fusion vs the old toggle. Off → exact previous behavior.
-            val anchorMatrix: FloatArray = if (fusionEnabled && anchorEstablished) {
+            // IMPLEMENTATION.md 0.9 — the correction needs `captureAnchorCam`, the anchor's pose in
+            // the CAPTURE camera's CV frame. `getFingerprintAnchor()` used to be passed here and is a
+            // WORLD-frame model matrix: composing it against a CV-convention PnP result put the
+            // correction in mixed frames, which the zero-drift invariant measured at 2.92 off.
+            //
+            // Null on a pre-Phase-2 fingerprint, and then fusion is SKIPPED rather than fed a
+            // world-frame anchor. Refusing to correct leaves the overlay on the ARCore backbone,
+            // which drifts; correcting in the wrong frame pulls it somewhere confidently wrong, and
+            // PAPER.md §8.3 is explicit that the second is worse.
+            val captureAnchorCam = slamManager.captureAnchorCam
+            val anchorMatrix: FloatArray = if (fusionEnabled && anchorEstablished && captureAnchorCam != null) {
                 poseFusion.currentAnchor(
                     backbone = backbone,
                     vCurrent = viewMatrix,
                     reloc = slamManager.getRelocResult(),
-                    fpAnchor = slamManager.getFingerprintAnchor(),
+                    captureAnchorCam = captureAnchorCam,
                     // THE teleological input, finally connected. The claim in TELEOLOGICAL_SLAM.md is
                     // that the further along the painting is, the more real-world corroboration the
                     // engine has and the harder the overlay locks. That third stage was never wired:

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/ComposeCorrectedFrameTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/ComposeCorrectedFrameTest.kt
@@ -1,0 +1,214 @@
+package com.hereliesaz.graffitixr.feature.ar.anchor
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.math.cos
+import kotlin.math.sin
+
+/**
+ * `IMPLEMENTATION.md` **0.9** — is `PoseFusion.composeCorrected` actually in consistent frames?
+ *
+ * 0.6 confirmed the factor ORDER with non-commuting rotations, and said explicitly that it made no
+ * claim about the frames. This file makes that claim testable, without a device, using an invariant
+ * that needs no external ground truth:
+ *
+ * > **If nothing has drifted since capture, the correction must be the identity.**
+ *
+ * `PoseFusion.currentAnchor` computes `newD = corrected · inverse(backbone)` and draws
+ * `D ∘ backbone`. So when ARCore has not drifted, `backbone` is already the right answer, the
+ * relocalizer sees exactly what the current view predicts, and `corrected` must come back equal to
+ * `backbone`. Any residual IS the composition error, and its shape says which factor is missing.
+ *
+ * ## Why this is not the circular test it could have been
+ *
+ * The one input that encodes a belief is `pnpMat` — what `solvePnP` would return under zero drift.
+ * Rather than assert my own convention, it is built from the repo's OWN shipped bridge:
+ *
+ *  - `MetricMarks.glViewToCv` is how every fingerprint's capture view is converted, and
+ *  - `MetricFingerprintBuilder` back-projects the fingerprint's 3D points through exactly that CV
+ *    view, storing `captureAnchorCam = cvView · anchorModel`.
+ *
+ * So the fingerprint frame IS the display-oriented CV camera frame at capture — not by assumption
+ * but by construction, in code that ships and whose fingerprints demonstrably relocalize. Under zero
+ * drift a point's live CV camera coordinates are therefore
+ * `V_cv(t) · V_cv(capture)⁻¹` applied to its fingerprint coordinates, which is the `pnpMat` below.
+ *
+ * The honest limit: this validates `composeCorrected` **against the fingerprint builder**. It cannot
+ * catch an error the two share. An inconsistency between them is precisely what 0.6's audit alleged,
+ * so it is aimed at the right target — but it is not a device.
+ */
+class ComposeCorrectedFrameTest {
+
+    private companion object {
+        /** Rigid pose from a Z-Y-X-ish mix, column-major. Deliberately not axis-aligned. */
+        fun pose(rxDeg: Float, ryDeg: Float, tx: Float, ty: Float, tz: Float): FloatArray {
+            val rx = Math.toRadians(rxDeg.toDouble())
+            val ry = Math.toRadians(ryDeg.toDouble())
+            val cx = cos(rx).toFloat(); val sx = sin(rx).toFloat()
+            val cy = cos(ry).toFloat(); val sy = sin(ry).toFloat()
+            // R = Ry * Rx, written out column-major [col*4 + row].
+            val r00 = cy;            val r01 = sy * sx;      val r02 = sy * cx
+            val r10 = 0f;            val r11 = cx;           val r12 = -sx
+            val r20 = -sy;           val r21 = cy * sx;      val r22 = cy * cx
+            return floatArrayOf(
+                r00, r10, r20, 0f,
+                r01, r11, r21, 0f,
+                r02, r12, r22, 0f,
+                tx, ty, tz, 1f,
+            )
+        }
+
+        fun assertMatrixEquals(msg: String, expected: FloatArray, actual: FloatArray, eps: Float) {
+            val worst = (0 until 16).maxOf { kotlin.math.abs(expected[it] - actual[it]) }
+            assertTrue(
+                "$msg\n  worst element error $worst\n  expected ${expected.toList()}\n  actual   ${actual.toList()}",
+                worst <= eps,
+            )
+        }
+    }
+
+    /** The capture-time camera pose, the live camera pose, and where the anchor sits. */
+    private val vGlCapture = pose(rxDeg = 12f, ryDeg = -25f, tx = 0.3f, ty = 1.4f, tz = -0.2f)
+    private val vGlLive = pose(rxDeg = -7f, ryDeg = 40f, tx = -0.6f, ty = 1.5f, tz = 0.9f)
+    private val anchorModel = pose(rxDeg = 3f, ryDeg = 18f, tx = 1.1f, ty = 0.4f, tz = -2.5f)
+
+    /**
+     * `pnpMat` as the relocalizer would produce it with no drift: the transform taking a point from
+     * the fingerprint frame (= the capture CV camera frame) to the live CV camera frame.
+     *
+     * Built through `MetricMarks.glViewToCv`, the repo's own converter, rather than by writing
+     * `diag(1,-1,-1)` here — so the test inherits the shipped convention instead of asserting one.
+     */
+    private fun zeroDriftPnp(): FloatArray {
+        val cvCapture = MetricMarks.glViewToCv(vGlCapture)
+        val cvLive = MetricMarks.glViewToCv(vGlLive)
+        return PoseMath.multiply(cvLive, PoseMath.rigidInverse(cvCapture))
+    }
+
+    /**
+     * The diagnosis. Under zero drift the current composition must return the anchor unchanged.
+     *
+     * This is the assertion that found 0.9's defect. Against the SHIPPED composition
+     * (`inv(V) · pnp · fpAnchor`, world-frame anchor, no axis conversion) it failed by 2.92 — not a
+     * rounding artefact but a wholly different pose. It now runs against the repaired one.
+     */
+    @Test
+    fun `zero drift corrects to the anchor itself`() {
+        val corrected = PoseFusion.composeCorrected(
+            vGlLive, zeroDriftPnp(), PoseMath.multiply(MetricMarks.glViewToCv(vGlCapture), anchorModel),
+        )
+        assertMatrixEquals(
+            "zero drift must correct to the anchor itself; a residual here IS a frame defect",
+            anchorModel, corrected, 1e-4f,
+        )
+    }
+
+    /**
+     * The proposed corrected composition, stated as an independent hypothesis and checked against
+     * the same invariant.
+     *
+     * Two things are wrong with the shipped form, and the derivation collapses the repair into one
+     * substitution plus one conversion:
+     *
+     *  - `pnpMat` is CV-convention, so it needs the `D = diag(1,-1,-1)` axis conversion;
+     *  - its domain is the FINGERPRINT frame — the capture CV camera — while `fpAnchor` is a
+     *    world-space model matrix, so a capture-view factor is needed between them.
+     *
+     * Since `captureAnchorCam = V_cv(capture) · anchorModel = D · V_gl(capture) · anchorModel`, the
+     * second factor supplies its own `D` and the repair is:
+     *
+     * ```
+     * corrected = inv(V_gl(t)) · [D · pnp] · captureAnchorCam
+     * ```
+     *
+     * `D · pnp` is exactly `MetricMarks.glViewToCv(pnp)`, and `captureAnchorCam` is a quantity
+     * Phase 2 already builds, persists and partitions with. So the fix needs no new geometry: it
+     * swaps `fpAnchor` for something the project already computes for another reason, and applies
+     * one existing converter.
+     */
+    @Test
+    fun `the corrected composition satisfies the invariant`() {
+        val captureAnchorCam =
+            PoseMath.multiply(MetricMarks.glViewToCv(vGlCapture), anchorModel)
+        val corrected = PoseMath.multiply(
+            PoseMath.rigidInverse(vGlLive),
+            PoseMath.multiply(MetricMarks.glViewToCv(zeroDriftPnp()), captureAnchorCam),
+        )
+        assertMatrixEquals(
+            "the corrected form must return the anchor unchanged under zero drift",
+            anchorModel, corrected, 1e-4f,
+        )
+    }
+
+    /**
+     * **Conjugating is wrong, and I wrote it that way first.**
+     *
+     * `D · pnp · D` is the textbook conversion of a *transform* between conventions, and reaching
+     * for it here is the natural move — but `captureAnchorCam` already carries a `D` of its own, so
+     * the trailing factor applies it twice and lands 4.29 away from the anchor. The shipped form is
+     * 2.92 away; the double conversion is *worse than the defect it was meant to fix*.
+     *
+     * That is §8.3's warning about signs arriving in person, and it is pinned here because the
+     * mistake survives inspection: both forms are one plausible sentence away from correct, and
+     * only the invariant tells them apart.
+     */
+    @Test
+    fun `converting pnp on both sides is worse than not converting it at all`() {
+        val captureAnchorCam =
+            PoseMath.multiply(MetricMarks.glViewToCv(vGlCapture), anchorModel)
+        val doubled = PoseMath.multiply(
+            PoseMath.rigidInverse(vGlLive),
+            PoseMath.multiply(cvToGlTransform(zeroDriftPnp()), captureAnchorCam),
+        )
+        // The ORIGINAL defective composition, written out rather than called: composeCorrected has
+        // since been fixed, so there is no longer a function that produces it.
+        val originalDefect = PoseMath.multiply(
+            PoseMath.multiply(PoseMath.rigidInverse(vGlLive), zeroDriftPnp()), anchorModel,
+        )
+        val worstDoubled = (0 until 16).maxOf { kotlin.math.abs(anchorModel[it] - doubled[it]) }
+        val worstOriginal = (0 until 16).maxOf { kotlin.math.abs(anchorModel[it] - originalDefect[it]) }
+        assertTrue("the double conversion must not satisfy the invariant", worstDoubled > 1e-3f)
+        assertTrue(
+            "double-converting ($worstDoubled) should be worse than the original defect " +
+                "($worstOriginal) — that is why it is pinned",
+            worstDoubled > worstOriginal,
+        )
+    }
+
+    /**
+     * `D · m · D` with `D = diag(1,-1,-1)` — the conversion of a TRANSFORM between the two
+     * conventions, as opposed to the conversion of a view matrix.
+     *
+     * The left factor reuses the shipped `glViewToCv` (which negates rows 1 and 2) so the test stays
+     * tied to the repo's convention rather than restating it. The right factor negates COLUMNS 1 and
+     * 2, which has no shipped helper because nothing else needed one — it is written out here, and
+     * `the converter negates rows, so the column pass is its mirror` checks the pair against each
+     * other rather than against my arithmetic.
+     */
+    private fun cvToGlTransform(m: FloatArray): FloatArray {
+        val dm = MetricMarks.glViewToCv(m)                 // D · m  (rows 1,2 negated)
+        val out = dm.copyOf()
+        for (row in 0 until 4) {                           // (D · m) · D  (cols 1,2 negated)
+            out[1 * 4 + row] = -out[1 * 4 + row]
+            out[2 * 4 + row] = -out[2 * 4 + row]
+        }
+        return out
+    }
+
+    /**
+     * The column pass above has no shipped counterpart, so it is checked against the one that does:
+     * `D` is symmetric, so negating the rows of `mᵀ` must equal negating the columns of `m`.
+     */
+    @Test
+    fun `the converter negates rows, so the column pass is its mirror`() {
+        val m = pose(rxDeg = 21f, ryDeg = -13f, tx = 0.7f, ty = -0.2f, tz = 1.9f)
+        val rowsNegated = MetricMarks.glViewToCv(m)
+        for (col in 0 until 4) {
+            for (row in 0 until 4) {
+                val expected = if (row == 1 || row == 2) -m[col * 4 + row] else m[col * 4 + row]
+                assertEquals("($row,$col)", expected, rowsNegated[col * 4 + row], 0f)
+            }
+        }
+    }
+}

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/PoseFusionTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/PoseFusionTest.kt
@@ -199,6 +199,72 @@ class PoseFusionTest {
         assertEquals(0f, r[11], 1e-6f); assertEquals(1f, r[15], 1e-6f)
     }
 
+    /**
+     * The diagnostics report a DECISION, and the decisions that matter most are the negative ones.
+     *
+     * Every failure this project has spent real time on was a stage that silently did not run, so a
+     * channel that only ever says "working" would be the same trap one level up. These assert the
+     * states that mean *nothing happened*, and that they are told apart from each other.
+     */
+    @Test fun `fusion reports waiting, rejection and holding as distinct states`() {
+        val f = PoseFusion()
+        assertEquals(
+            "before any relock the state must be WAITING_FOR_LOCK, not a working state",
+            com.hereliesaz.graffitixr.common.model.FusionState.WAITING_FOR_LOCK, f.diagnostics().state,
+        )
+        assertEquals("no correction stands yet", -1f, f.diagnostics().correctionMm, 0f)
+
+        // A relock that reaches fusion and is REFUSED here by MIN_INLIER_RATIO. From the reloc
+        // diagnostics' side this attempt succeeded, so nothing else in the system records it.
+        f.currentAnchor(trans(0f,0f,0f), identity(),
+            reloc(trans(10f,0f,0f), inliers = 10f, matches = 100f, seq = 1f), captureAtOrigin(),
+            confGlobal = 1f)
+        val refused = f.diagnostics()
+        assertEquals("a refused relock must be counted", 1, refused.snapsRejected)
+        assertEquals("...and must not be counted as accepted", 0, refused.snapsAccepted)
+        assertEquals("the ratio that got it refused must be visible", 0.1f, refused.lastInlierRatio, 1e-4f)
+        assertEquals(
+            "a refusal leaves fusion still waiting, not working",
+            com.hereliesaz.graffitixr.common.model.FusionState.WAITING_FOR_LOCK, refused.state,
+        )
+
+        // A confident cold relock is accepted and snaps.
+        f.currentAnchor(trans(0f,0f,0f), identity(),
+            reloc(trans(10f,0f,0f), inliers = 90f, matches = 100f, seq = 2f), captureAtOrigin(),
+            confGlobal = 1f)
+        val snapped = f.diagnostics()
+        assertEquals(com.hereliesaz.graffitixr.common.model.FusionState.COLD_SNAP, snapped.state)
+        assertEquals(1, snapped.snapsAccepted)
+        assertEquals("a snap has no blend rate, and -1 says so rather than 1.0", -1f, snapped.lastAlpha, 0f)
+        // 10 m of correction, reported in mm. The number an operator actually needs: a correction
+        // this large is either a real relock after real drift or a composition error.
+        assertEquals(10_000f, snapped.correctionMm, 1f)
+
+        // No new relock: the correction stands and is re-applied.
+        f.currentAnchor(trans(0f,0f,1f), identity(), FloatArray(19), captureAtOrigin(), confGlobal = 1f)
+        assertEquals(
+            "a standing correction with no new relock is HOLDING, not still snapping",
+            com.hereliesaz.graffitixr.common.model.FusionState.HOLDING, f.diagnostics().state,
+        )
+    }
+
+    /** A small, non-diverging relock blends, and the rate it blended at must be reported. */
+    @Test fun `fusion reports the blend rate it actually used`() {
+        val f = PoseFusion()
+        f.currentAnchor(trans(0f,0f,0f), identity(),
+            reloc(trans(10f,0f,0f), inliers = 90f, matches = 100f, seq = 1f), captureAtOrigin(),
+            confGlobal = 1f)
+        f.currentAnchor(trans(0f,0f,0f), identity(),
+            reloc(trans(10.05f,0f,0f), inliers = 60f, matches = 100f, seq = 2f), captureAtOrigin(),
+            confGlobal = 1f)
+        val d = f.diagnostics()
+        assertEquals(com.hereliesaz.graffitixr.common.model.FusionState.BLENDING, d.state)
+        // BASE_ALPHA(0.25) * inlierRatio(0.6) * effConf(1.0 at confGlobal=1) = 0.15. Written out
+        // rather than recomputed from the constants, so a change to any of them shows up here.
+        assertEquals(0.15f, d.lastAlpha, 1e-4f)
+        assertEquals(2, d.snapsAccepted)
+    }
+
     @Test fun `blend alpha 0 returns current, alpha 1 returns target`() {
         val cur = trans(0f,0f,0f); val tgt = trans(10f,0f,0f)
         assertEquals(0f, PoseFusion.blend(cur, tgt, 0f)[12], 1e-4f)

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/PoseFusionTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/PoseFusionTest.kt
@@ -11,16 +11,39 @@ class PoseFusionTest {
     private fun trans(x: Float, y: Float, z: Float) =
         floatArrayOf(1f,0f,0f,0f, 0f,1f,0f,0f, 0f,0f,1f,0f, x,y,z,1f)
 
-    /** reloc payload with vCurrent=I, fpAnchor=I so composeCorrected(reloc)=target. */
+    /**
+     * `captureAnchorCam` for the degenerate fixture these tests use: capture camera at the world
+     * origin, anchor at the world origin.
+     *
+     * That is `V_cv(capture) · anchorModel` with both factors identity in GL — and `V_cv = D · V_gl`,
+     * so it is `D = diag(1,-1,-1)`, not the identity. Passing `identity()` here would be passing a
+     * capture view that does not exist, and after 0.9 it shows: the composition would leave `D` in
+     * the rotation and these fixtures would come out mirrored in Y and Z.
+     *
+     * So this is the correct value, not a fudge to make old tests pass — and it is exactly the class
+     * of mistake 0.9 fixed, reproduced in miniature.
+     */
+    private fun captureAtOrigin() =
+        floatArrayOf(1f,0f,0f,0f, 0f,-1f,0f,0f, 0f,0f,-1f,0f, 0f,0f,0f,1f)
+
+    /** reloc payload carrying [target] as the pnp block, plus inlier/match/seq counters. */
     private fun reloc(target: FloatArray, inliers: Float, matches: Float, seq: Float) =
         FloatArray(19).also {
             System.arraycopy(target, 0, it, 0, 16); it[16] = inliers; it[17] = matches; it[18] = seq
         }
 
-    @Test fun `composeCorrected with V=pnp and fpAnchor=I yields identity`() {
+    /**
+     * `IMPLEMENTATION.md` **0.9** made the axis conversion visible here, and this test changed with
+     * it. It used to assert that `V == pnp` cancels to the identity — true only while `pnpMat` was
+     * chained in raw, which was the defect: `pnpMat` is CV-convention and the view is GL, so they
+     * cannot cancel. With the conversion applied what survives is exactly `D = diag(1,-1,-1)`, the
+     * handedness difference, with no translation left over.
+     */
+    @Test fun `composeCorrected with V=pnp leaves exactly the axis conversion`() {
         val v = trans(2f, 0f, 0f)
-        val r = PoseFusion.composeCorrected(vCurrent = v, pnpMat = v, fpAnchor = identity())
-        identity().forEachIndexed { i, e -> assertEquals(e, r[i], 1e-4f) }
+        val r = PoseFusion.composeCorrected(vCurrent = v, pnpMat = v, captureAnchorCam = identity())
+        val d = floatArrayOf(1f,0f,0f,0f, 0f,-1f,0f,0f, 0f,0f,-1f,0f, 0f,0f,0f,1f)
+        d.forEachIndexed { i, e -> assertEquals("element $i", e, r[i], 1e-4f) }
     }
 
     /**
@@ -35,11 +58,13 @@ class PoseFusionTest {
         val rotZ = floatArrayOf(0f,1f,0f,0f, -1f,0f,0f,0f, 0f,0f,1f,0f, 0f,0f,0f,1f)
         val v = rotZ                       // world -> camera is a pure rotation
         val pnp = identity()               // camera -> fingerprint world is identity
-        val fpAnchor = trans(1f, 0f, 0f)   // anchor sits +1 along the fingerprint frame's X
+        val captureAnchorCam = trans(1f, 0f, 0f)  // anchor sits +1 along the capture frame's X
 
-        // inverse(V)·pnp·fpAnchor = rotZ⁻¹ · I · trans(1,0,0). rotZ⁻¹ maps +X to -Y, so the composed
-        // anchor sits at (0, -1, 0). A composition in any other order does not land there.
-        val r = PoseFusion.composeCorrected(vCurrent = v, pnpMat = pnp, fpAnchor = fpAnchor)
+        // inverse(V)·[D·pnp]·captureAnchorCam = rotZ⁻¹ · D · trans(1,0,0). D leaves a +X translation
+        // alone (its Y and Z components are zero), and rotZ⁻¹ maps +X to -Y, so the composed anchor
+        // sits at (0, -1, 0) — unchanged by 0.9, which is worth knowing: this fixture cannot see the
+        // axis conversion, which is exactly why the test above exists alongside it.
+        val r = PoseFusion.composeCorrected(vCurrent = v, pnpMat = pnp, captureAnchorCam = captureAnchorCam)
         assertEquals(0f, r[12], 1e-4f)
         assertEquals(-1f, r[13], 1e-4f)
         assertEquals(0f, r[14], 1e-4f)
@@ -57,38 +82,39 @@ class PoseFusionTest {
      * neither could tell convention A from convention B; and neither would have failed under the
      * missing-factor defect described in 0.6/0.9. The claim lived in the KDoc, not the assertions.
      *
-     * What is genuinely testable here is the factor ORDER, which the test above already covers with
-     * non-commuting operands. Whether the three operands are in mutually consistent FRAMES is not a
-     * property of this function — it is a property of its four callers' data, and it is currently
-     * **false**: `vCurrent` is GL-convention, `pnpMat` is CV-convention, `pnpMat`'s domain is the
-     * capture camera frame, and `fpAnchor` is a world-space model matrix. See 0.9.
+     * **This test inverted at 0.9, and the inversion is the point.**
      *
-     * So this file deliberately asserts nothing about frames. A test that cannot fail is worse than
-     * no test, because it is counted as coverage.
+     * It used to assert that `composeCorrected` is frame-AGNOSTIC — pure composition, so
+     * `f(R, R, A) == f(I, I, A)` by associativity over `rigidInverse`, for any rigid `R`. That was
+     * true, and it was true because the function made no commitment about conventions at all. The
+     * commitment lived in four callers' data, where it was wrong.
+     *
+     * 0.9 moved the commitment INTO the function: `pnpMat` is now converted from CV to GL on the way
+     * through. So the cancellation no longer holds — `inv(R)·D·R` is not `D` unless `R` commutes
+     * with `D` — and the function is no longer frame-agnostic. Asserting the non-cancellation is
+     * what proves the conversion is actually applied, rather than named in a KDoc.
+     *
+     * The `Rx` case is kept and is the interesting one: `D = diag(1,-1,-1)` restricted to the Y-Z
+     * plane is `-I`, which commutes with every rotation about X. So a rotation about X DOES still
+     * cancel, and a test that only tried that axis would have concluded nothing had changed.
      */
-    @Test fun `composeCorrected is frame-agnostic — the convention lives in its callers`() {
-        // Pinned as executable documentation of the above: the function is pure composition, so it
-        // cannot detect a frame error and must not be credited with doing so.
+    @Test fun `composeCorrected embeds the axis conversion, so it no longer cancels`() {
         val rotZ90 = floatArrayOf(0f,1f,0f,0f, -1f,0f,0f,0f, 0f,0f,1f,0f, 0f,0f,0f,1f)
-        val fpAnchor = trans(1f, 0f, 0f)
-        val bothRotated = PoseFusion.composeCorrected(rotZ90, rotZ90, fpAnchor)
-        val neitherRotated = PoseFusion.composeCorrected(identity(), identity(), fpAnchor)
-        for (i in 0 until 16) assertEquals("element $i", neitherRotated[i], bothRotated[i], 1e-4f)
+        val anchor = trans(1f, 0f, 0f)
+        val neither = PoseFusion.composeCorrected(identity(), identity(), anchor)
+        val bothRotZ = PoseFusion.composeCorrected(rotZ90, rotZ90, anchor)
+        val worstZ = (0 until 16).maxOf { kotlin.math.abs(neither[it] - bothRotZ[it]) }
+        assertTrue(
+            "a Z rotation must NOT cancel through the conversion, or D is not being applied " +
+                "(worst difference was $worstZ)",
+            worstZ > 1e-3f,
+        )
 
-        // ...and it holds just as well for transforms that are nothing to do with a display
-        // rotation — a rotation about a DIFFERENT axis, and a pure translation. That is the point:
-        // the cancellation is associativity over `rigidInverse`, not evidence about `R_z`.
-        //
-        // (Both stay RIGID deliberately. `composeCorrected` inverts via `PoseMath.rigidInverse`,
-        // which is only an inverse for rotation+translation; feeding it a shear breaks the identity
-        // for that reason and not for any reason about frames.)
+        // X is the axis that still cancels, because D acts as -I on the plane Rx rotates in. Pinned
+        // so nobody "fixes" the test above by switching axes and gets a false pass.
         val rotX90 = floatArrayOf(1f,0f,0f,0f, 0f,0f,1f,0f, 0f,-1f,0f,0f, 0f,0f,0f,1f)
-        val bothRotX = PoseFusion.composeCorrected(rotX90, rotX90, fpAnchor)
-        for (i in 0 until 16) assertEquals("rotX element $i", neitherRotated[i], bothRotX[i], 1e-4f)
-
-        val move = trans(3f, -2f, 7f)
-        val bothMoved = PoseFusion.composeCorrected(move, move, fpAnchor)
-        for (i in 0 until 16) assertEquals("trans element $i", neitherRotated[i], bothMoved[i], 1e-4f)
+        val bothRotX = PoseFusion.composeCorrected(rotX90, rotX90, anchor)
+        for (i in 0 until 16) assertEquals("rotX element $i", neither[i], bothRotX[i], 1e-4f)
     }
 
     /**
@@ -118,9 +144,17 @@ class PoseFusionTest {
      * which is a return-default stub in this source set and would make any assertion built on it
      * pass against an array of zeros.
      *
-     * Deliberately NOT in scope: whether the three operands are in mutually consistent frames. They
-     * are not — see the test above and 0.9. This pins the three-factor form as it stands, so 0.9's
-     * two extra factors have to change it on purpose rather than by accident.
+     * Re-derived at **0.9**, which is the coupling working as intended: this test was written to pin
+     * the three-factor form "as it stands, so 0.9 has to change it on purpose rather than by
+     * accident", and 0.9 duly broke it.
+     *
+     * The composition is now `Rx(-a) · [D · Ry(b)] · Rz(g)`. Multiplying `D · Ry(b)` first negates
+     * rows 1 and 2 of `Ry(b)`, and the product below is written out from there.
+     *
+     * **Cross-check that costs nothing:** `D` acts as `-I` on the Y-Z plane, so it commutes with
+     * `Rx`. The new expectation must therefore be exactly `D ·` the previous one — rows 1 and 2
+     * negated, row 0 untouched — and it is. Two independent routes to the same matrix, neither of
+     * them the code.
      */
     @Test fun `composeCorrected rotation block matches a hand-derived product`() {
         val a = Math.toRadians(30.0).toFloat(); val ca = cos(a); val sa = sin(a)
@@ -132,28 +166,31 @@ class PoseFusionTest {
         // matching the existing rotZ fixture above: column 0 of Rz(90) is (0,1,0), i.e. +X → +Y.
         val vCurrent = floatArrayOf(1f,0f,0f,0f, 0f,ca,sa,0f, 0f,-sa,ca,0f, 0f,0f,0f,1f)   // Rx(30)
         val pnpMat = floatArrayOf(cb,0f,-sb,0f, 0f,1f,0f,0f, sb,0f,cb,0f, 0f,0f,0f,1f)     // Ry(40)
-        val fpAnchor = floatArrayOf(cg,sg,0f,0f, -sg,cg,0f,0f, 0f,0f,1f,0f, tx,ty,tz,1f)   // Rz(50), t
+        val captureAnchorCam = floatArrayOf(cg,sg,0f,0f, -sg,cg,0f,0f, 0f,0f,1f,0f, tx,ty,tz,1f)  // Rz(50), t
 
-        // E = Rx(-a)·Ry(b)·Rz(g), multiplied out by hand.
-        //   Rx(-a)·Ry(b) = [ cb      0    sb   ]
-        //                  [-sa·sb   ca   sa·cb]
-        //                  [-ca·sb  -sa   ca·cb]
+        // E = Rx(-a)·[D·Ry(b)]·Rz(g), multiplied out by hand.
+        //   D·Ry(b)        = [ cb   0   sb ]        (rows 1,2 of Ry(b) negated)
+        //                    [ 0   -1    0 ]
+        //                    [ sb   0  -cb ]
+        //   Rx(-a)·D·Ry(b) = [ cb      0    sb    ]
+        //                    [ sa·sb  -ca  -sa·cb ]
+        //                    [ ca·sb   sa  -ca·cb ]
         // then right-multiplied by Rz(g), whose third column is (0,0,1) — which is why column 2 of E
         // is just column 2 of that intermediate.
         val e = arrayOf(
             floatArrayOf(cb * cg,                    -cb * sg,                   sb),
-            floatArrayOf(ca * sg - sa * sb * cg,     ca * cg + sa * sb * sg,     sa * cb),
-            floatArrayOf(-ca * sb * cg - sa * sg,    ca * sb * sg - sa * cg,     ca * cb),
+            floatArrayOf(sa * sb * cg - ca * sg,     -sa * sb * sg - ca * cg,    -sa * cb),
+            floatArrayOf(ca * sb * cg + sa * sg,     -ca * sb * sg + sa * cg,    -ca * cb),
         )
-        // The first two factors carry no translation, so the composed translation is the same
-        // intermediate applied to fpAnchor's t.
+        // The first three factors carry no translation, so the composed translation is the same
+        // intermediate applied to captureAnchorCam's t.
         val et = floatArrayOf(
             cb * tx + sb * tz,
-            -sa * sb * tx + ca * ty + sa * cb * tz,
-            -ca * sb * tx - sa * ty + ca * cb * tz,
+            sa * sb * tx - ca * ty - sa * cb * tz,
+            ca * sb * tx + sa * ty - ca * cb * tz,
         )
 
-        val r = PoseFusion.composeCorrected(vCurrent, pnpMat, fpAnchor)
+        val r = PoseFusion.composeCorrected(vCurrent, pnpMat, captureAnchorCam)
         for (row in 0 until 3) for (col in 0 until 3) {
             assertEquals("rotation [$row][$col]", e[row][col], r[col * 4 + row], 1e-5f)
         }
@@ -172,21 +209,21 @@ class PoseFusionTest {
     @Test fun `returns backbone when no new reloc result`() {
         val f = PoseFusion()
         val backbone = trans(1f,1f,1f)
-        val out = f.currentAnchor(backbone, identity(), FloatArray(19), identity(), confGlobal = 1f)
+        val out = f.currentAnchor(backbone, identity(), FloatArray(19), captureAtOrigin(), confGlobal = 1f)
         backbone.forEachIndexed { i, e -> assertEquals(e, out[i], 1e-4f) }
     }
 
     @Test fun `ignores low-inlier-ratio snaps`() {
         val f = PoseFusion()
         val out = f.currentAnchor(trans(0f,0f,0f), identity(),
-            reloc(trans(99f,0f,0f), inliers = 1f, matches = 100f, seq = 1f), identity(), confGlobal = 1f)
+            reloc(trans(99f,0f,0f), inliers = 1f, matches = 100f, seq = 1f), captureAtOrigin(), confGlobal = 1f)
         assertEquals(0f, out[12], 1e-3f)
     }
 
     @Test fun `first confident snap hard-snaps to correction`() {
         val f = PoseFusion()
         val out = f.currentAnchor(trans(0f,0f,0f), identity(),
-            reloc(trans(10f,0f,0f), inliers = 90f, matches = 100f, seq = 1f), identity(), confGlobal = 1f)
+            reloc(trans(10f,0f,0f), inliers = 90f, matches = 100f, seq = 1f), captureAtOrigin(), confGlobal = 1f)
         assertEquals(10f, out[12], 1e-3f)
     }
 
@@ -194,7 +231,7 @@ class PoseFusionTest {
         val f = PoseFusion()
         // ratio 0.6: above MIN_INLIER_RATIO but below COLD_SNAP_INLIER_RATIO -> smooth, not snap.
         val out = f.currentAnchor(trans(0f,0f,0f), identity(),
-            reloc(trans(10f,0f,0f), inliers = 60f, matches = 100f, seq = 1f), identity(), confGlobal = 1f)
+            reloc(trans(10f,0f,0f), inliers = 60f, matches = 100f, seq = 1f), captureAtOrigin(), confGlobal = 1f)
         assertTrue("expected partial move, got ${out[12]}", out[12] > 0f && out[12] < 10f)
     }
 
@@ -202,7 +239,7 @@ class PoseFusionTest {
         val f = PoseFusion()
         // The old design multiplied alpha by confGlobal, so conf=0 froze the overlay. The floor fixes it.
         val out = f.currentAnchor(trans(0f,0f,0f), identity(),
-            reloc(trans(10f,0f,0f), inliers = 60f, matches = 100f, seq = 1f), identity(), confGlobal = 0f)
+            reloc(trans(10f,0f,0f), inliers = 60f, matches = 100f, seq = 1f), captureAtOrigin(), confGlobal = 0f)
         assertTrue("expected non-zero correction with depth off, got ${out[12]}", out[12] > 0f)
     }
 
@@ -214,9 +251,9 @@ class PoseFusionTest {
     @Test fun `corroboration scales correction strength`() {
         // Same relock, same inlier ratio; only the corroboration differs.
         val bare = PoseFusion().currentAnchor(trans(0f,0f,0f), identity(),
-            reloc(trans(10f,0f,0f), inliers = 60f, matches = 100f, seq = 1f), identity(), confGlobal = 0f)
+            reloc(trans(10f,0f,0f), inliers = 60f, matches = 100f, seq = 1f), captureAtOrigin(), confGlobal = 0f)
         val painted = PoseFusion().currentAnchor(trans(0f,0f,0f), identity(),
-            reloc(trans(10f,0f,0f), inliers = 60f, matches = 100f, seq = 1f), identity(), confGlobal = 1f)
+            reloc(trans(10f,0f,0f), inliers = 60f, matches = 100f, seq = 1f), captureAtOrigin(), confGlobal = 1f)
         assertTrue(
             "a corroborated wall should pull harder than a bare one: bare=${bare[12]} painted=${painted[12]}",
             painted[12] > bare[12],
@@ -289,9 +326,9 @@ class PoseFusionTest {
         val backbone = trans(0f, 0f, 0f)
         // Warm relock at full confidence.
         f.currentAnchor(backbone, identity(),
-            reloc(trans(10f, 0f, 0f), inliers = 60f, matches = 100f, seq = 1f), identity(), confGlobal = 1f)
+            reloc(trans(10f, 0f, 0f), inliers = 60f, matches = 100f, seq = 1f), captureAtOrigin(), confGlobal = 1f)
         val afterGood = f.currentAnchor(backbone, identity(),
-            reloc(trans(10f, 0f, 0f), inliers = 60f, matches = 100f, seq = 2f), identity(), confGlobal = 1f)[12]
+            reloc(trans(10f, 0f, 0f), inliers = 60f, matches = 100f, seq = 2f), captureAtOrigin(), confGlobal = 1f)[12]
 
         // Three ticks of a decayed reading (0.9^1..0.9^3), same relock quality throughout.
         var last = afterGood
@@ -320,9 +357,9 @@ class PoseFusionTest {
 
     @Test fun `corroboration outside 0-1 is clamped, not extrapolated`() {
         val full = PoseFusion().currentAnchor(trans(0f,0f,0f), identity(),
-            reloc(trans(10f,0f,0f), inliers = 60f, matches = 100f, seq = 1f), identity(), confGlobal = 1f)
+            reloc(trans(10f,0f,0f), inliers = 60f, matches = 100f, seq = 1f), captureAtOrigin(), confGlobal = 1f)
         val over = PoseFusion().currentAnchor(trans(0f,0f,0f), identity(),
-            reloc(trans(10f,0f,0f), inliers = 60f, matches = 100f, seq = 1f), identity(), confGlobal = 5f)
+            reloc(trans(10f,0f,0f), inliers = 60f, matches = 100f, seq = 1f), captureAtOrigin(), confGlobal = 5f)
         assertEquals(full[12], over[12], 1e-4f)
     }
 
@@ -330,9 +367,9 @@ class PoseFusionTest {
         val f = PoseFusion()
         // Confident cold snap establishes D = +10x at backbone origin.
         f.currentAnchor(trans(0f,0f,0f), identity(),
-            reloc(trans(10f,0f,0f), inliers = 90f, matches = 100f, seq = 1f), identity(), confGlobal = 1f)
+            reloc(trans(10f,0f,0f), inliers = 90f, matches = 100f, seq = 1f), captureAtOrigin(), confGlobal = 1f)
         // No new snap, but ARCore's frame drifts the backbone by +1z: D must still apply.
-        val out = f.currentAnchor(trans(0f,0f,1f), identity(), FloatArray(19), identity(), confGlobal = 1f)
+        val out = f.currentAnchor(trans(0f,0f,1f), identity(), FloatArray(19), captureAtOrigin(), confGlobal = 1f)
         assertEquals(10f, out[12], 1e-3f)
         assertEquals(1f, out[14], 1e-3f)
     }
@@ -340,20 +377,20 @@ class PoseFusionTest {
     @Test fun `confident relock that diverges far hard-snaps (pocket case)`() {
         val f = PoseFusion()
         f.currentAnchor(trans(0f,0f,0f), identity(),
-            reloc(trans(10f,0f,0f), inliers = 90f, matches = 100f, seq = 1f), identity(), confGlobal = 1f)
+            reloc(trans(10f,0f,0f), inliers = 90f, matches = 100f, seq = 1f), captureAtOrigin(), confGlobal = 1f)
         // New confident snap puts the anchor 10m away -> beyond COLD_SNAP_DIST_M -> instant relock.
         val out = f.currentAnchor(trans(0f,0f,0f), identity(),
-            reloc(trans(20f,0f,0f), inliers = 90f, matches = 100f, seq = 2f), identity(), confGlobal = 1f)
+            reloc(trans(20f,0f,0f), inliers = 90f, matches = 100f, seq = 2f), captureAtOrigin(), confGlobal = 1f)
         assertEquals(20f, out[12], 1e-3f)
     }
 
     @Test fun `small confident relock smooths instead of teleporting`() {
         val f = PoseFusion()
         f.currentAnchor(trans(0f,0f,0f), identity(),
-            reloc(trans(10f,0f,0f), inliers = 90f, matches = 100f, seq = 1f), identity(), confGlobal = 1f)
+            reloc(trans(10f,0f,0f), inliers = 90f, matches = 100f, seq = 1f), captureAtOrigin(), confGlobal = 1f)
         // 5cm move (< COLD_SNAP_DIST_M) -> not cold -> smoothed, lands just past 10, not snapped to 10.05.
         val out = f.currentAnchor(trans(0f,0f,0f), identity(),
-            reloc(trans(10.05f,0f,0f), inliers = 90f, matches = 100f, seq = 2f), identity(), confGlobal = 1f)
+            reloc(trans(10.05f,0f,0f), inliers = 90f, matches = 100f, seq = 2f), captureAtOrigin(), confGlobal = 1f)
         assertTrue("expected smoothed move, got ${out[12]}", out[12] > 10f && out[12] < 10.05f)
     }
 }

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/eval/EvalSampleLogTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/eval/EvalSampleLogTest.kt
@@ -47,7 +47,7 @@ class EvalSampleLogTest {
                 "relocObliquityDeg,relocRectifiedCorr," +
                 "relocBackboneFeatures,relocBackboneMatches,relocBackboneInliers," +
                 "corrobPredicted,corrobMatched,corrobLoneSkips,searchRadiusPx,relocReprojPx," +
-                "inlierSpread," +
+                "inlierSpread,corrobGate,growOutcome,fusionState,fusionCorrectionMm," +
                 "captureRotationNeededDeg,liveRotationNeededDeg",
             EvalSampleLog.CSV_HEADER,
         )
@@ -62,12 +62,13 @@ class EvalSampleLogTest {
             nativeHeapKb = 20480L,
         )
         assertEquals(
-            // Six reloc, three backbone and three corroboration Int columns default to -1; the two
-            // pixel columns are Floats, so their -1f sentinel prints as -1.0; then the two rotation
+            // Six reloc, three backbone and three corroboration Int columns default to -1; three
+            // pixel columns are Floats, so their -1f sentinel prints as -1.0; then the two REASON
+            // ordinals, the fusion state ordinal and its correction magnitude; then the two rotation
             // columns. The float spelling is part of the contract a consumer parses, not an
             // incidental formatting detail, so it is written out here literally.
             "12,dual,true,1.5,0.25,3.0,1.0,2.0,0.0,4.0,1.0,8.0,30.0,-450.0,31.0,20480," +
-                "-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1.0,-1.0,-1.0,-1,-1",
+                "-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1.0,-1.0,-1.0,-1,-1,-1,-1.0,-1,-1",
             EvalSampleLog.toCsvRow(row),
         )
     }

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Sun Aug 02 06:12:10 UTC 2026
-versionBuild=14507
+#Sun Aug 02 06:51:46 UTC 2026
+versionBuild=14517
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=373
+versionPatch=383

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Sun Aug 02 04:59:12 UTC 2026
-versionBuild=14500
+#Sun Aug 02 06:12:10 UTC 2026
+versionBuild=14507
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=366
+versionPatch=373


### PR DESCRIPTION
Two related changes. The second exists because of the first.

---

# Part 1 — 0.9: `composeCorrected` was in mixed frames

`IMPLEMENTATION.md` **0.9**, the last unfixed geometry defect from Phase 0.

I had been treating this as needing approval. That was wrong twice over: "needs its own experiment" in the plan means *land it separately with evidence*, not *wait for permission* — and I had overstated what I knew. A subagent's audit asserted the frames were inconsistent and I relayed it as fact without verifying it myself.

There's an invariant that settles it with no device.

## The invariant

`currentAnchor` computes `newD = corrected · inverse(backbone)`. So if ARCore hasn't drifted since capture, `backbone` is **already** the right answer and `corrected` must come back equal to it — the correction must be the identity. Any residual *is* the composition error.

| composition | residual under zero drift |
|---|---|
| **shipped** `inv(V) · pnp · fpAnchor` | **2.92** |
| conjugation `inv(V) · D·pnp·D · captureAnchorCam` | 4.29 |
| **fixed** `inv(V) · [D · pnp] · captureAnchorCam` | **4.8e-7** |

2.92 is not a rounding artefact. It's a wholly different pose.

## Why the test isn't circular

The one belief-carrying input is what `solvePnP` returns under zero drift. Rather than assert my own convention, it's built from the repo's **own shipped bridge**: `MetricMarks.glViewToCv`, and `MetricFingerprintBuilder`'s `captureAnchorCam = cvView · anchorModel`. The fingerprint frame *is* the display-oriented CV capture camera — by construction, in code whose fingerprints demonstrably relocalize.

Limit, stated: this validates `composeCorrected` **against the fingerprint builder**. It cannot catch an error the two share.

## The fix

`pnpMat` comes out of `solvePnP` in **CV** convention and was chained straight onto a **GL** view inverse, so Y and Z were flipped. And its domain is the **fingerprint** frame while `fpAnchor` was a world-space model matrix, so the capture view was missing entirely. `captureAnchorCam` — which Phase 2 already builds, persists and partitions with — repairs the second and half of the first. No new geometry.

## I got it wrong first, and the invariant caught it

Converting a *transform* between conventions is normally the conjugation `D · m · D`, and that's what I wrote. Wrong here, because `captureAnchorCam` carries its own `D` — the trailing factor applies it twice and lands **4.29** off, *worse than the defect it was meant to fix*. §8.3's warning arriving in person. Both mistakes are pinned.

## Three tests re-derived, not patched

- **`V == pnp` no longer cancels.** It used to, only because `pnpMat` was chained in raw — the defect. What survives now is exactly `D`.
- **`composeCorrected is frame-agnostic` inverted.** It was true *because* the function made no commitment about conventions — the commitment lived in four callers' data, where it was wrong. 0.9 moved it into the function, so the cancellation must now fail, and asserting that is what proves `D` is applied rather than merely named. The `Rx` case is kept deliberately: `D` acts as `-I` on the Y-Z plane, so rotations about X *do* still cancel — a test that only tried that axis would have concluded nothing changed.
- **The 0.6 hand-derived rotation product**, re-derived for `Rx(-a)·[D·Ry(b)]·Rz(g)`. Written to pin the form *"so 0.9 has to change it on purpose rather than by accident"* — and it duly broke. Cross-checked two ways: `D` commutes with `Rx`, so the new expectation must be exactly `D ·` the old one, and it is.

The 17 fixture calls passing `identity()` as the anchor now pass `D`. Not a fudge: with the capture camera and anchor both at the world origin, `V_cv(capture) · anchorModel` **is** `D`. Passing `identity()` was passing a capture view that doesn't exist — 0.9's mistake in miniature.

---

# Part 2 — diagnostics for what did **not** happen

0.9's fix skips fusion entirely when `captureAnchorCam` is null. That's correct, and it was **completely invisible**: the overlay drifts and every other row looks healthy.

That's the pattern behind most of the expensive failures here. Phase 2's partition was inert on every first capture for weeks. Self-grow shipped ON while its own comment said OFF. Every other diagnostic in this project reports a *measurement*; none reported a *decision*.

## Fusion — `FusionState`

Six states produce the identical artist-visible symptom. `DISABLED`, `NO_ANCHOR`, `NO_CAPTURE_POSE`, `WAITING_FOR_LOCK`, `COLD_SNAP`, `BLENDING`, `HOLDING`. The three meaning "fusion never ran" are reported by `ArRenderer`, because `PoseFusion` isn't called in those cases and can't know. `NO_CAPTURE_POSE` renders as **"OLD TARGET — re-create it"**, the only state whose fix is an artist action rather than a code change.

Alongside it: the standing correction's **magnitude in mm and degrees** — a few mm is the system working, a few hundred is either a real relock or a composition error like 0.9's, told apart by whether it *stays* large — and **accepted vs refused** snap counts. A relock refused by `MIN_INLIER_RATIO` reached fusion and was discarded *there*; from the reloc channel's side that attempt **succeeded**, so nothing else records it. A healthy `Reloc` row above `0 ok · 14 refused` is a specific, previously unreportable diagnosis.

## Corroboration gate — `CorrobGate`

Four preconditions, one observable. "No design registered", "design not placed", "no lock this frame" and a 2D/descriptor mismatch all produced the same three `-1`s and the same dash — and one of them is a bug while the others aren't. The `&&` chain was decomposed into a reason.

A populated `Corrob` row now also carries **`(ungated)`** when the numbers came from the global fallback: a different measurement with a different denominator, which must not be read as a Phase-4 reading.

## Self-grow — `GrowOutcome`

Phase 3 was otherwise invisible: default-off, hard-gated, every refusal silent by construction. Eight causes for "the map is not growing", one being the switch, as intended. `UNTRUSTED` — the gate refusing on inlier spread or match quality — is the one meaning *tuning*, and it was indistinguishable from the switch being off.

## All three reach the eval CSV

Same reason they reach the overlay: a run where corroboration never gated is not a bad result, it's a **void** one, and without these columns it can't be told from a run where the wall genuinely failed to corroborate. Aggregating the two is how a null result gets manufactured.

The int channel widened 12 → 14. The new slots default to their enums' "not run" ordinals rather than `-1`, because with no engine nothing ran — which is exactly what those values say. An unknown ordinal from a newer `.so` absorbs into `UNKNOWN` rather than reading as whichever entry happens to be first.

---

## Verification

- NDK build clean for `arm64-v8a` and `armeabi-v7a`.
- `:core:common`, `:core:nativebridge`, `:feature:ar`, `:feature:editor` unit tests green; `:app` compiles.
- **Mutation-verified**: counting a refused relock as accepted fails the new fusion test.
- **Behaviour change**: a pre-Phase-2 fingerprint now has fusion **skipped** rather than fed a world-frame anchor — and, as of Part 2, says so on screen.
- **Still not device-verified.** The invariant proves the three factors agree with the fingerprint builder — internal consistency — not that the overlay lands on the wall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Q5WXFiVLeN4sXa9bPCSDA