### PR TITLE
Stop the AR overlay spinning in sync with phone tilt on near-horizontal anchors

### DIFF
--- a/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
+++ b/feature/ar/src/main/java/com/hereliesaz/graffitixr/feature/ar/rendering/ArRenderer.kt
@@ -457,6 +457,17 @@ class ArRenderer(
     // (x,y,z); zero-length until an anchor is established, in which case the raw anchor frame is used.
     private val anchorSurfaceNormal = FloatArray(3)
 
+    // World-space camera up/forward axes, captured ONCE at anchor establishment for use ONLY when
+    // world-up (0,1,0) is unusable to build the overlay's in-plane frame (surface ~horizontal, or the
+    // rare edge-on-horizontal case). overlayDraw used to read the LIVE camera axes (viewMatrix rows)
+    // for this every frame, which quietly turned those two cases into a billboard: since the surface
+    // normal is fixed but the disambiguating "up" tracked the live camera, rolling/tilting the phone
+    // spun the artwork on-screen in lockstep with the tilt — "the image spins around the wall-normal
+    // needle exactly when and how my phone does". Freezing these at establishment, like
+    // [anchorSurfaceNormal] already is, makes the whole in-plane frame world-fixed again.
+    private val anchorFallbackUp = floatArrayOf(0f, 1f, 0f)
+    private val anchorFallbackForward = floatArrayOf(0f, 0f, 1f)
+
     @Volatile var exportRequested: Boolean = false
     var onExportCaptured: ((Bitmap) -> Unit)? = null
 
@@ -1228,6 +1239,17 @@ class ArRenderer(
                         }
                     } else {
                         anchorSurfaceNormal[0] = 0f; anchorSurfaceNormal[1] = 0f; anchorSurfaceNormal[2] = 0f
+                    }
+                    // Freeze this frame's camera up/forward as the fallback disambiguation axes (see
+                    // the field comment) — a one-time snapshot, not the live camera read overlayDraw
+                    // used to take every frame.
+                    run {
+                        val upAxis = FloatArray(3)
+                        camPose.getTransformedAxis(1, 1f, upAxis, 0)
+                        anchorFallbackUp[0] = upAxis[0]; anchorFallbackUp[1] = upAxis[1]; anchorFallbackUp[2] = upAxis[2]
+                        val fwdAxis = FloatArray(3)
+                        camPose.getTransformedAxis(2, 1f, fwdAxis, 0)
+                        anchorFallbackForward[0] = fwdAxis[0]; anchorFallbackForward[1] = fwdAxis[1]; anchorFallbackForward[2] = fwdAxis[2]
                     }
                     slamManager.updateAnchorTransform(anchorModelMatrix)
                     // Doodle demo: publish the wall plane (anchor point + surface normal) so the
