### PR TITLE
A fusion toggle with no renderer dropped the request and reported OFF

### DIFF
--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -515,8 +515,20 @@ class ArViewModel @Inject constructor(
 
     /** A/B switch for the pose fusion (Sub-project B): on = corrected snap-back fusion, off = old toggle. */
     fun evalSetFusionEnabled(on: Boolean) {
+        // The INTENT is recorded unconditionally; the renderer is updated if there is one.
+        //
+        // This used to read the value back — `_evalFusionEnabled.value = renderer?.fusionEnabled ?:
+        // false` — so a tap while no renderer was attached silently did nothing AND reported OFF.
+        // Entering AR, a surface rebuild, the moments around a target capture: any of them, and the
+        // artist turns drift correction on and watches the button say it is off. Reported as "I
+        // wasn't the one that turned it off", which is exactly right.
+        //
+        // I defended the read-back as honest mirroring, and it was the opposite. `attachSessionToRenderer`
+        // already pushes this value onto every renderer that attaches, so recording the intent is
+        // not a claim about a state that was never applied — it is a promise this class keeps.
+        // Dropping the request was the lie.
+        _evalFusionEnabled.value = on
         renderer?.fusionEnabled = on
-        _evalFusionEnabled.value = renderer?.fusionEnabled ?: false
         // Remembered across launches. See SettingsRepository.driftCorrectionEnabled — a field run
         // enabled this, ended, and silently came back off, and the next session discarded 241 good
         // relocalizations without a word.

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/ArViewModelTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/ArViewModelTest.kt
@@ -604,16 +604,32 @@ class ArViewModelTest {
     }
 
     /**
-     * With no renderer attached there is nothing to switch, and the toggle must say so rather than
-     * report a state it failed to apply.
+     * A toggle with no renderer attached still records the intent, and still reports it.
      *
-     * This is the read-back discipline paying for itself: `evalSetFusionEnabled` writes to the
-     * renderer and then reports whatever the renderer holds, so a null renderer yields OFF instead
-     * of a cheerful ON with nothing behind it.
+     * The inverse of this was asserted here, and defended in a comment as honest mirroring: the
+     * setter read the flag back through the renderer, so a tap with none attached silently dropped
+     * the request and reported OFF. Entering AR, a surface rebuild, the moments around a target
+     * capture — any of them and the artist turns drift correction on and watches the button say it
+     * is off. It was reported from the field as "I wasn't the one that turned it off".
+     *
+     * `attachSessionToRenderer` pushes this value onto every renderer that attaches, so recording
+     * the intent is not a claim about something that never happened. It is a promise that gets kept
+     * on the next attach, which for a control only reachable inside AR is immediate.
      */
     @Test
-    fun `enabling fusion with no renderer reports off rather than a state it could not apply`() = runTest {
+    fun `enabling fusion with no renderer still records the intent`() = runTest {
         viewModel.evalSetFusionEnabled(true)
+        assertTrue(
+            "the request must survive the absence of a renderer, not be silently dropped",
+            viewModel.evalFusionEnabled.value,
+        )
+    }
+
+    /** And turning it back off is equally unconditional. */
+    @Test
+    fun `disabling fusion with no renderer records the intent too`() = runTest {
+        viewModel.evalSetFusionEnabled(true)
+        viewModel.evalSetFusionEnabled(false)
         assertFalse(viewModel.evalFusionEnabled.value)
     }
 

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Sun Aug 02 21:44:43 UTC 2026
-versionBuild=14570
+#Sun Aug 02 21:53:14 UTC 2026
+versionBuild=14571
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=436
+versionPatch=437


### PR DESCRIPTION
Reported from the field as *"I wasn't the one that turned it off"* — and that is exactly what was happening.

`evalSetFusionEnabled` wrote the flag to the renderer and then read it back:

```kotlin
renderer?.fusionEnabled = on
_evalFusionEnabled.value = renderer?.fusionEnabled ?: false
```

With no renderer attached the write is a no-op and the read-back yields `false`. So the tap did nothing, **and the button then displayed OFF** — reporting a state the artist had not asked for, and had just asked to leave.

Entering AR, a surface rebuild, the moments either side of a target capture: each is a window where this happens, and this control is only reachable inside AR, where those windows are common.

## The reasoning that produced it

I wrote that read-back deliberately and defended it in a comment as honest mirroring — a switch must not claim an arm it failed to select. That principle is right, and it did not apply here: `attachSessionToRenderer` already pushes this value onto every renderer that attaches. Recording the intent is not a claim about something that never happened; it is a promise the class keeps on the next attach.

Dropping the request was the lie, and the mirror discipline was being used to justify it.

The intent is now recorded unconditionally and the renderer updated when there is one. The test that pinned the old behaviour asserted the defect, so it is replaced rather than adjusted.

## Relationship to the persistence fix

Separate failures, both of which produced the same symptom:

- **Persistence** (already merged) — the setting was lost across app restarts.
- **This** — the setting was lost mid-session, on a tap that appeared to do nothing.

Three field runs reported `Fusion: DISABLED ×100%`. Between them they discarded 324 good relocalizations at inlier ratios of 94–97%.

## Verification

- `:feature:ar:testDebugUnitTest` green
- `:app:compileDebugKotlin` green
- Two tests replacing the one that pinned the defect

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Q5WXFiVLeN4sXa9bPCSDA

---
_Generated by [Claude Code](https://claude.ai/code/session_011Q5WXFiVLeN4sXa9bPCSDA)_

## Summary by Sourcery

Record fusion toggle intent regardless of renderer availability so the UI reflects the requested state instead of dropping it when no renderer is attached.

Bug Fixes:
- Ensure fusion enable/disable requests persist even when no renderer is attached, preventing the toggle from incorrectly reporting OFF.
- Fix mid-session loss of the fusion setting caused by reading back through a null renderer.

Enhancements:
- Clarify ArViewModel fusion toggle behavior with commentary documenting intent recording versus renderer application.

Build:
- Increment application build and patch versions in version.properties.

Tests:
- Replace the previous test that asserted the faulty behavior with two tests verifying that enabling and disabling fusion without a renderer still record the requested state.