### PR TITLE
Hide the tap-to-distance eval overlay from ordinary artists

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -1258,8 +1258,19 @@ class MainActivity : ComponentActivity() {
                             // from hardware stereo (isHardwareStereoActive) and from VIO-baseline
                             // triangulation (currentCenterDepth > 0f populated in ArRenderer),
                             // both of which reach ArUiState, so gate on those instead.
+                            //
+                            // Eval-only instrumentation (DistanceFormat lives under feature.ar.eval),
+                            // but this condition was missing the diagnostic gate the sibling EvalOverlay
+                            // above has — so it rendered for every artist, in every build, whenever
+                            // depth was available (which is most of the time once VIO is triangulating).
+                            // Also never cleared: a tapMark from placing the target stays in
+                            // arUiState.tapMarks and keeps drawing its yellow label indefinitely, right
+                            // where the artist tapped to place it — a stray, unlabelled mark with no
+                            // way to dismiss it. Gated the same way EvalOverlay already is.
                             val hasDepth = arUiState.isHardwareStereoActive || arUiState.currentCenterDepth > 0f
-                            if (editorUiState.editorMode == EditorMode.AR && !showLibrary && !showSettings && hasDepth) {
+                            if (EVAL_OVERLAY_ENABLED && editorUiState.showDiagOverlay &&
+                                editorUiState.editorMode == EditorMode.AR && !showLibrary && !showSettings && hasDepth
+                            ) {
                                 androidx.compose.material3.Text(
                                     text = com.hereliesaz.graffitixr.feature.ar.eval.DistanceFormat.format(
                                         arUiState.currentCenterDepth, arUiState.isImperialUnits


### PR DESCRIPTION
## Summary

From a screenshot: a small cyan + yellow mark sitting in the middle of the artwork that the artist didn't recognize and wanted gone.

Traced it to the "Tap-to-distance (Sub-project C)" block in `MainActivity.kt` — dev instrumentation (`feature.ar.eval.DistanceFormat`) for measuring depth accuracy: a live cyan center-reticle distance label, plus a yellow distance label pinned at each tapped wall mark. Unlike its sibling `EvalOverlay` a few lines above (gated on `EVAL_OVERLAY_ENABLED && editorUiState.showDiagOverlay`), this block's condition never had that gate — only `editorMode == AR && !showLibrary && !showSettings && hasDepth`. Since `hasDepth` is true for most of an AR session once VIO is triangulating, this rendered for every artist, in every build.

It's also never cleared: the `tapMark` created when the artist taps to place their target stays in `arUiState.tapMarks` forever, so its yellow label keeps drawing indefinitely, right where they tapped — a small, unlabelled mark with no indication of what it is or how to dismiss it. That's the mark in the screenshot: the persistent yellow tap-mark label sitting next to the live cyan center-reticle label.

## Fix

Add the same `EVAL_OVERLAY_ENABLED && editorUiState.showDiagOverlay` gate the neighboring `EvalOverlay` already uses. The instrumentation stays available for internal debug-build diagnostics; it no longer renders for ordinary artists.

## Test plan

- [ ] No Android SDK in this environment, so this could not be compiled or run here — reviewed the diff manually against the existing `EvalOverlay` gate pattern immediately above it in the same file.
- [ ] On-device: confirm the cyan/yellow tap-distance labels no longer appear during normal AR use, and (in a debug build with the diagnostic overlay setting on) still appear as before for depth-accuracy debugging.


---
_Generated by [Claude Code](https://claude.ai/code/session_016jSB6s4512h5cDQZLsS6Pk)_

## Summary by Sourcery

Bug Fixes:
- Prevent persistent tap-to-distance debug markers from appearing for ordinary artists during normal AR sessions.