### PR TITLE
Widen plane debugView diag to diagnose why surface polygons aren't forming

### DIFF
--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -862,10 +862,24 @@ class ArRenderer(
             // (A3 deletes the native subsystem). ARCore-based perception layers above (feature points,
             // plane grids, accumulated cloud points) remain as the cheap "what am I seeing" indicators.
             if (frameCount % 120 == 0) {
-                // Decides "no data" vs "drawn but invisible" from the diag log alone.
-                val planeCount = activeSession.getAllTrackables(com.google.ar.core.Plane::class.java)
-                    .count { it.trackingState == TrackingState.TRACKING && it.subsumedBy == null }
-                onDiag("debugView: feat=${arDebugRenderer.lastPointCount} planes=$planeCount pts=${pointCloudRenderer.accumulatedPointCount} fps=${effectivePerceptionFps()}")
+                // Decides "no data" vs "drawn but invisible" from the diag log alone. planes=0 with
+                // healthy feat/pts for many seconds used to be a dead end: it doesn't say whether
+                // ARCore's plane finder ever fired at all (rawPlanes=0, a config/pipeline problem) or
+                // fired but the results never reached TRACKING (rawPlanes>0, planes=0 — a scene/motion
+                // problem, e.g. candidates stuck PAUSED or repeatedly discarded). cfg carries the
+                // session settings that change what the plane finder can see, so a capture spanning a
+                // mid-session focus/stereo change is no longer ambiguous about which mode was active
+                // when planes failed to form.
+                val allPlanes = activeSession.getAllTrackables(com.google.ar.core.Plane::class.java)
+                val planeCount = allPlanes.count { it.trackingState == TrackingState.TRACKING && it.subsumedBy == null }
+                val rawPlaneCount = allPlanes.size
+                val cfg = activeSession.config
+                onDiag(
+                    "debugView: feat=${arDebugRenderer.lastPointCount} planes=$planeCount rawPlanes=$rawPlaneCount " +
+                        "pts=${pointCloudRenderer.accumulatedPointCount} fps=${effectivePerceptionFps()} " +
+                        "focus=${cfg.focusMode} depth=${cfg.depthMode} planeMode=${cfg.planeFindingMode} " +
+                        "stereo=${activeSession.cameraConfig.stereoCameraUsage == com.google.ar.core.CameraConfig.StereoCameraUsage.REQUIRE_AND_USE}"
+                )
             }
         }
     }


### PR DESCRIPTION
## Summary

A device capture showed `planes=0` for ~35s of continuous, healthy tracking (features climbing past 200, accumulated point cloud past 6000 pts, real device translation confirmed) — ARCore's native plane detector never reached `TRACKING` on a single plane, which blocks target creation (tap-to-place needs a tracking plane under the tap) and the "surface polygons" the artist sees never form.

Static review ruled out the obvious culprits: `config.planeFindingMode = HORIZONTAL_AND_VERTICAL` is set once at session creation and never overridden (the focus/flash mid-session `configure()` calls only mutate their own field on the live config). With no repro environment available, the existing `debugView` diag log couldn't distinguish two very different root causes:

- ARCore's plane finder never fires at all (a config/pipeline problem), vs.
- candidates exist but never reach `TRACKING` (a scene/motion problem — e.g. stuck `PAUSED`, repeatedly discarded)

## Changes

- `ArRenderer.drawPerceptionLayers`: the periodic `debugView` diag line now also reports:
  - `rawPlanes` — total `Plane` trackables regardless of state (vs. `planes`, which is TRACKING-and-unsubsumed only)
  - `focus` / `depth` / `planeMode` — the live session `Config` at that moment
  - `stereo` — whether the active camera config is running hardware stereo vs. mono

This makes a future capture of the same symptom self-diagnosing instead of needing a follow-up round trip to correlate `planes=0` against whatever focus/stereo mode happened to be active at the time.

## Test plan

- [ ] No Android SDK is available in this environment, so this could not be compiled or run here — the change only adds an additive log line using APIs already used elsewhere in this file (`activeSession.config`, `activeSession.cameraConfig.stereoCameraUsage`).
- [ ] Next repro: capture the new `debugView` line during a scan where polygons fail to form, and use `rawPlanes` + `focus`/`depth`/`planeMode`/`stereo` to confirm which failure mode is occurring, then follow up with the actual fix.


---
_Generated by [Claude Code](https://claude.ai/code/session_016jSB6s4512h5cDQZLsS6Pk)_

## Summary by Sourcery

Enhancements:
- Extend the periodic debugView diagnostic line to report both tracking and total plane counts, along with current session focus, depth, plane-finding mode, and stereo camera usage.