### PR TITLE
Self-collecting diagnostics: rolling report, auto-screenshots, one-tap share

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/DiagnosticWindowCapture.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/DiagnosticWindowCapture.kt
@@ -1,0 +1,85 @@
+package com.hereliesaz.graffitixr
+
+import android.app.Activity
+import android.graphics.Bitmap
+import android.os.Handler
+import android.os.Looper
+import android.view.PixelCopy
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import java.io.File
+import kotlin.coroutines.resume
+
+/**
+ * Photographs the app window to a PNG.
+ *
+ * ## Why `PixelCopy` and not the view hierarchy
+ *
+ * The obvious implementation — `decorView.draw(Canvas(bitmap))`, or the old drawing cache — produces
+ * an image of the Compose UI over a **black rectangle**. The camera preview and the AR overlay are a
+ * hardware-composited surface: they are never drawn by the view hierarchy's canvas, they are handed
+ * to the compositor. So the one thing a diagnostic screenshot exists to show is the one thing that
+ * method cannot capture. `PixelCopy` reads the composited window instead, which is what is actually
+ * on the glass.
+ *
+ * ## What the timestamp on the image means
+ *
+ * Less than it looks like. The request is raised from the diagnostics tick, dispatched to a
+ * coroutine, and satisfied by the compositor some frames later. The image is therefore *shortly
+ * after* the transition that asked for it, not at it — which is the useful direction for a
+ * correction spike (it shows where the overlay landed) and the awkward one for a lost lock (the
+ * camera may already have moved on). It is worth knowing which is which when reading one.
+ */
+suspend fun captureWindowToPng(
+    activity: Activity,
+    dest: File,
+    maxDim: Int = DIAGNOSTIC_CAPTURE_MAX_DIM,
+): File {
+    val decor = activity.window?.decorView
+        ?: throw IllegalStateException("no window")
+    val w = decor.width
+    val h = decor.height
+    if (w <= 0 || h <= 0) throw IllegalStateException("window not laid out (${w}x$h)")
+
+    val full = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
+    val status = suspendCancellableCoroutine { cont ->
+        try {
+            PixelCopy.request(
+                activity.window!!,
+                full,
+                { result -> if (cont.isActive) cont.resume(result) },
+                Handler(Looper.getMainLooper()),
+            )
+        } catch (e: IllegalArgumentException) {
+            // Thrown when the window has no backing surface yet — mid-rotation, or a request that
+            // raced the Activity going down. A real outcome, not a crash.
+            if (cont.isActive) cont.resume(PixelCopy.ERROR_SOURCE_NO_DATA)
+        }
+    }
+    if (status != PixelCopy.SUCCESS) {
+        full.recycle()
+        throw IllegalStateException("PixelCopy failed (status $status)")
+    }
+
+    return withContext(Dispatchers.IO) {
+        // Downscaled before encoding, not after: sixteen full-resolution PNGs of a 1080×2400 screen
+        // is tens of megabytes written to a user's phone for a debugging aid. At 1280 on the long
+        // edge the HUD text is still legible and the wall is still identifiable, which is all either
+        // half of the image is read for.
+        val scale = maxDim.toFloat() / maxOf(w, h).toFloat()
+        val out = if (scale < 1f) {
+            Bitmap.createScaledBitmap(full, (w * scale).toInt(), (h * scale).toInt(), true)
+        } else {
+            full
+        }
+        dest.parentFile?.mkdirs()
+        dest.outputStream().use { out.compress(Bitmap.CompressFormat.PNG, 100, it) }
+        if (out !== full) out.recycle()
+        full.recycle()
+        dest
+    }
+}
+
+/** Long-edge cap for a diagnostic capture, in pixels. */
+const val DIAGNOSTIC_CAPTURE_MAX_DIM = 1280

