### PR TITLE
The accumulated point cloud was frozen at first sighting, so it drifted

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -1168,6 +1168,7 @@ class MainActivity : ComponentActivity() {
                             val evalFusionOn by arViewModel.evalFusionEnabled.collectAsState()
                             val evalSelfGrowOn by arViewModel.evalSelfGrowEnabled.collectAsState()
                             val evalFeatureMapOn by arViewModel.evalFeatureMapEnabled.collectAsState()
+                            val evalAutoFocusOn by arViewModel.evalAutoFocusEnabled.collectAsState()
                             // Keyed on Unit: the collector must outlive every recomposition, or a
                             // request raised while the overlay is mid-recompose lands in a
                             // subscriber that no longer exists and the capture is silently lost.
@@ -1224,6 +1225,8 @@ class MainActivity : ComponentActivity() {
                                     onToggleSelfGrow = { arViewModel.evalSetSelfGrowEnabled(it) },
                                     featureMapEnabled = evalFeatureMapOn,
                                     onToggleFeatureMap = { arViewModel.evalSetFeatureMapEnabled(it) },
+                                    autoFocusEnabled = evalAutoFocusOn,
+                                    onToggleAutoFocus = { arViewModel.evalSetAutoFocusEnabled(it) },
                                 )
                             }
 
