### PR TITLE
Fix the runaway artwork: reject outlier support anchors from the consensus

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -1202,7 +1202,16 @@ class MainActivity : ComponentActivity() {
                                     diagnostics = arUiState.relocDiagnostics,
                                     corroboration = arUiState.corroborationDiagnostics,
                                     fusion = arUiState.fusionDiagnostics,
-                                    fingerprintPoints = arUiState.evalLiveMetrics.wallCount,
+                                    // `wallFingerprintPoints`, NOT `evalLiveMetrics.wallCount`.
+                                    //
+                                    // evalLiveMetrics is only written while a dev eval log is
+                                    // running (`if (evalLogging)` in setTrackingState); in every
+                                    // release build it keeps its default, so this row displayed a
+                                    // hardcoded 0 forever. It read "FP PTS 0" beside "BACKBONE
+                                    // 1500 PTS · 1042 CORR · 1015 IN" on a locked device — and it
+                                    // is what made me tell the artist their target had never been
+                                    // created when the fingerprint was right there.
+                                    fingerprintPoints = arUiState.wallFingerprintPoints,
                                     paintingProgress = arUiState.paintingProgress,
                                     captureCount = diagnosticCaptures,
                                     onShareReport = { shareDiagnosticBundle() },

--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -2274,7 +2274,21 @@ private fun RelocDiagnosticsOverlay(
             "Inliers", "${d.inliers}/${d.matches} (${(d.inlierRatio * 100).toInt()}%)",
             androidx.compose.ui.graphics.Color.White,
         )
-        DiagnosticRow("In frame", "${d.detected} features", androidx.compose.ui.graphics.Color.White)
+        // "0 features" is a MEASUREMENT and must not be printed when nothing was measured.
+        //
+        // The native relocalizer early-returns on an empty fingerprint BEFORE it runs the detector,
+        // so `detected` keeps its default 0 and the row read "0 FEATURES" on a device — telling an
+        // artist their wall had no texture, and sending them to fix the lighting, when the real and
+        // only problem was that no target existed to match against. Same for a disabled relocalizer.
+        DiagnosticRow(
+            "In frame",
+            when (d.reject) {
+                RelocReject.NO_FINGERPRINT, RelocReject.DISABLED, RelocReject.UNKNOWN ->
+                    "not sampled"
+                else -> "${d.detected} features"
+            },
+            androidx.compose.ui.graphics.Color.White,
+        )
         // Whether the plane-guided rectification pass is firing. It was dead in practice until the
         // capture view started being stored, so seeing a real angle here is the confirmation that it
         // now runs; "off" means it wasn't eligible (no capture view, not tracking, too few points).
@@ -2322,6 +2336,11 @@ private fun RelocDiagnosticsOverlay(
                 // target", which no other state does, and it is the newest and least familiar.
                 com.hereliesaz.graffitixr.common.model.FusionState.NO_CAPTURE_POSE ->
                     "OLD TARGET — re-create it"
+                // Distinct from the line above, which used to cover this case and sent the artist to
+                // "re-create" a target that had never been created — directly contradicting the
+                // Reloc row's own "NO TARGET" three rows up.
+                com.hereliesaz.graffitixr.common.model.FusionState.NO_FINGERPRINT ->
+                    "NO TARGET — create one"
                 com.hereliesaz.graffitixr.common.model.FusionState.WAITING_FOR_LOCK -> "waiting for lock"
                 com.hereliesaz.graffitixr.common.model.FusionState.COLD_SNAP -> "snapped"
                 com.hereliesaz.graffitixr.common.model.FusionState.BLENDING ->
@@ -2332,6 +2351,7 @@ private fun RelocDiagnosticsOverlay(
                 // Red for the two that mean corrections are being computed and thrown away, or
                 // cannot be computed at all. Amber for the transient waits. White for working.
                 com.hereliesaz.graffitixr.common.model.FusionState.NO_CAPTURE_POSE,
+                com.hereliesaz.graffitixr.common.model.FusionState.NO_FINGERPRINT,
                 com.hereliesaz.graffitixr.common.model.FusionState.DISABLED ->
                     androidx.compose.ui.graphics.Color.Red
                 com.hereliesaz.graffitixr.common.model.FusionState.NO_ANCHOR,

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/FusionDiagnostics.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/FusionDiagnostics.kt
@@ -92,4 +92,24 @@ enum class FusionState {
      * is why [FusionDiagnostics.snapsAccepted] and the reloc row have to be read beside it.
      */
     HOLDING,
+
+    /**
+     * There is no wall fingerprint at all, so there is no capture pose to compose against.
+     *
+     * **Out of gate order, and deliberately so.** Every entry above is ordered by how early its gate
+     * sits; this one belongs beside [NO_CAPTURE_POSE], because both mean "no capture pose". It is
+     * appended instead because `EvalSampleLog` writes this enum's **ordinal** into the CSV, and
+     * inserting it in the right place would silently renumber `NO_CAPTURE_POSE` and everything after
+     * it, making every previously logged run incomparable to every later one without a single error.
+     *
+     * ## Why it needs to exist at all
+     *
+     * A device run reported `Reloc: NO TARGET` and `Fusion: OLD TARGET — re-create it` on the same
+     * screen. Both came from one condition — `captureAnchorCam == null` — which is true for a
+     * pre-Phase-2 fingerprint AND for no fingerprint whatsoever. The advice differs completely: one
+     * says re-create a target that exists, the other says create the first one. The overlay
+     * contradicted itself, and the aggregated report showed 54% `NO_CAPTURE_POSE` for a session that
+     * never had a fingerprint to begin with.
+     */
+    NO_FINGERPRINT,
 }

--- a/core/data/src/main/java/com/hereliesaz/graffitixr/data/repository/SettingsRepositoryImpl.kt
+++ b/core/data/src/main/java/com/hereliesaz/graffitixr/data/repository/SettingsRepositoryImpl.kt
@@ -39,6 +39,8 @@ class SettingsRepositoryImpl @Inject constructor(
      */
     private val LEGACY_CANVAS_MODE = "CLOUD_POINTS"
     private val SHOW_ANCHOR_BOUNDARY = booleanPreferencesKey("show_anchor_boundary")
+    private val DRIFT_CORRECTION_ENABLED = booleanPreferencesKey("drift_correction_enabled")
+    private val SELF_GROW_ENABLED = booleanPreferencesKey("self_grow_enabled")
     private val FORCED_STEREO_UNSTABLE = booleanPreferencesKey("forced_stereo_unstable")
     // Key intentionally renamed from "stereo_capability": the probe's meaning changed from "stereo
     // tracks" to "dual lenses actually triangulate depth", so pre-existing verdicts must be discarded
@@ -126,6 +128,27 @@ class SettingsRepositoryImpl @Inject constructor(
     override suspend fun setShowAnchorBoundary(show: Boolean) {
         context.dataStore.edit { preferences ->
             preferences[SHOW_ANCHOR_BOUNDARY] = show
+        }
+    }
+
+    // Both default false. Persistence remembers an explicit choice; it does not make one.
+    override val driftCorrectionEnabled: Flow<Boolean> = context.dataStore.data
+        .catch { if (it is IOException) emit(emptyPreferences()) else throw it }
+        .map { preferences -> preferences[DRIFT_CORRECTION_ENABLED] ?: false }
+
+    override suspend fun setDriftCorrectionEnabled(on: Boolean) {
+        context.dataStore.edit { preferences ->
+            preferences[DRIFT_CORRECTION_ENABLED] = on
+        }
+    }
+
+    override val selfGrowEnabled: Flow<Boolean> = context.dataStore.data
+        .catch { if (it is IOException) emit(emptyPreferences()) else throw it }
+        .map { preferences -> preferences[SELF_GROW_ENABLED] ?: false }
+
+    override suspend fun setSelfGrowEnabled(on: Boolean) {
+        context.dataStore.edit { preferences ->
+            preferences[SELF_GROW_ENABLED] = on
         }
     }
 

--- a/core/domain/src/main/java/com/hereliesaz/graffitixr/domain/repository/SettingsRepository.kt
+++ b/core/domain/src/main/java/com/hereliesaz/graffitixr/domain/repository/SettingsRepository.kt
@@ -49,6 +49,33 @@ interface SettingsRepository {
     suspend fun setShowAnchorBoundary(show: Boolean)
 
     /**
+     * Whether relocalization corrections are fused onto the overlay ("drift correction").
+     *
+     * Persisted, and that is the whole point. It was session-scoped, which cost a real field run:
+     * the artist enabled it, the session ended, and the next run silently reverted to off. The
+     * relocalizer locked on 31% of ticks at a 94% inlier ratio and every one of those corrections
+     * was computed and discarded, so the overlay drifted exactly as if nothing worked — and the
+     * report's own `Fusion: DISABLED ×777 (100%)` was the only place that said why.
+     *
+     * Off by default still: it is unvalidated on a device. But a switch the artist has to remember
+     * to find and re-flip on every launch is not a switch they have.
+     */
+    val driftCorrectionEnabled: Flow<Boolean>
+
+    suspend fun setDriftCorrectionEnabled(on: Boolean)
+
+    /**
+     * Whether self-grow may promote validated new marks into the reloc fingerprint.
+     *
+     * Persisted for the same reason, and still default-off for a stronger one: it is the only
+     * mechanism that permanently rewrites the map. Persistence remembers an explicit choice; it does
+     * not make one.
+     */
+    val selfGrowEnabled: Flow<Boolean>
+
+    suspend fun setSelfGrowEnabled(on: Boolean)
+
+    /**
      * Set once a device proves it can't run forced hardware-stereo (ARCore motion-stereo disparity
      * fails / VIO never tracks): future sessions skip the stereo config and stay on Canvas, so the
      * broken path can't thrash the device. Cleared when the user explicitly re-selects Mural.

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -59,6 +59,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
@@ -516,6 +517,32 @@ class ArViewModel @Inject constructor(
     fun evalSetFusionEnabled(on: Boolean) {
         renderer?.fusionEnabled = on
         _evalFusionEnabled.value = renderer?.fusionEnabled ?: false
+        // Remembered across launches. See SettingsRepository.driftCorrectionEnabled — a field run
+        // enabled this, ended, and silently came back off, and the next session discarded 241 good
+        // relocalizations without a word.
+        viewModelScope.launch { settingsRepository.setDriftCorrectionEnabled(on) }
+    }
+
+    /**
+     * Restores both experiment switches from storage.
+     *
+     * Only the view model's intent is set here — `attachSessionToRenderer` is what pushes it onto a
+     * renderer, and it runs on every attach, so a restore that lands before the renderer exists is
+     * still honoured.
+     */
+    private fun restoreExperimentSwitches() {
+        // firstOrNull, not first: `first()` throws NoSuchElementException on a flow that completes
+        // without emitting, and this runs in `init`, so the throw would take the whole view model
+        // down at construction. A store with nothing in it means "never chosen", which is the
+        // default — not an error.
+        viewModelScope.launch {
+            _evalFusionEnabled.value = settingsRepository.driftCorrectionEnabled.firstOrNull() ?: false
+            renderer?.fusionEnabled = _evalFusionEnabled.value
+        }
+        viewModelScope.launch {
+            _evalSelfGrowEnabled.value = settingsRepository.selfGrowEnabled.firstOrNull() ?: false
+            slamManager.setSelfGrowEnabled(_evalSelfGrowEnabled.value)
+        }
     }
 
     private val _evalFusionEnabled = MutableStateFlow(false)
@@ -543,6 +570,7 @@ class ArViewModel @Inject constructor(
     fun evalSetSelfGrowEnabled(on: Boolean) {
         slamManager.setSelfGrowEnabled(on)
         _evalSelfGrowEnabled.value = on
+        viewModelScope.launch { settingsRepository.setSelfGrowEnabled(on) }
     }
 
     /**
@@ -839,6 +867,7 @@ class ArViewModel @Inject constructor(
     init {
         NativeLibLoader.loadAll()
         startSystemThrottleMonitoring()
+        restoreExperimentSwitches()
         viewModelScope.launch(Dispatchers.IO) {
             slamManager.loadSuperPoint(appContext.assets)
             slamManager.loadDistortionHead(appContext.assets) // optional; inert if asset absent

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/AnchorOrchestrator.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/AnchorOrchestrator.kt
@@ -28,6 +28,20 @@ class AnchorOrchestrator {
     private val consensusAnchors = mutableListOf<ConsensusAnchor>()
     private val MAX_CONSENSUS_ANCHORS = 8
 
+    /**
+     * How far a support anchor's suggested artwork position may sit from the median before it is
+     * excluded from the consensus, in metres.
+     *
+     * Half a metre is chosen to sit above honest disagreement and below the failure. Anchors on one
+     * wall agree to within a few centimetres; ARCore drift between two anchors in the same room is
+     * tens of centimetres at worst. The run this was written for went metres, and kept going.
+     *
+     * A prior, not a measurement — no experiment has swept it. Erring large is the safe direction:
+     * too tight discards genuine anchors and reduces the consensus to one vote, which is the state
+     * this class exists to improve on.
+     */
+    private val OUTLIER_RADIUS_M = 0.5f
+
     // The master artwork pose in world space, set when the first anchor is established.
     private var masterArtworkPose: Pose? = null
 
@@ -107,12 +121,50 @@ class AnchorOrchestrator {
             return
         }
 
+        // Every tracking anchor's vote for where the artwork is.
+        val suggestions = tracking.map { it.anchor.pose.compose(it.artworkOffset) }
+
+        // Throw out the anchors that disagree with the rest before averaging.
+        //
+        // Without this, one support anchor is enough to take the artwork with it. ARCore anchors
+        // drift and occasionally jump — in a dim room with weak tracking, routinely — and a weighted
+        // MEAN has no defence against that: a single outlier moves the result in proportion to how
+        // wrong it is. Worse, `weight = 1/(1+dist)` is computed from the offset captured when the
+        // anchor was created, so an anchor that has since flown across the room keeps whatever
+        // authority it had when it was still trustworthy.
+        //
+        // A device run watched the artwork recede 4.6 → 4.8 → 5.6 → 7.2 → 26.3 ft over four seconds
+        // while relocalization held a 97% inlier ratio at 2px reprojection and fusion was off — so
+        // nothing downstream of this function was involved. The overlay "very literally ran away".
+        //
+        // The median is the right centre here precisely because it cannot be dragged: half the votes
+        // would have to be wrong before it moves. Anchors further than [OUTLIER_RADIUS_M] from it
+        // are excluded from the average entirely — they are not consensus, they are the thing
+        // consensus exists to survive.
+        val medianPos = floatArrayOf(
+            medianOf(suggestions.map { it.tx() }),
+            medianOf(suggestions.map { it.ty() }),
+            medianOf(suggestions.map { it.tz() }),
+        )
+        val kept = tracking.filterIndexed { i, _ ->
+            val s = suggestions[i]
+            val dx = s.tx() - medianPos[0]
+            val dy = s.ty() - medianPos[1]
+            val dz = s.tz() - medianPos[2]
+            dx * dx + dy * dy + dz * dz <= OUTLIER_RADIUS_M * OUTLIER_RADIUS_M
+        }.ifEmpty {
+            // Cannot happen with a real median — the median element is always within 0 of itself —
+            // but an empty list here would divide by a zero weight sum and write NaNs into the
+            // artwork matrix, which is a far worse failure than keeping everything.
+            tracking
+        }
+
         // Weighted Average of translation and SLERP for rotation
         var totalX = 0f; var totalY = 0f; var totalZ = 0f
         val quats = mutableListOf<FloatArray>()
         val weights = mutableListOf<Float>()
 
-        for (ca in tracking) {
+        for (ca in kept) {
             val suggestion = ca.anchor.pose.compose(ca.artworkOffset)
 
             // Proximity weight: anchors closer to the artwork (smaller stored offset) are more
@@ -171,6 +223,20 @@ class AnchorOrchestrator {
     }
 
     private fun identity() = floatArrayOf(1f,0f,0f,0f, 0f,1f,0f,0f, 0f,0f,1f,0f, 0f,0f,0f,1f)
+
+    /**
+     * Median of a non-empty list, by the lower element on an even count.
+     *
+     * Deliberately not the mean of the two middles: this is used per-axis on a set of 3D positions,
+     * and mixing an interpolated value into one axis while the others take real samples produces a
+     * centre that no anchor ever voted for. Picking an actual sample keeps the reference point on
+     * the manifold of things the anchors actually said.
+     */
+    private fun medianOf(values: List<Float>): Float {
+        if (values.isEmpty()) return 0f
+        val sorted = values.sorted()
+        return sorted[(sorted.size - 1) / 2]
+    }
 
     fun getActiveAnchorCount(): Int = synchronized(this) {
         consensusAnchors.count { it.anchor.trackingState == TrackingState.TRACKING }

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/DiagnosticRecorder.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/eval/DiagnosticRecorder.kt
@@ -148,6 +148,26 @@ class DiagnosticRecorder(
 
         // The four questions this report exists to answer, stated as answers rather than left for
         // the reader to derive from the histograms above.
+        // Root cause first, when there is one.
+        //
+        // A device run produced four "never happened" bullets — no lock, no correction, no gated
+        // corroboration, no promotion — which read as four faults and were one: the fingerprint was
+        // empty, so nothing downstream could run. Listing consequences beside their cause, in no
+        // particular order, makes the reader diagnose the report before they can diagnose the app.
+        //
+        // This is the opposite failure from the one the section was written for, and just as costly:
+        // not too few findings, too many.
+        val noFingerprint = ring.all { it.reloc.reject == RelocReject.NO_FINGERPRINT }
+        if (noFingerprint) {
+            sb.appendLine(
+                "**Root cause: there was no wall fingerprint for the entire window.** The target " +
+                    "was never created, or its capture produced no usable points. Relocalization " +
+                    "returns before it even runs its detector in this state, so every finding " +
+                    "below follows from this one and is not a separate fault.",
+            )
+            sb.appendLine()
+        }
+
         sb.appendLine("**Never happened:**")
         val never = buildList {
             if (ring.none { it.reloc.reject == RelocReject.OK }) add("relocalization never locked")
@@ -162,6 +182,13 @@ class DiagnosticRecorder(
                 // constant is not a finding, and the first reader to chase it wastes the trip.
                 if (ring.all { it.fusion.state == FusionState.DISABLED }) {
                     add("fusion was OFF for the whole run (expected — it ships default-off)")
+                } else if (ring.any { it.fusion.state == FusionState.NO_FINGERPRINT }) {
+                    add("fusion had no fingerprint to compose against — a consequence, not a fault")
+                } else if (ring.any { it.fusion.state == FusionState.NO_CAPTURE_POSE }) {
+                    add(
+                        "fusion was skipped because the fingerprint carries no capture pose " +
+                            "(pre-Phase-2 target — re-create it)",
+                    )
                 } else {
                     add("fusion never corrected the overlay")
                 }
@@ -170,7 +197,19 @@ class DiagnosticRecorder(
                 add("the gated corroboration match never ran (Phase 4 inactive for this run)")
             }
             if (ring.none { it.reloc.growOutcome == GrowOutcome.PROMOTED }) {
-                add("self-grow never promoted (expected — it ships default-off)")
+                // "(expected — it ships default-off)" was unconditional, and a device run switched
+                // self-grow ON and still got that parenthetical — telling the one reader who had
+                // deliberately enabled it that its silence was the default behaviour. The engine
+                // distinguishes the two: DISABLED is the switch, NOT_RUN is never reaching the code.
+                add(
+                    when {
+                        ring.all { it.reloc.growOutcome == GrowOutcome.DISABLED } ->
+                            "self-grow never promoted (switched off for this run)"
+                        ring.all { it.reloc.growOutcome == GrowOutcome.NOT_RUN } ->
+                            "self-grow never promoted — it never ran at all, so the switch is not the reason"
+                        else -> "self-grow never promoted"
+                    },
+                )
             }
         }
         if (never.isEmpty()) sb.appendLine("- (nothing — every stage ran at least once)")
@@ -210,8 +249,17 @@ class DiagnosticRecorder(
         stat(sb, "paintingProgress", ring.map { it.progress }) { it >= 0f }
         sb.appendLine()
 
+        // The same sentinel discipline as the table above it, which this line did not follow: it
+        // printed a bare `-1 / -1` on a real device report — the marker for "PoseFusion never
+        // sampled" rendered as though two relocalizations had been counted at minus one.
         val last = ring.last()
-        sb.appendLine("- snaps accepted/refused: ${last.fusion.snapsAccepted} / ${last.fusion.snapsRejected}")
+        sb.appendLine(
+            if (last.fusion.snapsAccepted < 0 || last.fusion.snapsRejected < 0) {
+                "- snaps accepted/refused: never sampled (pose fusion did not run)"
+            } else {
+                "- snaps accepted/refused: ${last.fusion.snapsAccepted} / ${last.fusion.snapsRejected}"
+            },
+        )
         sb.appendLine()
 
         appendParameters(sb, parameters)

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -1272,8 +1272,19 @@ class ArRenderer(
             fusionSkipReason = when {
                 !fusionEnabled -> com.hereliesaz.graffitixr.common.model.FusionState.DISABLED
                 !anchorEstablished -> com.hereliesaz.graffitixr.common.model.FusionState.NO_ANCHOR
+                // Two very different causes, one condition. A pre-Phase-2 fingerprint has points but
+                // no stored capture pose; a session where the target capture failed has no
+                // fingerprint at all. Reported as one state, the overlay told an artist to
+                // "re-create" a target that had never existed, one row under its own "NO TARGET".
+                //
+                // The keypoint count is only read on this branch — i.e. only when fusion is already
+                // skipping — so the healthy path pays nothing for the distinction.
                 captureAnchorCam == null ->
-                    com.hereliesaz.graffitixr.common.model.FusionState.NO_CAPTURE_POSE
+                    if (slamManager.getWallKeypointCount() <= 0) {
+                        com.hereliesaz.graffitixr.common.model.FusionState.NO_FINGERPRINT
+                    } else {
+                        com.hereliesaz.graffitixr.common.model.FusionState.NO_CAPTURE_POSE
+                    }
                 else -> null
             }
             val anchorMatrix: FloatArray = if (fusionEnabled && anchorEstablished && captureAnchorCam != null) {

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/eval/DiagnosticRecorderTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/eval/DiagnosticRecorderTest.kt
@@ -197,6 +197,95 @@ class DiagnosticRecorderTest {
         assertTrue(out, out.contains("None captured"))
     }
 
+    /**
+     * Four findings that are one cause must say so, and say it first.
+     *
+     * A device run produced exactly this: no lock, no correction, no gated corroboration, no
+     * promotion — read as four faults, and all four were the empty fingerprint. Relocalization
+     * returns before it runs its detector in that state, so nothing downstream could possibly have
+     * happened. Listing consequences beside their cause in no particular order makes the reader
+     * diagnose the report before they can diagnose the app: the opposite failure from the one this
+     * section was written for, and just as costly.
+     */
+    @Test
+    fun `an empty fingerprint is reported as the root cause of everything below it`() {
+        val r = recorder()
+        repeat(20) {
+            r.tick(
+                reject = RelocReject.NO_FINGERPRINT, gate = CorrobGate.NOT_RUN,
+                grow = GrowOutcome.NOT_RUN, state = FusionState.NO_FINGERPRINT,
+            )
+        }
+        val out = r.report(emptyMap(), emptyMap(), emptyList())
+        assertTrue(out, out.contains("Root cause: there was no wall fingerprint"))
+        assertTrue(out, out.indexOf("Root cause") < out.indexOf("Never happened"))
+        assertTrue(out, out.contains("a consequence, not a fault"))
+    }
+
+    /** A run that did have a fingerprint must not be handed a root cause it did not have. */
+    @Test
+    fun `a run with a fingerprint gets no root-cause claim`() {
+        val r = recorder()
+        repeat(10) { r.tick(reject = RelocReject.FEW_INLIERS) }
+        r.tick(reject = RelocReject.NO_FINGERPRINT)
+        val out = r.report(emptyMap(), emptyMap(), emptyList())
+        assertFalse(out, out.contains("Root cause"))
+    }
+
+    /**
+     * No fingerprint and a pre-Phase-2 fingerprint are opposite instructions.
+     *
+     * One says create the first target, the other says re-create an existing one. They shared a
+     * state until a device screenshot showed the overlay telling an artist to "re-create" a target
+     * one row under its own "NO TARGET".
+     */
+    @Test
+    fun `the two no-capture-pose causes give different instructions`() {
+        val noFp = recorder().apply { repeat(5) { tick(state = FusionState.NO_FINGERPRINT) } }
+            .report(emptyMap(), emptyMap(), emptyList())
+        assertTrue(noFp, noFp.contains("no fingerprint to compose against"))
+
+        val oldFp = recorder().apply { repeat(5) { tick(state = FusionState.NO_CAPTURE_POSE) } }
+            .report(emptyMap(), emptyMap(), emptyList())
+        assertTrue(oldFp, oldFp.contains("pre-Phase-2 target — re-create it"))
+        assertFalse(oldFp, oldFp.contains("no fingerprint to compose against"))
+    }
+
+    /**
+     * Telling someone who deliberately switched self-grow ON that its silence is the default is
+     * worse than saying nothing. The engine distinguishes the switch from never reaching the code.
+     */
+    @Test
+    fun `self-grow silence names the switch only when the switch is the reason`() {
+        val off = recorder().apply { repeat(5) { tick(grow = GrowOutcome.DISABLED) } }
+            .report(emptyMap(), emptyMap(), emptyList())
+        assertTrue(off, off.contains("switched off for this run"))
+
+        val neverRan = recorder().apply { repeat(5) { tick(grow = GrowOutcome.NOT_RUN) } }
+            .report(emptyMap(), emptyMap(), emptyList())
+        assertTrue(neverRan, neverRan.contains("never ran at all, so the switch is not the reason"))
+        assertFalse(neverRan, neverRan.contains("switched off for this run"))
+    }
+
+    /**
+     * The snaps line follows the same sentinel rule as the table above it, which it did not: a real
+     * device report printed a bare `-1 / -1`, the marker for "pose fusion never sampled" rendered as
+     * though two relocalizations had been counted at minus one.
+     */
+    @Test
+    fun `the snaps line does not print the not-sampled sentinel`() {
+        val r = recorder()
+        clock += 66
+        r.record(
+            RelocDiagnostics(), CorroborationDiagnostics(), FusionDiagnostics(),
+            wallPoints = 0, progress = 0f,
+        )
+        val out = r.report(emptyMap(), emptyMap(), emptyList())
+        val line = out.lines().first { it.startsWith("- snaps") }
+        assertFalse(line, line.contains("-1"))
+        assertTrue(line, line.contains("never sampled"))
+    }
+
     @Test
     fun `a healthy run reports nothing as never having happened`() {
         val r = recorder()

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Sun Aug 02 20:39:03 UTC 2026
-versionBuild=14567
+#Sun Aug 02 21:38:26 UTC 2026
+versionBuild=14569
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=433
+versionPatch=435

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Sun Aug 02 21:38:26 UTC 2026
-versionBuild=14569
+#Sun Aug 02 21:44:43 UTC 2026
+versionBuild=14570
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=435
+versionPatch=436

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Sun Aug 02 19:43:55 UTC 2026
-versionBuild=14564
+#Sun Aug 02 20:39:03 UTC 2026
+versionBuild=14567
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=430
+versionPatch=433


### PR DESCRIPTION
**The artwork receded 4.6 → 4.8 → 5.6 → 7.2 → 26.3 ft over four seconds and collapsed to a sliver**, while `RELOC` read `LOCKED` at a 97% inlier ratio and 2px reprojection, and `FUSION` read `OFF`.

Relocalization was working perfectly. Fusion was off, so nothing in the correction path was running. The artwork was not drifting — the anchor was being computed wrong, upstream of all of it.

## Root cause

`AnchorOrchestrator.getConsensusMatrix` took a weighted **mean** of every tracking support anchor's suggestion, with no outlier rejection.

A mean has no defence against a single bad vote: it moves in proportion to how wrong that vote is. ARCore anchors drift and occasionally jump — routinely, in a dim room with weak tracking. And the weight is `1/(1+dist)`, computed from the offset captured when the anchor was **created**, so an anchor that has since flown across the room keeps whatever authority it had while it was still trustworthy.

Support anchors are added on tap while the anchor is established, up to eight, so a session with a lot of tapping accumulates exactly the population this needs to survive.

## Fix

Take the per-axis **median** of the suggestions, drop anything further than 0.5 m from it, average what remains. The median is the right centre precisely because it cannot be dragged — half the votes would have to be wrong before it moves.

0.5 m sits above honest disagreement (anchors on one wall agree to centimetres; cross-room ARCore drift is tens of centimetres) and far below the failure, which went metres and kept going. It is a prior, not a measurement — no experiment has swept it.

The empty-after-filter branch cannot trigger with a real median, but an empty list would divide by a zero weight sum and write NaNs into the artwork matrix — much worse than keeping everything.

## Second fix: `FP PTS` was hardcoded 0 in every release build

The row read `arUiState.evalLiveMetrics.wallCount`, and `evalLiveMetrics` is only written while a dev eval log is running (`if (evalLogging)` in `setTrackingState`). Outside that it kept its default.

It displayed **`FP PTS 0`** next to **`BACKBONE 1500 PTS · 1042 CORR · 1015 IN`** on a device that was locked and matching — and it is what led to the conclusion that the target had never been created, when the fingerprint was right there. The real value was already in the same state object as `wallFingerprintPoints`.

## Also in this PR

- Four diagnostic misreports found by the first device run: `In frame: 0 FEATURES` when detection never ran, `OLD TARGET — re-create it` sitting under `NO TARGET`, the `-1 / -1` snaps sentinel, and four "never happened" bullets that were one root cause.
- Drift correction and self-grow now **persist across sessions**. Three field runs in a row reported `Fusion: DISABLED ×100%` because the toggle was session-scoped; run two discarded 241 good relocalizations and run three another 83, and from the outside that is indistinguishable from a relocalizer that never worked.

## Verification

- `:feature:ar:testDebugUnitTest`, `:app:testDebugUnitTest` green
- `:app:compileDebugKotlin` and `:app:compileReleaseKotlin` green

The outlier rejection is a hypothesis-driven fix: the evidence places the failure in this function and nowhere else, but it has not been reproduced on a device with the fix in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Q5WXFiVLeN4sXa9bPCSDA