### PR TITLE
The ordinary target-capture flow never reported its refusals anywhere a report could see

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainViewModel.kt
@@ -284,6 +284,15 @@ class MainViewModel @Inject constructor(
     ) {
         if (wallPlane == null || wallPlane.size < 6) {
             resetCaptureUi()
+            // Recorded into the SAME shared field `buildSingle` writes to below, on the OTHER two
+            // preconditions here and in ArViewModel's doodle path — this call never reaches
+            // buildSingle at all, so without this line a diagnostic report would show whatever the
+            // PREVIOUS attempt left behind, or nothing, in place of this refusal. See
+            // MetricFingerprintBuilder.lastRefusalReason: this Toast was the only record this
+            // failure ever had, and a Toast a report can't see is not a record.
+            MetricFingerprintBuilder.recordPreconditionFailure(
+                "no wall plane under the tap — face the wall more squarely, closer, or with more light",
+            )
             Toast.makeText(context, notOnGreenWallMessage, Toast.LENGTH_LONG).show()
             return
         }
@@ -309,6 +318,9 @@ class MainViewModel @Inject constructor(
             // instantly against the previous anchor's pose.
             val anchor = slamManager.awaitAnchorTransform(slamManager.captureAnchorGenerationBaseline)
             if (anchor == null || anchor.size != 16) {
+                MetricFingerprintBuilder.recordPreconditionFailure(
+                    "anchor never established for this capture — held steady long enough?",
+                )
                 withContext(Dispatchers.Main) {
                     Toast.makeText(
                         context,
@@ -324,6 +336,7 @@ class MainViewModel @Inject constructor(
             // happened — no target, no error, no clue that the missing piece was a project.
             val currentProject = projectRepository.currentProject.value
             if (currentProject == null) {
+                MetricFingerprintBuilder.recordPreconditionFailure("no project open to save the target into")
                 withContext(Dispatchers.Main) {
                     Toast.makeText(
                         context,

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -346,16 +346,17 @@ class ArViewModel @Inject constructor(
      */
     @Volatile private var diagnosticCaptureEnabled = false
 
-    /**
-     * Why the last target capture produced no fingerprint, or null if the last one succeeded.
-     *
-     * Carried into the report because it is the answer to the question every empty-fingerprint run
-     * raises and none of them could answer. `wallPoints 0` says the fingerprint is missing; this says
-     * whether the wall had no features at all or had plenty and none of them back-projected onto the
-     * plane — two problems with two different fixes, which the report otherwise leaves the reader to
-     * guess between.
-     */
-    @Volatile private var lastCaptureRefusal: String? = null
+    // This class used to keep its OWN `lastCaptureRefusal` field. It was wrong the moment a second
+    // capture flow existed: `MainViewModel.handleSingleCapture` — the "tap directly on your painted
+    // marks" review flow, which is the ORDINARY way a target gets created — builds a fingerprint
+    // through the exact same `MetricFingerprintBuilder`, on a failure it never touched this field,
+    // and its refusal reached the artist only as an ephemeral `Toast`. A report built from this
+    // class's own field then said "no refusal recorded" for a capture that HAD failed, moments
+    // earlier, through the flow the artist actually used — which is indistinguishable, to the field,
+    // from nothing having been attempted at all.
+    //
+    // `MetricFingerprintBuilder.lastRefusalReason` is the shared answer both flows read and write
+    // now; see its doc. The report below reads that directly.
 
     private val _captureRequests =
         MutableSharedFlow<com.hereliesaz.graffitixr.feature.ar.eval.CaptureTrigger>(
@@ -617,7 +618,8 @@ class ArViewModel @Inject constructor(
             "syncReloc" to slamManager.evalSyncRelocEveryN().let { if (it > 0) "every $it" else "async" },
             // The reason an empty-fingerprint run is empty. Without it the report can say the
             // fingerprint is missing and nothing about why, which is where three device runs stalled.
-            "lastCapture" to (lastCaptureRefusal?.let { "REFUSED — $it" } ?: "no refusal recorded"),
+            "lastCapture" to (com.hereliesaz.graffitixr.feature.ar.anchor.MetricFingerprintBuilder
+                .lastRefusalReason?.let { "REFUSED — $it" } ?: "no refusal recorded"),
             // The single most direct test for "the overlay is receding": is the ARCore anchor's OWN
             // pose moving, independent of fusion, relocalization, or the consensus average. A device
             // run went 6.2 -> 16.0 ft in four seconds with fusion off and no fingerprint — nothing
@@ -3200,13 +3202,15 @@ class ArViewModel @Inject constructor(
         val planeNormalOk = plane != null && plane.size >= 6 &&
             (plane[3] * plane[3] + plane[4] * plane[4] + plane[5] * plane[5]) > 1e-8f
         if (!planeNormalOk || intr == null) {
-            lastCaptureRefusal = when {
+            val reason = when {
                 plane == null -> "no wall plane yet — ARCore has not produced a usable surface to project onto"
                 plane.size < 6 -> "wall plane malformed (${plane.size} floats, need 6)"
                 !planeNormalOk -> "wall plane has a degenerate normal — nothing can back-project onto it"
                 else -> "no camera intrinsics for this frame"
             }
-            Timber.w("ARDIAG doodle capture skipped: $lastCaptureRefusal")
+            com.hereliesaz.graffitixr.feature.ar.anchor.MetricFingerprintBuilder
+                .recordPreconditionFailure(reason)
+            Timber.w("ARDIAG doodle capture skipped: $reason")
             slamManager.setMappingPaused(false)
             return
         }
@@ -3232,39 +3236,27 @@ class ArViewModel @Inject constructor(
                 )
                 if (fp != null) {
                     doodleFingerprintBuilt = true
-                    lastCaptureRefusal = null
+                    // No need to clear anything here: `buildSingle` already recorded its own success
+                    // (null) into `MetricFingerprintBuilder.lastRefusalReason` internally.
                 } else {
-                    // Say which way it fell short, on this path too.
-                    //
-                    // The tap-to-capture path has reported this for a while; the doodle path threw
-                    // the answer away. So a run could go: draw the glyphs, tap "I've drawn it",
-                    // watch the app capture over and over, silently fail every time, fall back to a
-                    // plain anchor, and hand back an overlay with no fingerprint and no explanation.
-                    // A device report showed exactly that — wallPoints 0 across 953 samples, and
-                    // every downstream stage correctly inert, with nothing anywhere saying why.
-                    //
-                    // "Not enough texture" would be the wrong message too: features found but not
-                    // landing on the plane is a different problem with a different fix from no
-                    // features at all, and only the pair of counts tells them apart.
-                    val detected = MetricFingerprintBuilder.lastDetected
-                    val placed = MetricFingerprintBuilder.lastPlaced
-                    val need = MetricFingerprintBuilder.lastRequired
-                    lastCaptureRefusal = if (detected < need) {
-                        "only $detected features detected (need $need) — too dark, too smooth, or out of focus"
-                    } else {
-                        "$detected features detected but only $placed landed on the wall plane " +
-                            "(need $need) — aim square at the middle of the detected wall"
-                    }
-                    Timber.w("ARDIAG target capture refused: $lastCaptureRefusal")
+                    // `buildSingle` already recorded WHY, from the same counts this used to
+                    // re-derive by hand — see `MetricFingerprintBuilder.lastRefusalReason`. Read it
+                    // back only to log it; the report reads the shared field directly.
+                    Timber.w(
+                        "ARDIAG target capture refused: " +
+                            "${MetricFingerprintBuilder.lastRefusalReason}",
+                    )
                 }
             } catch (t: Throwable) {
                 android.util.Log.w("ArViewModel", "Doodle fingerprint build failed", t)
-                // A throw is a refusal too, and the field above would otherwise stay null and let
-                // the report say "no refusal recorded" for a capture that blew up. `buildSingle`
-                // has at least one reachable throw of its own — `glViewToCvDisplay` requires a
-                // multiple of 90 — and reporting a crash as an absence is the failure this whole
-                // effort exists to stop.
-                lastCaptureRefusal = "threw ${t.javaClass.simpleName}: ${t.message ?: "no message"}"
+                // A throw is a refusal too, and without this the shared field would otherwise keep
+                // whatever it held before this attempt — success OR failure — and let the report
+                // describe a DIFFERENT capture than the one that just blew up. `buildSingle` has at
+                // least one reachable throw of its own — `glViewToCvDisplay` requires a multiple of
+                // 90 — and reporting a crash as an unrelated result is the failure this whole effort
+                // exists to stop.
+                com.hereliesaz.graffitixr.feature.ar.anchor.MetricFingerprintBuilder
+                    .recordPreconditionFailure("threw ${t.javaClass.simpleName}: ${t.message ?: "no message"}")
             } finally {
                 // Always resume the mapping that requestCapture paused — otherwise a throw would
                 // wedge SLAM with mapping paused for the rest of the session.

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/MetricFingerprintBuilder.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/anchor/MetricFingerprintBuilder.kt
@@ -165,6 +165,48 @@ object MetricFingerprintBuilder {
     @Volatile var lastRequired: Int = 0
         private set
 
+    /**
+     * Why the last capture attempt through ANY call site failed, or null if the last attempt
+     * succeeded (or none has been made this process).
+     *
+     * It has to live here, on the shared object, rather than on either caller: there are at least
+     * two independent capture flows that reach this class — the doodle demo
+     * (`ArViewModel.buildDoodleFingerprint`) and the "tap directly on your painted marks" review flow
+     * (`MainViewModel.handleSingleCapture`) — and each built its own version of this message from the
+     * same three counts. A refusal-reporting fix landed on the doodle path while `handleSingleCapture`
+     * kept reporting failures through an ephemeral `Toast` with no record anywhere a diagnostic report
+     * could read. An artist placed a target, the capture failed, a message appeared and vanished, and
+     * the report said "no refusal recorded" — true of that one field, false of what had actually
+     * happened on the device. One shared field means a fix here reaches every caller, including ones
+     * not written yet.
+     *
+     * Set two ways: automatically, by [buildSingle]/`ingestSingle` on every exit, from the counts
+     * they already track; or explicitly, via [recordPreconditionFailure], by a caller that refuses
+     * BEFORE ever reaching this class — no wall plane, no anchor, no open project — none of which
+     * [lastDetected] and friends can describe, because no detector ever ran.
+     */
+    @Volatile var lastRefusalReason: String? = null
+        private set
+
+    /**
+     * Records a refusal this class never saw, for a report reading [lastRefusalReason] to still
+     * account for. See the field doc: a missing wall plane or anchor refuses before `buildSingle` is
+     * ever called, and without this call the report would show the PREVIOUS attempt's outcome — or
+     * none — in place of the one that actually happened.
+     */
+    fun recordPreconditionFailure(reason: String) {
+        lastRefusalReason = reason
+    }
+
+    private fun recordAttemptOutcome(succeeded: Boolean) {
+        lastRefusalReason = if (succeeded) null else if (lastDetected < lastRequired) {
+            "only $lastDetected features detected (need $lastRequired) — too dark, too smooth, or out of focus"
+        } else {
+            "$lastDetected features detected but only $lastPlaced landed on the wall plane " +
+                "(need $lastRequired) — aim square at the middle of the detected wall"
+        }
+    }
+
 
     /**
      * @param rotationDeg `rotationNeeded` for this capture — the angle the caller already applied
@@ -215,7 +257,12 @@ object MetricFingerprintBuilder {
         try {
             clahe.apply(gray, norm)
             orb.detectAndCompute(norm, Mat(), kp, d)
-            if (d.empty()) return null
+            if (d.empty()) {
+                // Both detectors produced nothing at all: `lastDetected` is whatever the SuperPoint
+                // pass left it at (0, if it ran and found nothing), which is the honest count.
+                recordAttemptOutcome(succeeded = false)
+                return null
+            }
             val pixels = kp.toArray().map { PlaneMarks.Pixel(it.pt.x.toFloat(), it.pt.y.toFloat()) }
             return ingestSingle(slam, d, pixels, cvView, intr,
                 planePointWorld, planeNormalWorld, anchorModel, minPoints, glView, rotationDeg)
@@ -246,7 +293,14 @@ object MetricFingerprintBuilder {
         // and ORB is the fallback, so keep whichever pass got furthest rather than the last one.
         if (pixels.size > lastDetected) lastDetected = pixels.size
         if (res.count > lastPlaced) lastPlaced = res.count
-        if (res.count < minPoints) return null
+        if (res.count < minPoints) {
+            recordAttemptOutcome(succeeded = false)
+            return null
+        }
+        // Reaching here means this pass will return a Fingerprint below. Set eagerly rather than at
+        // the final `return` so every path through the rest of this function — there is only one —
+        // does not need its own copy of this line.
+        recordAttemptOutcome(succeeded = true)
 
         // IMPLEMENTATION.md 2.4's capture-time half: the anchor's pose in THIS frame, so the
         // partition can be composed later without a world frame. `res.pointsCam` is in the capture

--- a/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/MetricFingerprintBuilderRefusalTest.kt
+++ b/feature/ar/src/test/java/com/hereliesaz/graffitixr/feature/ar/anchor/MetricFingerprintBuilderRefusalTest.kt
@@ -1,0 +1,43 @@
+package com.hereliesaz.graffitixr.feature.ar.anchor
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * `MetricFingerprintBuilder.lastRefusalReason` — the shared answer to "why did the last capture
+ * attempt produce no fingerprint", written by BOTH capture flows in the app.
+ *
+ * A device report showed the gap this closes: the artist used the ordinary "tap directly on your
+ * painted marks" flow (`MainViewModel.handleSingleCapture`), a precondition refused the capture
+ * before `buildSingle` was ever called, the only record of it was an ephemeral `Toast`, and a
+ * diagnostic report pulled moments later said "no refusal recorded" — true of the field it read,
+ * false of what had just happened on the device.
+ *
+ * ## What this does not cover
+ *
+ * `recordAttemptOutcome` — the branch that derives a message from [MetricFingerprintBuilder.lastDetected]
+ * / `lastPlaced` / `lastRequired` — is private and only reachable through `buildSingle`, which needs a
+ * real `SlamManager` (native) and OpenCV's `ORB`/`CLAHE` (JNI). Neither is available in this harness,
+ * the same limitation noted for `ArRenderer` elsewhere in this codebase. What IS tested here is the
+ * half every caller outside this class actually depends on: [MetricFingerprintBuilder.recordPreconditionFailure],
+ * the escape hatch for a refusal this class never saw.
+ */
+class MetricFingerprintBuilderRefusalTest {
+
+    @Test fun `recordPreconditionFailure sets the reason verbatim`() {
+        MetricFingerprintBuilder.recordPreconditionFailure("no wall plane under the tap")
+        assertEquals("no wall plane under the tap", MetricFingerprintBuilder.lastRefusalReason)
+    }
+
+    /**
+     * Two independent flows write here. A precondition failure from ONE (MainViewModel) must not be
+     * silently overwritten back to null by the OTHER's unrelated success — but a precondition failure
+     * from EITHER must overwrite whatever the field held before, since it describes what just
+     * happened, not what happened earlier. This pins the second half: the last write wins.
+     */
+    @Test fun `a later precondition failure replaces an earlier one`() {
+        MetricFingerprintBuilder.recordPreconditionFailure("first reason")
+        MetricFingerprintBuilder.recordPreconditionFailure("second reason")
+        assertEquals("second reason", MetricFingerprintBuilder.lastRefusalReason)
+    }
+}

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,7 @@
 #Auto-incremented on compile
-#Mon Aug 03 00:51:06 UTC 2026
-versionBuild=14578
+#Mon Aug 03 03:14:03 UTC 2026
+versionBuild=14581
 versionMajor=1
 versionMinor=35
 versionMinorLast=35
-versionPatch=444
+versionPatch=447


### PR DESCRIPTION
The user pushed back on the previous report, correctly: they had placed a target, so a report reading "no refusal recorded" and "no anchor established" could not be the honest state of a session where nothing was attempted. It wasn't. Something was attempted, through a flow this project's refusal reporting had never been wired to.

## The gap

Every earlier fix this week (persistence, the dropped tap, the zero-normal plane, the trackable-attached anchor) targeted `ArViewModel.buildDoodleFingerprint` — the doodle demo. There is a **second, completely independent capture flow**: `MainViewModel.handleSingleCapture`, the ordinary "tap directly on your painted marks" review flow. It calls the exact same `MetricFingerprintBuilder.buildSingle`, and on failure reported it only through an ephemeral `Toast`. Nothing about that `Toast` ever reached `ArViewModel`'s report-building code — the two live in different ViewModels with no shared state for this.

So a real sequence happened: tap to place, ARCore establishes the anchor, the fingerprint build refuses for one of several reasons, a `Toast` says why and vanishes, and a diagnostic report pulled afterward describes a session where nothing had happened at all — because the one field the report read was never written by the flow the artist actually used.

## Fix

Move the shared state off `ArViewModel` and onto `MetricFingerprintBuilder` itself:

- **`lastRefusalReason`** — set automatically by `buildSingle`/`ingestSingle` on every exit. Success clears it; failure derives it from the same `detected`/`placed`/`required` counts both call sites were independently re-deriving.
- **`recordPreconditionFailure(reason)`** — for refusals that happen *before* `buildSingle` is ever reached: no wall plane, no anchor, no open project. The builder can't see these on its own.

Both flows now write into this one place:

- `ArViewModel.buildDoodleFingerprint` — the plane precondition, the `buildSingle` failure branch (now just reads the shared field instead of re-deriving it), and the catch block.
- `MainViewModel.handleSingleCapture` — no wall plane, no anchor, no project.

`ArViewModel`'s own private `lastCaptureRefusal` is gone. The report reads `MetricFingerprintBuilder.lastRefusalReason` directly, so a *third* future capture flow can't reintroduce this gap by forgetting to wire a private field only one class knew existed.

## Verification

- `:feature:ar:testDebugUnitTest`, `:app:testDebugUnitTest` green
- `:app:compileDebugKotlin` and `:app:compileReleaseKotlin` green
- Two tests cover the reachable-without-native-code half: `recordPreconditionFailure` and last-write-wins

## What isn't tested, and why

The counts-derived branch lives inside `buildSingle`, which needs a real `SlamManager` and OpenCV's `ORB`/`CLAHE` via JNI — untestable in this harness for the same reason `ArRenderer` is. Said so in the test file rather than left unexplained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Q5WXFiVLeN4sXa9bPCSDA

---
_Generated by [Claude Code](https://claude.ai/code/session_011Q5WXFiVLeN4sXa9bPCSDA)_

## Summary by Sourcery

Centralize capture refusal reporting in MetricFingerprintBuilder so all target-capture flows surface their last failure reason consistently in diagnostic reports.

Bug Fixes:
- Ensure refusals from the ordinary tap-to-capture flow are recorded and reflected in diagnostic reports instead of appearing as "no refusal recorded".
- Prevent capture crashes and precondition failures from leaving stale or misleading refusal state in reports by explicitly recording pre-build failures.

Enhancements:
- Move last-capture refusal state from ArViewModel into MetricFingerprintBuilder as a shared lastRefusalReason field used by all capture flows.
- Have MetricFingerprintBuilder automatically derive and store refusal reasons from feature detection/counts on every buildSingle/ingestSingle attempt.
- Wire MainViewModel precondition failures (no wall plane, no anchor, no open project) into the shared refusal state instead of only showing ephemeral Toasts.

Build:
- Bump app version build and patch numbers in version.properties.

Tests:
- Add unit tests for MetricFingerprintBuilder refusal tracking, covering recordPreconditionFailure behavior and last-write-wins semantics.