### PR TITLE
The primary anchor was attached to a still-forming Plane, and rode it

### DIFF
--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -618,6 +618,17 @@ class ArViewModel @Inject constructor(
             // The reason an empty-fingerprint run is empty. Without it the report can say the
             // fingerprint is missing and nothing about why, which is where three device runs stalled.
             "lastCapture" to (lastCaptureRefusal?.let { "REFUSED — $it" } ?: "no refusal recorded"),
+            // The single most direct test for "the overlay is receding": is the ARCore anchor's OWN
+            // pose moving, independent of fusion, relocalization, or the consensus average. A device
+            // run went 6.2 -> 16.0 ft in four seconds with fusion off and no fingerprint — nothing
+            // downstream of the anchor was even running — traced to the primary anchor being attached
+            // to a still-forming ARCore Plane trackable rather than a fixed world pose, so ARCore's
+            // own plane refinement dragged it along. Fixed by anchoring to a fixed pose instead; this
+            // number is what proves whether that fix held on the NEXT run, rather than requiring a
+            // burst of screenshots and a stopwatch again.
+            "anchorDriftM" to (renderer?.primaryAnchorDriftMeters()?.let {
+                if (it >= 0f) String.format(java.util.Locale.US, "%.3f", it) else "no anchor established"
+            } ?: "no renderer attached"),
         ),
         parameters = diagnosticParameters(),
         captures = captureManifest.toList(),

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/AnchorOrchestrator.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/AnchorOrchestrator.kt
@@ -45,6 +45,26 @@ class AnchorOrchestrator {
     // The master artwork pose in world space, set when the first anchor is established.
     private var masterArtworkPose: Pose? = null
 
+    // The primary anchor's translation at the instant it was established. Compared against its
+    // live translation so a report can state, in metres, exactly how far the anchor itself has
+    // moved — not the consensus average, not the rendered overlay, the raw ARCore Anchor. This is
+    // the number that tells the next reader whether a "runs away" report is this mechanism again or
+    // something new, instead of re-deriving it from a distance HUD and a stopwatch.
+    private var establishedTranslation: FloatArray? = null
+
+    /**
+     * How far the primary anchor's own pose has moved since [setInitialAnchor], in metres, or -1 if
+     * there is no established anchor or it has stopped tracking.
+     */
+    fun primaryAnchorDriftMeters(): Float = synchronized(this) {
+        val e0 = establishedTranslation ?: return -1f
+        val primary = consensusAnchors.firstOrNull() ?: return -1f
+        if (primary.anchor.trackingState != TrackingState.TRACKING) return -1f
+        val t = primary.anchor.pose.translation
+        val dx = t[0] - e0[0]; val dy = t[1] - e0[1]; val dz = t[2] - e0[2]
+        return kotlin.math.sqrt(dx * dx + dy * dy + dz * dz)
+    }
+
     // The last successfully-computed consensus matrix. Held during a (usually brief) tracking loss so
     // the overlay stays put on the wall instead of teleporting to the world origin — this is exactly
     // the "stays stuck even in your pocket" behaviour the app is built around.
@@ -59,6 +79,7 @@ class AnchorOrchestrator {
             consensusAnchors.forEach { it.anchor.detach() }
             consensusAnchors.clear()
             masterArtworkPose = null
+            establishedTranslation = null
             hasLastGood = false
         }
     }