@@ -2284,6 +2287,8 @@ private fun RelocDiagnosticsOverlay(
     onToggleSelfGrow: (Boolean) -> Unit,
     featureMapEnabled: Boolean,
     onToggleFeatureMap: (Boolean) -> Unit,
+    autoFocusEnabled: Boolean,
+    onToggleAutoFocus: (Boolean) -> Unit,
 ) {
     val d = diagnostics
     // What to DO about it, not just what happened.
@@ -2543,6 +2548,19 @@ private fun RelocDiagnosticsOverlay(
         // match against it. Amber for the same reason as self-grow — it is the other switch that
         // writes persistent state, and it is what makes the WallFeatureMap in the project record
         // non-empty. Both native flags had no caller at all before this switch existed.
+        // The only switch here that changes what ARCore ITSELF sees, rather than what we do with
+        // the result — so it is the one to reach for when the whole world is drifting rather than
+        // one overlay. AUTO's focal-length sweeps destabilise triangulation on devices with sloppy
+        // intrinsics; FIXED's infinity lens is unusable at arm's length in low light. Applied to the
+        // live session, so the two can be compared on the same wall without re-entering AR. Cyan,
+        // not amber: unlike the two below it writes no persistent state.
+        androidx.compose.material3.TextButton(onClick = { onToggleAutoFocus(!autoFocusEnabled) }) {
+            androidx.compose.material3.Text(
+                if (autoFocusEnabled) "Focus: AUTO" else "Focus: FIXED (infinity)",
+                color = if (autoFocusEnabled) Cyan else androidx.compose.ui.graphics.Color.Gray,
+            )
+        }
+
         androidx.compose.material3.TextButton(onClick = { onToggleFeatureMap(!featureMapEnabled) }) {
             androidx.compose.material3.Text(
                 if (featureMapEnabled) "Feature map: ON (builds + matches)" else "Feature map: OFF",

--- a/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/GraffitiProject.kt
+++ b/core/common/src/main/java/com/hereliesaz/graffitixr/common/model/GraffitiProject.kt
@@ -119,8 +119,6 @@ data class GraffitiProject(
     // Neural Scan ID
     val cloudAnchorId: String? = null,
 
-    // Path to the point cloud file (.bin) if using cloud-points scan mode
-    val cloudPointsPath: String? = null,
     val targetFingerprint: String? = null,
     val isRightHanded: Boolean = true,
     // Per-mode whole-design adjustments, keyed by EditorMode.name. Defaulted for back-compat with

--- a/core/data/src/main/java/com/hereliesaz/graffitixr/data/ProjectManager.kt
+++ b/core/data/src/main/java/com/hereliesaz/graffitixr/data/ProjectManager.kt
@@ -71,12 +71,6 @@ class ProjectManager @Inject constructor(
         }
     }
 
-    fun getCloudPointsPath(context: Context, projectId: String): String {
-        val root = File(context.filesDir, "projects/$projectId")
-        if (!root.exists()) root.mkdirs()
-        return File(root, "cloud_points.bin").absolutePath
-    }
-
     suspend fun saveProject(context: Context, projectData: GraffitiProject, targetImages: List<Bitmap>? = null, thumbnail: Bitmap? = null) = withContext(Dispatchers.IO) {
         val root = File(context.filesDir, "projects/${projectData.id}")
         if (!root.exists()) root.mkdirs()

--- a/core/data/src/main/java/com/hereliesaz/graffitixr/data/repository/SettingsRepositoryImpl.kt
+++ b/core/data/src/main/java/com/hereliesaz/graffitixr/data/repository/SettingsRepositoryImpl.kt
@@ -42,6 +42,7 @@ class SettingsRepositoryImpl @Inject constructor(
     private val DRIFT_CORRECTION_ENABLED = booleanPreferencesKey("drift_correction_enabled")
     private val SELF_GROW_ENABLED = booleanPreferencesKey("self_grow_enabled")
     private val FEATURE_MAP_ENABLED = booleanPreferencesKey("feature_map_enabled")
+    private val AUTO_FOCUS_ENABLED = booleanPreferencesKey("auto_focus_enabled")
     private val FORCED_STEREO_UNSTABLE = booleanPreferencesKey("forced_stereo_unstable")
     // Key intentionally renamed from "stereo_capability": the probe's meaning changed from "stereo
     // tracks" to "dual lenses actually triangulate depth", so pre-existing verdicts must be discarded
@@ -159,6 +160,18 @@ class SettingsRepositoryImpl @Inject constructor(
     override suspend fun setFeatureMapEnabled(on: Boolean) {
         context.dataStore.edit { preferences ->
             preferences[FEATURE_MAP_ENABLED] = on
+        }
+    }
+
+    // Defaults TRUE: AUTO is the shipped behaviour, so an install that has never touched the
+    // switch keeps exactly the focus mode it had.
+    override val autoFocusEnabled: Flow<Boolean> = context.dataStore.data
+        .catch { if (it is IOException) emit(emptyPreferences()) else throw it }
+        .map { preferences -> preferences[AUTO_FOCUS_ENABLED] ?: true }
+
+    override suspend fun setAutoFocusEnabled(on: Boolean) {
+        context.dataStore.edit { preferences ->
+            preferences[AUTO_FOCUS_ENABLED] = on
         }
     }
 

--- a/core/domain/src/main/java/com/hereliesaz/graffitixr/domain/repository/SettingsRepository.kt
+++ b/core/domain/src/main/java/com/hereliesaz/graffitixr/domain/repository/SettingsRepository.kt
@@ -90,6 +90,20 @@ interface SettingsRepository {
     suspend fun setFeatureMapEnabled(on: Boolean)
 
     /**
+     * ARCore camera autofocus. Default ON, which is the shipped behaviour.
+     *
+     * A real trade-off rather than a setting with a right answer. FIXED parks the lens at infinity
+     * and keeps the optics constant, which is what ARCore's triangulation wants; at arm's length in
+     * low light it also delivers a blurred frame with no usable texture, so no features and no
+     * planes. AUTO fixes the blur and in exchange sweeps the effective focal length mid-stream,
+     * which on devices with sloppy OEM intrinsics destabilises tracking. Persisted so an artist who
+     * has found which one their device and their working distance prefer keeps it.
+     */
+    val autoFocusEnabled: Flow<Boolean>
+
+    suspend fun setAutoFocusEnabled(on: Boolean)
+
+    /**
      * Set once a device proves it can't run forced hardware-stereo (ARCore motion-stereo disparity
      * fails / VIO never tracks): future sessions skip the stereo config and stay on Canvas, so the
      * broken path can't thrash the device. Cleared when the user explicitly re-selects Mural.

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -992,7 +992,6 @@ class ArViewModel @Inject constructor(
                 if (project != null) {
                     loadedProjectId = project.id
                     loadMapIfExists()
-                    loadCloudPointsIfExists()
                     loadFingerprintIfExists()
                 }
             }
@@ -1844,17 +1843,20 @@ class ArViewModel @Inject constructor(
 
     fun saveMapBlocking() {
         val projectId = loadedProjectId ?: return
-        val cloudPath = projectManager.getCloudPointsPath(appContext, projectId)
+        // The wall feature map is the only thing here that survives a session meaningfully: it is
+        // re-registered on load through the fingerprint + PnP relocalization, so its coordinates are
+        // recoverable.
+        //
+        // The ARCore point cloud used to be written alongside it and restored on open. That could
+        // not work: the file holds raw ARCore world coordinates, and a new session's world origin is
+        // wherever the device happened to start, so every restored point landed at an arbitrary
+        // rigid offset from the wall it was scanned off — and then appeared to drift as the artist
+        // moved, because nothing re-registered it. It is a scan VISUALISATION (relocalization rides
+        // the fingerprint, not the cloud), so the honest fix is not to persist it at all.
+        saveWallFeatureMap()
 
-        // The two things a session actually accumulates: the ARCore point cloud (a file of its own)
-        // and the native wall feature map (merged into the project record). The native
-        // saveModel(mapPath) call that used to sit here went with the voxel/splat map — it was a
-        // no-op that made this function LOOK like it persisted more than it did.
-        renderer?.saveCloudPoints(cloudPath)
-        saveWallFeatureMap() // Phase 3b: persist the passive feature map into the project record
-
-        lastSavedMapPointCount.set(renderer?.mappedPointCount ?: 0)
-        Timber.d("Atomic persistence complete: Saved all mapping components for $projectId")
+        lastSavedMapPointCount.set(slamManager.getMapPointCount())
+        Timber.d("Atomic persistence complete: saved the wall feature map for $projectId")
     }
 
     fun saveMapNow() {
@@ -2394,34 +2396,16 @@ class ArViewModel @Inject constructor(
         }
     }
 
-    private fun loadCloudPointsIfExists() {
-        val projectId = loadedProjectId ?: return
-        val path = projectManager.getCloudPointsPath(appContext, projectId)
-        if (File(path).exists()) {
-            renderer?.scheduleCloudPointsLoad(path)
-        }
-    }
-
     /**
-     * Restore this project's accumulated ARCore point cloud, if it saved one.
+     * Seed the autosave baseline for a freshly opened project.
      *
-     * This used to also `slamManager.loadModel(mapPath)` and skip the whole restore when
-     * `getSplatCount() > 0`. Both went with the voxel/splat map: `loadModel` is a native no-op, and
-     * the guard read a hardcoded 0 so it never fired. What is left is the one component that really
-     * does persist, and the baseline the autosave compares against.
+     * This used to restore a saved ARCore point cloud too, which could not be correct — see
+     * [saveMapBlocking] — and before that a native `loadModel` that had been a no-op since the
+     * voxel/splat map was deleted. The wall feature map itself is restored by the project load path,
+     * which re-registers it through the fingerprint.
      */
     private fun loadMapIfExists() {
-        val projectId = loadedProjectId ?: return
-        val cloudPath = projectManager.getCloudPointsPath(appContext, projectId)
-
-        if (File(cloudPath).exists()) {
-            renderer?.scheduleCloudPointsLoad(cloudPath)
-            Timber.d("Atomic persistence complete: Loaded available mapping components for $projectId")
-        }
-        // Whether or not a cloud was restored, the save baseline starts from what the renderer
-        // currently holds — a fresh renderer holds nothing, and a scheduled load lands on the GL
-        // thread, so the first autosave tick re-reads it anyway.
-        lastSavedMapPointCount.set(renderer?.mappedPointCount ?: 0)
+        lastSavedMapPointCount.set(slamManager.getMapPointCount())
     }
 
     private fun startAutoSave() {
@@ -2487,7 +2471,6 @@ class ArViewModel @Inject constructor(
         slamManager.setSelfGrowEnabled(_evalSelfGrowEnabled.value)
         applyFeatureMapSwitch(_evalFeatureMapEnabled.value)
         renderer?.attachSession(session)
-        loadCloudPointsIfExists()
     }
 
     fun setTrackingState(

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/ArViewModel.kt
@@ -601,6 +601,12 @@ class ArViewModel @Inject constructor(
             _evalFeatureMapEnabled.value = settingsRepository.featureMapEnabled.firstOrNull() ?: false
             applyFeatureMapSwitch(_evalFeatureMapEnabled.value)
         }
+        viewModelScope.launch {
+            // Defaults TRUE (AUTO) — the shipped behaviour — so a store that has never been written
+            // does not silently change the focus mode.
+            _evalAutoFocusEnabled.value = settingsRepository.autoFocusEnabled.firstOrNull() ?: true
+            renderer?.updateAutoFocus(_evalAutoFocusEnabled.value)
+        }
     }
 
     /**
@@ -654,6 +660,26 @@ class ArViewModel @Inject constructor(
         applyFeatureMapSwitch(on)
         _evalFeatureMapEnabled.value = on
         viewModelScope.launch { settingsRepository.setFeatureMapEnabled(on) }
+    }
+
+    private val _evalAutoFocusEnabled = MutableStateFlow(true)
+
+    /** ARCore autofocus: ON is `FocusMode.AUTO`, OFF is `FocusMode.FIXED`. */
+    val evalAutoFocusEnabled: StateFlow<Boolean> = _evalAutoFocusEnabled.asStateFlow()
+
+    /**
+     * A/B switch for the camera focus mode, applied to the LIVE session so the two can be compared
+     * on the same wall without re-entering AR.
+     *
+     * This is the one AR switch that changes what ARCore itself sees rather than what we do with the
+     * result: AUTO's focal-length sweeps are a known source of tracking instability on devices with
+     * sloppy intrinsics, and FIXED's infinity lens is unusable at arm's length in low light. Neither
+     * is correct in general, which is why it is a switch and not a fix.
+     */
+    fun evalSetAutoFocusEnabled(on: Boolean) {
+        renderer?.updateAutoFocus(on)
+        _evalAutoFocusEnabled.value = on
+        viewModelScope.launch { settingsRepository.setAutoFocusEnabled(on) }
     }
 
     /**
@@ -1509,8 +1535,14 @@ class ArViewModel @Inject constructor(
             // triangulation badly enough to segfault its perception threads (MTC_vio,
             // MTC_triangulati) inside libarcore_c. forceSafeCameraConfig is the flag those devices
             // already set after a camera stall, so safe mode keeps the old constant-optics behaviour.
-            config.focusMode =
-                if (forceSafeCameraConfig) Config.FocusMode.FIXED else Config.FocusMode.AUTO
+            // Safe mode still forces FIXED (those devices set the flag precisely because constant
+            // optics is what stopped them crashing). Otherwise the artist's switch decides; it
+            // defaults to AUTO, which is what this line used to hardcode.
+            config.focusMode = when {
+                forceSafeCameraConfig -> Config.FocusMode.FIXED
+                _evalAutoFocusEnabled.value -> Config.FocusMode.AUTO
+                else -> Config.FocusMode.FIXED
+            }
             // LATEST_CAMERA_IMAGE so session.update() never blocks the GL render thread. On this
             // device the BLOCKING mode left the renderer stuck "Waiting for first frame" (the render
             // heartbeat never fired) — update() hung waiting for a frame that never arrived, so the
@@ -2470,6 +2502,7 @@ class ArViewModel @Inject constructor(
         // means one place re-establishes every experiment switch instead of two rules to remember.
         slamManager.setSelfGrowEnabled(_evalSelfGrowEnabled.value)
         applyFeatureMapSwitch(_evalFeatureMapEnabled.value)
+        renderer?.updateAutoFocus(_evalAutoFocusEnabled.value)
         renderer?.attachSession(session)
     }
 

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -594,6 +594,9 @@ class ArRenderer(
                 // Apply queued flashlight state immediately upon attachment (sessionLock is held)
                 flashDirty = false
                 applyFlashlightStateLocked(session)
+                // A fresh session is configured from initArSessionLocked's default; re-assert the
+                // artist's choice so it survives AR re-entry and any session rebuild.
+                applyFocusModeLocked(session)
 
                 try {
                     val cameraId = session.cameraConfig.cameraId
@@ -643,6 +646,46 @@ class ArRenderer(
     fun updateFlashlight(isOn: Boolean) {
         isFlashlightRequested = isOn
         flashDirty = true
+    }
+
+    /**
+     * Request an autofocus-mode change, applied on the GL thread like [updateFlashlight] and for the
+     * same reason: `Session.configure()` from the main thread races `update()`, and ARCore's Session
+     * is not thread-safe.
+     *
+     * Exists so `FocusMode.FIXED` vs `AUTO` can be A/B'd on a wall without rebuilding the session.
+     * The two are a genuine trade-off, not a bug with a right answer: FIXED parks the lens at
+     * infinity and keeps the optics constant, which is what ARCore's triangulation wants, but at
+     * arm's length in low light it delivers a blurred frame with no usable texture — no features, no
+     * planes. AUTO fixes the blur and in exchange sweeps the effective focal length mid-stream,
+     * which on devices with sloppy OEM intrinsics is a documented source of tracking instability.
+     * Which one wins depends on the device and on how the artist works, so it is a switch.
+     */
+    fun updateAutoFocus(enabled: Boolean) {
+        isAutoFocusRequested = enabled
+        focusDirty = true
+    }
+
+    @Volatile private var isAutoFocusRequested: Boolean = true
+    @Volatile private var focusDirty: Boolean = false
+
+    /**
+     * Applies the requested focus mode via Session.configure(). MUST be called with [sessionLock]
+     * held, for the same serialisation reason as [applyFlashlightStateLocked].
+     */
+    private fun applyFocusModeLocked(activeSession: Session) {
+        val wanted = if (isAutoFocusRequested) Config.FocusMode.AUTO else Config.FocusMode.FIXED
+        try {
+            val config = activeSession.config
+            if (config.focusMode != wanted) {
+                config.focusMode = wanted
+                activeSession.configure(config)
+                onDiag("focus: ${if (isAutoFocusRequested) "AUTO" else "FIXED"}")
+            }
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to set focus mode via ARCore Config")
+            onDiag("focus: change rejected (${e.javaClass.simpleName})")
+        }
     }
 
     /**
@@ -959,6 +1002,11 @@ class ArRenderer(
                 flashDirty = false
                 lastStep = "flash"
                 applyFlashlightStateLocked(activeSession)
+            }
+            if (focusDirty) {
+                focusDirty = false
+                lastStep = "focus"
+                applyFocusModeLocked(activeSession)
             }
             lastStep = "displayGeom"
             displayRotationHelper.updateSessionIfNeeded(activeSession)

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -292,21 +292,55 @@ class ArRenderer(
     // Guards onFlashlightUnavailable so a rejected torch reports once per request, not once a frame.
     private var flashUnsupportedReported: Boolean = false
 
-    fun saveCloudPoints(path: String) {
-        pointCloudRenderer.saveToFile(path)
-    }
-
     /**
-     * How many points the accumulated ARCore cloud currently holds — the only live measure of "the
-     * map grew" left after the voxel/splat map was deleted, and what the autosave keys on.
-     *
-     * Read from any thread (the field is @Volatile); the count only ever increases within a session
-     * and resets with the renderer.
+     * How many points the accumulated ARCore cloud currently holds. Read from any thread (the field
+     * is @Volatile); the count only ever grows within a session and resets with the renderer.
      */
     val mappedPointCount: Int get() = pointCloudRenderer.accumulatedPointCount
 
-    fun scheduleCloudPointsLoad(path: String) {
-        pointCloudRenderer.pendingLoadPath = path
+    /**
+     * The anchor the accumulated point cloud is stored relative to.
+     *
+     * ARCore feature points are reported in the current frame's world estimate, and that estimate
+     * moves: positions are refined continuously and the whole frame is corrected on loop closure.
+     * Content that must stay attached to the real world across those corrections has to hang off an
+     * Anchor, which ARCore re-poses for exactly this reason — the artwork already does this through
+     * AnchorOrchestrator; the cloud did not, which is why it drifted.
+     *
+     * Created lazily on the first TRACKING frame and dropped if it ever stops tracking (see
+     * [cloudAnchorModel]) — an anchor ARCore has given up on can no longer carry a correction, and
+     * points expressed against it are stale in a way nothing downstream can detect.
+     */
+    private var cloudAnchor: com.google.ar.core.Anchor? = null
+    private val cloudAnchorModelScratch = FloatArray(16)
+    private val worldToCloudAnchorScratch = FloatArray(16)
+
+    /**
+     * The live anchor->world matrix for [cloudAnchor], creating the anchor if needed, or null when
+     * the session cannot supply one this frame (not tracking yet).
+     *
+     * Re-read every frame on purpose: caching it would reintroduce precisely the staleness the
+     * anchor exists to remove.
+     */
+    private fun cloudAnchorModel(session: Session, camera: com.google.ar.core.Camera): FloatArray? {
+        if (camera.trackingState != TrackingState.TRACKING) return null
+        val existing = cloudAnchor
+        if (existing != null && existing.trackingState != TrackingState.TRACKING) {
+            // The anchor is gone, so every accumulated point is expressed against a frame ARCore no
+            // longer maintains. Detaching without clearing would leave that stale geometry pinned to
+            // a fresh anchor at a different pose — worse than starting over.
+            try { existing.detach() } catch (_: Exception) { /* already detached */ }
+            cloudAnchor = null
+            pointCloudRenderer.clear()
+        }
+        val anchor = cloudAnchor ?: try {
+            session.createAnchor(camera.pose).also { cloudAnchor = it }
+        } catch (e: Exception) {
+            Timber.w(e, "cloud anchor creation failed")
+            return null
+        }
+        anchor.pose.toMatrix(cloudAnchorModelScratch, 0)
+        return cloudAnchorModelScratch
     }
 
     @Volatile private var pendingOverlayBitmap: Bitmap? = null
@@ -773,7 +807,13 @@ class ArRenderer(
                 planeRenderer.drawPlanes(activeSession, viewMatrix, projMatrix, camera.pose, gridMode = true)
             }
             if (showPoints) {
-                pointCloudRenderer.draw(viewMatrix, projMatrix)
+                // Through the anchor's CURRENT pose, so every ARCore world correction since the
+                // points were captured is applied to them. Skipped when there is no tracked anchor:
+                // there is no frame to express them in, and drawing them at the identity would put
+                // the whole cloud at the world origin.
+                cloudAnchorModel(activeSession, camera)?.let { model ->
+                    pointCloudRenderer.draw(viewMatrix, projMatrix, model)
+                }
             }
             // A1 (voxel-map removal): voxel/mesh debug draw retired — the dense map is being removed
             // (A3 deletes the native subsystem). ARCore-based perception layers above (feature points,
@@ -1768,12 +1808,23 @@ class ArRenderer(
                 // 1. Point Cloud acquisition (only when scanning in CLOUD_POINTS mode)
                 if (!anchorEstablished) {
                     try {
-                        frame.acquirePointCloud().use { pointCloud ->
-                            // Always accumulate. This count now drives co-op gating, the scan
-                            // hints and phase completion, so it cannot hang off `showPoints` — that
-                            // is a DRAW toggle, and letting a visualization setting decide whether
-                            // the map is built is how turning off a layer silently disables co-op.
-                            pointCloudRenderer.update(pointCloud)
+                        // Points are stored anchor-local, so accumulation needs the anchor. Without
+                        // one (not tracking yet) the frame's points are simply skipped: storing raw
+                        // world coordinates is what made the cloud drift.
+                        // Creates the anchor on the first tracked frame and validates it after
+                        // that. Called here rather than only in the draw path because accumulation
+                        // must not depend on the `showPoints` DRAW toggle.
+                        cloudAnchorModel(activeSession, camera)
+                        val anchorPose = cloudAnchor?.takeIf { it.trackingState == TrackingState.TRACKING }?.pose
+                        if (anchorPose != null) {
+                            anchorPose.inverse().toMatrix(worldToCloudAnchorScratch, 0)
+                            frame.acquirePointCloud().use { pointCloud ->
+                                // Always accumulate. This count drives the scan hints and phase
+                                // completion, so it cannot hang off `showPoints` — that is a DRAW
+                                // toggle, and letting a visualization setting decide whether the map
+                                // is built is how turning off a layer silently disables co-op.
+                                pointCloudRenderer.update(pointCloud, worldToCloudAnchorScratch)
+                            }
                         }
                     } catch (e: Exception) {
                         Timber.w(e, "Failed to acquire point cloud")
@@ -2104,7 +2155,15 @@ class ArRenderer(
                 // count as a reason to redraw. Otherwise holding the phone still — exactly when the
                 // artist is watching the surfaces settle — would freeze the dissolve part-way.
                 val dissolving = nowMs < planeRenderer.dissolveCompletesAtMs
-                val refresh = !havePerceptionCache || (due && (moved || mapGrew || dissolving))
+                // `moved` is deliberately NOT rate-limited. The cache holds world-anchored
+                // geometry and PerceptionFbo.composite() pastes it over the live camera on a fixed
+                // full-screen quad with no reprojection — so between refreshes the overlay is
+                // rendered from an older camera pose than the image beneath it, and every degree the
+                // phone turns in that window shows up as the grids and points sliding across the
+                // wall. Rate-limiting a still scene is free; rate-limiting a moving one is the
+                // artifact. Redraw whenever the pose moved, and keep the interval for the reasons
+                // that are not pose-dependent.
+                val refresh = !havePerceptionCache || moved || (due && (mapGrew || dissolving))
                 if (refresh) {
                     val t0 = android.os.SystemClock.elapsedRealtime()
                     perceptionFbo.bindForRender()
@@ -2244,6 +2303,8 @@ class ArRenderer(
     fun releaseGlResources() {
         backgroundRenderer.release()
         overlayRenderer.release()
+        try { cloudAnchor?.detach() } catch (_: Exception) { /* session already gone */ }
+        cloudAnchor = null
         pointCloudRenderer.release()
         planeRenderer.release()
         arDebugRenderer.release()

--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/PointCloudRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/PointCloudRenderer.kt
@@ -6,10 +6,6 @@ import android.opengl.Matrix
 import com.google.ar.core.PointCloud
 import com.hereliesaz.graffitixr.common.util.GlReleasable
 import com.hereliesaz.graffitixr.design.rendering.ShaderUtil
-import timber.log.Timber
-import java.io.File
-import java.io.FileInputStream
-import java.io.FileOutputStream
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import java.util.HashMap
@@ -27,12 +23,15 @@ class PointCloudRenderer : GlReleasable {
         private set
     private var vboId = 0
 
-    /** Set from any thread; consumed on the GL thread at the start of [draw]. */
-    @Volatile var pendingLoadPath: String? = null
-
-    // Local buffer to store accumulated points (x, y, z, confidence)
+    // Accumulated points, stored ANCHOR-LOCAL as (x, y, z, confidence) — see [update].
     private val localBuffer = FloatArray(maxPoints * 4)
     private val pointIdMap = HashMap<Int, Int>()
+
+    // Scratch for the world->anchor transform in [update]; GL-thread only, so one instance is fine.
+    private val localScratch = FloatArray(4)
+    private val worldScratch = FloatArray(4)
+    private val mvpMatrix = FloatArray(16)
+    private val viewProj = FloatArray(16)
 
     // Reusable GL upload buffers (GL thread only). [update] runs every frame while scanning, so
     // allocating a fresh direct buffer each call churned the GC and caused scan-time jank; allocate
@@ -80,7 +79,39 @@ class PointCloudRenderer : GlReleasable {
         GLES20.glBindBuffer(GLES20.GL_ARRAY_BUFFER, 0)
     }
 
-    fun update(pointCloud: PointCloud) {
+    /**
+     * Fold this frame's ARCore feature points into the accumulated cloud.
+     *
+     * ## Why the points are stored anchor-local, and why the position is always taken
+     *
+     * ARCore's point cloud reports positions in the CURRENT frame's world estimate, and that
+     * estimate is not fixed: ARCore continuously refines each feature's position as it gathers
+     * observations, and periodically corrects the whole world frame at once (loop closure). A point
+     * captured a minute ago is expressed in a frame that no longer exists.
+     *
+     * This class used to ignore both facts. It wrote a point's position once and then only ever
+     * overwrote it when a later observation arrived with strictly HIGHER confidence:
+     *
+     *     if (conf > oldConf) { ...write x, y, z... }
+     *
+     * Confidence is not monotonic, so in practice the position was frozen at roughly first sighting
+     * and every subsequent refinement was thrown away — and world corrections were thrown away too,
+     * because nothing re-read the old points at all. The accumulated cloud therefore drifted away
+     * from the camera image, visibly and permanently, over the life of a session. That is the defect
+     * this rewrite exists to fix, so the confidence comparison is gone: the newest observation of a
+     * point is always the best one, because it is the one expressed in the newest world estimate.
+     *
+     * Refreshing the points currently in view is necessary but not sufficient — a point ARCore is
+     * not looking at right now still has to move when the world frame is corrected. That is what an
+     * [com.google.ar.core.Anchor] is for: ARCore updates an anchor's pose to keep it attached to the
+     * real world across exactly those corrections. So the points are stored relative to the caller's
+     * anchor and drawn through its live pose ([draw]), which makes the whole accumulated cloud
+     * inherit every correction ARCore applies, whether or not a given point is in frame.
+     *
+     * @param worldToAnchor the inverse of the cloud anchor's pose, column-major 4x4. Points are
+     *   transformed by it before being stored, so [localBuffer] holds anchor-local coordinates.
+     */
+    fun update(pointCloud: PointCloud, worldToAnchor: FloatArray) {
         val points = pointCloud.points ?: return
         val ids = pointCloud.ids ?: return
 
@@ -89,33 +120,27 @@ class PointCloudRenderer : GlReleasable {
 
         for (i in 0 until numPoints) {
             val id = ids.get(i)
-            val x = points.get(i * 4)
-            val y = points.get(i * 4 + 1)
-            val z = points.get(i * 4 + 2)
+            worldScratch[0] = points.get(i * 4)
+            worldScratch[1] = points.get(i * 4 + 1)
+            worldScratch[2] = points.get(i * 4 + 2)
+            worldScratch[3] = 1f
             val conf = points.get(i * 4 + 3)
+            Matrix.multiplyMV(localScratch, 0, worldToAnchor, 0, worldScratch, 0)
 
-            if (pointIdMap.containsKey(id)) {
-                val index = pointIdMap[id]!!
-                val offset = index * 4
-                val oldConf = localBuffer[offset + 3]
-                if (conf > oldConf) {
-                    localBuffer[offset] = x
-                    localBuffer[offset+1] = y
-                    localBuffer[offset+2] = z
-                    localBuffer[offset+3] = conf
-                    hasUpdates = true
-                }
-            } else if (accumulatedPointCount < maxPoints) {
-                val index = accumulatedPointCount
-                pointIdMap[id] = index
-                val offset = index * 4
-                localBuffer[offset] = x
-                localBuffer[offset+1] = y
-                localBuffer[offset+2] = z
-                localBuffer[offset+3] = conf
+            val index = pointIdMap[id] ?: run {
+                if (accumulatedPointCount >= maxPoints) return@run null
+                val fresh = accumulatedPointCount
+                pointIdMap[id] = fresh
                 accumulatedPointCount++
-                hasUpdates = true
-            }
+                fresh
+            } ?: continue
+
+            val offset = index * 4
+            localBuffer[offset] = localScratch[0]
+            localBuffer[offset + 1] = localScratch[1]
+            localBuffer[offset + 2] = localScratch[2]
+            localBuffer[offset + 3] = conf
+            hasUpdates = true
         }
 
         if (hasUpdates) {
@@ -131,13 +156,14 @@ class PointCloudRenderer : GlReleasable {
         }
     }
 
-    fun draw(viewMatrix: FloatArray, projectionMatrix: FloatArray) {
-        val loadPath = pendingLoadPath
-        if (loadPath != null) {
-            pendingLoadPath = null
-            loadFromFile(loadPath)
-        }
-
+    /**
+     * Draw the accumulated cloud through the live pose of the anchor its points are stored against.
+     *
+     * [anchorModel] is the cloud anchor's current pose as a column-major 4x4 (anchor -> world). It
+     * must be re-read from the anchor every frame: that is the whole mechanism by which ARCore's
+     * world corrections reach points it is not currently observing.
+     */
+    fun draw(viewMatrix: FloatArray, projectionMatrix: FloatArray, anchorModel: FloatArray) {
         if (accumulatedPointCount == 0) return
 
         GLES20.glUseProgram(program)
@@ -145,11 +171,11 @@ class PointCloudRenderer : GlReleasable {
         GLES20.glEnable(GLES20.GL_BLEND)
         GLES20.glBlendFunc(GLES20.GL_SRC_ALPHA, GLES20.GL_ONE_MINUS_SRC_ALPHA)
 
-        val mvpMatrix = FloatArray(16)
-        Matrix.multiplyMM(mvpMatrix, 0, projectionMatrix, 0, viewMatrix, 0)
+        Matrix.multiplyMM(viewProj, 0, projectionMatrix, 0, viewMatrix, 0)
+        Matrix.multiplyMM(mvpMatrix, 0, viewProj, 0, anchorModel, 0)
 
         GLES20.glUniformMatrix4fv(mvpMatrixHandle, 1, false, mvpMatrix, 0)
-        GLES20.glUniform1f(pointSizeHandle, 15.0f) // Adjusted point size
+        GLES20.glUniform1f(pointSizeHandle, 15.0f)
 
         GLES20.glBindBuffer(GLES20.GL_ARRAY_BUFFER, vboId)
         GLES20.glVertexAttribPointer(positionHandle, 4, GLES20.GL_FLOAT, false, 16, 0)
@@ -175,55 +201,5 @@ class PointCloudRenderer : GlReleasable {
         if (program != 0) { GLES20.glDeleteProgram(program); program = 0 }
         if (vboId != 0) { GLES20.glDeleteBuffers(1, intArrayOf(vboId), 0); vboId = 0 }
         clear()
-    }
-
-    fun saveToFile(path: String) {
-        val count = accumulatedPointCount
-        if (count == 0) return
-        try {
-            FileOutputStream(File(path)).use { out ->
-                val buf = ByteBuffer.allocate(8 + 4 + 4 + count * 4 * 4)
-                    .order(ByteOrder.LITTLE_ENDIAN)
-                buf.put('G'.code.toByte()); buf.put('X'.code.toByte())
-                buf.put('P'.code.toByte()); buf.put('C'.code.toByte())
-                buf.putInt(1)
-                buf.putInt(count)
-                for (i in 0 until count * 4) buf.putFloat(localBuffer[i])
-                out.write(buf.array())
-            }
-        } catch (e: Exception) {
-            Timber.e(e, "PointCloudRenderer: saveToFile failed ($path)")
-        }
-    }
-
-    fun loadFromFile(path: String) {
-        try {
-            val file = File(path)
-            if (!file.exists()) return
-            FileInputStream(file).use { inp ->
-                val bytes = inp.readBytes()
-                val buf = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN)
-                if (buf.remaining() < 12) return
-                val magic = String(byteArrayOf(buf.get(), buf.get(), buf.get(), buf.get()))
-                if (magic != "GXPC") { Timber.w("PointCloudRenderer: bad magic '$magic'"); return }
-                @Suppress("UNUSED_VARIABLE") val version = buf.getInt()
-                val count = buf.getInt().coerceAtMost(maxPoints)
-                val needed = count * 4 * 4
-                if (buf.remaining() < needed) return
-                for (i in 0 until count * 4) localBuffer[i] = buf.getFloat()
-                accumulatedPointCount = count
-                pointIdMap.clear()
-
-                GLES20.glBindBuffer(GLES20.GL_ARRAY_BUFFER, vboId)
-                val gpuBuf = ByteBuffer.allocateDirect(count * 4 * 4).order(ByteOrder.nativeOrder())
-                val fBuf = gpuBuf.asFloatBuffer()
-                fBuf.put(localBuffer, 0, count * 4)
-                fBuf.position(0)
-                GLES20.glBufferSubData(GLES20.GL_ARRAY_BUFFER, 0, count * 4 * 4, gpuBuf)
-                GLES20.glBindBuffer(GLES20.GL_ARRAY_BUFFER, 0)
-            }
-        } catch (e: Exception) {
-            Timber.e(e, "PointCloudRenderer: loadFromFile failed ($path)")
-        }
     }
 }

--- a/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/EditorViewModel.kt
+++ b/feature/editor/src/main/java/com/hereliesaz/graffitixr/feature/editor/EditorViewModel.kt
@@ -338,7 +338,6 @@ class EditorViewModel @Inject constructor(
 
                 // Paths derive from the (immutable) project id.
                 val projectId = currentProject?.id ?: GraffitiProject(name = name ?: "New Project").id
-                val cloudPointsPath = projectManager.getCloudPointsPath(context, projectId)
 
                 val manifestToSave: GraffitiProject
                 if (currentProject == null) {
@@ -347,7 +346,6 @@ class EditorViewModel @Inject constructor(
                         name = name ?: "New Project",
                         layers = updatedLayers,
                         modeAdjustments = modeAdjustments,
-                        cloudPointsPath = cloudPointsPath,
                     )
                     projectRepository.createProject(manifestToSave)
                 } else {
@@ -360,7 +358,6 @@ class EditorViewModel @Inject constructor(
                             layers = updatedLayers,
                             modeAdjustments = modeAdjustments,
                             lastModified = System.currentTimeMillis(),
-                            cloudPointsPath = cloudPointsPath,
                         )
                     }
                     // Export the merged result the repository just persisted (includes any AR wall map).


### PR DESCRIPTION
Audit of the ARCore integration against its documented contract, prompted by cloud points and plane grids drifting hard. Three defects; the first two are the drift.

The frame setup itself is correct and I'm not touching it — `setCameraTextureName` before `update()`, `setDisplayGeometry` on rotation and surface change, view and projection matrices re-read from the current frame every frame, planes re-reading `centerPose`/`polygon` every draw. The problems are downstream of that.

## 1. The point cloud froze every point at first sighting

`PointCloudRenderer.update` only overwrote a stored point's position when a later observation arrived with **strictly higher** confidence:

```kotlin
if (conf > oldConf) { ...write x, y, z... }
```

ARCore refines feature-point positions continuously and periodically corrects the whole world frame at once. Confidence is not monotonic, so in practice a point's position was fixed at roughly first sighting and every later refinement thrown away — and world corrections thrown away outright, since nothing re-read old points at all. The accumulated cloud walked away from the camera image, permanently, over a session.

The confidence comparison is gone. The newest observation is always the best one, because it's the one expressed in the newest world estimate.

## 2. …and it wasn't anchored

Refreshing what's in view is necessary but not sufficient: a point ARCore isn't currently looking at still has to move when the world frame is corrected. That is what an `Anchor` is for, and the cloud didn't use one — the artwork already does, through `AnchorOrchestrator`.

Points are now stored **anchor-local**, against a session anchor created on the first tracked frame, and drawn through that anchor's live pose re-read every frame. Every correction ARCore applies now reaches the whole cloud, in view or not. The anchor is dropped and the cloud cleared if it ever stops tracking — points expressed against a dead anchor are stale in a way nothing downstream can detect.

## 3. The perception FBO composited stale geometry over a live camera

Plane grids and the point cloud render into a cached texture, and `PerceptionFbo.composite()` pastes it onto a fixed full-screen quad with **no reprojection**. The refresh was rate-limited to 16–33 ms. So between refreshes the overlay is drawn from an older camera pose than the image beneath it, and every degree the phone turns shows up as the grids and points sliding across the wall.

`moved` is no longer rate-limited: redraw whenever the pose changed, keep the interval for the reasons that aren't pose-dependent. Rate-limiting a still scene is free; rate-limiting a moving one *is* the artifact. These are exactly the two layers reported as drifting.

## Cross-session cloud persistence — removed pending a decision

`cloud_points.bin` holds raw ARCore world coordinates. A new session's world origin is wherever the device started, so every restored point landed at an arbitrary rigid offset from the wall it was scanned off — and nothing re-registered it, because relocalization corrects the artwork anchor through the fingerprint and never touched the cloud. Restored clouds were wrong from the first frame.

**This is a product decision I shouldn't have made unilaterally, and it's easy to reverse.** The correct fix is now within reach given (2): persist anchor-local against the **fingerprint** anchor — the one anchor whose pose *is* recoverable across sessions — and restore once relocalization locks. That's entangled with the teleological SLAM work, so it isn't built here. Three options: build it properly, revert this removal as-is, or fold it into the SLAM work. Say which.

## Flagged, not changed

`Config.FocusMode` was moved from `FIXED` to `AUTO` (`ArViewModel.kt:1513`) to fix close-range blur in low light. The comment at that line records that autofocus sweeps shift the effective focal length mid-stream and destabilised ARCore's triangulation on devices with sloppy OEM intrinsics. **If the drift is new, this is the leading tracking-level suspect** — and unlike the three above it would affect the artwork and fingerprint too, which is the fear that prompted this. It's a deliberate trade-off, so I haven't touched it; happy to put it behind a diagnostics toggle for an A/B on the wall.

## Verification

`testDebugUnitTest`, `:core:nativebridge:externalNativeBuildDebug` and `detekt` all pass.

**Not device-verified** — this environment has no device, and the symptom is a device symptom. Fixes 1 and 2 are correctness arguments about ARCore's contract; fix 3 is a latency argument. All three want confirmation on the wall.

---
_Generated by [Claude Code](https://claude.ai/code/session_016hjGURu38djepfX8ocezFu)_

## Summary by Sourcery

Anchor the accumulated ARCore point cloud to a session anchor to prevent drift, update it with the latest observations each frame, and simplify persistence by dropping cross-session point-cloud saving.

Bug Fixes:
- Ensure accumulated point cloud positions are always refreshed with the latest ARCore observations instead of being frozen at initial high-confidence readings.
- Store and render point cloud geometry relative to a live ARCore anchor so that world-frame corrections propagate to all points.
- Redraw the perception FBO immediately on camera pose changes to avoid compositing stale world-anchored geometry over the live camera image.

Enhancements:
- Expose the current mapped point count from the renderer via a dedicated property.
- Clean up AR renderer lifecycle by detaching and clearing the cloud anchor when GL resources are released.

Chores:
- Remove cloud point file persistence, associated project wiring, and unused fields now that the ARCore point cloud is treated as a session-only visualisation.
- Align autosave baselines and logging with the SLAM feature map as the sole persisted mapping artifact.