@@ -2015,7 +2037,9 @@ class ArRenderer(
             // orthonormal frame at the live anchor position whose +Z = the captured surface normal
             // (already oriented toward the camera). +Y = world-up projected ⟂ to +Z so the artwork is
             // upright; +X = +Y × +Z (= width, horizontal). If the surface is near-horizontal (normal
-            // ≈ world-up, e.g. floor/ceiling) world-up is degenerate, so fall back to the camera's up.
+            // ≈ world-up, e.g. floor/ceiling) world-up is degenerate, so fall back to the camera's up
+            // AS CAPTURED AT ESTABLISHMENT ([anchorFallbackUp]) — not the live camera. Reading the live
+            // camera here rotated the artwork in lockstep with every phone tilt/roll on these surfaces.
             // A zero stored normal (no anchor yet) leaves the raw anchor frame.
             System.arraycopy(anchorMatrix, 0, overlayBaseScratch, 0, 16)
             run {
@@ -2030,9 +2054,10 @@ class ArRenderer(
                     // Pick an up reference that isn't parallel to the normal.
                     var upX = 0f; var upY = 1f; var upZ = 0f
                     if (kotlin.math.abs(ny) > 0.95f) {
-                        // Surface ≈ horizontal: world-up ∥ normal is unusable. Use the camera's up
-                        // (viewMatrix row 1 is the camera up axis in world space).
-                        upX = viewMatrix[1]; upY = viewMatrix[5]; upZ = viewMatrix[9]
+                        // Surface ≈ horizontal: world-up ∥ normal is unusable. Use the camera's up as
+                        // captured at anchor establishment — frozen, so it doesn't track the live
+                        // camera and spin the artwork as the phone tilts.
+                        upX = anchorFallbackUp[0]; upY = anchorFallbackUp[1]; upZ = anchorFallbackUp[2]
                     }
                     // +Y = up projected onto the plane ⟂ to the normal, normalized.
                     val dot = upX * nx + upY * ny + upZ * nz
@@ -2040,9 +2065,10 @@ class ArRenderer(
                     var yLen = kotlin.math.sqrt(yX * yX + yY * yY + yZ * yZ)
                     if (yLen <= 1e-4f) {
                         // Up reference parallel to the normal (e.g. a level camera edge-on to a
-                        // horizontal surface): fall back to the camera's forward axis (viewMatrix row 2)
-                        // so the in-plane frame is still well-defined instead of reverting to raw.
-                        upX = viewMatrix[2]; upY = viewMatrix[6]; upZ = viewMatrix[10]
+                        // horizontal surface): fall back to the camera's forward axis, also frozen at
+                        // establishment, so the in-plane frame is still well-defined instead of
+                        // reverting to raw — and still doesn't track the live camera.
+                        upX = anchorFallbackForward[0]; upY = anchorFallbackForward[1]; upZ = anchorFallbackForward[2]
                         val dot2 = upX * nx + upY * ny + upZ * nz
                         yX = upX - dot2 * nx; yY = upY - dot2 * ny; yZ = upZ - dot2 * nz
                         yLen = kotlin.math.sqrt(yX * yX + yY * yY + yZ * yZ)


### PR DESCRIPTION
## Summary

Follow-up to #1827 (merged): with the plane-detection diagnostics in place, on-device testing showed translation/sliding much improved, but a new symptom — the artwork stays positionally locked to the wall, but visibly **spins around its own normal in lockstep with the phone's tilt/roll**, as if a needle through the center of the image (its local Z / wall-normal axis) turns exactly when and how the phone does.

## Root cause

`ArRenderer`'s per-frame `overlayDraw` block rebuilds the artwork's in-plane orientation every frame from the anchor's (frozen, established-once) surface normal, using **world-up `(0,1,0)`** as the reference to disambiguate "which way is up" on the surface. That's correctly constant frame-to-frame for ordinary walls.

But world-up is degenerate for a near-horizontal surface (normal ≈ world-up — floor/ceiling, or a normal that ends up mostly vertical from the depth-point/fallback anchor path when no real `Plane` trackable is available — the exact condition #1827 was diagnosing). For that case the code fell back to the **live camera's up axis**, read fresh from `viewMatrix` every single frame — and a second, rarer fallback (up-reference parallel to the normal) did the same with the live camera's forward axis.

Since the surface normal is fixed but that disambiguating "up" tracked the live camera, the whole in-plane frame silently became a billboard on those surfaces: rolling/tilting the phone rotated the computed frame right along with it, so the artwork visibly spun to match — exactly the reported symptom.

## Fix

`anchorSurfaceNormal` was already captured once at anchor establishment and held fixed. This change captures the camera's up/forward axes the same way, at the same moment (`anchorFallbackUp`, `anchorFallbackForward`), and has the per-frame `overlayDraw` block read those frozen vectors instead of `viewMatrix`. The in-plane frame is now fully world-fixed on every code path, not just the common one.

## Test plan

- [ ] No Android SDK in this environment, so this could not be compiled or run here — reviewed the diff manually against the existing pattern (`anchorSurfaceNormal`) and confirmed `camPose` is in scope at the insertion point.
- [ ] On-device: place the artwork on a surface that triggers the near-horizontal fallback (floor/ceiling, or a fallback/depth-point anchor with a mostly-vertical estimated normal) and confirm the artwork no longer rotates as the phone tilts/rolls.


---
_Generated by [Claude Code](https://claude.ai/code/session_016jSB6s4512h5cDQZLsS6Pk)_

## Summary by Sourcery

Bug Fixes:
- Prevent AR overlays placed on near-horizontal or fallback-anchored surfaces from rotating in sync with phone tilt/roll by using cached camera up/forward vectors instead of the live camera each frame.