@@ -71,6 +92,7 @@ class AnchorOrchestrator {
             // clear() re-enters this monitor (reentrant), keeping the reset+seed atomic.
             clear()
             masterArtworkPose = anchor.pose
+            establishedTranslation = anchor.pose.translation
             consensusAnchors.add(ConsensusAnchor(anchor, Pose.IDENTITY))
         }
         Timber.d("Initial consensus anchor established at ${anchor.pose}")

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -238,6 +238,14 @@ class ArRenderer(
     @Volatile var fusionSkipReason: com.hereliesaz.graffitixr.common.model.FusionState? = null
 
     /**
+     * How far the primary ARCore anchor's own pose has moved since establishment, in metres, or -1
+     * with no established anchor. See `AnchorOrchestrator.primaryAnchorDriftMeters` — added to give
+     * a "the overlay is receding" report a number to check FIRST, before anything downstream of the
+     * anchor (fusion, relocalization) is even considered.
+     */
+    fun primaryAnchorDriftMeters(): Float = anchorOrchestrator.primaryAnchorDriftMeters()
+
+    /**
      * The last fusion decision, for the overlay and the eval CSV. Combines [fusionSkipReason] — the
      * states only the renderer can see — with `PoseFusion`'s own record of what it did when it ran.
      */
@@ -1071,9 +1079,31 @@ class ArRenderer(
                         val dist = Math.sqrt((dx * dx + dy * dy + dz * dz).toDouble())
                         if (dist in 0.1..10.0) {
                             pose.toMatrix(anchorModelMatrix, 0) // full surface pose (position + normal)
-                            // Anchor to the hit's trackable so ARCore keeps it pinned to the wall as the
-                            // artist moves, instead of a free world point at a guessed depth.
-                            anchor = chosen.createAnchor()
+                            // A FIXED world pose, not `chosen.createAnchor()`.
+                            //
+                            // `HitResult.createAnchor()` attaches to the TRACKABLE, so the anchor's
+                            // pose keeps following that Plane as ARCore continues to refine, grow and
+                            // merge it — normally a small correction. In a difficult scene (dim room,
+                            // few real features) the plane can still be actively forming when this
+                            // fires, spanning several unrelated surfaces at once, and each refinement
+                            // shifts its centre by a lot. The anchor rides along.
+                            //
+                            // A device run showed exactly this: the overlay receding 6.2 -> 16.0 ft in
+                            // four seconds, accelerating, with fusion off and no fingerprint — nothing
+                            // downstream of the anchor was even running. A screenshot from the same
+                            // session showed the plane polygon itself spanning a canvas, a doorway and
+                            // the floor as one badly-fit surface — the exact shape of trackable this
+                            // produces the failure on. `getConsensusMatrix` had exactly one vote
+                            // (`setInitialAnchor` always seeds a fresh single anchor), so the
+                            // multi-anchor outlier rejection added earlier could not have caught this;
+                            // it guards disagreement between anchors, and there was only one.
+                            //
+                            // `addSupportAnchor` already creates its anchors this way
+                            // (`session.createAnchor(worldPose)`); the primary anchor was the one
+                            // inconsistent case. The cost is real: the anchor no longer nudges itself
+                            // as ARCore's plane estimate improves in the following second or so. That
+                            // is a small, one-time precision loss against an unbounded runaway.
+                            anchor = activeSession.createAnchor(pose)
                             // Capture the surface normal so the overlay can be laid flat & facing the
                             // user. A plane pose's local +Y is the wall normal; a depth/feature point
                             // has no reliable orientation, so use the anchor→camera direction (a surface

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/AnchorOrchestratorDriftTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/AnchorOrchestratorDriftTest.kt
@@ -1,0 +1,85 @@
+package com.hereliesaz.graffitixr.feature.ar.anchor
+
+import com.google.ar.core.Anchor
+import com.google.ar.core.Pose
+import com.google.ar.core.TrackingState
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * `primaryAnchorDriftMeters` — the diagnostic added to make the "the overlay is receding" report
+ * falsifiable instead of another round of screenshots and a stopwatch.
+ *
+ * It answers exactly one question: has the ARCore anchor's OWN pose moved since it was established,
+ * independent of fusion, relocalization, or the consensus average. A device run went 6.2 -> 16.0 ft
+ * in four seconds with fusion off and no fingerprint — nothing downstream of the anchor was even
+ * running — traced to the primary anchor being attached to a still-forming ARCore Plane trackable
+ * rather than a fixed world pose, so ARCore's own plane refinement dragged it along.
+ */
+class AnchorOrchestratorDriftTest {
+
+    private fun anchorAt(x: Float, y: Float, z: Float, state: TrackingState = TrackingState.TRACKING): Anchor {
+        val a = mockk<Anchor>(relaxed = true)
+        every { a.pose } returns Pose(floatArrayOf(x, y, z), floatArrayOf(0f, 0f, 0f, 1f))
+        every { a.trackingState } returns state
+        return a
+    }
+
+    @Test fun `no established anchor reports the not-measured sentinel`() {
+        assertEquals(-1f, AnchorOrchestrator().primaryAnchorDriftMeters(), 0f)
+    }
+
+    @Test fun `an anchor that has not moved reports zero drift`() {
+        val o = AnchorOrchestrator()
+        o.setInitialAnchor(anchorAt(1f, 2f, 3f))
+        assertEquals(0f, o.primaryAnchorDriftMeters(), 1e-5f)
+    }
+
+    /**
+     * The mechanism under test: a mock `Anchor` returning a DIFFERENT pose on a later call is
+     * exactly what a trackable-attached anchor does as ARCore keeps refining the plane it rides on
+     * — the anchor object is the same, its `.pose` is not.
+     */
+    @Test fun `an anchor whose pose has moved reports the true 3D distance`() {
+        val a = mockk<Anchor>(relaxed = true)
+        every { a.trackingState } returns TrackingState.TRACKING
+        every { a.pose } returns Pose(floatArrayOf(0f, 0f, 0f), floatArrayOf(0f, 0f, 0f, 1f))
+
+        val o = AnchorOrchestrator()
+        o.setInitialAnchor(a)
+
+        // 3-4-0 right triangle: distance is exactly 5.
+        every { a.pose } returns Pose(floatArrayOf(3f, 4f, 0f), floatArrayOf(0f, 0f, 0f, 1f))
+        assertEquals(5f, o.primaryAnchorDriftMeters(), 1e-4f)
+    }
+
+    @Test fun `re-establishing resets the drift baseline to the new anchor`() {
+        val o = AnchorOrchestrator()
+        o.setInitialAnchor(anchorAt(0f, 0f, 0f))
+        o.setInitialAnchor(anchorAt(100f, 100f, 100f))
+        // If the old baseline survived, this would report ~173m instead of 0.
+        assertEquals(0f, o.primaryAnchorDriftMeters(), 1e-4f)
+    }
+
+    @Test fun `clear drops the baseline back to not-measured`() {
+        val o = AnchorOrchestrator()
+        o.setInitialAnchor(anchorAt(1f, 1f, 1f))
+        o.clear()
+        assertEquals(-1f, o.primaryAnchorDriftMeters(), 0f)
+    }
+
+    /** A dropped-tracking anchor cannot report a live drift; -1 is honest, not a stale number. */
+    @Test fun `a paused anchor reports not-measured rather than a stale distance`() {
+        val a = mockk<Anchor>(relaxed = true)
+        every { a.pose } returns Pose(floatArrayOf(0f, 0f, 0f), floatArrayOf(0f, 0f, 0f, 1f))
+        every { a.trackingState } returns TrackingState.TRACKING
+        val o = AnchorOrchestrator()
+        o.setInitialAnchor(a)
+
+        every { a.trackingState } returns TrackingState.PAUSED
+        assertEquals(-1f, o.primaryAnchorDriftMeters(), 0f)
+    }
+}

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Sun Aug 02 23:06:20 UTC 2026
-versionBuild=14575
+#Mon Aug 03 00:51:06 UTC 2026
+versionBuild=14578
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=441
+versionPatch=444


### PR DESCRIPTION
A device run after #1817 merged: the overlay receded **6.2 → 7.3 → 8.8 → 10.3 → 12.2 → 16.0 ft** over four seconds, accelerating, with `Fusion: OFF` and no fingerprint at all — nothing downstream of the anchor was even running. This is a **different mechanism** from the one #1815 fixed.

## Why #1815 couldn't have caught this

#1815's outlier rejection guards against multiple consensus anchors disagreeing. It cannot touch this case: `setInitialAnchor` always resets to exactly **one** anchor (`clear()` then a single `ConsensusAnchor` with `Pose.IDENTITY` offset), so `getConsensusMatrix`'s output *is* that one anchor's live pose, unfiltered. A median of one value is that value.

## The actual mechanism

The primary anchor was created with:

```kotlin
anchor = chosen.createAnchor()
```

`HitResult.createAnchor()` attaches to the **trackable**, not a fixed point. When that trackable is a `Plane` still being refined, grown, and merged by ARCore, the anchor's pose follows every refinement. Normally that's a small correction.

In a difficult scene it isn't: a screenshot from the same session showed the plane polygon itself spanning a canvas, a doorway, and the floor as one badly-fit surface — exactly the shape of trackable that keeps re-centering by a lot as ARCore keeps absorbing more of the room into it.

`addSupportAnchor` already avoided this — `session.createAnchor(worldPose)`, a fixed pose independent of any trackable. The primary anchor was the one inconsistent case, now made to match: `activeSession.createAnchor(pose)` at the same hit location, same normal computation, just not bound to the plane's future.

The cost is real and named in the comment: the anchor no longer nudges itself as ARCore's plane estimate improves in the following second or so. A small, one-time precision loss against an unbounded runaway.

## Making the next report prove it instead of guess it

Adds `AnchorOrchestrator.primaryAnchorDriftMeters()` — how far the anchor's **own** pose has moved since establishment, independent of fusion or the consensus average — surfaced in the report as `anchorDriftM`.

This isolates the exact mechanism just fixed from every other moving part in the pipeline, so the next report settles whether it held without another burst of screenshots and a stopwatch.

## Verification

- `:feature:ar:testDebugUnitTest`, `:app:testDebugUnitTest` green
- `:app:compileDebugKotlin` and `:app:compileReleaseKotlin` green
- Six new tests for the drift metric, including the mechanism itself (a mock `Anchor` returning a different pose on a later call — exactly what a trackable-attached anchor does as ARCore refines the plane it rides on) and the two ways it could go stale: surviving a re-establishment, and reporting a frozen number instead of "not measured" when tracking is lost

## What's still unconfirmed

This is diagnosed from source and corroborated by the screenshot, not reproduced on a device with the fix in place. The drift metric exists so the next run settles it either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Q5WXFiVLeN4sXa9bPCSDA

---
_Generated by [Claude Code](https://claude.ai/code/session_011Q5WXFiVLeN4sXa9bPCSDA)_

## Summary by Sourcery

Anchor the primary ARCore anchor at a fixed world pose instead of a still-forming Plane trackable and add diagnostics to measure and report its drift over time.

New Features:
- Expose primaryAnchorDriftMeters from the renderer and include its value in diagnostic reports as anchorDriftM to quantify anchor pose movement.

Enhancements:
- Track the primary anchor’s initial translation in AnchorOrchestrator and compute live drift distance to distinguish anchor motion from downstream fusion behavior.

Build:
- Increment application version build and patch numbers.

Tests:
- Add AnchorOrchestratorDriftTest to validate the new drift metric across no-anchor, stationary, moved, re-established, cleared, and paused tracking scenarios.