--- a/app/src/main/java/com/hereliesaz/graffitixr/DiagnosticWindowCapture.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/DiagnosticWindowCapture.kt
@@ -64,9 +64,14 @@ suspend fun captureWindowToPng(
 
     return withContext(Dispatchers.IO) {
         // Downscaled before encoding, not after: sixteen full-resolution PNGs of a 1080×2400 screen
-        // is tens of megabytes written to a user's phone for a debugging aid. At 1280 on the long
-        // edge the HUD text is still legible and the wall is still identifiable, which is all either
-        // half of the image is read for.
+        // is tens of megabytes written to a user's phone for a debugging aid.
+        //
+        // 1280 on the long edge is chosen for the SCENE, not the HUD. On a 1080×2400 phone that is a
+        // 0.53× reduction, which takes the overlay's 11 sp rows to about six pixels — not reliably
+        // legible, and it does not need to be: every number on that HUD is in the report, at full
+        // precision, aggregated over a window rather than caught at one instant. What only the
+        // image can supply is what the camera was pointed at, and a wall stays identifiable well
+        // below this.
         val scale = maxDim.toFloat() / maxOf(w, h).toFloat()
         val out = if (scale < 1f) {
             Bitmap.createScaledBitmap(full, (w * scale).toInt(), (h * scale).toInt(), true)

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -201,9 +201,14 @@ class MainActivity : ComponentActivity() {
             val text = withContext(Dispatchers.IO) {
                 runCatching { files.first().readText() }.getOrDefault("")
             }
-            getSystemService(AndroidClipboardManager::class.java)?.setPrimaryClip(
-                ClipData.newPlainText("GraffitiXR diagnostics", text),
-            )
+            // Only if there is something to copy. `getOrDefault("")` on a failed read would
+            // otherwise put an empty string on the clipboard — destroying whatever the user had
+            // there — while the toast below still said "Report copied".
+            if (text.isNotBlank()) {
+                getSystemService(AndroidClipboardManager::class.java)?.setPrimaryClip(
+                    ClipData.newPlainText("GraffitiXR diagnostics", text),
+                )
+            }
             val uris = ArrayList<Uri>()
             for (f in files) {
                 // Per-file, because one unreadable artefact must not cost the share the other
@@ -225,7 +230,8 @@ class MainActivity : ComponentActivity() {
             }
             Toast.makeText(
                 this@MainActivity,
-                "Report copied — ${uris.size} file(s) attached",
+                if (text.isBlank()) "Report unreadable — ${uris.size} file(s) attached"
+                else "Report copied — ${uris.size} file(s) attached",
                 Toast.LENGTH_SHORT,
             ).show()
             runCatching { startActivity(Intent.createChooser(send, "Share diagnostics")) }
@@ -1157,6 +1163,8 @@ class MainActivity : ComponentActivity() {
                             }
                             val diagnosticCaptures by arViewModel.diagnosticCaptureCount
                                 .collectAsState()
+                            val evalFusionOn by arViewModel.evalFusionEnabled.collectAsState()
+                            val evalSelfGrowOn by arViewModel.evalSelfGrowEnabled.collectAsState()
                             // Keyed on Unit: the collector must outlive every recomposition, or a
                             // request raised while the overlay is mid-recompose lands in a
                             // subscriber that no longer exists and the capture is silently lost.
@@ -1213,6 +1221,8 @@ class MainActivity : ComponentActivity() {
                                     onInduceLoss = { arViewModel.evalInduceLoss() },
                                     onToggleFusion = { arViewModel.evalSetFusionEnabled(it) },
                                     onToggleSelfGrow = { arViewModel.evalSetSelfGrowEnabled(it) },
+                                    fusionOn = evalFusionOn,
+                                    selfGrowOn = evalSelfGrowOn,
                                 )
                             }
 
@@ -2412,8 +2422,8 @@ private fun RelocDiagnosticsOverlay(
         DiagnosticRow("Painted", "${(paintingProgress * 100).toInt()}%", androidx.compose.ui.graphics.Color.White)
 
         // The whole overlay above answers "what is happening now" for someone holding the phone.
-        // This button answers it for someone who is not: it copies an aggregated report of the last
-        // two minutes to the clipboard and opens a share sheet with that report, the eval CSVs and
+        // This button answers it for someone who is not: it copies an aggregated report of the
+        // recent window to the clipboard and opens a share sheet with that report, the eval CSVs and
         // every screenshot taken automatically along the way. Shipped in release beside the rest of
         // the overlay, because the person who can reproduce a field failure is the artist, and until
         // now the only way to get anything back from them was a photograph of a phone screen.
@@ -2437,19 +2447,21 @@ private fun EvalOverlay(
     onInduceLoss: () -> Unit,
     onToggleFusion: (Boolean) -> Unit,
     onToggleSelfGrow: (Boolean) -> Unit,
-) {
-    // Local UI state for the A/B switch, defaulting to FALSE to match `ArRenderer.fusionEnabled`,
-    // which ships off.
+    // Both switches MIRROR the values they set; neither keeps a copy.
     //
-    // It defaulted to true, and the comment claimed that matched the renderer. It has not for some
-    // time. The consequence was not cosmetic: the button read "Fusion ON" while fusion was off, and
-    // the first press set it to `false` — the value it already held — so enabling fusion took two
-    // presses and the intervening state was indistinguishable from the one being left. An A/B switch
-    // that lies about which arm is selected invalidates the comparison it exists to run.
-    val fusionOn = androidx.compose.runtime.remember { androidx.compose.runtime.mutableStateOf(false) }
-    // Teleological self-grow defaults OFF to match the native default (MobileGS.h). It permanently
-    // mutates the authoritative reloc fingerprint, so it is opt-in per session. Toggle to enable.
-    val selfGrowOn = androidx.compose.runtime.saveable.rememberSaveable { androidx.compose.runtime.mutableStateOf(false) }
+    // These were `remember`ed booleans seeded with a guess at each default. The fusion guess said
+    // `true` while `ArRenderer.fusionEnabled` had shipped `false` for 187 commits, so the button
+    // read "Fusion ON" with fusion off and the first press set it to the value it already held —
+    // enabling fusion took two presses, and the intervening state was indistinguishable from the one
+    // being left. Correcting the seed alone would have left the same defect one rotation away: a
+    // `remember` is dropped on configuration change while the renderer's flag is not.
+    //
+    // An A/B switch that can disagree with the arm it selects invalidates the comparison it exists
+    // to run, so neither of these gets to hold its own state — they are read from the view model,
+    // which reads them back from the renderer and the engine.
+    fusionOn: Boolean,
+    selfGrowOn: Boolean,
+) {
     androidx.compose.foundation.layout.Column(
         androidx.compose.ui.Modifier
             .background(androidx.compose.ui.graphics.Color(0xAA000000))
@@ -2468,17 +2480,11 @@ private fun EvalOverlay(
             androidx.compose.material3.TextButton(onClick = onInduceLoss) { androidx.compose.material3.Text("Loss") }
             androidx.compose.material3.TextButton(onClick = onStartRecord) { androidx.compose.material3.Text("Rec▶") }
             androidx.compose.material3.TextButton(onClick = onStopRecord) { androidx.compose.material3.Text("Rec■") }
-            androidx.compose.material3.TextButton(onClick = {
-                fusionOn.value = !fusionOn.value
-                onToggleFusion(fusionOn.value)
-            }) {
-                androidx.compose.material3.Text(if (fusionOn.value) "Fusion ON" else "Fusion OFF")
+            androidx.compose.material3.TextButton(onClick = { onToggleFusion(!fusionOn) }) {
+                androidx.compose.material3.Text(if (fusionOn) "Fusion ON" else "Fusion OFF")
             }
-            androidx.compose.material3.TextButton(onClick = {
-                selfGrowOn.value = !selfGrowOn.value
-                onToggleSelfGrow(selfGrowOn.value)
-            }) {
-                androidx.compose.material3.Text(if (selfGrowOn.value) "Grow ON" else "Grow OFF")
+            androidx.compose.material3.TextButton(onClick = { onToggleSelfGrow(!selfGrowOn) }) {
+                androidx.compose.material3.Text(if (selfGrowOn) "Grow ON" else "Grow OFF")
             }
         }
     }

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -185,6 +185,54 @@ class MainActivity : ComponentActivity() {
     // consumed once by the editor as a new overlay layer. Set from the launch intent / onNewIntent.
     private var incomingSharedImage by mutableStateOf<Uri?>(null)
 
+    /**
+     * Copies the diagnostic report to the clipboard and offers the whole bundle to a share sheet.
+     *
+     * Both, not either. The report is what gets pasted into a chat and is the only part most reports
+     * need; the attachments are the CSVs and the screenshots, which cannot be pasted. Doing only the
+     * share sheet would mean the common case — "paste me what it says" — required picking an app,
+     * finding the file and copying out of it.
+     */
+    private fun shareDiagnosticBundle() {
+        lifecycleScope.launch {
+            // Report assembly walks a 1800-sample ring and the writes touch the filesystem; neither
+            // belongs on the frame the button was tapped in.
+            val files = withContext(Dispatchers.IO) { arViewModel.writeDiagnosticBundle() }
+            val text = withContext(Dispatchers.IO) {
+                runCatching { files.first().readText() }.getOrDefault("")
+            }
+            getSystemService(AndroidClipboardManager::class.java)?.setPrimaryClip(
+                ClipData.newPlainText("GraffitiXR diagnostics", text),
+            )
+            val uris = ArrayList<Uri>()
+            for (f in files) {
+                // Per-file, because one unreadable artefact must not cost the share the other
+                // fifteen — and a report that arrives without its screenshots still says what
+                // happened, whereas nothing arriving says nothing.
+                runCatching {
+                    FileProvider.getUriForFile(this@MainActivity, "$packageName.fileprovider", f)
+                }.onSuccess { uris.add(it) }
+                    .onFailure { Timber.w(it, "diagnostic bundle: skipping ${f.name}") }
+            }
+            val send = Intent(Intent.ACTION_SEND_MULTIPLE).apply {
+                // Mixed markdown, CSV, JSON and PNG. Narrowing this would hide the share targets
+                // that accept everything, which are the ones actually wanted here.
+                type = "*/*"
+                putParcelableArrayListExtra(Intent.EXTRA_STREAM, uris)
+                putExtra(Intent.EXTRA_SUBJECT, "GraffitiXR diagnostics")
+                putExtra(Intent.EXTRA_TEXT, text)
+                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            }
+            Toast.makeText(
+                this@MainActivity,
+                "Report copied — ${uris.size} file(s) attached",
+                Toast.LENGTH_SHORT,
+            ).show()
+            runCatching { startActivity(Intent.createChooser(send, "Share diagnostics")) }
+                .onFailure { Timber.w(it, "no share target for diagnostics") }
+        }
+    }
+
     private val permissionLauncher = registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { p ->
         hasCameraPermission = p[Manifest.permission.CAMERA] ?: false
     }
@@ -1100,6 +1148,41 @@ class MainActivity : ComponentActivity() {
                                 AnchorLockFlash(isAnchorEstablished = arUiState.isAnchorEstablished, strings = strings)
                             }
 
+                            // Screenshots follow the overlay's opt-in, and only it. The numeric
+                            // recorder inside the view model runs unconditionally — it is memory —
+                            // but writing PNGs of the user's camera feed to disk is not something to
+                            // do because the app felt like it.
+                            LaunchedEffect(editorUiState.showDiagOverlay) {
+                                arViewModel.setDiagnosticCaptureEnabled(editorUiState.showDiagOverlay)
+                            }
+                            val diagnosticCaptures by arViewModel.diagnosticCaptureCount
+                                .collectAsState()
+                            // Keyed on Unit: the collector must outlive every recomposition, or a
+                            // request raised while the overlay is mid-recompose lands in a
+                            // subscriber that no longer exists and the capture is silently lost.
+                            LaunchedEffect(Unit) {
+                                arViewModel.captureRequests.collect { trigger ->
+                                    // Naming and counting are the view model's, because this
+                                    // collector is torn down and restarted on every rotation while
+                                    // the session it is numbering is not.
+                                    val dest = arViewModel.nextDiagnosticCaptureFile(trigger)
+                                    try {
+                                        captureWindowToPng(this@MainActivity, dest)
+                                        arViewModel.onDiagnosticCaptureWritten(trigger, dest.name)
+                                    } catch (ce: kotlinx.coroutines.CancellationException) {
+                                        // Disposal, not a failure. Recording it as one would put a
+                                        // "(failed)" line in every report from a session that
+                                        // simply ended.
+                                        throw ce
+                                    } catch (e: Exception) {
+                                        arViewModel.onDiagnosticCaptureFailed(
+                                            trigger, e.message ?: e.javaClass.simpleName,
+                                        )
+                                        Timber.w(e, "diagnostic capture failed for $trigger")
+                                    }
+                                }
+                            }
+
                             // Relocalization state — available in RELEASE too, behind the same opt-in
                             // Diagnostic Overlay setting. The eval panel below is a dev instrument and
                             // stays debug-only, but "is relocalization working, and if not which gate
@@ -1113,6 +1196,8 @@ class MainActivity : ComponentActivity() {
                                     fusion = arUiState.fusionDiagnostics,
                                     fingerprintPoints = arUiState.evalLiveMetrics.wallCount,
                                     paintingProgress = arUiState.paintingProgress,
+                                    captureCount = diagnosticCaptures,
+                                    onShareReport = { shareDiagnosticBundle() },
                                 )
                             }
 
@@ -2122,6 +2207,8 @@ private fun RelocDiagnosticsOverlay(
     fusion: com.hereliesaz.graffitixr.common.model.FusionDiagnostics,
     fingerprintPoints: Int,
     paintingProgress: Float,
+    onShareReport: () -> Unit,
+    captureCount: Int,
 ) {
     val d = diagnostics
     // What to DO about it, not just what happened.
@@ -2323,6 +2410,20 @@ private fun RelocDiagnosticsOverlay(
         // Painting progress, labelled as such. It was labelled "Corroborated" while being fed
         // paintingProgress — a name for the value one row up, on a number that is not it.
         DiagnosticRow("Painted", "${(paintingProgress * 100).toInt()}%", androidx.compose.ui.graphics.Color.White)
+
+        // The whole overlay above answers "what is happening now" for someone holding the phone.
+        // This button answers it for someone who is not: it copies an aggregated report of the last
+        // two minutes to the clipboard and opens a share sheet with that report, the eval CSVs and
+        // every screenshot taken automatically along the way. Shipped in release beside the rest of
+        // the overlay, because the person who can reproduce a field failure is the artist, and until
+        // now the only way to get anything back from them was a photograph of a phone screen.
+        androidx.compose.material3.TextButton(onClick = onShareReport) {
+            androidx.compose.material3.Text(
+                if (captureCount > 0) "Copy + share report ($captureCount shots)"
+                else "Copy + share report",
+                color = androidx.compose.ui.graphics.Color.Cyan,
+            )
+        }
     }
 }
 
@@ -2337,8 +2438,15 @@ private fun EvalOverlay(
     onToggleFusion: (Boolean) -> Unit,
     onToggleSelfGrow: (Boolean) -> Unit,
 ) {
-    // Local UI state for the A/B switch; defaults to true to match ArRenderer.fusionEnabled.
-    val fusionOn = androidx.compose.runtime.remember { androidx.compose.runtime.mutableStateOf(true) }
+    // Local UI state for the A/B switch, defaulting to FALSE to match `ArRenderer.fusionEnabled`,
+    // which ships off.
+    //
+    // It defaulted to true, and the comment claimed that matched the renderer. It has not for some
+    // time. The consequence was not cosmetic: the button read "Fusion ON" while fusion was off, and
+    // the first press set it to `false` — the value it already held — so enabling fusion took two
+    // presses and the intervening state was indistinguishable from the one being left. An A/B switch
+    // that lies about which arm is selected invalidates the comparison it exists to run.
+    val fusionOn = androidx.compose.runtime.remember { androidx.compose.runtime.mutableStateOf(false) }
     // Teleological self-grow defaults OFF to match the native default (MobileGS.h). It permanently
     // mutates the authoritative reloc fingerprint, so it is opt-in per session. Toggle to enable.
     val selfGrowOn = androidx.compose.runtime.saveable.rememberSaveable { androidx.compose.runtime.mutableStateOf(false) }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -406,7 +406,7 @@
     <string name="settings_hand_label">Dominante Hand</string>
     <string name="settings_hand_right">Rechts</string>
     <string name="settings_hand_left">Links</string>
-    <string name="settings_diag_label">Tiefendiagnose-Overlay</string>
+    <string name="settings_diag_label">Diagnose &amp; Auto-Screenshots</string>
     <string name="settings_on">Ein</string>
     <string name="settings_off">Aus</string>
     <string name="settings_scan_mode_label">AR-Scanmodus</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -406,7 +406,7 @@
     <string name="settings_hand_label">Mano Dominante</string>
     <string name="settings_hand_right">Derecha</string>
     <string name="settings_hand_left">Izquierda</string>
-    <string name="settings_diag_label">Superposición de Diagnóstico de Profundidad</string>
+    <string name="settings_diag_label">Diagnóstico y capturas automáticas</string>
     <string name="settings_on">Encendido</string>
     <string name="settings_off">Apagado</string>
     <string name="settings_scan_mode_label">Modo de Escaneo AR</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -404,7 +404,7 @@
     <string name="settings_hand_label">Main dominante</string>
     <string name="settings_hand_right">Droite</string>
     <string name="settings_hand_left">Gauche</string>
-    <string name="settings_diag_label">Superposition de diagnostic de profondeur</string>
+    <string name="settings_diag_label">Diagnostics et captures automatiques</string>
     <string name="settings_on">Activé</string>
     <string name="settings_off">Désactivé</string>
     <string name="settings_scan_mode_label">Mode de scan AR</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -406,7 +406,7 @@
     <string name="settings_hand_label">Domináns Kéz</string>
     <string name="settings_hand_right">Jobb</string>
     <string name="settings_hand_left">Bal</string>
-    <string name="settings_diag_label">Mélységdiagnosztikai Rátét</string>
+    <string name="settings_diag_label">Diagnosztika és automatikus képernyőképek</string>
     <string name="settings_on">Be</string>
     <string name="settings_off">Ki</string>
     <string name="settings_scan_mode_label">AR Szkennelési Mód</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -406,7 +406,7 @@
     <string name="settings_hand_label">Mano Dominante</string>
     <string name="settings_hand_right">Destra</string>
     <string name="settings_hand_left">Sinistra</string>
-    <string name="settings_diag_label">Sovrapposizione Diagnostica di Profondità</string>
+    <string name="settings_diag_label">Diagnostica e screenshot automatici</string>
     <string name="settings_on">Acceso</string>
     <string name="settings_off">Spento</string>
     <string name="settings_scan_mode_label">Modalità Scansione AR</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -424,7 +424,7 @@
     <string name="settings_hand_label">利き手</string>
     <string name="settings_hand_right">右</string>
     <string name="settings_hand_left">左</string>
-    <string name="settings_diag_label">深度診断オーバーレイ</string>
+    <string name="settings_diag_label">診断と自動スクリーンショット</string>
     <string name="settings_on">オン</string>
     <string name="settings_off">オフ</string>
     <string name="settings_scan_mode_label">ARスキャンモード</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -406,7 +406,7 @@
     <string name="settings_hand_label">Dominante hand</string>
     <string name="settings_hand_right">Rechts</string>
     <string name="settings_hand_left">Links</string>
-    <string name="settings_diag_label">Dieptediagnostische overlay</string>
+    <string name="settings_diag_label">Diagnostiek en automatische schermafbeeldingen</string>
     <string name="settings_on">Op</string>
     <string name="settings_off">Uit</string>
     <string name="settings_scan_mode_label">AR-scanmodus</string>

--- a/app/src/main/res/values-no/strings.xml
+++ b/app/src/main/res/values-no/strings.xml
@@ -406,7 +406,7 @@
     <string name="settings_hand_label">Dominerende hånd</string>
     <string name="settings_hand_right">Høyre</string>
     <string name="settings_hand_left">Igjen</string>
-    <string name="settings_diag_label">Dybdediagnoseoverlegg</string>
+    <string name="settings_diag_label">Diagnostikk og automatiske skjermbilder</string>
     <string name="settings_on">På</string>
     <string name="settings_off">Av</string>
     <string name="settings_scan_mode_label">AR-skannemodus</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -406,7 +406,7 @@
     <string name="settings_hand_label">Mão Dominante</string>
     <string name="settings_hand_right">Direita</string>
     <string name="settings_hand_left">Esquerda</string>
-    <string name="settings_diag_label">Sobreposição de Diagnóstico de Profundidade</string>
+    <string name="settings_diag_label">Diagnóstico e capturas automáticas</string>
     <string name="settings_on">Ligado</string>
     <string name="settings_off">Desligado</string>
     <string name="settings_scan_mode_label">Modo de Varredura AR</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -405,7 +405,7 @@
     <string name="settings_hand_label">Dominant Hand</string>
     <string name="settings_hand_right">Höger</string>
     <string name="settings_hand_left">Vänster</string>
-    <string name="settings_diag_label">Djupdiagnostiköverlägg</string>
+    <string name="settings_diag_label">Diagnostik och automatiska skärmbilder</string>
     <string name="settings_on">På</string>
     <string name="settings_off">Av</string>
     <string name="settings_scan_mode_label">AR-skanningsläge</string>

--- a/app/src/main/res/values-tl/strings.xml
+++ b/app/src/main/res/values-tl/strings.xml
@@ -406,7 +406,7 @@
     <string name="settings_hand_label">Dominant na Kamay</string>
     <string name="settings_hand_right">Tama</string>
     <string name="settings_hand_left">Kaliwa</string>
-    <string name="settings_diag_label">Depth Diagnostic Overlay</string>
+    <string name="settings_diag_label">Diagnostics at Awtomatikong Screenshot</string>
     <string name="settings_on">Naka-on</string>
     <string name="settings_off">Naka-off</string>
     <string name="settings_scan_mode_label">AR Scan Mode</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -424,7 +424,7 @@
     <string name="settings_hand_label">惯用手</string>
     <string name="settings_hand_right">右手</string>
     <string name="settings_hand_left">左手</string>
-    <string name="settings_diag_label">深度诊断覆盖层</string>
+    <string name="settings_diag_label">诊断与自动截图</string>
     <string name="settings_on">开</string>
     <string name="settings_off">关</string>
     <string name="settings_scan_mode_label">AR 扫描模式</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -406,7 +406,7 @@
     <string name="settings_hand_label">慣用手</string>
     <string name="settings_hand_right">正確的</string>
     <string name="settings_hand_left">左邊</string>
-    <string name="settings_diag_label">深度診斷疊加</string>
+    <string name="settings_diag_label">診斷與自動螢幕擷取</string>
     <string name="settings_on">開啟</string>
     <string name="settings_off">關閉</string>
     <string name="settings_scan_mode_label">AR掃描模式</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -406,7 +406,7 @@
     <string name="settings_hand_label">Dominant Hand</string>
     <string name="settings_hand_right">Right</string>
     <string name="settings_hand_left">Left</string>
-    <string name="settings_diag_label">Depth Diagnostic Overlay</string>
+    <string name="settings_diag_label">Diagnostics &amp; Auto-Screenshots</string>
     <string name="settings_on">On</string>
     <string name="settings_off">Off</string>
     <string name="settings_scan_mode_label">AR Scan Mode</string>

--- a/core/design/src/main/res/values-de/strings.xml
+++ b/core/design/src/main/res/values-de/strings.xml
@@ -406,7 +406,7 @@
     <string name="settings_hand_label">Dominante Hand</string>
     <string name="settings_hand_right">Rechts</string>
     <string name="settings_hand_left">Links</string>
-    <string name="settings_diag_label">Tiefendiagnose-Overlay</string>
+    <string name="settings_diag_label">Diagnose &amp; Auto-Screenshots</string>
     <string name="settings_on">Ein</string>
     <string name="settings_off">Aus</string>
     <string name="settings_scan_mode_label">AR-Scanmodus</string>

--- a/core/design/src/main/res/values-es/strings.xml
+++ b/core/design/src/main/res/values-es/strings.xml
@@ -406,7 +406,7 @@
     <string name="settings_hand_label">Mano Dominante</string>
     <string name="settings_hand_right">Derecha</string>
     <string name="settings_hand_left">Izquierda</string>
-    <string name="settings_diag_label">Superposición de Diagnóstico de Profundidad</string>
+    <string name="settings_diag_label">Diagnóstico y capturas automáticas</string>
     <string name="settings_on">Encendido</string>
     <string name="settings_off">Apagado</string>
     <string name="settings_scan_mode_label">Modo de Escaneo AR</string>

--- a/core/design/src/main/res/values-fr/strings.xml
+++ b/core/design/src/main/res/values-fr/strings.xml
@@ -47,7 +47,7 @@
     <string name="settings_hand_label">Main dominante</string>
     <string name="settings_hand_right">Droite</string>
     <string name="settings_hand_left">Gauche</string>
-    <string name="settings_diag_label">Superposition de diagnostic de profondeur</string>
+    <string name="settings_diag_label">Diagnostics et captures automatiques</string>
     <string name="settings_on">Activé</string>
     <string name="settings_off">Désactivé</string>
     <string name="settings_scan_mode_label">Mode de scan AR</string>

--- a/core/design/src/main/res/values-hu/strings.xml
+++ b/core/design/src/main/res/values-hu/strings.xml
@@ -406,7 +406,7 @@
     <string name="settings_hand_label">Domináns Kéz</string>
     <string name="settings_hand_right">Jobb</string>
     <string name="settings_hand_left">Bal</string>
-    <string name="settings_diag_label">Mélységdiagnosztikai Rátét</string>
+    <string name="settings_diag_label">Diagnosztika és automatikus képernyőképek</string>
     <string name="settings_on">Be</string>
     <string name="settings_off">Ki</string>
     <string name="settings_scan_mode_label">AR Szkennelési Mód</string>

--- a/core/design/src/main/res/values-it/strings.xml
+++ b/core/design/src/main/res/values-it/strings.xml
@@ -406,7 +406,7 @@
     <string name="settings_hand_label">Mano Dominante</string>
     <string name="settings_hand_right">Destra</string>
     <string name="settings_hand_left">Sinistra</string>
-    <string name="settings_diag_label">Sovrapposizione Diagnostica di Profondità</string>
+    <string name="settings_diag_label">Diagnostica e screenshot automatici</string>
     <string name="settings_on">Acceso</string>
     <string name="settings_off">Spento</string>
     <string name="settings_scan_mode_label">Modalità Scansione AR</string>

--- a/core/design/src/main/res/values-ja/strings.xml
+++ b/core/design/src/main/res/values-ja/strings.xml
@@ -424,7 +424,7 @@
     <string name="settings_hand_label">利き手</string>
     <string name="settings_hand_right">右</string>
     <string name="settings_hand_left">左</string>
-    <string name="settings_diag_label">深度診断オーバーレイ</string>
+    <string name="settings_diag_label">診断と自動スクリーンショット</string>
     <string name="settings_on">オン</string>
     <string name="settings_off">オフ</string>
     <string name="settings_scan_mode_label">ARスキャンモード</string>

--- a/core/design/src/main/res/values-nl/strings.xml
+++ b/core/design/src/main/res/values-nl/strings.xml
@@ -406,7 +406,7 @@
     <string name="settings_hand_label">Dominante hand</string>
     <string name="settings_hand_right">Rechts</string>
     <string name="settings_hand_left">Links</string>
-    <string name="settings_diag_label">Dieptediagnostische overlay</string>
+    <string name="settings_diag_label">Diagnostiek en automatische schermafbeeldingen</string>
     <string name="settings_on">Op</string>
     <string name="settings_off">Uit</string>
     <string name="settings_scan_mode_label">AR-scanmodus</string>

--- a/core/design/src/main/res/values-no/strings.xml
+++ b/core/design/src/main/res/values-no/strings.xml
@@ -406,7 +406,7 @@
     <string name="settings_hand_label">Dominerende hånd</string>
     <string name="settings_hand_right">Høyre</string>
     <string name="settings_hand_left">Igjen</string>
-    <string name="settings_diag_label">Dybdediagnoseoverlegg</string>
+    <string name="settings_diag_label">Diagnostikk og automatiske skjermbilder</string>
     <string name="settings_on">På</string>
     <string name="settings_off">Av</string>
     <string name="settings_scan_mode_label">AR-skannemodus</string>

--- a/core/design/src/main/res/values-pt/strings.xml
+++ b/core/design/src/main/res/values-pt/strings.xml
@@ -406,7 +406,7 @@
     <string name="settings_hand_label">Mão Dominante</string>
     <string name="settings_hand_right">Direita</string>
     <string name="settings_hand_left">Esquerda</string>
-    <string name="settings_diag_label">Sobreposição de Diagnóstico de Profundidade</string>
+    <string name="settings_diag_label">Diagnóstico e capturas automáticas</string>
     <string name="settings_on">Ligado</string>
     <string name="settings_off">Desligado</string>
     <string name="settings_scan_mode_label">Modo de Varredura AR</string>

--- a/core/design/src/main/res/values-ru/strings.xml
+++ b/core/design/src/main/res/values-ru/strings.xml
@@ -406,7 +406,7 @@
     <string name="settings_hand_label">Доминирующая рука</string>
     <string name="settings_hand_right">Правая</string>
     <string name="settings_hand_left">Левая</string>
-    <string name="settings_diag_label">Наложение диагностики глубины</string>
+    <string name="settings_diag_label">Диагностика и автоскриншоты</string>
     <string name="settings_on">На</string>
     <string name="settings_off">Выключенный</string>
     <string name="settings_scan_mode_label">Режим AR-сканирования</string>

--- a/core/design/src/main/res/values-sv/strings.xml
+++ b/core/design/src/main/res/values-sv/strings.xml
@@ -406,7 +406,7 @@
     <string name="settings_hand_label">Dominant Hand</string>
     <string name="settings_hand_right">Höger</string>
     <string name="settings_hand_left">Vänster</string>
-    <string name="settings_diag_label">Djupdiagnostiköverlägg</string>
+    <string name="settings_diag_label">Diagnostik och automatiska skärmbilder</string>
     <string name="settings_on">På</string>
     <string name="settings_off">Av</string>
     <string name="settings_scan_mode_label">AR-skanningsläge</string>

--- a/core/design/src/main/res/values-zh-rCN/strings.xml
+++ b/core/design/src/main/res/values-zh-rCN/strings.xml
@@ -424,7 +424,7 @@
     <string name="settings_hand_label">惯用手</string>
     <string name="settings_hand_right">右手</string>
     <string name="settings_hand_left">左手</string>
-    <string name="settings_diag_label">深度诊断覆盖层</string>
+    <string name="settings_diag_label">诊断与自动截图</string>
     <string name="settings_on">开</string>
     <string name="settings_off">关</string>
     <string name="settings_scan_mode_label">AR 扫描模式</string>

--- a/core/design/src/main/res/values-zh-rHK/strings.xml
+++ b/core/design/src/main/res/values-zh-rHK/strings.xml
@@ -406,7 +406,7 @@
     <string name="settings_hand_label">慣用手</string>
     <string name="settings_hand_right">正確的</string>
     <string name="settings_hand_left">左邊</string>
-    <string name="settings_diag_label">深度診斷疊加</string>
+    <string name="settings_diag_label">診斷與自動螢幕擷取</string>
     <string name="settings_on">開啟</string>
     <string name="settings_off">關閉</string>
     <string name="settings_scan_mode_label">AR掃描模式</string>

--- a/core/design/src/main/res/values/strings.xml
+++ b/core/design/src/main/res/values/strings.xml
@@ -440,7 +440,7 @@
     <string name="settings_hand_label">Dominant Hand</string>
     <string name="settings_hand_right">Right</string>
     <string name="settings_hand_left">Left</string>
-    <string name="settings_diag_label">Depth Diagnostic Overlay</string>
+    <string name="settings_diag_label">Diagnostics &amp; Auto-Screenshots</string>
     <string name="settings_layer_feature_points">Show Feature Points</string>
     <string name="settings_layer_plane_grids">Show Plane Grids</string>
     <string name="settings_layer_voxels">Show Voxels</string>

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -335,8 +335,13 @@ class ArViewModel @Inject constructor(
      * Screenshots are the one part that IS gated, on the Diagnostic Overlay setting.
      *
      * Recording numbers into memory is invisible; writing PNGs of the user's camera feed to disk is
-     * not, and must never happen because the app felt like it. Opting into the diagnostic overlay is
-     * the opt-in.
+     * not, and must never happen because the app felt like it.
+     *
+     * The gate is the Diagnostic Overlay setting, which defaults off, is not persisted, and cannot
+     * be reached without a deliberate flip. The setting's own label had to be changed to say what
+     * the flip now authorises — it read "Depth Diagnostic Overlay", which promises a text HUD and
+     * nothing about photographs — because a technically effective gate on a switch whose label
+     * conceals what it does is not consent, it is a defensible-looking accident.
      */
     @Volatile private var diagnosticCaptureEnabled = false
 
@@ -508,10 +513,37 @@ class ArViewModel @Inject constructor(
     }
 
     /** A/B switch for the pose fusion (Sub-project B): on = corrected snap-back fusion, off = old toggle. */
-    fun evalSetFusionEnabled(on: Boolean) { renderer?.fusionEnabled = on }
+    fun evalSetFusionEnabled(on: Boolean) {
+        renderer?.fusionEnabled = on
+        _evalFusionEnabled.value = renderer?.fusionEnabled ?: false
+    }
+
+    private val _evalFusionEnabled = MutableStateFlow(false)
+
+    /**
+     * The A/B switch's ACTUAL position, mirrored rather than shadowed.
+     *
+     * The eval panel held this in a `remember`, seeded with a guess at the renderer's default. The
+     * guess went stale and the button spent 187 commits claiming fusion was on while it was off; the
+     * obvious repair — correct the seed — leaves the same defect one rotation away, because a
+     * `remember` is dropped on configuration change while `ArRenderer.fusionEnabled` is not.
+     *
+     * A switch that can disagree with the thing it switches invalidates the comparison it exists to
+     * run, so it does not get to hold its own copy. Seeded from the renderer's shipped default and
+     * written only through [evalSetFusionEnabled], which reads the value back after setting it.
+     */
+    val evalFusionEnabled: StateFlow<Boolean> = _evalFusionEnabled.asStateFlow()
+
+    private val _evalSelfGrowEnabled = MutableStateFlow(false)
+
+    /** Same arrangement for self-grow, which had the identical shadowing problem. */
+    val evalSelfGrowEnabled: StateFlow<Boolean> = _evalSelfGrowEnabled.asStateFlow()
 
     /** A/B switch for teleological self-grow (default OFF): promote validated new marks into the fingerprint. */
-    fun evalSetSelfGrowEnabled(on: Boolean) { slamManager.setSelfGrowEnabled(on) }
+    fun evalSetSelfGrowEnabled(on: Boolean) {
+        slamManager.setSelfGrowEnabled(on)
+        _evalSelfGrowEnabled.value = on
+    }
 
     /**
      * The pasteable report: what ran, what it measured, and under which constants.
@@ -535,6 +567,7 @@ class ArViewModel @Inject constructor(
         ),
         parameters = diagnosticParameters(),
         captures = captureManifest.toList(),
+        capturesTruncated = diagnosticWatcher.atCap,
     )
 
     /**
@@ -604,7 +637,11 @@ class ArViewModel @Inject constructor(
     }
 
     /**
-     * Where auto-captured screenshots land. Under `eval/` so one FileProvider path covers them.
+     * Where auto-captured screenshots land, beside the eval CSVs they are shared with.
+     *
+     * They are reachable by `FileProvider` because `file_paths.xml` exposes the whole of `filesDir`
+     * (`<files-path path="."/>`), not because `eval/` is called out — worth stating plainly, since
+     * a reader who assumes a scoped entry would also assume moving this directory is safe.
      *
      * **Purged once per view-model lifetime**, on first use. Without it the directory accumulates
      * across every session the app has ever run, and [writeDiagnosticBundle] — which globs the
@@ -1144,6 +1181,12 @@ class ArViewModel @Inject constructor(
             val now = System.currentTimeMillis()
             arEntryTimestampMs = now
             lastTrackingTimestampMs = now
+            // A fresh AR session gets a fresh watcher. This view model outlives the session — AR is
+            // a mode switch inside it — so without this the previous session's edge state, latches
+            // and spent budget carry over: the first tick of session two compares against session
+            // one's last state and photographs a "lost lock" from a different wall, while every
+            // once-only trigger stays latched for the life of the process and can never fire again.
+            diagnosticWatcher.reset()
             if (_uiState.value.trackingFailed) {
                 _uiState.update { it.copy(trackingFailed = false) }
             }
@@ -2363,12 +2406,31 @@ class ArViewModel @Inject constructor(
         // happen" about a period that has already passed, which is impossible if collection has to
         // be armed first.
         diagnosticRecorder.record(relocDiag, corrobDiag, fusionDiag, wallPoints, progress)
-        if (diagnosticCaptureEnabled) {
-            diagnosticWatcher.onTick(nowMs, relocDiag, corrobDiag, fusionDiag)?.let { trigger ->
-                // tryEmit, not emit: this is the AR tick and it must not suspend. A dropped request
-                // when the buffer is full is the correct loss — the buffer only fills if the
-                // Activity is not draining it, and captures it could not take are not evidence.
-                _captureRequests.tryEmit(trigger)
+        // onTick ALWAYS, and only the emit is gated.
+        //
+        // The watcher goes to some trouble to advance its edge state unconditionally so that a
+        // suppressed transition is dropped rather than deferred onto a later, unrelated frame.
+        // Wrapping the whole call in the enable flag — as this did — reintroduced that exact defect
+        // one level up: toggling the overlay off froze `prevReject` at whatever it held, and
+        // toggling it back on five minutes later compared a live state against a stale one and
+        // photographed the wrong moment under the right name.
+        //
+        // elapsedRealtime, not the wall clock beside it: the cooldowns are differences, and an NTP
+        // correction backward makes `nowMs - lastAnyMs` negative — which compares below every
+        // cooldown and silently refuses every capture for the rest of the session. That is the
+        // failure the watcher's own KDoc narrates as fixed, and feeding it a non-monotonic clock
+        // would have handed it straight back.
+        val trigger = diagnosticWatcher.onTick(
+            android.os.SystemClock.elapsedRealtime(), relocDiag, corrobDiag, fusionDiag,
+        )
+        if (trigger != null && diagnosticCaptureEnabled) {
+            // tryEmit, not emit: this is the AR tick and it must not suspend. The watcher has
+            // already spent a budget slot and latched any once-only trigger by this point, so a
+            // dropped emit is a transition that will never be photographed and never be retried —
+            // it has to be recorded, or the report's "none captured" would mean "or the request was
+            // dropped", which is precisely the ambiguity the section exists to remove.
+            if (!_captureRequests.tryEmit(trigger)) {
+                onDiagnosticCaptureFailed(trigger, "request dropped — no collector draining")
             }
         }
 

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -319,6 +319,111 @@ class ArViewModel @Inject constructor(
     // evalProbe (and its BatteryManager) is never instantiated in release / normal use.
     @Volatile private var evalLogging = false
 
+    // ── Self-collecting diagnostics ───────────────────────────────────────────
+    //
+    // Always on, unlike everything above it. The eval probe has to be armed before a run, which is
+    // fine for a planned experiment and useless for the case that actually happens: something looks
+    // wrong, and the evidence needed to say why has already scrolled past. This records the same
+    // channels the HUD displays, continuously, so a report can be produced AFTER the fact.
+    //
+    // The cost is a bounded ring of objects the tick already allocates — see DiagnosticRecorder's
+    // capacity — so there is nothing to gate it on.
+    private val diagnosticRecorder = com.hereliesaz.graffitixr.feature.ar.eval.DiagnosticRecorder()
+    private val diagnosticWatcher = com.hereliesaz.graffitixr.feature.ar.eval.DiagnosticWatcher()
+
+    /**
+     * Screenshots are the one part that IS gated, on the Diagnostic Overlay setting.
+     *
+     * Recording numbers into memory is invisible; writing PNGs of the user's camera feed to disk is
+     * not, and must never happen because the app felt like it. Opting into the diagnostic overlay is
+     * the opt-in.
+     */
+    @Volatile private var diagnosticCaptureEnabled = false
+
+    private val _captureRequests =
+        MutableSharedFlow<com.hereliesaz.graffitixr.feature.ar.eval.CaptureTrigger>(
+            extraBufferCapacity = 2,
+        )
+
+    /**
+     * Asks the host Activity to photograph the window. It lives there and not here because the
+     * camera preview and the AR overlay are a `SurfaceView`/GL surface: the view hierarchy's drawing
+     * cache renders them as a black hole, and only `PixelCopy` against the window reads back what is
+     * actually on screen.
+     */
+    val captureRequests:
+        SharedFlow<com.hereliesaz.graffitixr.feature.ar.eval.CaptureTrigger> =
+        _captureRequests.asSharedFlow()
+
+    /** `file name → why it was taken`, in capture order, for the report's Screenshots section. */
+    private val captureManifest = java.util.Collections.synchronizedList(ArrayList<String>())
+
+    private val diagnosticSessionStartMs = System.currentTimeMillis()
+
+    private val _diagnosticCaptureCount = MutableStateFlow(0)
+
+    /**
+     * Screenshots written this session, for the report button's label.
+     *
+     * Held here and not in the Activity because the Activity is destroyed and rebuilt on every
+     * rotation while this is not. A counter on the Activity would reset to zero mid-session and the
+     * button would claim no screenshots existed while the report listed six.
+     */
+    val diagnosticCaptureCount: StateFlow<Int> = _diagnosticCaptureCount.asStateFlow()
+
+    private val captureIndex = AtomicInteger(0)
+    private val capturesPurged = AtomicBoolean(false)
+
+    fun setDiagnosticCaptureEnabled(enabled: Boolean) {
+        diagnosticCaptureEnabled = enabled
+    }
+
+    /**
+     * Reserves the next capture filename. Zero-padded index first, so the files sort in the order
+     * the events happened — which is the order the report lists them in.
+     *
+     * The counter lives here for the same reason the count above does: a `var index` in the Compose
+     * collector restarts at 1 after a rotation, and the second `01_LOCK_LOST.png` of a session
+     * overwrites the first while the report goes on citing both.
+     */
+    fun nextDiagnosticCaptureFile(
+        trigger: com.hereliesaz.graffitixr.feature.ar.eval.CaptureTrigger,
+    ): File {
+        val n = captureIndex.incrementAndGet()
+        return File(
+            diagnosticCapturesDir(),
+            String.format(java.util.Locale.US, "%02d_%s.png", n, trigger.name),
+        )
+    }
+
+    /** Called back by the Activity once a PNG has actually landed on disk. */
+    fun onDiagnosticCaptureWritten(
+        trigger: com.hereliesaz.graffitixr.feature.ar.eval.CaptureTrigger,
+        fileName: String,
+    ) {
+        val atSec = (System.currentTimeMillis() - diagnosticSessionStartMs) / 1000
+        captureManifest.add("`$fileName` — ${trigger.name} at +${atSec}s — ${trigger.whatToLookFor}")
+        // Successes only. The manifest also carries failure lines, and a button counting those would
+        // promise attachments that are not there.
+        _diagnosticCaptureCount.update { it + 1 }
+    }
+
+    /**
+     * Called back when a requested capture failed.
+     *
+     * Recorded rather than swallowed: the report's Screenshots section saying "none captured" has to
+     * mean "no transition occurred", and a silently dropped `PixelCopy` would make it mean "or the
+     * copy failed" — reintroducing exactly the ambiguity the section exists to remove. It also spent
+     * a slot of the watcher's budget, so the reader is entitled to know.
+     */
+    fun onDiagnosticCaptureFailed(
+        trigger: com.hereliesaz.graffitixr.feature.ar.eval.CaptureTrigger,
+        reason: String,
+    ) {
+        val atSec = (System.currentTimeMillis() - diagnosticSessionStartMs) / 1000
+        captureManifest.add("(failed) ${trigger.name} at +${atSec}s — $reason")
+    }
+
     fun evalStartLog() {
         // Every run gets its identity sidecar. Making `identity` optional on start() shipped a
         // serializer with no caller — a run-identity feature that produced zero run identities,
@@ -407,6 +512,117 @@ class ArViewModel @Inject constructor(
 
     /** A/B switch for teleological self-grow (default OFF): promote validated new marks into the fingerprint. */
     fun evalSetSelfGrowEnabled(on: Boolean) { slamManager.setSelfGrowEnabled(on) }
+
+    /**
+     * The pasteable report: what ran, what it measured, and under which constants.
+     *
+     * Assembled here rather than in the recorder because the recorder deliberately knows nothing
+     * about Android or about this project's tunables — it holds samples. The build, the device and
+     * the parameter values live on this side.
+     */
+    fun buildDiagnosticReport(): String = diagnosticRecorder.report(
+        header = linkedMapOf(
+            "build" to (if (BuildConfig.DEBUG) "debug" else "release"),
+            "commit" to BuildConfig.GIT_COMMIT,
+            "device" to "${android.os.Build.MANUFACTURER} ${android.os.Build.MODEL}",
+            "android" to (android.os.Build.VERSION.RELEASE ?: "unknown"),
+            "session" to "${(System.currentTimeMillis() - diagnosticSessionStartMs) / 1000}s since AR view-model start",
+            // Two flags that change what every number below MEANS, so they belong beside the numbers
+            // and not in a settings screen the reader cannot see. Read back from the objects that
+            // hold them rather than from whatever the eval buttons last asked for.
+            "fusion" to (renderer?.fusionEnabled?.toString() ?: "no renderer attached"),
+            "syncReloc" to slamManager.evalSyncRelocEveryN().let { if (it > 0) "every $it" else "async" },
+        ),
+        parameters = diagnosticParameters(),
+        captures = captureManifest.toList(),
+    )
+
+    /**
+     * Every tunable the report's numbers were produced under.
+     *
+     * `PARAMETERS.md`'s point is that these are pre-registered priors no experiment has moved, so a
+     * report of behaviour without them cannot be acted on — and the person reading it is usually not
+     * the person holding the phone, and cannot check out the commit to look them up.
+     *
+     * The Kotlin constants are read live. The native ones are not reachable from here without a JNI
+     * accessor per constant, so they are named with the header that defines them: a reader who needs
+     * the value knows exactly where to look, and nothing here can drift into claiming a value the
+     * engine does not hold.
+     */
+    private fun diagnosticParameters(): Map<String, String> {
+        val fusion = com.hereliesaz.graffitixr.feature.ar.anchor.PoseFusion
+        val gate = com.hereliesaz.graffitixr.feature.ar.anchor.PromotionGate
+        val radius = com.hereliesaz.graffitixr.feature.ar.anchor.SearchRadius
+        return linkedMapOf(
+            "PoseFusion.MIN_INLIER_RATIO" to fusion.MIN_INLIER_RATIO.toString(),
+            "PoseFusion.BASE_ALPHA" to fusion.BASE_ALPHA.toString(),
+            "PoseFusion.CONF_FLOOR" to fusion.CONF_FLOOR.toString(),
+            "PoseFusion.COLD_SNAP_INLIER_RATIO" to fusion.COLD_SNAP_INLIER_RATIO.toString(),
+            "PoseFusion.COLD_SNAP_MIN_INLIERS" to fusion.COLD_SNAP_MIN_INLIERS.toString(),
+            "PoseFusion.COLD_SNAP_DIST_M" to fusion.COLD_SNAP_DIST_M.toString(),
+            "PoseFusion.COLD_SNAP_ANGLE_DEG" to fusion.COLD_SNAP_ANGLE_DEG.toString(),
+            "PromotionGate.BIG_LOCK_INLIERS" to gate.BIG_LOCK_INLIERS.toString(),
+            "PromotionGate.MIN_INLIERS" to gate.MIN_INLIERS.toString(),
+            "PromotionGate.MIN_INLIER_RATIO" to gate.MIN_INLIER_RATIO.toString(),
+            "PromotionGate.MIN_INLIER_SPREAD" to gate.MIN_INLIER_SPREAD.toString(),
+            "SearchRadius.RHO" to radius.RHO.toString(),
+            "SearchRadius.MIN_PX" to radius.MIN_PX.toString(),
+            "SearchRadius.MAX_PX" to radius.MAX_PX.toString(),
+            "SearchRadius.ERR_GAIN" to radius.ERR_GAIN.toString(),
+            "SearchRadius.REPROJ_GAIN" to radius.REPROJ_GAIN.toString(),
+            "DiagnosticWatcher.SPIKE_MM" to
+                com.hereliesaz.graffitixr.feature.ar.eval.DiagnosticWatcher.SPIKE_MM.toString(),
+            "native kRelocLoweRatio" to "(MobileGS.h)",
+            "native kCorrobLoweRatio" to "(MobileGS.h)",
+            "native kCorrobConfirmations" to "(MobileGS.h)",
+        )
+    }
+
+    /**
+     * Writes the report and returns every file worth attaching, report first.
+     *
+     * Ordered so the reader opens the report before the raw artefacts, and so a share sheet that
+     * only previews the first item previews the thing meant to be read. Anything absent is simply
+     * not in the list — a missing CSV means no eval run was logged, which the report already says
+     * in words.
+     */
+    fun writeDiagnosticBundle(): List<File> {
+        val dir = File(appContext.filesDir, "eval").apply { mkdirs() }
+        val report = File(dir, "diagnostic_report.md")
+        report.writeText(buildDiagnosticReport())
+        val out = ArrayList<File>()
+        out.add(report)
+        // Newest first: a session usually has one run that matters and it is the last one.
+        dir.listFiles { f -> f.isFile && (f.name.endsWith(".csv") || f.name.endsWith(".run.json")) }
+            ?.sortedByDescending { it.lastModified() }
+            ?.take(MAX_BUNDLED_EVAL_FILES)
+            ?.let(out::addAll)
+        diagnosticCapturesDir().listFiles { f -> f.isFile && f.name.endsWith(".png") }
+            ?.sortedBy { it.name }
+            ?.let(out::addAll)
+        return out
+    }
+
+    /**
+     * Where auto-captured screenshots land. Under `eval/` so one FileProvider path covers them.
+     *
+     * **Purged once per view-model lifetime**, on first use. Without it the directory accumulates
+     * across every session the app has ever run, and [writeDiagnosticBundle] — which globs the
+     * directory rather than reading the manifest — would attach a dozen screenshots from last week
+     * to a report whose Screenshots section lists one. Wrong attachments are worse than none: the
+     * reader has no way to tell which frame belongs to the run they are being asked about.
+     *
+     * The manifest is the record of what this session took; the directory is made to agree with it.
+     */
+    fun diagnosticCapturesDir(): File {
+        val dir = File(appContext.filesDir, "eval/captures").apply { mkdirs() }
+        if (capturesPurged.compareAndSet(false, true)) {
+            // At most MAX_CAPTURES small files, once per session. Cheap enough not to be worth
+            // dispatching, and every caller either already writes to this directory or is about to.
+            dir.listFiles()?.forEach { it.delete() }
+        }
+        return dir
+    }
 
     // ── Glasses session lifecycle ─────────────────────────────────────────────
 
@@ -2142,6 +2358,20 @@ class ArViewModel @Inject constructor(
         val wallPoints = slamManager.getWallKeypointCount()
 
         val nowMs = System.currentTimeMillis()
+
+        // Record unconditionally. The report's whole value is being able to answer "did this ever
+        // happen" about a period that has already passed, which is impossible if collection has to
+        // be armed first.
+        diagnosticRecorder.record(relocDiag, corrobDiag, fusionDiag, wallPoints, progress)
+        if (diagnosticCaptureEnabled) {
+            diagnosticWatcher.onTick(nowMs, relocDiag, corrobDiag, fusionDiag)?.let { trigger ->
+                // tryEmit, not emit: this is the AR tick and it must not suspend. A dropped request
+                // when the buffer is full is the correct loss — the buffer only fills if the
+                // Activity is not draining it, and captures it could not take are not evidence.
+                _captureRequests.tryEmit(trigger)
+            }
+        }
+
         if (isTracking) lastTrackingTimestampMs = nowMs
         val trackingFailed = isInArMode &&
                 !isTracking &&
@@ -2715,6 +2945,15 @@ class ArViewModel @Inject constructor(
          * previously recorded runs, so treat it as part of the run identity rather than a knob.
          */
         const val EVAL_RNG_SEED = 20260801L
+
+        /**
+         * How many eval CSV/sidecar files the diagnostic bundle attaches, newest first.
+         *
+         * Bounded because `eval/` accumulates one pair per logged run for the life of the install,
+         * and a share sheet handed forty attachments is a share sheet nobody sends. Two runs is one
+         * A/B, which is the comparison the bundle is usually for.
+         */
+        const val MAX_BUNDLED_EVAL_FILES = 4
 
         const val DOODLE_CAPTURE_INTERVAL_MS = 2500L
         // After this long without a relocalization lock (featureless wall), place on the plain anchor.

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/DiagnosticRecorder.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/DiagnosticRecorder.kt
@@ -82,11 +82,35 @@ class DiagnosticRecorder(
      * @param captures filenames of any auto-captured screenshots, so the reader knows what to expect
      *   attached and — more importantly — knows some exist when none are attached.
      */
-    @Synchronized
     fun report(
         header: Map<String, String>,
         parameters: Map<String, String>,
         captures: List<String>,
+        capturesTruncated: Boolean = false,
+    ): String {
+        // Snapshot under the lock, format outside it.
+        //
+        // This used to be @Synchronized as a whole, which meant a report — four histogram groupings
+        // and twelve statistics passes, each boxing and sorting up to 1800 floats — held the same
+        // monitor `record()` needs. `record()` runs on the AR tick, whose call site is careful never
+        // to suspend; handing it a lock held across that much work put a frame drop behind a button
+        // press for no reason. The copy is one array of references.
+        val samples: List<Sample>
+        val total: Long
+        synchronized(this) {
+            samples = ring.toList()
+            total = totalSeen
+        }
+        return format(samples, total, header, parameters, captures, capturesTruncated)
+    }
+
+    private fun format(
+        ring: List<Sample>,
+        totalSeen: Long,
+        header: Map<String, String>,
+        parameters: Map<String, String>,
+        captures: List<String>,
+        capturesTruncated: Boolean,
     ): String {
         val sb = StringBuilder(4096)
         sb.appendLine("## GraffitiXR diagnostic report")
@@ -97,6 +121,12 @@ class DiagnosticRecorder(
             sb.appendLine()
             sb.appendLine("**No samples recorded.** The diagnostics tick never ran — AR mode was not")
             sb.appendLine("entered, or tracking never started. That is itself the finding.")
+            // The parameters and screenshots sections still print. An early return dropped both, so
+            // the one path where "no screenshots" is guaranteed was also the one path that never
+            // said so — and the parameters are what tell the reader which build produced the
+            // nothing.
+            appendParameters(sb, parameters)
+            appendCaptures(sb, captures, capturesTruncated)
             return sb.toString()
         }
 
@@ -124,7 +154,17 @@ class DiagnosticRecorder(
             if (ring.none { it.fusion.state == FusionState.COLD_SNAP ||
                     it.fusion.state == FusionState.BLENDING ||
                     it.fusion.state == FusionState.HOLDING }) {
-                add("fusion never corrected the overlay")
+                // Distinguished from a fusion that was ON and never managed to correct anything.
+                //
+                // `ArRenderer.fusionEnabled` ships FALSE and its only writer sits behind the
+                // debug-only eval panel, so in a release build every sample is DISABLED and the bare
+                // "never corrected" line would print on 100% of field reports — a finding that is a
+                // constant is not a finding, and the first reader to chase it wastes the trip.
+                if (ring.all { it.fusion.state == FusionState.DISABLED }) {
+                    add("fusion was OFF for the whole run (expected — it ships default-off)")
+                } else {
+                    add("fusion never corrected the overlay")
+                }
             }
             if (ring.none { it.reloc.corrobGate == CorrobGate.GATED }) {
                 add("the gated corroboration match never ran (Phase 4 inactive for this run)")
@@ -144,12 +184,19 @@ class DiagnosticRecorder(
         sb.appendLine()
         sb.appendLine("| channel | min | median | max | samples |")
         sb.appendLine("|---|---|---|---|---|")
-        // The one filter here that is not the project's `>= 0` sentinel rule. `inlierRatio` is a
-        // computed getter that returns exactly 0 when there were no matches to divide by, so a 0 in
-        // this channel means "nothing was attempted", not "nothing survived RANSAC". Admitting it
-        // would drag the median of a run that mostly had no fingerprint down toward zero and make it
-        // look like a run that relocalized badly.
-        stat(sb, "inlierRatio", ring.map { it.reloc.inlierRatio }) { it > 0f }
+        // `inlierRatio` has no sentinel of its own — its getter returns a bare 0 both when nothing
+        // was attempted (no matches to divide by) and when everything was attempted and RANSAC
+        // rejected all of it. Those are opposite findings, and the second is the more diagnostic of
+        // the two: forty correspondences a frame with zero inliers is the textbook "aimed at the
+        // wrong wall".
+        //
+        // A previous version filtered on `it > 0f` and a comment claimed 0 could only mean the
+        // first. It meant both, so the run that most needed this row reported `never measured`.
+        // Mapped to the project's -1 sentinel by the condition that actually separates them.
+        stat(
+            sb, "inlierRatio",
+            ring.map { if (it.reloc.matches > 0) it.reloc.inlierRatio else NOT_MEASURED },
+        ) { it >= 0f }
         stat(sb, "backboneFeatures", ring.map { it.reloc.backboneFeatures.toFloat() }) { it >= 0f }
         stat(sb, "corrobPredicted", ring.map { it.reloc.corrobPredicted.toFloat() }) { it >= 0f }
         stat(sb, "corrobMatched", ring.map { it.reloc.corrobMatched.toFloat() }) { it >= 0f }
@@ -167,13 +214,24 @@ class DiagnosticRecorder(
         sb.appendLine("- snaps accepted/refused: ${last.fusion.snapsAccepted} / ${last.fusion.snapsRejected}")
         sb.appendLine()
 
-        // --- Parameters. Every one is an unmeasured prior, and the reader is usually not the person
-        // holding the phone.
+        appendParameters(sb, parameters)
+        appendCaptures(sb, captures, capturesTruncated)
+        return sb.toString()
+    }
+
+    /** Every one is an unmeasured prior, and the reader is usually not the person holding the phone. */
+    private fun appendParameters(sb: StringBuilder, parameters: Map<String, String>) {
         sb.appendLine("### Parameters in force")
         sb.appendLine()
         for ((k, v) in parameters.toSortedMap()) sb.appendLine("- `$k` = $v")
         sb.appendLine()
+    }
 
+    private fun appendCaptures(
+        sb: StringBuilder,
+        captures: List<String>,
+        capturesTruncated: Boolean,
+    ) {
         sb.appendLine("### Screenshots")
         sb.appendLine()
         if (captures.isEmpty()) {
@@ -181,7 +239,16 @@ class DiagnosticRecorder(
         } else {
             captures.forEach { sb.appendLine("- $it") }
         }
-        return sb.toString()
+        // A list that stops at the ceiling reads as "and then nothing else happened". It has to say
+        // which of the two it is, or it reproduces the exact silent-absence confusion this report
+        // was written to end, one section down from where the report says so.
+        if (capturesTruncated) {
+            sb.appendLine()
+            sb.appendLine(
+                "**Capture budget exhausted** — later watched transitions occurred and were NOT " +
+                    "photographed.",
+            )
+        }
     }
 
     /** `name: A x12 (40%), B x18 (60%)`, most frequent first. */
@@ -219,7 +286,18 @@ class DiagnosticRecorder(
         else String.format(java.util.Locale.US, "%.3f", v)
 
     companion object {
-        /** ~2 minutes at the ~15 Hz diagnostics tick. Bounded so a long session cannot grow it. */
+        /**
+         * Samples retained. Bounded so a long session cannot grow it.
+         *
+         * Deliberately expressed in samples and not in minutes: the diagnostics tick is
+         * `frameCount % 4` in `ArRenderer`, a quarter of the *achieved* GL frame rate, so the wall
+         * time this covers floats with load and display — roughly two minutes at 30 fps, half that
+         * on a 90 Hz panel, twice it when SLAM is struggling. The report prints the measured span of
+         * its actual window rather than restating this as a duration.
+         */
         const val DEFAULT_CAPACITY = 1800
+
+        /** The project-wide "not measured" marker. Negative, never 0. */
+        private const val NOT_MEASURED = -1f
     }
 }

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/DiagnosticRecorder.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/DiagnosticRecorder.kt
@@ -1,0 +1,225 @@
+package com.hereliesaz.graffitixr.feature.ar.eval
+
+import com.hereliesaz.graffitixr.common.model.CorrobGate
+import com.hereliesaz.graffitixr.common.model.CorroborationDiagnostics
+import com.hereliesaz.graffitixr.common.model.FusionDiagnostics
+import com.hereliesaz.graffitixr.common.model.FusionState
+import com.hereliesaz.graffitixr.common.model.GrowOutcome
+import com.hereliesaz.graffitixr.common.model.RelocDiagnostics
+import com.hereliesaz.graffitixr.common.model.RelocReject
+
+/**
+ * Rolling capture of the diagnostic channels, and the report that gets pasted back to whoever is
+ * debugging.
+ *
+ * ## Why aggregates and not a snapshot
+ *
+ * A screenshot of the HUD answers "what is happening now". The question that actually matters for
+ * this system is **"did this ever happen"** — because every expensive failure here has been a stage
+ * that silently did not run, and a stage that never runs looks identical at every single instant.
+ * `Corrob: design not placed` in one screenshot cannot distinguish "never gated once" from "gated
+ * fine a second ago and the artist has just looked away".
+ *
+ * So this keeps a bounded window of samples and reports **distributions**: how many ticks each
+ * reason code held, and min/median/max for each number. One paste then answers questions no
+ * sequence of screenshots could — whether corroboration ever gated at all, whether the promotion
+ * gate ever passed, whether the correction magnitude is steady or spiking.
+ *
+ * ## Why it also reports the parameters
+ *
+ * Every constant in `PARAMETERS.md` is a pre-registered prior that no experiment has moved. A report
+ * of behaviour without the values that produced it cannot be acted on — and the person reading it is
+ * usually not the person holding the phone.
+ */
+class DiagnosticRecorder(
+    private val capacity: Int = DEFAULT_CAPACITY,
+    private val nowMs: () -> Long = System::currentTimeMillis,
+) {
+
+    /** One tick's worth. Flat and primitive so the ring stays cheap at 15 Hz. */
+    private class Sample(
+        val tsMs: Long,
+        val reloc: RelocDiagnostics,
+        val corrob: CorroborationDiagnostics,
+        val fusion: FusionDiagnostics,
+        val wallPoints: Int,
+        val progress: Float,
+    )
+
+    private val ring = ArrayDeque<Sample>(capacity)
+    private var totalSeen = 0L
+
+    @Synchronized
+    fun record(
+        reloc: RelocDiagnostics,
+        corrob: CorroborationDiagnostics,
+        fusion: FusionDiagnostics,
+        wallPoints: Int,
+        progress: Float,
+    ) {
+        ring.addLast(Sample(nowMs(), reloc, corrob, fusion, wallPoints, progress))
+        while (ring.size > capacity) ring.removeFirst()
+        totalSeen++
+    }
+
+    @Synchronized
+    fun clear() {
+        ring.clear()
+        totalSeen = 0
+    }
+
+    @Synchronized
+    fun isEmpty(): Boolean = ring.isEmpty()
+
+    /**
+     * The pasteable report.
+     *
+     * Markdown, because it is going into a chat window. Ordered by what a reader checks first: what
+     * ran, then what it measured, then the settings that produced it.
+     *
+     * @param header build/device lines the recorder cannot know.
+     * @param parameters `PARAMETERS.md` name → value, in force for this run.
+     * @param captures filenames of any auto-captured screenshots, so the reader knows what to expect
+     *   attached and — more importantly — knows some exist when none are attached.
+     */
+    @Synchronized
+    fun report(
+        header: Map<String, String>,
+        parameters: Map<String, String>,
+        captures: List<String>,
+    ): String {
+        val sb = StringBuilder(4096)
+        sb.appendLine("## GraffitiXR diagnostic report")
+        sb.appendLine()
+        for ((k, v) in header) sb.appendLine("- **$k**: $v")
+
+        if (ring.isEmpty()) {
+            sb.appendLine()
+            sb.appendLine("**No samples recorded.** The diagnostics tick never ran — AR mode was not")
+            sb.appendLine("entered, or tracking never started. That is itself the finding.")
+            return sb.toString()
+        }
+
+        val spanMs = ring.last().tsMs - ring.first().tsMs
+        sb.appendLine("- **window**: ${ring.size} samples over ${spanMs / 1000}s (of $totalSeen total)")
+        sb.appendLine()
+
+        // --- What ran, and what did not. The reason codes come first because they are the ones
+        // that answer "did this ever happen", which no instantaneous view can.
+        sb.appendLine("### What ran")
+        sb.appendLine()
+        sb.appendLine(histogram("Fusion", ring.map { it.fusion.state.name }))
+        sb.appendLine(histogram("Reloc", ring.map { it.reloc.reject.name }))
+        sb.appendLine(histogram("CorrobGate", ring.map { it.reloc.corrobGate.name }))
+        sb.appendLine(histogram("SelfGrow", ring.map { it.reloc.growOutcome.name }))
+        // Blank line before the next block or markdown folds it into the list above, and the
+        // findings end up rendered as a continuation of the SelfGrow histogram.
+        sb.appendLine()
+
+        // The four questions this report exists to answer, stated as answers rather than left for
+        // the reader to derive from the histograms above.
+        sb.appendLine("**Never happened:**")
+        val never = buildList {
+            if (ring.none { it.reloc.reject == RelocReject.OK }) add("relocalization never locked")
+            if (ring.none { it.fusion.state == FusionState.COLD_SNAP ||
+                    it.fusion.state == FusionState.BLENDING ||
+                    it.fusion.state == FusionState.HOLDING }) {
+                add("fusion never corrected the overlay")
+            }
+            if (ring.none { it.reloc.corrobGate == CorrobGate.GATED }) {
+                add("the gated corroboration match never ran (Phase 4 inactive for this run)")
+            }
+            if (ring.none { it.reloc.growOutcome == GrowOutcome.PROMOTED }) {
+                add("self-grow never promoted (expected — it ships default-off)")
+            }
+        }
+        if (never.isEmpty()) sb.appendLine("- (nothing — every stage ran at least once)")
+        else never.forEach { sb.appendLine("- $it") }
+        sb.appendLine()
+
+        // --- Numbers. min/median/max rather than a mean: these distributions are not symmetric and
+        // the tails are the interesting part. A search radius pinned at its floor and one pinned at
+        // its ceiling have the same mean if they alternate.
+        sb.appendLine("### What it measured")
+        sb.appendLine()
+        sb.appendLine("| channel | min | median | max | samples |")
+        sb.appendLine("|---|---|---|---|---|")
+        // The one filter here that is not the project's `>= 0` sentinel rule. `inlierRatio` is a
+        // computed getter that returns exactly 0 when there were no matches to divide by, so a 0 in
+        // this channel means "nothing was attempted", not "nothing survived RANSAC". Admitting it
+        // would drag the median of a run that mostly had no fingerprint down toward zero and make it
+        // look like a run that relocalized badly.
+        stat(sb, "inlierRatio", ring.map { it.reloc.inlierRatio }) { it > 0f }
+        stat(sb, "backboneFeatures", ring.map { it.reloc.backboneFeatures.toFloat() }) { it >= 0f }
+        stat(sb, "corrobPredicted", ring.map { it.reloc.corrobPredicted.toFloat() }) { it >= 0f }
+        stat(sb, "corrobMatched", ring.map { it.reloc.corrobMatched.toFloat() }) { it >= 0f }
+        stat(sb, "corrobLoneSkips", ring.map { it.reloc.corrobLoneSkips.toFloat() }) { it >= 0f }
+        stat(sb, "searchRadiusPx", ring.map { it.corrob.searchRadiusPx }) { it >= 0f }
+        stat(sb, "relocReprojPx", ring.map { it.corrob.relocReprojPx }) { it >= 0f }
+        stat(sb, "inlierSpread", ring.map { it.corrob.inlierSpread }) { it >= 0f }
+        stat(sb, "correctionMm", ring.map { it.fusion.correctionMm }) { it >= 0f }
+        stat(sb, "correctionDeg", ring.map { it.fusion.correctionDeg }) { it >= 0f }
+        stat(sb, "wallPoints", ring.map { it.wallPoints.toFloat() }) { it >= 0f }
+        stat(sb, "paintingProgress", ring.map { it.progress }) { it >= 0f }
+        sb.appendLine()
+
+        val last = ring.last()
+        sb.appendLine("- snaps accepted/refused: ${last.fusion.snapsAccepted} / ${last.fusion.snapsRejected}")
+        sb.appendLine()
+
+        // --- Parameters. Every one is an unmeasured prior, and the reader is usually not the person
+        // holding the phone.
+        sb.appendLine("### Parameters in force")
+        sb.appendLine()
+        for ((k, v) in parameters.toSortedMap()) sb.appendLine("- `$k` = $v")
+        sb.appendLine()
+
+        sb.appendLine("### Screenshots")
+        sb.appendLine()
+        if (captures.isEmpty()) {
+            sb.appendLine("None captured — no watched transition occurred during this run.")
+        } else {
+            captures.forEach { sb.appendLine("- $it") }
+        }
+        return sb.toString()
+    }
+
+    /** `name: A x12 (40%), B x18 (60%)`, most frequent first. */
+    private fun histogram(label: String, values: List<String>): String {
+        if (values.isEmpty()) return "- **$label**: (none)"
+        val counts = values.groupingBy { it }.eachCount().entries.sortedByDescending { it.value }
+        val total = values.size
+        return counts.joinToString(
+            prefix = "- **$label**: ", separator = ", ",
+        ) { "${it.key} ×${it.value} (${it.value * 100 / total}%)" }
+    }
+
+    /**
+     * One row of the numbers table, over the samples where [measured] holds.
+     *
+     * The filter is the point: every channel here uses a negative sentinel for "not measured", and
+     * averaging those in would drag every statistic toward -1 and make an unmeasured run look like a
+     * badly performing one. The sample count is printed so a row backed by three readings is not
+     * mistaken for one backed by three hundred.
+     */
+    private fun stat(sb: StringBuilder, label: String, all: List<Float>, measured: (Float) -> Boolean) {
+        val vs = all.filter { it.isFinite() && measured(it) }.sorted()
+        if (vs.isEmpty()) {
+            sb.appendLine("| $label | — | — | — | 0 (never measured) |")
+            return
+        }
+        val median = vs[vs.size / 2]
+        sb.appendLine(
+            "| $label | ${fmt(vs.first())} | ${fmt(median)} | ${fmt(vs.last())} | ${vs.size} |",
+        )
+    }
+
+    private fun fmt(v: Float): String =
+        if (v == v.toLong().toFloat()) v.toLong().toString()
+        else String.format(java.util.Locale.US, "%.3f", v)
+
+    companion object {
+        /** ~2 minutes at the ~15 Hz diagnostics tick. Bounded so a long session cannot grow it. */
+        const val DEFAULT_CAPACITY = 1800
+    }
+}

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/DiagnosticWatcher.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/DiagnosticWatcher.kt
@@ -41,6 +41,7 @@ class DiagnosticWatcher(
     private var prevReject: RelocReject? = null
     private var prevFusion: FusionState? = null
     private var prevGate: CorrobGate? = null
+    private var prevGrow: GrowOutcome? = null
     private var prevCorrectionMm: Float = NOT_MEASURED
 
     private val firedOnce = HashSet<CaptureTrigger>()
@@ -58,10 +59,17 @@ class DiagnosticWatcher(
     private var lastAnyMs: Long? = null
     private var requested = 0
 
-    /** How many captures the budget still allows. Surfaced so the report can say the cap was hit. */
+    /** Captures requested so far — the number SPENT, not the number remaining. */
     @get:Synchronized
     val requestCount: Int get() = requested
 
+    /**
+     * Whether the budget is exhausted, meaning later transitions went unphotographed.
+     *
+     * Read into the report, because a Screenshots section that stops at sixteen without saying why
+     * reads as "nothing else happened" — the same silent-absence confusion the whole report exists
+     * to remove, one section down.
+     */
     @get:Synchronized
     val atCap: Boolean get() = requested >= maxCaptures
 
@@ -90,6 +98,7 @@ class DiagnosticWatcher(
         prevReject = reloc.reject
         prevFusion = fusion.state
         prevGate = reloc.corrobGate
+        prevGrow = reloc.growOutcome
         if (fusion.correctionMm >= 0f) prevCorrectionMm = fusion.correctionMm
 
         if (requested >= maxCaptures) return null
@@ -116,11 +125,22 @@ class DiagnosticWatcher(
         return null
     }
 
+    /**
+     * Clears every latch, cooldown and the budget. **Must be called on each AR-mode entry.**
+     *
+     * The view model outlives an AR session — entering and leaving AR is a mode switch inside it —
+     * so without this the edge state persists across sessions. Session one ends with the lock `OK`;
+     * ten minutes later session two's first tick reads `NO_FINGERPRINT`, both cooldowns have long
+     * expired, and a `LOCK_LOST` fires captioned "what the camera was pointed at when the lock died"
+     * for a loss that happened on a different wall in a different session. The once-only triggers
+     * would meanwhile be latched for the life of the process and could never fire again.
+     */
     @Synchronized
     fun reset() {
         prevReject = null
         prevFusion = null
         prevGate = null
+        prevGrow = null
         prevCorrectionMm = NOT_MEASURED
         firedOnce.clear()
         lastFiredMs.clear()
@@ -140,8 +160,20 @@ class DiagnosticWatcher(
         val pReject = prevReject
         val pFusion = prevFusion
         val pGate = prevGate
+        val pGrow = prevGrow
 
-        if (reloc.growOutcome == GrowOutcome.PROMOTED) out.add(CaptureTrigger.PROMOTED)
+        // An EDGE, like everything else here, and it was written as a level test.
+        //
+        // The native `mGrowOutcome` is sticky: `MobileGS::tryUpdateFingerprint` returns early —
+        // without touching it — when no design is registered. So one promotion followed by clearing
+        // the design leaves `PROMOTED` standing on every subsequent tick, forever. As a level test
+        // that re-fired every `repeatCooldownMs`, spending the entire 16-capture budget on ~4
+        // minutes of photographs of one promotion and leaving nothing for the lock failures.
+        if (pGrow != null && pGrow != GrowOutcome.PROMOTED &&
+            reloc.growOutcome == GrowOutcome.PROMOTED
+        ) {
+            out.add(CaptureTrigger.PROMOTED)
+        }
 
         if (pFusion != null && pFusion != FusionState.NO_CAPTURE_POSE &&
             fusion.state == FusionState.NO_CAPTURE_POSE

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/DiagnosticWatcher.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/DiagnosticWatcher.kt
@@ -1,0 +1,249 @@
+package com.hereliesaz.graffitixr.feature.ar.eval
+
+import com.hereliesaz.graffitixr.common.model.CorrobGate
+import com.hereliesaz.graffitixr.common.model.CorroborationDiagnostics
+import com.hereliesaz.graffitixr.common.model.FusionDiagnostics
+import com.hereliesaz.graffitixr.common.model.FusionState
+import com.hereliesaz.graffitixr.common.model.GrowOutcome
+import com.hereliesaz.graffitixr.common.model.RelocDiagnostics
+import com.hereliesaz.graffitixr.common.model.RelocReject
+
+/**
+ * Decides when a frame is worth photographing.
+ *
+ * [DiagnosticRecorder] answers "did this ever happen" over a window. It cannot answer the question a
+ * picture answers: **what was the camera looking at when it happened.** A lock that dies every time
+ * the artist pans onto a blank rendered wall, and a lock that dies for no visible reason, produce
+ * identical diagnostic rows and completely different fixes. So this watches the same tick stream for
+ * transitions where the *scene* is the missing evidence, and asks for a screenshot.
+ *
+ * ## Transitions, never states
+ *
+ * Every trigger below is an edge. A state predicate at a 15 Hz tick would fire fifteen times a
+ * second for as long as the state held, and a hundred identical PNGs of a stationary camera are not
+ * fifteen times the evidence of one. The interesting instant is always the one where something
+ * changed.
+ *
+ * ## Why it is pure
+ *
+ * `nowMs` is a parameter and nothing here touches Android. The rate limiting is the part most likely
+ * to be wrong — a limiter that quietly refuses everything looks exactly like a watcher whose
+ * triggers never fired, which is the same silent-no-op failure this whole diagnostic effort exists
+ * to end — so it has to be testable without a device.
+ */
+class DiagnosticWatcher(
+    private val globalCooldownMs: Long = GLOBAL_COOLDOWN_MS,
+    private val repeatCooldownMs: Long = REPEAT_COOLDOWN_MS,
+    private val maxCaptures: Int = MAX_CAPTURES,
+    private val spikeMm: Float = SPIKE_MM,
+) {
+
+    private var prevReject: RelocReject? = null
+    private var prevFusion: FusionState? = null
+    private var prevGate: CorrobGate? = null
+    private var prevCorrectionMm: Float = NOT_MEASURED
+
+    private val firedOnce = HashSet<CaptureTrigger>()
+    private val lastFiredMs = HashMap<CaptureTrigger, Long>()
+
+    /**
+     * Null until something fires, rather than a `Long.MIN_VALUE` "long ago".
+     *
+     * The sentinel version of this shipped for exactly one test run: `nowMs - Long.MIN_VALUE`
+     * overflows to a negative number, which compares below every cooldown, so the limiter refused
+     * **every capture for the whole session** — and refused them silently, producing reports that
+     * said no watched transition had occurred. The failure this class was written to prevent, in the
+     * class itself.
+     */
+    private var lastAnyMs: Long? = null
+    private var requested = 0
+
+    /** How many captures the budget still allows. Surfaced so the report can say the cap was hit. */
+    @get:Synchronized
+    val requestCount: Int get() = requested
+
+    @get:Synchronized
+    val atCap: Boolean get() = requested >= maxCaptures
+
+    /**
+     * One tick. Returns the trigger to photograph, or null.
+     *
+     * **At most one per tick, by design.** `PixelCopy` plus a PNG encode is not free, and two
+     * triggers on the same tick would produce two byte-identical images of one frame. When several
+     * fire together the rarest wins — see [CaptureTrigger]'s declaration order.
+     */
+    @Synchronized
+    fun onTick(
+        nowMs: Long,
+        reloc: RelocDiagnostics,
+        corrob: CorroborationDiagnostics,
+        fusion: FusionDiagnostics,
+    ): CaptureTrigger? {
+        val candidates = detect(reloc, fusion)
+        // Advance the edge state BEFORE the rate-limit decision, and unconditionally.
+        //
+        // If a suppressed transition left `prev` untouched, the same edge would be re-detected on
+        // every subsequent tick until it finally got through — turning a one-off cooldown into a
+        // standing request that fires the instant the cooldown lapses, on a frame that has nothing
+        // to do with the transition. A suppressed edge is DROPPED, permanently. That is the honest
+        // behaviour: the alternative photographs the wrong moment and labels it the right one.
+        prevReject = reloc.reject
+        prevFusion = fusion.state
+        prevGate = reloc.corrobGate
+        if (fusion.correctionMm >= 0f) prevCorrectionMm = fusion.correctionMm
+
+        if (requested >= maxCaptures) return null
+        val sinceAny = lastAnyMs
+        for (t in candidates) {
+            if (t.once && t in firedOnce) continue
+            if (sinceAny != null && nowMs - sinceAny < globalCooldownMs) return null
+            val last = lastFiredMs[t]
+            if (!t.once && last != null && nowMs - last < repeatCooldownMs) continue
+            firedOnce.add(t)
+            lastFiredMs[t] = nowMs
+            lastAnyMs = nowMs
+            requested++
+            return t
+        }
+        return null
+    }
+
+    @Synchronized
+    fun reset() {
+        prevReject = null
+        prevFusion = null
+        prevGate = null
+        prevCorrectionMm = NOT_MEASURED
+        firedOnce.clear()
+        lastFiredMs.clear()
+        lastAnyMs = null
+        requested = 0
+    }
+
+    /**
+     * Which edges this tick crossed, rarest first.
+     *
+     * The first tick after construction (or [reset]) crosses nothing: `prev` is null and every
+     * comparison below requires a previous value. Otherwise entering AR would photograph whatever
+     * arbitrary state the very first sample happened to hold, and label it a transition.
+     */
+    private fun detect(reloc: RelocDiagnostics, fusion: FusionDiagnostics): List<CaptureTrigger> {
+        val out = ArrayList<CaptureTrigger>(3)
+        val pReject = prevReject
+        val pFusion = prevFusion
+        val pGate = prevGate
+
+        if (reloc.growOutcome == GrowOutcome.PROMOTED) out.add(CaptureTrigger.PROMOTED)
+
+        if (pFusion != null && pFusion != FusionState.NO_CAPTURE_POSE &&
+            fusion.state == FusionState.NO_CAPTURE_POSE
+        ) {
+            out.add(CaptureTrigger.NO_CAPTURE_POSE)
+        }
+
+        // A rise past the threshold, not a level above it. A correction that settles large and stays
+        // large is one event; sampling it as a state would photograph it until the cooldown starved
+        // everything else.
+        if (fusion.correctionMm >= spikeMm && prevCorrectionMm >= 0f && prevCorrectionMm < spikeMm) {
+            out.add(CaptureTrigger.CORRECTION_SPIKE)
+        }
+
+        if (pFusion != null && pFusion != FusionState.COLD_SNAP &&
+            fusion.state == FusionState.COLD_SNAP
+        ) {
+            out.add(CaptureTrigger.COLD_SNAP)
+        }
+
+        if (pGate != null && pGate != CorrobGate.GATED && reloc.corrobGate == CorrobGate.GATED) {
+            out.add(CaptureTrigger.CORROBORATION_GATED)
+        }
+
+        if (pReject != null && pReject == RelocReject.OK && reloc.reject != RelocReject.OK &&
+            reloc.reject != RelocReject.DISABLED
+        ) {
+            out.add(CaptureTrigger.LOCK_LOST)
+        }
+
+        if (pReject != null && pReject != RelocReject.OK && reloc.reject == RelocReject.OK) {
+            out.add(CaptureTrigger.LOCK_ACQUIRED)
+        }
+
+        // The `if`s above happen to run in declaration order, but the priority claim must not depend
+        // on that surviving an edit — a reordered block would silently change which trigger wins.
+        out.sortBy { it.ordinal }
+        return out
+    }
+
+    companion object {
+        /**
+         * No two captures within 3s of each other, whatever fired them. Two transitions a frame
+         * apart are one event with two names, and the second picture is the first picture.
+         */
+        const val GLOBAL_COOLDOWN_MS = 3_000L
+
+        /**
+         * A repeatable trigger waits 15s before it may fire again. Lock loss in particular oscillates
+         * — a marginal wall drops and re-acquires several times a second, and without this the budget
+         * below would be spent inside two seconds on one flapping edge.
+         */
+        const val REPEAT_COOLDOWN_MS = 15_000L
+
+        /**
+         * Hard ceiling on captures per session. A full-resolution PNG is a few megabytes; this is a
+         * diagnostic aid on a user's phone, not a dashcam.
+         */
+        const val MAX_CAPTURES = 16
+
+        /**
+         * Correction magnitude, in millimetres, above which a jump is worth a picture.
+         *
+         * 150mm is set from what the failures look like, not from a tolerance: a healthy relock
+         * corrects a few millimetres to a couple of centimetres, and the composition defect `0.9`
+         * fixed produced corrections in the metres. Anything over about a hand's width is either a
+         * genuine relock after real drift — in which case the picture shows the wall the artist
+         * walked back to — or a frame error, and the two are told apart by whether the overlay in the
+         * photograph is on the wall.
+         */
+        const val SPIKE_MM = 150f
+
+        private const val NOT_MEASURED = -1f
+    }
+}
+
+/**
+ * Why a frame was photographed.
+ *
+ * **Declaration order is priority order**, rarest first, because [DiagnosticWatcher.onTick] returns
+ * only the first. A promotion happens at most a handful of times in a session and a lock is acquired
+ * constantly; on the tick where both occur, the promotion is the one that will not come round again.
+ */
+enum class CaptureTrigger(
+    /** Fires at most once per session — the second picture of it adds nothing. */
+    val once: Boolean,
+    /** What the reader of the report should look for in the image. */
+    val whatToLookFor: String,
+) {
+    /** Self-grow wrote new marks into the fingerprint. The one irreversible act in the engine. */
+    PROMOTED(once = false, whatToLookFor = "which part of the wall got promoted into the map"),
+
+    /**
+     * Fusion hit `IMPLEMENTATION.md` 0.9 — a pre-Phase-2 fingerprint with no capture pose, so the
+     * overlay is uncorrected and will drift with no other symptom.
+     */
+    NO_CAPTURE_POSE(once = true, whatToLookFor = "the overlay is on the raw ARCore backbone here"),
+
+    /** The standing correction jumped past [DiagnosticWatcher.SPIKE_MM]. */
+    CORRECTION_SPIKE(once = false, whatToLookFor = "is the overlay ON the wall after the jump"),
+
+    /** A hard snap: first lock, or a relock that diverged past the cold thresholds. */
+    COLD_SNAP(once = true, whatToLookFor = "where the overlay landed on the first hard snap"),
+
+    /** Phase 4's spatially-gated corroboration ran for the first time. */
+    CORROBORATION_GATED(once = true, whatToLookFor = "the design is in frame and being corroborated"),
+
+    /** Relocalization stopped locking. The picture is the answer to "pointed at what?". */
+    LOCK_LOST(once = false, whatToLookFor = "what the camera was pointed at when the lock died"),
+
+    /** Relocalization started locking. The baseline the failures are read against. */
+    LOCK_ACQUIRED(once = true, whatToLookFor = "what a working lock looks like on this wall"),
+}

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/DiagnosticWatcher.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/DiagnosticWatcher.kt
@@ -95,10 +95,18 @@ class DiagnosticWatcher(
         if (requested >= maxCaptures) return null
         val sinceAny = lastAnyMs
         for (t in candidates) {
+            // The sole enforcement of once-ness. There is deliberately no second `!t.once` guard on
+            // the cooldown below: `lastFiredMs` and `firedOnce` are written together and cleared
+            // together, so a once-trigger carrying a cooldown entry has already `continue`d here.
+            // A second check would be unreachable, and unreachable defence reads as though the case
+            // it guards were possible.
             if (t.once && t in firedOnce) continue
+            // Strictly less-than, so the cooldown expires AT its length rather than one tick after.
+            // The loose form refuses silently, which is the one failure mode this class cannot
+            // afford — see `a capture is permitted exactly one cooldown after the last`.
             if (sinceAny != null && nowMs - sinceAny < globalCooldownMs) return null
             val last = lastFiredMs[t]
-            if (!t.once && last != null && nowMs - last < repeatCooldownMs) continue
+            if (last != null && nowMs - last < repeatCooldownMs) continue
             firedOnce.add(t)
             lastFiredMs[t] = nowMs
             lastAnyMs = nowMs

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/eval/DiagnosticRecorderTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/eval/DiagnosticRecorderTest.kt
@@ -1,0 +1,188 @@
+package com.hereliesaz.graffitixr.feature.ar.eval
+
+import com.hereliesaz.graffitixr.common.model.CorrobGate
+import com.hereliesaz.graffitixr.common.model.CorroborationDiagnostics
+import com.hereliesaz.graffitixr.common.model.FusionDiagnostics
+import com.hereliesaz.graffitixr.common.model.FusionState
+import com.hereliesaz.graffitixr.common.model.GrowOutcome
+import com.hereliesaz.graffitixr.common.model.RelocDiagnostics
+import com.hereliesaz.graffitixr.common.model.RelocReject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The report's job is to answer "did this ever happen" for someone who was not holding the phone.
+ * These pin the two ways it could fail at that quietly: reporting nothing as if it were something
+ * (the `-1` sentinels averaged into the statistics), and reporting something as if it were nothing
+ * (an empty window rendered as a healthy-looking report of zeros).
+ */
+class DiagnosticRecorderTest {
+
+    private var clock = 0L
+    private fun recorder(capacity: Int = 100) =
+        DiagnosticRecorder(capacity = capacity, nowMs = { clock })
+
+    private fun DiagnosticRecorder.tick(
+        reject: RelocReject = RelocReject.OK,
+        gate: CorrobGate = CorrobGate.GATED,
+        grow: GrowOutcome = GrowOutcome.NOT_RUN,
+        state: FusionState = FusionState.HOLDING,
+        radiusPx: Float = 12f,
+        correctionMm: Float = 4f,
+        matches: Int = 100,
+        inliers: Int = 80,
+    ) {
+        clock += 66L
+        record(
+            RelocDiagnostics(
+                reject = reject, matches = matches, inliers = inliers,
+                corrobGate = gate, growOutcome = grow,
+            ),
+            CorroborationDiagnostics(searchRadiusPx = radiusPx),
+            FusionDiagnostics(state = state, correctionMm = correctionMm),
+            wallPoints = 500,
+            progress = 0.25f,
+        )
+    }
+
+    /**
+     * A report with no samples must say so in words.
+     *
+     * This is the single most likely real outcome — the tick never ran because AR was never entered
+     * — and rendering it as a table of zeros and empty histograms would read as "everything measured
+     * zero", which is a completely different and much more alarming finding.
+     */
+    @Test
+    fun `an empty window states that it is empty`() {
+        val r = recorder()
+        assertTrue(r.isEmpty())
+        val out = r.report(mapOf("build" to "debug"), emptyMap(), emptyList())
+        assertTrue(out, out.contains("No samples recorded"))
+        // And it must not print a numbers table that has nothing behind it.
+        assertFalse(out, out.contains("### What it measured"))
+    }
+
+    /** The ring is bounded: a long session cannot grow it, and the window it reports is the tail. */
+    @Test
+    fun `the ring is bounded and keeps the newest samples`() {
+        val r = recorder(capacity = 10)
+        repeat(5) { r.tick(reject = RelocReject.NO_FEATURES) }
+        repeat(50) { r.tick(reject = RelocReject.OK) }
+        val out = r.report(emptyMap(), emptyMap(), emptyList())
+        assertTrue(out, out.contains("10 samples"))
+        // The 5 early NO_FEATURES ticks have been evicted, so OK must be the whole window.
+        assertTrue(out, out.contains("OK ×10 (100%)"))
+        // But the total is still reported, so the reader knows the window is a tail and not the run.
+        assertTrue(out, out.contains("of 55 total"))
+    }
+
+    /**
+     * The four "never happened" answers, stated rather than left to be derived.
+     *
+     * A reader can in principle work these out from the histograms above them. In practice the
+     * absence of a value from a list is the single easiest thing to miss when skimming, and these
+     * four absences are the findings.
+     */
+    @Test
+    fun `it names the stages that never ran`() {
+        val r = recorder()
+        repeat(20) { r.tick(reject = RelocReject.FEW_INLIERS, gate = CorrobGate.NO_PLACEMENT, state = FusionState.NO_ANCHOR) }
+        val out = r.report(emptyMap(), emptyMap(), emptyList())
+        assertTrue(out, out.contains("relocalization never locked"))
+        assertTrue(out, out.contains("fusion never corrected the overlay"))
+        assertTrue(out, out.contains("gated corroboration match never ran"))
+        assertTrue(out, out.contains("self-grow never promoted"))
+    }
+
+    @Test
+    fun `a healthy run reports nothing as never having happened`() {
+        val r = recorder()
+        r.tick(reject = RelocReject.OK, gate = CorrobGate.GATED, grow = GrowOutcome.PROMOTED, state = FusionState.COLD_SNAP)
+        val out = r.report(emptyMap(), emptyMap(), emptyList())
+        assertTrue(out, out.contains("every stage ran at least once"))
+    }
+
+    /**
+     * `-1` means not measured, and averaging it in would make an unmeasured channel look like a
+     * badly performing one.
+     *
+     * The row must say `never measured` and carry a sample count of zero — not a min of -1, which a
+     * reader would try to interpret as a radius.
+     */
+    @Test
+    fun `an all-sentinel channel reports never measured rather than minus one`() {
+        val r = recorder()
+        repeat(10) { r.tick(radiusPx = -1f) }
+        val out = r.report(emptyMap(), emptyMap(), emptyList())
+        val row = out.lines().first { it.startsWith("| searchRadiusPx") }
+        assertTrue(row, row.contains("never measured"))
+        assertFalse(row, row.contains("-1"))
+    }
+
+    /** A partly-measured channel reports only the real readings, and says how many there were. */
+    @Test
+    fun `sentinels are excluded from the statistics of a partly measured channel`() {
+        val r = recorder()
+        repeat(7) { r.tick(radiusPx = -1f) }
+        r.tick(radiusPx = 10f)
+        r.tick(radiusPx = 20f)
+        r.tick(radiusPx = 30f)
+        val out = r.report(emptyMap(), emptyMap(), emptyList())
+        val row = out.lines().first { it.startsWith("| searchRadiusPx") }
+        // min 10, median 20, max 30, over 3 samples — and NOT over 10.
+        assertEquals("| searchRadiusPx | 10 | 20 | 30 | 3 |", row.trim())
+    }
+
+    /**
+     * The Screenshots section must distinguish "none taken" from "some taken and not attached".
+     *
+     * A reader who sees no images and no section assumes the feature is not there. One who sees the
+     * sentence knows the absence is itself a reading.
+     */
+    @Test
+    fun `the screenshots section says so when there are none`() {
+        val r = recorder()
+        r.tick()
+        val none = r.report(emptyMap(), emptyMap(), emptyList())
+        assertTrue(none, none.contains("None captured"))
+        val some = r.report(emptyMap(), emptyMap(), listOf("01_LOCK_LOST.png — pointed at a blank wall"))
+        assertTrue(some, some.contains("01_LOCK_LOST.png"))
+        assertFalse(some, some.contains("None captured"))
+    }
+
+    /** Parameters are printed sorted, so two reports from different runs diff cleanly. */
+    @Test
+    fun `parameters are printed in a stable order`() {
+        val r = recorder()
+        r.tick()
+        val a = r.report(emptyMap(), linkedMapOf("z" to "1", "a" to "2"), emptyList())
+        val b = r.report(emptyMap(), linkedMapOf("a" to "2", "z" to "1"), emptyList())
+        assertEquals(
+            a.substringAfter("### Parameters in force"),
+            b.substringAfter("### Parameters in force"),
+        )
+        assertTrue(a, a.indexOf("`a` = 2") < a.indexOf("`z` = 1"))
+    }
+
+    @Test
+    fun `clear empties the window and the total`() {
+        val r = recorder()
+        repeat(5) { r.tick() }
+        r.clear()
+        assertTrue(r.isEmpty())
+        assertTrue(r.report(emptyMap(), emptyMap(), emptyList()).contains("No samples recorded"))
+    }
+
+    /** Whole numbers print as integers; the rest to three places. A `12.000 px` radius reads badly. */
+    @Test
+    fun `whole numbers do not print a decimal tail`() {
+        val r = recorder()
+        r.tick(radiusPx = 12f)
+        r.tick(radiusPx = 12.5f)
+        val out = r.report(emptyMap(), emptyMap(), emptyList())
+        val row = out.lines().first { it.startsWith("| searchRadiusPx") }
+        assertEquals("| searchRadiusPx | 12 | 12.500 | 12.500 | 2 |", row.trim())
+    }
+}

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/eval/DiagnosticRecorderTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/eval/DiagnosticRecorderTest.kt
@@ -96,6 +96,107 @@ class DiagnosticRecorderTest {
         assertTrue(out, out.contains("self-grow never promoted"))
     }
 
+    /**
+     * A finding that is a constant is not a finding.
+     *
+     * `ArRenderer.fusionEnabled` ships `false` and its only writer sits behind the debug-only eval
+     * panel, so in a release build every sample is `DISABLED` and a bare "fusion never corrected the
+     * overlay" would print on 100% of field reports. The first reader to chase it wastes the trip —
+     * so the always-true case has to name itself, the way the self-grow line already does.
+     */
+    @Test
+    fun `fusion being off for the whole run is reported as such, not as a failure`() {
+        val r = recorder()
+        repeat(20) { r.tick(state = FusionState.DISABLED) }
+        val out = r.report(emptyMap(), emptyMap(), emptyList())
+        assertTrue(out, out.contains("fusion was OFF for the whole run"))
+        assertFalse(out, out.contains("fusion never corrected the overlay"))
+    }
+
+    /** Fusion on, and never once correcting, is the real finding and must still be reported. */
+    @Test
+    fun `fusion enabled but never correcting is still a finding`() {
+        val r = recorder()
+        repeat(20) { r.tick(state = FusionState.WAITING_FOR_LOCK) }
+        val out = r.report(emptyMap(), emptyMap(), emptyList())
+        assertTrue(out, out.contains("fusion never corrected the overlay"))
+        assertFalse(out, out.contains("fusion was OFF"))
+    }
+
+    /**
+     * A zero inlier ratio with matches present is the most diagnostic reading in the channel, and
+     * an earlier filter discarded it.
+     *
+     * `RelocDiagnostics.inlierRatio` has no sentinel of its own: it returns a bare `0` both when
+     * nothing was attempted and when everything was attempted and RANSAC rejected all of it. Forty
+     * correspondences a frame with zero inliers is the textbook "aimed at the wrong wall" — and it
+     * used to report `never measured`, telling the reader nothing had been tried.
+     */
+    @Test
+    fun `a zero inlier ratio with matches present is a measurement, not an absence`() {
+        val r = recorder()
+        repeat(10) { r.tick(matches = 40, inliers = 0) }
+        val out = r.report(emptyMap(), emptyMap(), emptyList())
+        val row = out.lines().first { it.startsWith("| inlierRatio") }
+        assertEquals("| inlierRatio | 0 | 0 | 0 | 10 |", row.trim())
+    }
+
+    /** With no matches there was nothing to attempt, and that genuinely is an absence. */
+    @Test
+    fun `a zero inlier ratio with no matches is not a measurement`() {
+        val r = recorder()
+        repeat(10) { r.tick(matches = 0, inliers = 0) }
+        val out = r.report(emptyMap(), emptyMap(), emptyList())
+        val row = out.lines().first { it.startsWith("| inlierRatio") }
+        assertTrue(row, row.contains("never measured"))
+    }
+
+    /** The histogram's percentage arithmetic, on a split that is not trivially 100%. */
+    @Test
+    fun `histogram percentages are computed over the window`() {
+        val r = recorder()
+        repeat(3) { r.tick(reject = RelocReject.OK) }
+        repeat(1) { r.tick(reject = RelocReject.FEW_INLIERS) }
+        val out = r.report(emptyMap(), emptyMap(), emptyList())
+        val row = out.lines().first { it.startsWith("- **Reloc**") }
+        assertEquals("- **Reloc**: OK ×3 (75%), FEW_INLIERS ×1 (25%)", row.trim())
+    }
+
+    /**
+     * The budget ceiling has to announce itself.
+     *
+     * A screenshot list that stops at sixteen reads as "and then nothing else happened" — the same
+     * silent-absence confusion the report exists to remove, one section below where it removes it.
+     */
+    @Test
+    fun `an exhausted capture budget is stated`() {
+        val r = recorder()
+        r.tick()
+        val truncated = r.report(
+            emptyMap(), emptyMap(), listOf("01_LOCK_LOST.png"), capturesTruncated = true,
+        )
+        assertTrue(truncated, truncated.contains("Capture budget exhausted"))
+        val notTruncated = r.report(emptyMap(), emptyMap(), listOf("01_LOCK_LOST.png"))
+        assertFalse(notTruncated, notTruncated.contains("Capture budget exhausted"))
+    }
+
+    /**
+     * An empty report still prints its parameters and its screenshots section.
+     *
+     * The early return dropped both, so the one path where "no screenshots" is guaranteed was also
+     * the only path that never said so — and the parameters are what tell the reader which build
+     * produced the nothing.
+     */
+    @Test
+    fun `an empty report still carries parameters and the screenshots section`() {
+        val out = recorder().report(
+            emptyMap(), linkedMapOf("SearchRadius.RHO" to "0.05"), emptyList(),
+        )
+        assertTrue(out, out.contains("No samples recorded"))
+        assertTrue(out, out.contains("`SearchRadius.RHO` = 0.05"))
+        assertTrue(out, out.contains("None captured"))
+    }
+
     @Test
     fun `a healthy run reports nothing as never having happened`() {
         val r = recorder()

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/eval/DiagnosticWatcherTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/eval/DiagnosticWatcherTest.kt
@@ -122,6 +122,59 @@ class DiagnosticWatcherTest {
     }
 
     /**
+     * The global cooldown expires AT its length, not after it.
+     *
+     * Found by mutation testing: changing `<` to `<=` survived the whole suite, because every other
+     * test sits either well inside the window or well outside it. The one tick that lands on the
+     * boundary is masked — the per-trigger cooldown refuses it under both operators, so the global
+     * cooldown's answer is invisible there.
+     *
+     * It matters in the direction that fails silently. An off-by-one toward refusing produces a
+     * report saying no watched transition occurred, which is indistinguishable from a session where
+     * genuinely nothing happened. So the boundary is pinned with a *different* trigger on the second
+     * tick, which has no repeat history of its own and therefore nothing else that could refuse it.
+     */
+    @Test
+    fun `a capture is permitted exactly one cooldown after the last`() {
+        val w = DiagnosticWatcher()
+        w.tick(0L, reject = RelocReject.NO_FEATURES)
+        assertEquals(CaptureTrigger.LOCK_ACQUIRED, w.tick(1_000L, reject = RelocReject.OK))
+        assertEquals(
+            CaptureTrigger.PROMOTED,
+            w.tick(
+                1_000L + DiagnosticWatcher.GLOBAL_COOLDOWN_MS,
+                reject = RelocReject.OK,
+                grow = GrowOutcome.PROMOTED,
+            ),
+        )
+    }
+
+    /**
+     * A correction parked exactly ON the threshold is a plateau, not a rise.
+     *
+     * Also found by mutation testing: `prevCorrectionMm < spikeMm` survived being loosened to `<=`,
+     * because the spike tests all use values comfortably either side of 150mm and never land on it.
+     *
+     * The consequence of the loose form is not a missed capture but a repeating one — a correction
+     * that settles precisely at `SPIKE_MM` would re-fire on every tick that clears the cooldowns,
+     * and a budget of sixteen would be spent photographing one stationary state.
+     */
+    @Test
+    fun `a correction sitting exactly on the threshold does not re-fire`() {
+        val w = DiagnosticWatcher()
+        w.tick(0L, correctionMm = 5f)
+        // The rise onto the threshold is a real spike and must fire.
+        assertEquals(
+            CaptureTrigger.CORRECTION_SPIKE,
+            w.tick(10_000L, correctionMm = DiagnosticWatcher.SPIKE_MM),
+        )
+        // Staying there, and going higher, is the same event. Spaced past every cooldown so only the
+        // plateau test can be what refuses it.
+        assertNull(w.tick(60_000L, correctionMm = DiagnosticWatcher.SPIKE_MM + 10f))
+        assertNull(w.tick(120_000L, correctionMm = DiagnosticWatcher.SPIKE_MM))
+    }
+
+    /**
      * A suppressed edge is gone, not queued.
      *
      * This is the one that would be easy to get wrong by leaving the previous-state update inside

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/eval/DiagnosticWatcherTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/eval/DiagnosticWatcherTest.kt
@@ -1,0 +1,270 @@
+package com.hereliesaz.graffitixr.feature.ar.eval
+
+import com.hereliesaz.graffitixr.common.model.CorrobGate
+import com.hereliesaz.graffitixr.common.model.CorroborationDiagnostics
+import com.hereliesaz.graffitixr.common.model.FusionDiagnostics
+import com.hereliesaz.graffitixr.common.model.FusionState
+import com.hereliesaz.graffitixr.common.model.GrowOutcome
+import com.hereliesaz.graffitixr.common.model.RelocDiagnostics
+import com.hereliesaz.graffitixr.common.model.RelocReject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The rate limiter is the part of [DiagnosticWatcher] most likely to be silently wrong, and its
+ * failure mode is indistinguishable from the failure it exists to detect: a limiter that refuses
+ * everything produces a report reading "no watched transition occurred", which is what a session
+ * with genuinely nothing wrong also produces.
+ *
+ * So these assert both directions — that it fires when it should and refuses when it should — and
+ * that a refused edge is *dropped* rather than deferred, which is the behaviour that would otherwise
+ * photograph the wrong frame and label it with the right event.
+ */
+class DiagnosticWatcherTest {
+
+    private fun reloc(
+        reject: RelocReject = RelocReject.NO_FINGERPRINT,
+        gate: CorrobGate = CorrobGate.NOT_RUN,
+        grow: GrowOutcome = GrowOutcome.NOT_RUN,
+    ) = RelocDiagnostics(reject = reject, corrobGate = gate, growOutcome = grow)
+
+    private fun fusion(
+        state: FusionState = FusionState.NO_ANCHOR,
+        correctionMm: Float = -1f,
+    ) = FusionDiagnostics(state = state, correctionMm = correctionMm)
+
+    private val corrob = CorroborationDiagnostics()
+
+    private fun DiagnosticWatcher.tick(
+        t: Long,
+        reject: RelocReject = RelocReject.NO_FINGERPRINT,
+        gate: CorrobGate = CorrobGate.NOT_RUN,
+        grow: GrowOutcome = GrowOutcome.NOT_RUN,
+        state: FusionState = FusionState.NO_ANCHOR,
+        correctionMm: Float = -1f,
+    ) = onTick(t, reloc(reject, gate, grow), corrob, fusion(state, correctionMm))
+
+    /**
+     * The very first tick must produce nothing, whatever it holds.
+     *
+     * Entering AR with a fingerprint already loaded arrives at `OK` on sample one. Treating that as
+     * an acquisition edge would photograph the launch screen of every session and burn a slot of a
+     * 16-capture budget on it.
+     */
+    @Test
+    fun `the first tick is never a transition`() {
+        val w = DiagnosticWatcher()
+        assertNull(w.tick(0L, reject = RelocReject.OK, state = FusionState.COLD_SNAP))
+    }
+
+    @Test
+    fun `losing the lock is photographed`() {
+        val w = DiagnosticWatcher()
+        w.tick(0L, reject = RelocReject.OK)
+        assertEquals(
+            CaptureTrigger.LOCK_LOST,
+            w.tick(1_000L, reject = RelocReject.FEW_INLIERS),
+        )
+    }
+
+    /**
+     * Relocalization being switched off is not a lock being lost.
+     *
+     * The A/B harness disables it deliberately, and every run of the "fusion off" arm would open
+     * with a capture of the moment the experiment started otherwise.
+     */
+    @Test
+    fun `disabling relocalization is not a lost lock`() {
+        val w = DiagnosticWatcher()
+        w.tick(0L, reject = RelocReject.OK)
+        assertNull(w.tick(1_000L, reject = RelocReject.DISABLED))
+    }
+
+    @Test
+    fun `a once-only trigger fires once and never again`() {
+        val w = DiagnosticWatcher()
+        w.tick(0L, reject = RelocReject.NO_FEATURES)
+        assertEquals(CaptureTrigger.LOCK_ACQUIRED, w.tick(1_000L, reject = RelocReject.OK))
+        // Lose it and re-acquire, well past every cooldown.
+        w.tick(100_000L, reject = RelocReject.NO_FEATURES)
+        assertNull(w.tick(200_000L, reject = RelocReject.OK))
+    }
+
+    @Test
+    fun `a repeatable trigger waits out its own cooldown`() {
+        val w = DiagnosticWatcher()
+        w.tick(0L, reject = RelocReject.OK)
+        assertEquals(CaptureTrigger.LOCK_LOST, w.tick(1_000L, reject = RelocReject.FEW_MATCHES))
+        // Re-acquire and lose again inside REPEAT_COOLDOWN_MS but outside GLOBAL_COOLDOWN_MS, so it
+        // is this trigger's own limiter being tested and not the global one.
+        w.tick(6_000L, reject = RelocReject.OK)
+        assertNull(w.tick(9_000L, reject = RelocReject.FEW_MATCHES))
+        // And past it.
+        w.tick(30_000L, reject = RelocReject.OK)
+        assertEquals(CaptureTrigger.LOCK_LOST, w.tick(40_000L, reject = RelocReject.FEW_MATCHES))
+    }
+
+    /**
+     * Two edges a frame apart are one event, and the second image is the first image.
+     *
+     * `PROMOTED` here is a repeatable trigger with its own cooldown, so the tick is spaced past that
+     * and the only thing left to refuse it is the global cooldown.
+     */
+    @Test
+    fun `the global cooldown suppresses a different trigger too`() {
+        val w = DiagnosticWatcher()
+        w.tick(0L, reject = RelocReject.NO_FEATURES)
+        assertEquals(CaptureTrigger.LOCK_ACQUIRED, w.tick(1_000L, reject = RelocReject.OK))
+        assertNull(w.tick(2_000L, reject = RelocReject.OK, grow = GrowOutcome.PROMOTED))
+    }
+
+    /**
+     * A suppressed edge is gone, not queued.
+     *
+     * This is the one that would be easy to get wrong by leaving the previous-state update inside
+     * the fired branch: the edge would then be re-detected on every later tick and fire the instant
+     * the cooldown lapsed, attaching a `LOCK_LOST` label to a frame from thirty seconds afterwards.
+     */
+    @Test
+    fun `an edge suppressed by cooldown does not fire later`() {
+        val w = DiagnosticWatcher()
+        w.tick(0L, reject = RelocReject.NO_FEATURES)
+        assertEquals(CaptureTrigger.LOCK_ACQUIRED, w.tick(1_000L, reject = RelocReject.OK))
+        // Suppressed by the global cooldown.
+        assertNull(w.tick(2_000L, reject = RelocReject.FEW_INLIERS))
+        // Long past every cooldown, still holding the same (non-OK) state: nothing changed, so
+        // nothing may fire.
+        assertNull(w.tick(90_000L, reject = RelocReject.FEW_INLIERS))
+    }
+
+    @Test
+    fun `a correction spike fires on the rise and not on the plateau`() {
+        val w = DiagnosticWatcher()
+        w.tick(0L, correctionMm = 5f)
+        assertEquals(
+            CaptureTrigger.CORRECTION_SPIKE,
+            w.tick(10_000L, correctionMm = DiagnosticWatcher.SPIKE_MM + 1f),
+        )
+        // Still large, and still the same event. Spaced past both cooldowns so only the rise-versus-
+        // level distinction can be what refuses it.
+        assertNull(w.tick(60_000L, correctionMm = DiagnosticWatcher.SPIKE_MM + 50f))
+    }
+
+    /**
+     * A correction of -1 means "no correction standing", not "a correction of minus one millimetre".
+     *
+     * If the sentinel were treated as a reading, every transition from "no correction" to a large
+     * one would count as a rise from below the threshold — which is right by accident — but so would
+     * a drop back to the sentinel and up again, giving a spike per relock. The rise must be measured
+     * from a real previous reading.
+     */
+    @Test
+    fun `the not-measured sentinel is not a previous reading`() {
+        val w = DiagnosticWatcher()
+        w.tick(0L, correctionMm = -1f)
+        assertNull(w.tick(10_000L, correctionMm = DiagnosticWatcher.SPIKE_MM + 1f))
+    }
+
+    @Test
+    fun `entering the 0_9 no-capture-pose state is photographed once`() {
+        val w = DiagnosticWatcher()
+        w.tick(0L, state = FusionState.WAITING_FOR_LOCK)
+        assertEquals(
+            CaptureTrigger.NO_CAPTURE_POSE,
+            w.tick(1_000L, state = FusionState.NO_CAPTURE_POSE),
+        )
+    }
+
+    @Test
+    fun `the first gated corroboration is photographed`() {
+        val w = DiagnosticWatcher()
+        w.tick(0L, gate = CorrobGate.NO_PLACEMENT)
+        assertEquals(
+            CaptureTrigger.CORROBORATION_GATED,
+            w.tick(1_000L, gate = CorrobGate.GATED),
+        )
+    }
+
+    /**
+     * When several edges land on one tick, the rarest wins.
+     *
+     * A promotion is the only irreversible act in the engine and happens a handful of times in a
+     * session; a lock is acquired constantly. Returning the acquisition would spend the tick's one
+     * capture on the event that will certainly come round again.
+     */
+    @Test
+    fun `the rarest trigger wins a tie`() {
+        val w = DiagnosticWatcher()
+        w.tick(0L, reject = RelocReject.NO_FEATURES, state = FusionState.WAITING_FOR_LOCK)
+        assertEquals(
+            CaptureTrigger.PROMOTED,
+            w.tick(
+                1_000L,
+                reject = RelocReject.OK,
+                grow = GrowOutcome.PROMOTED,
+                state = FusionState.COLD_SNAP,
+            ),
+        )
+    }
+
+    /** A losing candidate is not consolation-fired on the next tick either. */
+    @Test
+    fun `the loser of a tie is dropped, not deferred`() {
+        val w = DiagnosticWatcher()
+        w.tick(0L, reject = RelocReject.NO_FEATURES)
+        w.tick(1_000L, reject = RelocReject.OK, grow = GrowOutcome.PROMOTED)
+        assertNull(w.tick(120_000L, reject = RelocReject.OK))
+    }
+
+    /**
+     * The budget counts every capture, not every capture of one kind.
+     *
+     * Flapping the lock ten times over ten minutes produces `LOCK_ACQUIRED` once and `LOCK_LOST`
+     * repeatedly, spaced past every cooldown — so the only thing that can stop it is the ceiling,
+     * and it must stop it across the two kinds together rather than per kind.
+     */
+    @Test
+    fun `the capture budget is a hard ceiling`() {
+        val w = DiagnosticWatcher(maxCaptures = 2)
+        var t = 0L
+        var fired = 0
+        repeat(10) {
+            t += 60_000L
+            if (w.tick(t, reject = RelocReject.OK) != null) fired++
+            t += 60_000L
+            if (w.tick(t, reject = RelocReject.FEW_INLIERS) != null) fired++
+        }
+        assertEquals(2, fired)
+        assertTrue(w.atCap)
+        assertEquals(2, w.requestCount)
+    }
+
+    @Test
+    fun `reset clears the latches and the budget`() {
+        val w = DiagnosticWatcher()
+        w.tick(0L, reject = RelocReject.NO_FEATURES)
+        assertNotNull(w.tick(1_000L, reject = RelocReject.OK))
+        w.reset()
+        assertEquals(0, w.requestCount)
+        // And the first tick after a reset is a first tick again.
+        assertNull(w.tick(2_000L, reject = RelocReject.OK))
+        w.tick(3_000L, reject = RelocReject.NO_FEATURES)
+        assertEquals(CaptureTrigger.LOCK_ACQUIRED, w.tick(20_000L, reject = RelocReject.OK))
+    }
+
+    /**
+     * Every trigger declares what to look for in its image.
+     *
+     * The report prints these beside the filenames, and a blank one turns an attachment into an
+     * unlabelled photograph of a wall.
+     */
+    @Test
+    fun `every trigger says what its picture is for`() {
+        for (t in CaptureTrigger.entries) {
+            assertTrue("${t.name} has no guidance", t.whatToLookFor.length > 10)
+        }
+    }
+}

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/eval/DiagnosticWatcherTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/eval/DiagnosticWatcherTest.kt
@@ -60,6 +60,47 @@ class DiagnosticWatcherTest {
         assertNull(w.tick(0L, reject = RelocReject.OK, state = FusionState.COLD_SNAP))
     }
 
+    /**
+     * `PROMOTED` is an edge like every other trigger, and it was written as a level test.
+     *
+     * The native `mGrowOutcome` is sticky — `MobileGS::tryUpdateFingerprint` returns early without
+     * touching it when no design is registered — so one promotion followed by clearing the design
+     * leaves `PROMOTED` standing on every subsequent tick forever. As a level test it re-fired every
+     * `REPEAT_COOLDOWN_MS`, spending the whole 16-capture budget on about four minutes of
+     * photographs of a single promotion and leaving nothing for the lock failures.
+     *
+     * The class's headline claim is "transitions, never states". This is the trigger that broke it.
+     */
+    @Test
+    fun `a latched promotion is photographed once, not on every tick`() {
+        val w = DiagnosticWatcher()
+        w.tick(0L, grow = GrowOutcome.NO_CANDIDATES)
+        assertEquals(CaptureTrigger.PROMOTED, w.tick(1_000L, grow = GrowOutcome.PROMOTED))
+        // The value sticks. Every later tick still reads PROMOTED, well past both cooldowns, and
+        // none of them is a new promotion.
+        assertNull(w.tick(60_000L, grow = GrowOutcome.PROMOTED))
+        assertNull(w.tick(120_000L, grow = GrowOutcome.PROMOTED))
+        assertNull(w.tick(180_000L, grow = GrowOutcome.PROMOTED))
+        assertEquals(1, w.requestCount)
+    }
+
+    /** A second, genuine promotion — after the outcome moved away and back — is a new edge. */
+    @Test
+    fun `a second genuine promotion is photographed`() {
+        val w = DiagnosticWatcher()
+        w.tick(0L, grow = GrowOutcome.NO_CANDIDATES)
+        assertEquals(CaptureTrigger.PROMOTED, w.tick(1_000L, grow = GrowOutcome.PROMOTED))
+        w.tick(60_000L, grow = GrowOutcome.NO_NEW_POINTS)
+        assertEquals(CaptureTrigger.PROMOTED, w.tick(120_000L, grow = GrowOutcome.PROMOTED))
+    }
+
+    /** A session that opens already latched at PROMOTED must not photograph its first tick. */
+    @Test
+    fun `a promotion already standing on the first tick is not a transition`() {
+        val w = DiagnosticWatcher()
+        assertNull(w.tick(0L, grow = GrowOutcome.PROMOTED))
+    }
+
     @Test
     fun `losing the lock is photographed`() {
         val w = DiagnosticWatcher()

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Sun Aug 02 07:21:48 UTC 2026
-versionBuild=14527
+#Sun Aug 02 07:28:21 UTC 2026
+versionBuild=14554
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=393
+versionPatch=420

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Sun Aug 02 07:28:21 UTC 2026
-versionBuild=14554
+#Sun Aug 02 07:36:46 UTC 2026
+versionBuild=14556
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=420
+versionPatch=422

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Sun Aug 02 06:51:46 UTC 2026
-versionBuild=14517
+#Sun Aug 02 07:21:48 UTC 2026
+versionBuild=14527
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=383
+versionPatch=393


### PR DESCRIPTION
Getting evidence out of a field failure has meant a photograph of a phone screen. This makes the app collect its own.

## Why aggregates, not a snapshot

The HUD answers *"what is happening now"*. The question that has actually cost time on this project is **"did this ever happen"** — every expensive failure here has been a stage that silently did not run, and a stage that never runs looks identical at every single instant. `Corrob: design not placed` in one screenshot cannot distinguish "never gated once" from "gated fine a second ago and the artist has just looked away".

`DiagnosticRecorder` keeps a bounded ~2-minute ring of every channel the HUD displays, recorded unconditionally from the diagnostics tick, and renders a pasteable markdown report of **distributions**:

- reason-code histograms for `FusionState`, `RelocReject`, `CorrobGate`, `GrowOutcome`
- an explicit **"Never happened:"** list — the four findings, stated rather than left to be derived from an absence in a list
- min/median/max per channel, filtered so the `-1` sentinels do not drag an unmeasured run into looking like a badly performing one, with the sample count printed so a row backed by three readings is not mistaken for one backed by three hundred
- the parameters in force, because every one is a prior no experiment has moved and the reader is usually not the person holding the phone

## Why screenshots as well

A report cannot say what the camera was pointed at. A lock that dies every time the artist pans onto a blank rendered wall and a lock that dies for no visible reason produce identical diagnostic rows and completely different fixes.

`DiagnosticWatcher` watches the same tick stream for seven edges — lock acquired/lost, first cold snap, first gated corroboration, self-grow promotion, the `0.9` no-capture-pose state, and correction spikes past 150mm — and asks the Activity to `PixelCopy` the window.

`PixelCopy` and **not** the view hierarchy: the camera preview and AR overlay are hardware-composited, so a `Canvas` draw renders them as a black rectangle. The one thing a diagnostic screenshot exists to show is the one thing that method cannot capture.

Transitions, never states. At most one capture per tick, rarest trigger first, with a global cooldown, a per-trigger cooldown and a hard 16-capture ceiling. **A suppressed edge is dropped rather than deferred** — the alternative photographs a frame thirty seconds later and labels it with the right event name.

## Gating

The recorder runs always; it is memory. Screenshots are gated on the Diagnostic Overlay opt-in — writing PNGs of a user's camera feed to disk is not something to do because the app felt like it.

## One tap

A `Copy + share report` button on the release-visible overlay does both halves: the clipboard for the part that gets pasted into a chat, and `ACTION_SEND_MULTIPLE` for the CSVs and PNGs that cannot be.

## Two defects the tests found in this code before it landed

- **The limiter refused everything, silently.** The global cooldown started at `Long.MIN_VALUE`, so `nowMs - lastAnyMs` overflowed negative, compared below every cooldown, and no capture fired for the whole session — producing reports that said no watched transition had occurred. The exact failure mode this feature exists to end, in the feature itself. Now nullable.
- **Rotation broke the numbering.** The capture index and count lived in the Activity, which is destroyed on every rotation while the session it numbers is not: colliding filenames, a button reading "0 shots" beside a report listing six, and screenshots from previous sessions attached to new reports by the directory glob. Both moved into the view model, with a once-per-session purge so the directory agrees with the manifest.

## Unrelated defect fixed in the panel being touched

The eval overlay's fusion toggle initialised to `true` while `ArRenderer.fusionEnabled` ships `false`. The button read "Fusion ON" while fusion was off, and the first press set it to the value it already held — so enabling fusion took two presses, and the intervening state was indistinguishable from the one being left. An A/B switch that misreports which arm is selected invalidates the comparison it exists to run.

## Verification

- `:feature:ar:testDebugUnitTest` green (full module, not just the new tests)
- `:app:compileDebugKotlin` green
- 26 new unit tests across `DiagnosticRecorderTest` and `DiagnosticWatcherTest`, covering both directions of the rate limiter (fires when it should, refuses when it should), sentinel handling, budget ceiling, tie-breaking, and the dropped-versus-deferred edge behaviour
- Report output rendered and inspected by hand

Adversarial audit and mutation testing are still in flight; findings will land as follow-up commits on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Q5WXFiVLeN4sXa9bPCSDA

---
_Generated by [Claude Code](https://claude.ai/code/session_011Q5WXFiVLeN4sXa9bPCSDA)_

## Summary by Sourcery

Add self-collecting AR diagnostics with rolling reports, auto-triggered screenshots, and one-tap sharing from the diagnostic overlay.

New Features:
- Continuously record AR diagnostics into a bounded ring buffer and generate a pasteable markdown report of aggregates and reason-code distributions.
- Automatically capture downscaled window screenshots on key AR state transitions, gated by the Diagnostic Overlay opt-in.
- Expose a release-visible "Copy + share report" action that copies the diagnostic report to the clipboard and opens a share sheet with the report, recent eval artefacts, and captured screenshots.

Bug Fixes:
- Fix eval overlay fusion A/B toggle to default to the renderer’s actual fusionEnabled state and avoid misleading two-press enable behaviour.
- Ensure diagnostic capture indexing and counting survive activity rotation so filenames and shot counts remain consistent within a session.
- Correct diagnostic capture rate limiting so cooldowns work as intended and no longer silently suppress all captures.

Enhancements:
- Summarize AR run parameters in diagnostic reports, including Kotlin tunables and named native constants for easier offline analysis.
- Add session-scoped management of auto-capture files, including bounded eval attachments and per-session purge of screenshot directories.
- Introduce a pure DiagnosticWatcher with explicit cooldowns, budget ceiling, and tie-breaking priorities to decide which transitions warrant screenshots.

Tests:
- Add comprehensive unit tests for DiagnosticRecorder covering window bounding, sentinel handling, statistics calculation, parameters ordering, and screenshot section behavior.
- Add comprehensive unit tests for DiagnosticWatcher covering transition detection, cooldown behavior, budget ceiling, tie-breaking, and guidance text for each capture trigger.