### PR TITLE
Ship the fusion and self-grow toggles behind the diagnostics setting

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -1206,6 +1206,10 @@ class MainActivity : ComponentActivity() {
                                     paintingProgress = arUiState.paintingProgress,
                                     captureCount = diagnosticCaptures,
                                     onShareReport = { shareDiagnosticBundle() },
+                                    fusionEnabled = evalFusionOn,
+                                    onToggleFusion = { arViewModel.evalSetFusionEnabled(it) },
+                                    selfGrowEnabled = evalSelfGrowOn,
+                                    onToggleSelfGrow = { arViewModel.evalSetSelfGrowEnabled(it) },
                                 )
                             }
 
@@ -1219,10 +1223,6 @@ class MainActivity : ComponentActivity() {
                                     onStartLog = { arViewModel.evalStartLog() },
                                     onStopLog = { arViewModel.evalStopLog() },
                                     onInduceLoss = { arViewModel.evalInduceLoss() },
-                                    onToggleFusion = { arViewModel.evalSetFusionEnabled(it) },
-                                    onToggleSelfGrow = { arViewModel.evalSetSelfGrowEnabled(it) },
-                                    fusionOn = evalFusionOn,
-                                    selfGrowOn = evalSelfGrowOn,
                                 )
                             }
 
@@ -2219,6 +2219,18 @@ private fun RelocDiagnosticsOverlay(
     paintingProgress: Float,
     onShareReport: () -> Unit,
     captureCount: Int,
+    // The two experiment switches, moved here from the debug-only eval panel.
+    //
+    // Both ship OFF and both stay off until switched on. Off-by-default is right because neither has
+    // been validated on a device — no E-series experiment has run — but "unvalidated" argues for a
+    // default, not for making them unreachable. Fusion is the correction that stops the overlay
+    // drifting, and self-grow is what keeps relocalization alive as the artist paints over the very
+    // marks it relocalizes against; a release build that can never enable either has no answer to
+    // the two problems the artist actually has.
+    fusionEnabled: Boolean,
+    onToggleFusion: (Boolean) -> Unit,
+    selfGrowEnabled: Boolean,
+    onToggleSelfGrow: (Boolean) -> Unit,
 ) {
     val d = diagnostics
     // What to DO about it, not just what happened.
@@ -2421,6 +2433,34 @@ private fun RelocDiagnosticsOverlay(
         // paintingProgress — a name for the value one row up, on a number that is not it.
         DiagnosticRow("Painted", "${(paintingProgress * 100).toInt()}%", androidx.compose.ui.graphics.Color.White)
 
+        // Drift correction. Off means the overlay rides the raw ARCore anchor and will drift as
+        // tracking does; on means each accepted relocalization pulls it back. The `Fusion` row above
+        // reports what it is actually doing, so the pair reads as control-then-consequence.
+        androidx.compose.material3.TextButton(onClick = { onToggleFusion(!fusionEnabled) }) {
+            androidx.compose.material3.Text(
+                if (fusionEnabled) "Drift correction: ON" else "Drift correction: OFF",
+                color = if (fusionEnabled) androidx.compose.ui.graphics.Color.Green
+                else androidx.compose.ui.graphics.Color.Gray,
+            )
+        }
+        // Self-grow. Promotes newly validated marks into the reloc fingerprint so relocalization
+        // survives the original marks being painted over — the whole point of the teleological
+        // fingerprint, and useless to an artist if it can only be switched on in a debug build.
+        //
+        // Amber rather than green when on: it is the one switch here that WRITES to the map instead
+        // of reading it. A promotion that should not have happened stays in the fingerprint and
+        // compounds, and the remedy is to re-create the target — which replaces the fingerprint
+        // outright (`mWallDescriptors = d.clone()`) rather than merging into it, so the damage is
+        // bounded to one target and is undone by an action the app already asks for when the overlay
+        // misbehaves. Recoverable, then, but not free, and the colour should say so.
+        androidx.compose.material3.TextButton(onClick = { onToggleSelfGrow(!selfGrowEnabled) }) {
+            androidx.compose.material3.Text(
+                if (selfGrowEnabled) "Self-grow: ON (writes the map)" else "Self-grow: OFF",
+                color = if (selfGrowEnabled) androidx.compose.ui.graphics.Color(0xFFFFC107)
+                else androidx.compose.ui.graphics.Color.Gray,
+            )
+        }
+
         // The whole overlay above answers "what is happening now" for someone holding the phone.
         // This button answers it for someone who is not: it copies an aggregated report of the
         // recent window to the clipboard and opens a share sheet with that report, the eval CSVs and
@@ -2445,22 +2485,6 @@ private fun EvalOverlay(
     onStartLog: () -> Unit,
     onStopLog: () -> Unit,
     onInduceLoss: () -> Unit,
-    onToggleFusion: (Boolean) -> Unit,
-    onToggleSelfGrow: (Boolean) -> Unit,
-    // Both switches MIRROR the values they set; neither keeps a copy.
-    //
-    // These were `remember`ed booleans seeded with a guess at each default. The fusion guess said
-    // `true` while `ArRenderer.fusionEnabled` had shipped `false` for 187 commits, so the button
-    // read "Fusion ON" with fusion off and the first press set it to the value it already held —
-    // enabling fusion took two presses, and the intervening state was indistinguishable from the one
-    // being left. Correcting the seed alone would have left the same defect one rotation away: a
-    // `remember` is dropped on configuration change while the renderer's flag is not.
-    //
-    // An A/B switch that can disagree with the arm it selects invalidates the comparison it exists
-    // to run, so neither of these gets to hold its own state — they are read from the view model,
-    // which reads them back from the renderer and the engine.
-    fusionOn: Boolean,
-    selfGrowOn: Boolean,
 ) {
     androidx.compose.foundation.layout.Column(
         androidx.compose.ui.Modifier
@@ -2480,12 +2504,10 @@ private fun EvalOverlay(
             androidx.compose.material3.TextButton(onClick = onInduceLoss) { androidx.compose.material3.Text("Loss") }
             androidx.compose.material3.TextButton(onClick = onStartRecord) { androidx.compose.material3.Text("Rec▶") }
             androidx.compose.material3.TextButton(onClick = onStopRecord) { androidx.compose.material3.Text("Rec■") }
-            androidx.compose.material3.TextButton(onClick = { onToggleFusion(!fusionOn) }) {
-                androidx.compose.material3.Text(if (fusionOn) "Fusion ON" else "Fusion OFF")
-            }
-            androidx.compose.material3.TextButton(onClick = { onToggleSelfGrow(!selfGrowOn) }) {
-                androidx.compose.material3.Text(if (selfGrowOn) "Grow ON" else "Grow OFF")
-            }
+            // Fusion and self-grow used to live here. They are on RelocDiagnosticsOverlay now,
+            // which renders in release behind the same Diagnostic Overlay setting — and which
+            // renders in debug too, so this panel loses nothing by not duplicating them. Two
+            // buttons for one flag is how the last desync got in.
         }
     }
 }

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -2363,6 +2363,22 @@ class ArViewModel @Inject constructor(
         // touches a SensorManager or a location client it does not own.
         renderer?.attitudeSampler = { attitudeProvider?.snapshot() }
         renderer?.locationSampler = { locationFix() }
+        // Re-apply the experiment switches to the FRESH renderer.
+        //
+        // `ArRenderer` is reconstructed whenever the AR view is (leaving and re-entering AR, and
+        // some configuration changes), and a new one starts at its shipped default — `fusionEnabled
+        // = false`. Without this, turning fusion on and then stepping out of AR and back would leave
+        // the renderer off while `evalFusionEnabled` still reported on: the toggle would read ON, the
+        // HUD would read DISABLED, and the two would disagree with no way for the artist to tell
+        // which was lying. That is the same shadow-versus-mirror defect the toggle itself had, one
+        // layer down, and it only became reachable once these moved out of the debug panel.
+        //
+        // The view model holds the INTENT; the renderer is made to match it, never the reverse.
+        renderer?.fusionEnabled = _evalFusionEnabled.value
+        // Self-grow lives in the native engine rather than the renderer, so it does not reset with
+        // a new ArRenderer — but re-asserting it is idempotent and costs one atomic store, and it
+        // means one place re-establishes every experiment switch instead of two rules to remember.
+        slamManager.setSelfGrowEnabled(_evalSelfGrowEnabled.value)
         renderer?.attachSession(session)
         loadCloudPointsIfExists()
     }

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/ArViewModelTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/ArViewModelTest.kt
@@ -574,6 +574,49 @@ class ArViewModelTest {
         }
     }
 
+
+    /**
+     * Attaching a renderer re-asserts the standing self-grow intent on the engine.
+     *
+     * Exactly twice: once from the toggle itself, once from the attach. One call would mean the
+     * attach did not re-apply it, which is the whole point.
+     *
+     * ## Why the fusion half of this fix has no test
+     *
+     * `attachSessionToRenderer` also pushes the fusion intent onto the renderer, and that is the
+     * half that actually fixes a user-visible desync — `ArRenderer` is rebuilt when the AR view is,
+     * so a new one starts at its shipped `fusionEnabled = false` while the toggle still reads ON.
+     *
+     * It is not covered because `ArRenderer` cannot be mocked in this harness: `mockk(relaxed = true)`
+     * does not intercept it, so `attachSession` runs its real body and dereferences a `sessionLock`
+     * that a constructor-less mock never initialised. Every route to the assertion goes through that
+     * call. Passing `null` — as this test does — exercises the engine write but skips the renderer
+     * write entirely, since it is behind `renderer?.`.
+     *
+     * So the fusion re-apply is verified by reading, not by a test, and this note exists so nobody
+     * later mistakes the presence of a nearby green test for coverage of it.
+     */
+    @Test
+    fun `attaching re-applies the self-grow intent`() = runTest {
+        viewModel.evalSetSelfGrowEnabled(true)
+        viewModel.attachSessionToRenderer(null)
+        verify(exactly = 2) { slamManager.setSelfGrowEnabled(true) }
+    }
+
+    /**
+     * With no renderer attached there is nothing to switch, and the toggle must say so rather than
+     * report a state it failed to apply.
+     *
+     * This is the read-back discipline paying for itself: `evalSetFusionEnabled` writes to the
+     * renderer and then reports whatever the renderer holds, so a null renderer yields OFF instead
+     * of a cheerful ON with nothing behind it.
+     */
+    @Test
+    fun `enabling fusion with no renderer reports off rather than a state it could not apply`() = runTest {
+        viewModel.evalSetFusionEnabled(true)
+        assertFalse(viewModel.evalFusionEnabled.value)
+    }
+
     @Suppress("UNCHECKED_CAST")
     private fun enableArCore() {
         // setArMode(true) early-returns unless ARCore is reported available; flip the flag on the

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Sun Aug 02 08:06:10 UTC 2026
-versionBuild=14557
+#Sun Aug 02 19:28:36 UTC 2026
+versionBuild=14563
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=423
+versionPatch=429


### PR DESCRIPTION
Both switches were reachable only from the eval panel, which is `BuildConfig.DEBUG`-gated. So on any build a user can actually install — including the Play release — drift correction could never be switched on and self-grow could never run.

## Why this matters more for self-grow than for fusion

Self-grow is what keeps relocalization alive as the artist paints over the very marks it relocalizes against. That is the central problem the teleological fingerprint exists to solve. Shipping it permanently unreachable means the problem is never solved for anyone using the app.

Both still default **OFF**. Neither has been validated on a device — no E-series experiment has run — but *unvalidated* argues for a default, not for making a feature impossible to enable.

## The amber

Self-grow renders amber rather than green when on, because it is the one switch here that **writes** to the map rather than reading it. A promotion that should not have happened stays in the fingerprint and compounds.

The remedy is to re-create the target, which replaces the fingerprint outright — `mWallDescriptors = d.clone()`, assignment rather than a merge — so the damage is bounded to one target and is undone by an action the app already asks for when the overlay misbehaves. Recoverable, but not free, and the colour should say so.

## A desync this move makes reachable

`ArRenderer` is reconstructed whenever the AR view is, and a new one starts at its shipped `fusionEnabled = false`. Turning drift correction on, stepping out of AR and back, would leave the renderer off while `evalFusionEnabled` still reported on: the toggle reads ON, the HUD reads DISABLED, and nothing tells the artist which is lying.

The view model now holds the intent and re-applies it to every renderer that attaches. Same shadow-versus-mirror defect the toggle itself had an hour ago, one layer down — and only reachable now that an artist can leave AR mid-session with these switched on.

The eval panel no longer carries copies of either button. `RelocDiagnosticsOverlay` renders in debug builds too, so the panel loses nothing, and two buttons bound to one flag is how the previous desync got in.

## Verification

- `:feature:ar:testDebugUnitTest`, `:app:testDebugUnitTest` green
- `:app:compileDebugKotlin` **and** `:app:compileReleaseKotlin` green — the release variant matters here, since this overlay now ships there

## What is not tested, stated plainly

The self-grow re-apply is covered, as is the read-back discipline that makes the toggle report OFF when there is no renderer to honour it.

The **fusion re-apply — the half that fixes the user-visible desync — is not covered.** `ArRenderer` cannot be mocked in this harness: `mockk(relaxed = true)` does not intercept it, so `attachSession` runs its real body and dereferences a `sessionLock` that a constructor-less mock never initialised, and every route to the assertion goes through that call. It is verified by reading. The test file says so at length, so that a nearby green test is not later mistaken for coverage of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Q5WXFiVLeN4sXa9bPCSDA

---
_Generated by [Claude Code](https://claude.ai/code/session_011Q5WXFiVLeN4sXa9bPCSDA)_

## Summary by Sourcery

Expose fusion and self-grow experiment toggles via the diagnostics overlay so they are available in release builds, and ensure their state is correctly reapplied and reported by the AR view model.

New Features:
- Add fusion and self-grow controls to the RelocDiagnosticsOverlay, gated by the diagnostics setting and available in release builds.

Bug Fixes:
- Ensure fusion and self-grow intents are reapplied when a new AR renderer is attached to avoid toggle and HUD desync.
- Make fusion toggling report OFF when no renderer is attached, avoiding misleading ON states with no effect.

Enhancements:
- Remove duplicate fusion and self-grow controls from the debug-only eval panel to prevent state divergence.
- Document the limitations of test coverage around fusion re-apply behavior and verify self-grow re-application with new tests.

Build:
- Increment app version build and patch numbers.

Tests:
- Add tests verifying self-grow intent is re-applied on renderer attachment and that fusion reports OFF when no renderer is available.