### PR TITLE
Fix dominant-hand rail docking: dock on the off-hand side

### DIFF
--- a/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
+++ b/app/src/main/java/com/hereliesaz/graffitixr/MainActivity.kt
@@ -728,12 +728,10 @@ class MainActivity : ComponentActivity() {
                     )
                     azConfig(
                         packButtons = true,
-                        // "Thumb Range Only" (docs/UI_UX.md): the rail docks on the side the free
-                        // thumb naturally reaches — right side for a right-handed grip, left for
-                        // left-handed. AzDockingSide.LEFT/RIGHT are screen-relative (visual left/right;
-                        // see docs/AZNAVRAIL_COMPLETE_GUIDE.md's usePhysicalDocking note), so this must
-                        // match handedness directly, not invert it.
-                        dockingSide = if (editorUiState.isRightHanded) AzDockingSide.RIGHT else AzDockingSide.LEFT,
+                        // "Thumb Range Only" (docs/UI_UX.md): dominant hand holds the spray can/pen,
+                        // not the phone — the phone sits in the off-hand, so the rail must dock on
+                        // the side opposite the dominant hand for that hand's thumb to reach it.
+                        dockingSide = if (editorUiState.isRightHanded) AzDockingSide.LEFT else AzDockingSide.RIGHT,
                         noMenu = railMenuDisabled
                     )
                     azAdvanced(


### PR DESCRIPTION
## Summary

PR #1831 (batch 5 of the glee-audit remediation) inverted the nav rail's handedness-docking logic based on a wrong assumption: that the rail should dock under the *dominant* hand's thumb.

That's backwards. The dominant hand is the one holding the spray can, pen, or brush — it's occupied. The phone sits in the off-hand, so the rail needs to dock on the side that hand's thumb reaches, which is the side *opposite* the dominant hand.

This reverts `dockingSide` in `MainActivity.kt` back to `LEFT` for right-handed / `RIGHT` for left-handed (the pre-#1831 behavior), and rewrites the comment to explain why.

## Test plan

- [ ] On-device manual verification that the rail docks on the off-hand side for both Dominant Hand settings

---
_Generated by [Claude Code](https://claude.ai/code/session_016jSB6s4512h5cDQZLsS6Pk)_

## Summary by Sourcery

Bug Fixes:
- Fix handedness-based docking logic so the nav rail docks on the side opposite the dominant hand, matching pre-#1831 behavior.