### PR TITLE
chore: versionBuild=14557 from a diagnostic debug build

### DIFF
--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Sun Aug 02 07:36:46 UTC 2026
-versionBuild=14556
+#Sun Aug 02 08:06:10 UTC 2026
+versionBuild=14557
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=422
+versionPatch=423


### PR DESCRIPTION
No code change. `version.properties` only.

The bump was produced by an `assembleDebug` run made to investigate a reported "debug APK won't install", not by any source edit. It is committed rather than reverted because the counter is monotonic and this build number has been consumed.

## What the diagnostic build found

The build itself is healthy — `assembleDebug` completed with exit 0, producing a 139 MB APK at versionCode 14557. The install failure is a signing conflict, not a build problem:

```
Signer #1 certificate DN: C=US, O=Android, CN=Android Debug
```

`app/build.gradle.kts` signs the **debug** variant with the **release** key when a keystore is present, and falls back to the default debug key when it is not:

```kotlin
debug {
    signingConfig = signingConfigs.findByName("release") ?: signingConfig
}
```

There is no `applicationIdSuffix`, so the CI-published debug APK (release key), a locally built debug APK (debug key), and the Play build (Play App Signing key) all install as `com.hereliesaz.graffitixr` under up to three different signatures. Android refuses to replace an installed package with a differently-signed one, which surfaces on the device as "App not installed".

No fix is proposed here. Resolving it properly is a product decision — an `applicationIdSuffix` on debug would let the variants coexist, but it would also orphan every existing install of the auto-published debug APK, which is this project's distribution artifact.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Q5WXFiVLeN4sXa9bPCSDA)_

## Summary by Sourcery

Retain the auto-incremented version.properties state from a diagnostic debug build without introducing any functional code changes.

Enhancements:
- Update version.properties metadata to reflect the latest compiled build number while keeping existing version values unchanged.

Build:
- Record the latest debug build in version.properties so the monotonic build counter reflects the consumed versionBuild.